### PR TITLE
Fix gateway trace spans not showing issue

### DIFF
--- a/components/application-connector/README.md
+++ b/components/application-connector/README.md
@@ -157,7 +157,7 @@ The UI API Facade must check the status of the Application Connector services in
 In the current solution, the UI API Facade iterates through services to find those which match the criteria, and then uses the health endpoint to determine the status.
 The UI API Facade has the following obligatory requirements:
 - The Kubernetes service for each Application Connector service uses the `remoteEnvironment` key, with the value as the name of the remote environment.
-- The Kubernetes service for each Application Connector service contains one port with the `ext-api-port` name. The system uses this port for the status check.
+- The Kubernetes service for each Application Connector service contains one port with the `http-api-port` name. The system uses this port for the status check.
 - Find the Kubernetes Application Connector service service in the `kyma-integration` Namespace. You can change its location in the `ui-api-layer` chart configuration.
 - The `/v1/health` endpoint returns a status of `HTTP 200`. Any other status code indicates the service is not healthy.
 

--- a/components/gateway/README.md
+++ b/components/gateway/README.md
@@ -156,7 +156,7 @@ The UI API Facade must check the status of the Gateway instance that represents 
 In the current solution, the UI API Facade iterates through services to find those which match the criteria, and then uses the health endpoint to determine the status.
 The UI API Facade has the following obligatory requirements:
 - The Kubernetes Gateway service uses the `remoteEnvironment` key, with the value as the name of the remote environment.
-- The Kubernetes Gateway service contains one port with the `ext-api-port` name. The system uses this port for the status check.
+- The Kubernetes Gateway service contains one port with the `http-api-port` name. The system uses this port for the status check.
 - Find the Kubernetes Gateway service in the `kyma-integration` Namespace. You can change its location in the `ui-api-layer` chart configuration.
 - The `/v1/health` endpoint returns a status of `HTTP 200`. Any other status code indicates the service is not healthy.
 

--- a/components/ui-api-layer/internal/domain/remoteenvironment/gateway/provider.go
+++ b/components/ui-api-layer/internal/domain/remoteenvironment/gateway/provider.go
@@ -17,14 +17,14 @@ import (
 
 const (
 	remoteEnvironmentLabelName = "remoteEnvironment"
-	externalAPIPortName        = "ext-api-port"
+	externalAPIPortName        = "http-api-port"
 )
 
 /*
 The contract, which describes, how to find service for given remote environment:
 
 1. K8s service is labelled with key remoteEnvironment, value is the name of the remote environment
-2. K8s Service contains one port with name “ext-api-port” and this port is used for status check.
+2. K8s Service contains one port with name “http-api-port” and this port is used for status check.
 3. K8s Service is in the ysf-integration namespace (this can be changed in ui-api-layer chart configuration)
 4. The endpoint is /v1/health, and we are expecting HTTP 200, any other status code means service is not healthy.
 */

--- a/components/ui-api-layer/internal/domain/remoteenvironment/gateway/provider_test.go
+++ b/components/ui-api-layer/internal/domain/remoteenvironment/gateway/provider_test.go
@@ -85,7 +85,7 @@ func fixReService(name, namespace, reName string) *apiv1.Service {
 			Selector: map[string]string{"app": "svc"},
 			Ports: []apiv1.ServicePort{
 				{
-					Name:       "ext-api-port",
+					Name:       "http-api-port",
 					Protocol:   "TCP",
 					Port:       80,
 					TargetPort: intstr.IntOrString{Type: intstr.Int, IntVal: 8080},

--- a/resources/core/charts/application-connector/charts/connector-service/templates/deployment.yaml
+++ b/resources/core/charts/application-connector/charts/connector-service/templates/deployment.yaml
@@ -50,4 +50,4 @@ spec:
           - containerPort: {{ .Values.deployment.args.internalAPIPort }}
             name: int-api-port
           - containerPort: {{ .Values.deployment.args.externalAPIPort }}
-            name: ext-api-port
+            name: http-api-port

--- a/resources/core/charts/application-connector/charts/metadata-service/templates/deployment.yaml
+++ b/resources/core/charts/application-connector/charts/metadata-service/templates/deployment.yaml
@@ -48,4 +48,4 @@ spec:
           - containerPort: {{ .Values.deployment.args.proxyPort }}
             name: proxy-port
           - containerPort: {{ .Values.deployment.args.externalAPIPort }}
-            name: ext-api-port
+            name: http-api-port

--- a/resources/core/charts/application-connector/charts/metadata-service/templates/service.yaml
+++ b/resources/core/charts/application-connector/charts/metadata-service/templates/service.yaml
@@ -14,7 +14,7 @@ spec:
   ports:
     - port: {{ .Values.service.externalapi.port }}
       protocol: TCP
-      name: ext-api-port
+      name: http-api-port
   selector:
     app: {{ .Chart.Name }}
     release: {{ .Chart.Name }}

--- a/resources/remote-environments/templates/deployment.yaml
+++ b/resources/remote-environments/templates/deployment.yaml
@@ -49,4 +49,4 @@ spec:
           - containerPort: {{ .Values.deployment.args.proxyPort }}
             name: proxy-port
           - containerPort: {{ .Values.deployment.args.externalAPIPort }}
-            name: ext-api-port
+            name: http-api-port

--- a/resources/remote-environments/templates/service.yaml
+++ b/resources/remote-environments/templates/service.yaml
@@ -14,7 +14,7 @@ spec:
   ports:
     - port: {{ .Values.service.externalapi.port }}
       protocol: TCP
-      name: ext-api-port
+      name: http-api-port
   selector:
     app: {{ .Release.Name }}-gateway
     release: {{ .Release.Name }}-gateway


### PR DESCRIPTION
Confirm these statements before you submit your pull request:

- [x] I have read and submitted the required [Contributor Licence Agreements](https://github.com/kyma-project/community/blob/master/CONTRIBUTING.md#agreements-and-licenses).
- [x] This pull request follows the contributing guidelines, recommended Git workflow, and templates.
- [x] I have tested my changes.
- [x] I have updated the relevant documentation.
---

**Description**

Changes proposed in this pull request:

Change the external API port name to have "http" as a prefix for the "application-connector" and "remote-environments" services/deployments to fix the trace spans not showing issue.

As per https://istio.io/help/faq/traffic-management/#naming-port-convention `The port names must be of the form protocol-suffix with http, http2, grpc, mongo, or redis as the protocol in order to take advantage of Istio’s routing features`.

- Update the external api port name for both the "application-connector" and "remote-environments" services/deployments to comply with Istio’s port naming conventions.
- Update the two readme files for "application-connector" and "remote-environments" with the new port name accordingly.
- Update the `ui-api-layer` tests accordingly with the new external api port name.