### PR TITLE
fix externalPublicIp value override for istio ingressgateway

### DIFF
--- a/components/installer/pkg/overrides/istio.go
+++ b/components/installer/pkg/overrides/istio.go
@@ -8,12 +8,12 @@ import (
 )
 
 const istioTplStr = `
-ingress:
+ingressgateway:
   service:
     externalPublicIp: {{.ExternalIPAddress}}
 `
 
-// GetIstioOverrides returns values overrides for istio ingress
+// GetIstioOverrides returns values overrides for istio ingressgateway
 func GetIstioOverrides(installationData *config.InstallationData) (string, error) {
 	if hasIPAddress(installationData) == false {
 		return "", nil

--- a/components/installer/pkg/overrides/istio_test.go
+++ b/components/installer/pkg/overrides/istio_test.go
@@ -20,7 +20,7 @@ func TestGetIstioOverrides(t *testing.T) {
 
 		Convey("when IP address is specified should contain yaml", func() {
 			const dummyOverridesForIstio = `
-ingress:
+ingressgateway:
   service:
     externalPublicIp: 100.100.100.100
 `


### PR DESCRIPTION
Confirm these statements before you submit your pull request:

- [x] I have read and submitted the required [Contributor Licence Agreements](https://github.com/kyma-project/community/blob/master/CONTRIBUTING.md#agreements-and-licenses).
- [x] This pull request follows the contributing guidelines, recommended Git workflow, and templates.
- [ ] I have tested my changes.
- [x] I have updated the relevant documentation.
---

**Description**

Changes proposed in this pull request:

- fix externalPublicIp value override for istio ingressgateway after migration to istio gateway
**Issue link**

<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->