### PR TITLE
Update the component event-bus charts version to `0.2.133`

### DIFF
--- a/resources/core/charts/event-bus/values.yaml
+++ b/resources/core/charts/event-bus/values.yaml
@@ -33,7 +33,7 @@ global:
         memory: "32M"
   trace:
     apiURL: http://zipkin.kyma-system:9411/api/v1/spans
-  eventBusVersion: "0.2.91"
+  eventBusVersion: "0.2.133"
 e2eTests:
   nameTester: "test-core-event-bus-tester"
   nameSubscriber: "test-core-event-bus-subscriber"    


### PR DESCRIPTION
Update the component event-bus charts version 0.2.133 to be consistent with the tests event-bus published docker image

Fixes #1 
