### PR TITLE
Support for local run on linux

### DIFF
--- a/docs/kyma/docs/031-gs-local-installation.md
+++ b/docs/kyma/docs/031-gs-local-installation.md
@@ -6,7 +6,7 @@ internal: true
 
 ## Overview
 
-This Getting Started guide instructs developers to quickly deploy Kyma locally on a Mac, Linux or Windows. Kyma installs locally using a proprietary installer based on a Kubernetes operator.
+This Getting Started guide instructs developers to quickly deploy Kyma locally on a Mac, Linux, or Windows. Kyma installs locally using a proprietary installer based on a Kubernetes operator.
 The document provides the prerequisites, the instructions on how to install Kyma locally and verify the deployment, and the troubleshooting tips.
 
 ## Prerequisites
@@ -17,7 +17,7 @@ To run Kyma locally, download these tools:
 - [kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl/) 1.9.0
 - [Helm](https://github.com/kubernetes/helm) 2.8.2
 - [Hyperkit driver](https://github.com/kubernetes/minikube/blob/master/docs/drivers.md#hyperkit-driver) - Mac only
-- [Virtualbox](https://www.virtualbox.org/) - Linux / Windows
+- [Virtualbox](https://www.virtualbox.org/) - Linux or Windows
 - Hyper-V - Windows
 
 Read the [prerequisite reasoning](019-prereq-reasoning.md) document to learn why Kyma uses these tools.
@@ -48,7 +48,7 @@ Follow these steps to "always trust" the Kyma certificate on macOS:
   cd installation
   ```
 
-2. Run the `run.sh` (Mac / Linux) or `run.ps1` (Windows) script:
+2. Depending on your operating system, run `run.sh` for Mac and Linux or `run.ps1` for Windows
   ```
   cmd/run.sh
   ```

--- a/docs/kyma/docs/031-gs-local-installation.md
+++ b/docs/kyma/docs/031-gs-local-installation.md
@@ -6,7 +6,7 @@ internal: true
 
 ## Overview
 
-This Getting Started guide instructs developers to quickly deploy Kyma locally on a Mac. Kyma installs locally using a proprietary installer based on a Kubernetes operator.
+This Getting Started guide instructs developers to quickly deploy Kyma locally on a Mac, Linux or Windows. Kyma installs locally using a proprietary installer based on a Kubernetes operator.
 The document provides the prerequisites, the instructions on how to install Kyma locally and verify the deployment, and the troubleshooting tips.
 
 ## Prerequisites
@@ -16,7 +16,9 @@ To run Kyma locally, download these tools:
 - [Minikube](https://github.com/kubernetes/minikube) 0.28.0
 - [kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl/) 1.9.0
 - [Helm](https://github.com/kubernetes/helm) 2.8.2
-- [Hyperkit driver](https://github.com/kubernetes/minikube/blob/master/docs/drivers.md#hyperkit-driver)
+- [Hyperkit driver](https://github.com/kubernetes/minikube/blob/master/docs/drivers.md#hyperkit-driver) - Mac only
+- [Virtualbox](https://www.virtualbox.org/) - Linux / Windows
+- Hyper-V - Windows
 
 Read the [prerequisite reasoning](019-prereq-reasoning.md) document to learn why Kyma uses these tools.
 
@@ -46,7 +48,7 @@ Follow these steps to "always trust" the Kyma certificate on macOS:
   cd installation
   ```
 
-2. Run the `run.sh` script:
+2. Run the `run.sh` (Mac / Linux) or `run.ps1` (Windows) script:
   ```
   cmd/run.sh
   ```

--- a/installation/cmd/run.sh
+++ b/installation/cmd/run.sh
@@ -29,19 +29,24 @@ do
 done
 set -- "${POSITIONAL[@]}" # restore positional parameters
 
+VM_DRIVER="virtualbox"
+if [ `uname -s` = "Darwin" ]; then
+    VM_DRIVER="hyperkit"
+fi
+
 if [[ ! ${SKIP_MINIKUBE_START} ]]; then
-    bash $CURRENT_DIR/../scripts/minikube.sh --domain ${DOMAIN}
+    bash ${CURRENT_DIR}/../scripts/minikube.sh --domain "${DOMAIN}" --vm-driver "${VM_DRIVER}"
 fi
 
 if [ -z "$CR_PATH" ]; then
 
-    TMPDIR=`mktemp -d "$CURRENT_DIR/../../temp-XXXXXXXXXX"`
-    CR_PATH="$TMPDIR/installer-cr-local.yaml"
+    TMPDIR=`mktemp -d "${CURRENT_DIR}/../../temp-XXXXXXXXXX"`
+    CR_PATH="${TMPDIR}/installer-cr-local.yaml"
 
-    bash $CURRENT_DIR/../scripts/create-cr.sh --output ${CR_PATH} --domain ${DOMAIN}
-    bash $CURRENT_DIR/../scripts/installer.sh --local --cr "$CR_PATH"
+    bash ${CURRENT_DIR}/../scripts/create-cr.sh --output "${CR_PATH}" --domain "${DOMAIN}"
+    bash ${CURRENT_DIR}/../scripts/installer.sh --local --cr "${CR_PATH}"
 
     rm -rf $TMPDIR
 else
-    bash $CURRENT_DIR/../scripts/installer.sh --cr "$CR_PATH"
+    bash ${CURRENT_DIR}/../scripts/installer.sh --cr "${CR_PATH}"
 fi

--- a/installation/cmd/run.sh
+++ b/installation/cmd/run.sh
@@ -30,6 +30,7 @@ do
             VM_DRIVER="$2"
             shift
             shift
+        ;;
         *)    # unknown option
             POSITIONAL+=("$1") # save it in an array for later
             shift # past argument

--- a/installation/cmd/run.sh
+++ b/installation/cmd/run.sh
@@ -6,6 +6,11 @@ CURRENT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 DOMAIN="kyma.local"
 
+VM_DRIVER="virtualbox"
+if [ `uname -s` = "Darwin" ]; then
+    VM_DRIVER="hyperkit"
+fi
+
 POSITIONAL=()
 while [[ $# -gt 0 ]]
 do
@@ -21,6 +26,10 @@ do
             shift # past argument
             shift # past value
         ;;
+        --vm-driver)
+            VM_DRIVER="$2"
+            shift
+            shift
         *)    # unknown option
             POSITIONAL+=("$1") # save it in an array for later
             shift # past argument
@@ -28,11 +37,6 @@ do
     esac
 done
 set -- "${POSITIONAL[@]}" # restore positional parameters
-
-VM_DRIVER="virtualbox"
-if [ `uname -s` = "Darwin" ]; then
-    VM_DRIVER="hyperkit"
-fi
 
 if [[ ! ${SKIP_MINIKUBE_START} ]]; then
     bash ${CURRENT_DIR}/../scripts/minikube.sh --domain "${DOMAIN}" --vm-driver "${VM_DRIVER}"


### PR DESCRIPTION
Confirm these statements before you submit your pull request:

- [x] I have read and submitted the required [Contributor Licence Agreements](https://github.com/kyma-project/community/blob/master/CONTRIBUTING.md#agreements-and-licenses).
- [x] This pull request follows the contributing guidelines, recommended Git workflow, and templates.
- [x] I have tested my changes.
- [x] I have updated the relevant documentation.
---

**Description**

Changes in run.sh script to distinguish the running platform and accordingly set vm-driver parameter for minikube. On mac we use hyperkit, on linux we support virtualbox.

Tested on:
- Ubuntu Server 16.04 4.15.0-1018-azure x86_64
- VirtualBox 5.2.16 

Changes proposed in this pull request:

- Support for vm-driver switching based on the platform
- Docs update

**Issue link**
Resolves #27 
