### PR TITLE
allowing to install kyma with minikube version newer than 0.28.0

### DIFF
--- a/installation/scripts/minikube.sh
+++ b/installation/scripts/minikube.sh
@@ -120,7 +120,7 @@ function checkIfMinikubeIsInitialized() {
 function checkMinikubeVersion() {
     local version=$(minikube version | awk '{print  $3}')
 
-    if [[ "${version}" != *"${MINIKUBE_VERSION}"* ]]; then
+    if [[ "${version}" < *"${MINIKUBE_VERSION}"* ]]; then
         echo "Your minikube is in v${version}. v${MINIKUBE_VERSION} is supported version of minikube. Install supported version!"
         exit -1
     fi


### PR DESCRIPTION
Confirm these statements before you submit your pull request:

- [x] I have read and submitted the required [Contributor Licence Agreements](https://github.com/kyma-project/community/blob/master/CONTRIBUTING.md#agreements-and-licenses).
- [x] This pull request follows the contributing guidelines, recommended Git workflow, and templates.
- [x] I have tested my changes. (I've tested it with minikube 0.28.2 on macOS)
- [x] I have updated the relevant documentation. (no docs was required)
---

**Description**

Changes proposed in this pull request:

- Before this change, I wasn't able to install kyma with minikube version 0.28.2
- In this PR, I'm allowing to install kyma with minikube version newer than 0.28.0 (previously it was possible to install it with 0.28.0 version **only**)
