### PR TITLE
Fix for relative path issue in sync-bundles.sh

### DIFF
--- a/resources/helm-broker-repo/development/sync-bundles.sh
+++ b/resources/helm-broker-repo/development/sync-bundles.sh
@@ -2,9 +2,11 @@
 
 NAMESPACE=kyma-system
 
-PROVISIONING_DIR="$(dirname $0)/../provisioning"
+BASE_DIR="$(dirname $0)/.."
 
-bash ${PROVISIONING_DIR}/provision-bundles.sh bundles
+PROVISIONING_DIR="${BASE_DIR}/provisioning"
+
+bash ${PROVISIONING_DIR}/provision-bundles.sh ${BASE_DIR}/bundles
 
 HELM_BROKER_POD_NAME=$(kubectl get po -n ${NAMESPACE} -l app=core-helm-broker -o jsonpath="{.items[0].metadata.name}")
 

--- a/resources/helm-broker-repo/development/sync-bundles.sh
+++ b/resources/helm-broker-repo/development/sync-bundles.sh
@@ -2,11 +2,11 @@
 
 NAMESPACE=kyma-system
 
-BASE_DIR="$(dirname $0)/.."
+readonly CURRENT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+readonly PROVISIONING_DIR="${CURRENT_DIR}/../provisioning"
+readonly BUNDLES_DIR="${CURRENT_DIR}/../bundles"
 
-PROVISIONING_DIR="${BASE_DIR}/provisioning"
-
-bash ${PROVISIONING_DIR}/provision-bundles.sh ${BASE_DIR}/bundles
+bash ${PROVISIONING_DIR}/provision-bundles.sh ${BUNDLES_DIR}
 
 HELM_BROKER_POD_NAME=$(kubectl get po -n ${NAMESPACE} -l app=core-helm-broker -o jsonpath="{.items[0].metadata.name}")
 


### PR DESCRIPTION
Confirm these statements before you submit your pull request:

- [x] I have read and submitted the required [Contributor Licence Agreements](https://github.com/kyma-project/community/blob/master/CONTRIBUTING.md#agreements-and-licenses).
- [x] This pull request follows the contributing guidelines, recommended Git workflow, and templates.
- [x] I have tested my changes.
- [x] I have updated the relevant documentation.
---

**Description**

Executing original script from 'development' directory causes "bundles does not exists" error message - path is resolved relative to 'development' not 'helm-broker-repo'. Repository is not synced correctly because of this.


Changes proposed in this pull request:

Change script to resolve 'bundles' path relative to 'helm-broker-repo' directory.

**Issue link**

Fixes #60
