### PR TITLE
Fix Docker image for the etcd-backup tool

### DIFF
--- a/tools/etcd-backup/Dockerfile
+++ b/tools/etcd-backup/Dockerfile
@@ -1,6 +1,10 @@
-FROM scratch
+FROM alpine:3.7
+
+RUN apk --no-cache add ca-certificates
+RUN apk add --no-cache curl
 
 LABEL source = git@github.com:kyma-project/kyma.git
+
 ADD etcd-backup /
 
 CMD ["/etcd-backup"]


### PR DESCRIPTION
Confirm these statements before you submit your pull request:

- [x] I have read and submitted the required [Contributor Licence Agreements](https://github.com/kyma-project/community/blob/master/CONTRIBUTING.md#agreements-and-licenses).
- [x] This pull request follows the contributing guidelines, recommended Git workflow, and templates.
- [x] I have tested my changes.
- [x] I have updated the relevant documentation.
---

**Description**

Changes proposed in this pull request:

- Fix the problem with the certificates: `x509: failed to load system roots and no roots provided\n"`
