### PR TITLE
Update Kubeless and monitoring test images

### DIFF
--- a/tests/kubeless-test-client/Dockerfile
+++ b/tests/kubeless-test-client/Dockerfile
@@ -1,12 +1,18 @@
-FROM debian:stable-slim
+FROM alpine:latest
 
 LABEL source="git@github.com:kyma-project/kyma.git"
 
-RUN apt-get update && apt-get install -y curl unzip && rm -r /var/lib/apt/lists/*
+RUN apk add --no-cache curl
 
-RUN curl -Lo /usr/local/bin/kubectl https://storage.googleapis.com/kubernetes-release/release/v1.11.1/bin/linux/amd64/kubectl && chmod +x /usr/local/bin/kubectl
+RUN curl -Lo /usr/bin/kubectl https://storage.googleapis.com/kubernetes-release/release/v1.10.0/bin/linux/amd64/kubectl && chmod +x /usr/bin/kubectl
 
-RUN curl -Lo /tmp/kubeless.zip https://github.com/kubeless/kubeless/releases/download/v1.0.0-alpha.7/kubeless_linux-amd64.zip && unzip -uq /tmp/kubeless.zip -d /tmp/ && mv /tmp/bundles/kubeless_linux-amd64/kubeless /usr/local/bin/ && rm -r /tmp/kubeless.zip /tmp/bundles && chmod +x /usr/local/bin/kubeless
+# To automatically get the latest version:
+#RUN curl -Lo /usr/bin/kubectl https://storage.googleapis.com/kubernetes-release/release/v/bin/linux/amd64/kubectl && chmod +x /usr/bin/kubectl
+
+RUN curl -Lo /tmp/kubeless.zip https://github.com/kubeless/kubeless/releases/download/v1.0.0-alpha.7/kubeless_linux-amd64.zip && unzip -q /tmp/kubeless.zip -d /tmp/ && mv /tmp/bundles/kubeless_linux-amd64/kubeless /usr/bin/ && rm -r /tmp/kubeless.zip /tmp/bundles && chmod +x /usr/bin/kubeless
+
+# To automatically get the latest version:
+#RUN curl -Lo /tmp/kubeless.zip "$(curl -s https://api.github.com/repos/kubeless/kubeless/releases/latest | jq -r '.assets[]|select(.name=="kubeless_linux-amd64.zip").browser_download_url')" && unzip -q /tmp/kubeless.zip -d /tmp/ && mv /tmp/bundles/kubeless_linux-amd64/kubeless /usr/bin/ && rm -r /tmp/kubeless.zip /tmp/bundles && chmod +x /usr/bin/kubeless
 
 RUN mkdir -p /root/.kube && touch /root/.kube/config
 COPY ns.yaml k8s.yaml dependencies.json hello.js event.js svcbind.yaml /

--- a/tests/test-logging-monitoring/Dockerfile
+++ b/tests/test-logging-monitoring/Dockerfile
@@ -1,10 +1,13 @@
-FROM debian:stable-slim
+FROM alpine:latest
 
 LABEL source="git@github.com:kyma-project/kyma.git"
 
-RUN apt-get update && apt-get install -y curl unzip && rm -r /var/lib/apt/lists/*
+RUN apk add --no-cache curl
 
-RUN curl -Lo /usr/local/bin/kubectl https://storage.googleapis.com/kubernetes-release/release/v1.10.0/bin/linux/amd64/kubectl && chmod +x /usr/local/bin/kubectl
+RUN curl -Lo /usr/bin/kubectl https://storage.googleapis.com/kubernetes-release/release/v1.10.0/bin/linux/amd64/kubectl && chmod +x /usr/bin/kubectl
+
+# To automatically get the latest version:
+#RUN curl -Lo /usr/bin/kubectl https://storage.googleapis.com/kubernetes-release/release/v/bin/linux/amd64/kubectl && chmod +x /usr/bin/kubectl
 
 RUN mkdir -p /root/.kube && touch /root/.kube/config
 COPY bin/app /test-logging-monitoring


### PR DESCRIPTION
The images use the latest stable Alpine Linux as base and automatically
download the latest stable kubectl and kubeless.

Confirm these statements before you submit your pull request:

- [x] I have read and submitted the required [Contributor Licence Agreements](https://github.com/kyma-project/community/blob/master/CONTRIBUTING.md#agreements-and-licenses).
- [x] This pull request follows the contributing guidelines, recommended Git workflow, and templates.
- [x] I have tested my changes.
- [x] I have updated the relevant documentation.
