### PR TITLE
Enhance event bus e2e tests to be more readable

### DIFF
--- a/tests/event-bus/Gopkg.lock
+++ b/tests/event-bus/Gopkg.lock
@@ -73,7 +73,7 @@
     "components/event-bus/internal/ea/apis/remoteenvironment.kyma.cx/v1alpha1",
     "components/event-bus/test/util"
   ]
-  revision = "c4e06fbb6c180bffec61adf3c296d826c1465cd9"
+  revision = "846df1b0a0234d22509d135d995b3dce8d1ef5de"
 
 [[projects]]
   name = "github.com/modern-go/concurrent"


### PR DESCRIPTION
Confirm these statements before you submit your pull request:

- [x] I have read and submitted the required [Contributor Licence Agreements](https://github.com/kyma-project/community/blob/master/CONTRIBUTING.md#agreements-and-licenses).
- [x] This pull request follows the contributing guidelines, recommended Git workflow, and templates.
- [x] I have tested my changes.
- [x] I have updated the relevant documentation.
---

**Description**

Changes proposed in this pull request:

- Update the e2e-tester event, subscription and event activation data to not use hardcoded values except from constant for better readability and more rebustness.
- Fixes borken master event-bus helm tests
