### PR TITLE
Pluggable SBU - add finalizer to UsageKind

### DIFF
--- a/components/binding-usage-controller/docs/proposals/usage-kind.md
+++ b/components/binding-usage-controller/docs/proposals/usage-kind.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-**UsageKind** allows dynamic, in the runtime, Binding Usage Controller configuration. It allows you to define what resources can be bound with **ServiceBinding** and how to bind them. Currently, you can bind only **Deployment** and **Function** resources. Adding a new resource requires changes in the Binding Usage Controller code. The goal is to make it possible only with the configuration.
+UsageKind allows dynamic, in the runtime, Binding Usage Controller (BUC) configuration. It allows you to define what resources can be bound with ServiceBinding and how to bind them. Currently, you can bind only Deployment and Function resources. Adding a new resource requires changes in the Binding Usage Controller code. The goal is to make it possible only with the configuration.
 
 ## UsageKind 
 
@@ -37,15 +37,15 @@ UI needs two new endpoints which return:
  * all resources with a given kind. The result must be filtered out by the **metadata.ownerReference** field. If the resource contains **metadata.ownerReference**, the user should not see such a resource in the UI.
 ## Binding Usage Controller
 
-**Binding Usage Controller** takes the value of the `spec.usedBy.kind` field of the binding usage resource, looks for the corresponding usage kind which contains information about the kind of resource to be bound. The controller must handle resources even if the specified `labelsPath` field does not exist.
+The Binding Usage Controller takes the value of the **spec.usedBy.kind** field of the ServiceBindingUsage resource, looks for the corresponding UsageKind which contains information about the kind of resource to be bound. The controller must handle resources even if the specified **labelsPath** field does not exist.
 
 ## Security
 
-The administrator who adds **UsageKind** must take care of RBAC settings. BUC and ui-api-layer must be allowed to perform needed operations on resources with the kind defined or referenced in the usage kind object.
+The administrator who adds UsageKind must take care of RBAC settings. BUC and ui-api-layer must be allowed to perform needed operations on resources with the kind defined in the UsageKind resource.
 
 ## Example
 
-There is a defined **UsageKind**:
+There is a defined UsageKind:
 ```yaml
 apiVersion: servicecatalog.kyma.cx/v1alpha1
 kind: UsageKind
@@ -59,12 +59,19 @@ spec:
     version: v1beta1
   labelsPath: spec.deployment.spec.template.metadata.labels
 ```
-There is also a RBAC role with the following rule::
+There is also a RBAC role with the following rule for the Binding Usage Controller:
 ```yaml
 - apiGroups: ["kubeless.io"]
   resources: ["functions"]
-  verbs: ["get","list","watch", "update"]
+  verbs: ["get", "update"]
 ```
+and for the UI-Api-Layer:
+```yaml
+- apiGroups: ["kubeless.io"]
+  resources: ["functions"]
+  verbs: ["list"]
+```
+
 The user creates binding and binding usage:
 ```yaml
 apiVersion: servicecatalog.k8s.io/v1beta1
@@ -86,12 +93,108 @@ spec:
     kind: function
     name: redis-client
 ```
-The ServiceBindingUsage **spec.usedBy.kind** field matches the name of the **UsageKind** instance.
+The ServiceBindingUsage **spec.usedBy.kind** field matches the name of the UsageKind instance.
 
 ## Testing
 
-It is important to have an easy way to create a test for a new **UsageKind**. There should be a way to check that the proper RBAC role is set or that the **labelsPath** field is correct. The purpose is to design a solution that makes writing such acceptance tests as easy as possible.
+It is important to have an easy way to create a test for a new UsageKind. There should be a way to check that the proper RBAC role is set or that the **labelsPath** field is correct. The purpose is to design a solution that makes writing such acceptance tests as easy as possible.
+
+## UsageKind and ServiceBindingUsage finalizers
+
+The Binding Usage Controller implementation cannot handle the ServiceBindingUsage deletion if the UsageKind has been deleted. The idea is to have a finalizer in the UsageKind instance. The finalizer is removed only when the UsageKind is not used by any ServiceBindingUsage. The Binding Usage Controller requires the UsageKind to delete the ServiceBindingUsage. For this reason, a finalizer is needed in the ServiceBindingUsage. The deletion scenario looks as follows:
+
+1. In this scenario, there are the following UsageKind and ServiceBindingUsage:
+```yaml
+apiVersion: servicecatalog.kyma.cx/v1alpha1
+kind: UsageKind
+metadata:
+  clusterName: ""
+  creationTimestamp: 2018-08-06T08:02:19Z
+  finalizers:
+  - servicecatalog.kyma.cx/usage-kind-protection
+  generation: 1
+  name: deployment
+  namespace: ""
+  resourceVersion: "10984"
+  selfLink: /apis/servicecatalog.kyma.cx/v1alpha1/usagekinds/deployment
+  uid: 0a7716ef-994f-11e8-98a9-560fb490844b
+spec:
+  displayName: Deployment
+  labelsPath: spec.template.metadata.labels
+  resource:
+    group: apps
+    kind: deployment
+    version: v1beta1
+```
+
+```yaml
+apiVersion: servicecatalog.kyma.cx/v1alpha1
+  kind: ServiceBindingUsage
+  metadata:
+    clusterName: ""
+    creationTimestamp: 2018-08-06T08:02:34Z
+    finalizers:
+      - servicecatalog.kyma.cx/sbu-protection
+    generation: 1
+    name: deploy-redis-client
+    namespace: default
+    resourceVersion: "11016"
+    selfLink: /apis/servicecatalog.kyma.cx/v1alpha1/namespaces/default/servicebindingusages/deploy-redis-client
+    uid: 13c260e7-994f-11e8-98a9-560fb490844b
+  spec:
+    serviceBindingRef:
+      name: redis-instance-credential
+    usedBy:
+      kind: deployment
+      name: redis-client
+  status:
+    conditions:
+    - lastTransitionTime: 2018-08-06T08:02:35Z
+      lastUpdateTime: 2018-08-06T08:02:35Z
+      status: "True"
+      type: Ready
+```
+
+2. The administrator performs the UsageKind deletion.
+3. The Usage Kind Protection Controller handles the UsageKind update. The controller does not remove the UsageKind finalizer as it is used by the ServiceBindingUsage. The UsageKind looks as follows:
+```yaml
+apiVersion: servicecatalog.kyma.cx/v1alpha1
+kind: UsageKind
+metadata:
+  clusterName: ""
+  creationTimestamp: 2018-08-06T08:02:19Z
+  deletionGracePeriodSeconds: 0
+  deletionTimestamp: 2018-08-06T08:15:09Z
+  finalizers:
+  - servicecatalog.kyma.cx/usage-kind-protection
+  generation: 2
+  name: deployment
+  namespace: ""
+  resourceVersion: "12019"
+  selfLink: /apis/servicecatalog.kyma.cx/v1alpha1/usagekinds/deployment
+  uid: 0a7716ef-994f-11e8-98a9-560fb490844b
+spec:
+  displayName: Deployment
+  labelsPath: spec.template.metadata.labels
+  resource:
+    group: apps
+    kind: deployment
+    version: v1beta1
+``` 
+4. The administrator requests deletion of the ServiceBindingUsage. 
+5. The Binding Usage Controller handles the deletion request and removes the ServiceBindingUsage finalizer.
+6. Kubernetes removes the ServiceBindingUsage instance.
+7. The Usage Kind Protection Controller handles the ServiceBindingUsage deletion and checks, if the UsageKind is used by any ServiceBindingUsage. Then, the Usage Kind Protection Controller removes the UsageKind finalizer.
+8. Kubernetes removes the UsageKind instance.
+
+Without ServiceBindingUsage finalizers the implementation is not clean. The controller, which manages UsageKind finalizers, is triggered by the main controller instead of k8s which is not good. The cache in the indexer is not up to date (need investigation) and processing is not going through the working queue. It can cause a race condition. 
+
+## UsageKind snapshots in the ConfigMap storage
+
+The controller can store all information about the UsageKind used in the ServiceBindingUsage in the storage as a UsageKind snapshot. Such approach allows you to modify a UsageKind instance without losing information about the used **labelsPath** value. Handling ServiceBindingUsage deletion does not require existing UsageKind. The BUC could works fine without UsageKind finalizer. 
 
 ## Status
 
-Proposed at 2018.07.20
+Proposed on 2018-07-20.
+
+Updated on 2018-08-06.

--- a/components/binding-usage-controller/examples/deploy/service-binding-usage.yaml
+++ b/components/binding-usage-controller/examples/deploy/service-binding-usage.yaml
@@ -6,5 +6,5 @@ spec:
  serviceBindingRef:
    name: redis-instance-credential
  usedBy:
-   kind: Deployment
+   kind: deployment
    name: redis-client

--- a/components/binding-usage-controller/examples/function/service-binding-usage.yaml
+++ b/components/binding-usage-controller/examples/function/service-binding-usage.yaml
@@ -6,7 +6,7 @@ spec:
  serviceBindingRef:
    name: redis-instance-credential
  usedBy:
-   kind: Function
+   kind: function
    name: redis-client
  parameters:
    envPrefix:

--- a/components/binding-usage-controller/internal/controller/event.go
+++ b/components/binding-usage-controller/internal/controller/event.go
@@ -1,0 +1,8 @@
+package controller
+
+// SBUDeletedEvent contains information about deleted ServiceBindingUsage
+type SBUDeletedEvent struct {
+	UsedByKind string
+	Namespace  string
+	Name       string
+}

--- a/components/binding-usage-controller/internal/controller/usagekind/helpers_test.go
+++ b/components/binding-usage-controller/internal/controller/usagekind/helpers_test.go
@@ -1,0 +1,78 @@
+package usagekind_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/kyma-project/kyma/components/binding-usage-controller/internal/controller"
+	"github.com/kyma-project/kyma/components/binding-usage-controller/internal/controller/usagekind"
+	"github.com/kyma-project/kyma/components/binding-usage-controller/pkg/apis/servicecatalog/v1alpha1"
+	"github.com/kyma-project/kyma/components/binding-usage-controller/pkg/client/clientset/versioned/fake"
+)
+
+type testCase struct {
+	ctrl           runnable
+	cancel         context.CancelFunc
+	timeoutContext context.Context
+	clientSet      *fake.Clientset
+}
+
+type runnable interface {
+	Run(stopCh <-chan struct{})
+}
+
+func (tc *testCase) RunController() {
+	go tc.ctrl.Run(tc.timeoutContext.Done())
+}
+
+func (tc *testCase) TearDown() {
+	defer tc.cancel()
+}
+
+func (tc *testCase) AddSBU(t *testing.T, sbu *v1alpha1.ServiceBindingUsage) {
+	_, err := tc.clientSet.Servicecatalog().ServiceBindingUsages(sbu.Namespace).Create(sbu)
+	require.NoError(t, err)
+}
+
+func (tc *testCase) RemoveSBU(t *testing.T, sbu *v1alpha1.ServiceBindingUsage) {
+	err := tc.clientSet.Servicecatalog().ServiceBindingUsages(sbu.Namespace).Delete(sbu.Name, &v1.DeleteOptions{})
+	require.NoError(t, err)
+	tc.ctrl.(*usagekind.ProtectionController).OnDeleteSBU(&controller.SBUDeletedEvent{
+		Name:       sbu.Name,
+		Namespace:  sbu.Namespace,
+		UsedByKind: sbu.Spec.UsedBy.Kind,
+	})
+}
+
+func (tc *testCase) AddUsageKind(t *testing.T, uk *v1alpha1.UsageKind) {
+	_, err := tc.clientSet.Servicecatalog().UsageKinds().Create(uk)
+	require.NoError(t, err)
+}
+
+func (tc *testCase) UpdateUsageKind(t *testing.T, uk *v1alpha1.UsageKind) {
+	_, err := tc.clientSet.Servicecatalog().UsageKinds().Update(uk)
+	require.NoError(t, err)
+}
+
+func (tc *testCase) GetUsageKind(t *testing.T, name string) *v1alpha1.UsageKind {
+	obj, err := tc.clientSet.Servicecatalog().UsageKinds().Get(name, v1.GetOptions{})
+	require.NoError(t, err)
+	return obj
+}
+
+func (tc *testCase) RemoveUsageKind(t *testing.T, name string) {
+	err := tc.clientSet.Servicecatalog().UsageKinds().Delete(name, &v1.DeleteOptions{})
+	require.NoError(t, err)
+}
+
+func (tc *testCase) WaitForChan(t *testing.T, ch chan struct{}, timeout time.Duration) {
+	select {
+	case <-ch:
+	case <-time.After(timeout):
+		t.Fatalf("timeout occured when waiting for channel")
+	}
+}

--- a/components/binding-usage-controller/internal/controller/usagekind/protection_controller.go
+++ b/components/binding-usage-controller/internal/controller/usagekind/protection_controller.go
@@ -1,0 +1,316 @@
+package usagekind
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
+	apiErrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/client-go/util/workqueue"
+
+	"github.com/kyma-project/kyma/components/binding-usage-controller/internal/controller"
+	"github.com/kyma-project/kyma/components/binding-usage-controller/pkg/apis/servicecatalog/v1alpha1"
+	ukClient "github.com/kyma-project/kyma/components/binding-usage-controller/pkg/client/clientset/versioned/typed/servicecatalog/v1alpha1"
+	sbuInformer "github.com/kyma-project/kyma/components/binding-usage-controller/pkg/client/informers/externalversions/servicecatalog/v1alpha1"
+	ukInformer "github.com/kyma-project/kyma/components/binding-usage-controller/pkg/client/informers/externalversions/servicecatalog/v1alpha1"
+	ukLister "github.com/kyma-project/kyma/components/binding-usage-controller/pkg/client/listers/servicecatalog/v1alpha1"
+)
+
+const (
+	finalizerName = "servicecatalog.kyma.cx/usage-kind-protection"
+	indexKind     = "usedByKind"
+)
+
+// ProtectionController adds and removes UsageKindProtection finalizer.
+type ProtectionController struct {
+	queue workqueue.RateLimitingInterface
+
+	bindingUsageInformer     cache.SharedIndexInformer
+	bindingUsageListerSynced cache.InformerSynced
+
+	usageKindLister       ukLister.UsageKindLister
+	usageKindListerSynced cache.InformerSynced
+	ukClient              ukClient.ServicecatalogV1alpha1Interface
+
+	log        logrus.FieldLogger
+	maxRetires int
+
+	// test hooks used only in unit tests
+	testHookAddFinalizerDone    func()
+	testHookProcessDeletionDone func()
+}
+
+type namespaceNameKey struct {
+	Namespace string
+	Name      string
+}
+
+// NewProtectionController creates a new instance of ProtectionController.
+func NewProtectionController(
+	kindInformer ukInformer.UsageKindInformer,
+	sbuInformer sbuInformer.ServiceBindingUsageInformer,
+	usageKindInterface ukClient.ServicecatalogV1alpha1Interface,
+	log logrus.FieldLogger,
+) *ProtectionController {
+	serviceBindingUsageInformer := sbuInformer.Informer()
+	serviceBindingUsageInformer.AddIndexers(cache.Indexers{
+		indexKind: func(obj interface{}) ([]string, error) {
+			sbu, ok := obj.(*v1alpha1.ServiceBindingUsage)
+			if !ok {
+				return nil, fmt.Errorf("cannot convert item, expected ServiceBindingUsage, but was %T", obj)
+			}
+			return []string{sbu.Spec.UsedBy.Kind}, nil
+		},
+	})
+
+	c := &ProtectionController{
+		queue:                    workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "UsageKindProtection"),
+		bindingUsageInformer:     serviceBindingUsageInformer,
+		bindingUsageListerSynced: serviceBindingUsageInformer.HasSynced,
+		usageKindLister:          kindInformer.Lister(),
+		usageKindListerSynced:    kindInformer.Informer().HasSynced,
+		ukClient:                 usageKindInterface,
+
+		log: log.WithField("service", "controller:usage-kind-protection"),
+
+		maxRetires: defaultMaxRetries,
+	}
+
+	kindInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
+		AddFunc: c.onAddOrUpdateUsageKind,
+		UpdateFunc: func(old, new interface{}) {
+			c.onAddOrUpdateUsageKind(new)
+		},
+		// no need to react on deletion
+	})
+
+	// TODO: UsageKind must not be deleted before referenced ServiceBindingUsage deletion work is done
+	// TODO (implement-sbu-finalizer): after adding finalizer to SBU or other solution, uncomment this
+	//sbuInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
+	//	DeleteFunc: c.OnDeleteSBU,
+	//})
+	return c
+}
+
+func (c *ProtectionController) onAddOrUpdateUsageKind(obj interface{}) {
+	key, err := cache.MetaNamespaceKeyFunc(obj)
+	if err != nil {
+		c.log.Errorf("while handling addition event: couldn't get key: %v", err)
+		return
+	}
+	c.queue.Add(key)
+}
+
+// OnDeleteSBU reacts on ServiceBindingUsage deletion
+func (c *ProtectionController) OnDeleteSBU(event *controller.SBUDeletedEvent) {
+	// TODO (implement-sbu-finalizer): this is temporary solution, the method should be removed when SBU finalizer is implemented
+
+	// The processing is not going through the working queue because ServiceBindingUsage cache may be not up to date.
+	// Warning: processing without working queue may cause race condition in a corner case - processing deletion in 2 SBU in the same time.
+	// Start processing in a separate goroutine to not block the origin process (the main binding usage controller)
+	go func() {
+		c.log.Debugf("OnDeleteSBU %s/%s", event.Namespace, event.Name)
+
+		uk, err := c.usageKindLister.Get(event.UsedByKind)
+		switch {
+		case err == nil:
+		case apiErrors.IsNotFound(err):
+			c.log.Debugf("UsageKind %s not found, ignoring", event.UsedByKind)
+			return
+		default:
+			c.log.Debugf("Could not process SBU deletion %v, will retry. Error: ", event, err.Error())
+			c.queue.AddRateLimited(event.UsedByKind)
+			return
+		}
+
+		if c.isDeletionCandidate(uk) {
+			err := c.removeFinalizerIfNotUsed(uk, namespaceNameKey{
+				Namespace: event.Namespace,
+				Name:      event.Name,
+			})
+
+			if err != nil {
+				c.log.Debugf("Could not remove finalizer in UsageKind %s, will retry. Error: ", event.UsedByKind, err.Error())
+				c.queue.AddRateLimited(event.UsedByKind)
+				return
+			}
+		}
+	}()
+}
+
+// TODO (implement-sbu-finalizer): the method will be used after implementing SBU finalizer.
+func (c *ProtectionController) onDeleteSBU(obj interface{}) {
+	sbu, ok := obj.(*v1alpha1.ServiceBindingUsage)
+	if !ok {
+		c.log.Errorf("incorrect type of incoming object, expected *ServiceBindingUsage but was %T", obj)
+		return
+	}
+	c.queue.Add(sbu.Spec.UsedBy.Kind)
+}
+
+// Run begins watching and syncing.
+func (c *ProtectionController) Run(stopCh <-chan struct{}) {
+	go func() {
+		<-stopCh
+		c.queue.ShutDown()
+	}()
+
+	c.log.Infof("Starting usage kind protection controller")
+	defer c.log.Infof("Shutting down usage kind protection controller")
+
+	if !cache.WaitForCacheSync(stopCh, c.bindingUsageListerSynced, c.usageKindListerSynced) {
+		c.log.Error("Timeout occurred on waiting for caches to sync. Shutdown the controller.")
+		return
+	}
+
+	wait.Until(c.worker, time.Second, stopCh)
+}
+
+func (c *ProtectionController) worker() {
+	for c.processNextWorkItem() {
+	}
+}
+
+func (c *ProtectionController) processNextWorkItem() bool {
+	key, shutdown := c.queue.Get()
+	if shutdown {
+		return false
+	}
+	defer c.queue.Done(key)
+
+	err := c.processUsageKind(key.(string))
+	switch {
+	case err == nil:
+		c.queue.Forget(key)
+
+	case c.queue.NumRequeues(key) < c.maxRetires:
+		c.log.Debugf("Error processing %q (will retry - it's %d of %d): %v", key, c.queue.NumRequeues(key), c.maxRetires, err)
+		c.queue.AddRateLimited(key)
+
+	default: // err != nil and too many retries
+		c.log.Errorf("Error processing %q (giving up - to many retires): %v", key, err)
+		c.queue.Forget(key)
+	}
+
+	return true
+}
+
+func (c *ProtectionController) processUsageKind(name string) error {
+	uk, err := c.usageKindLister.Get(name)
+	switch {
+	case err == nil:
+	case apiErrors.IsNotFound(err):
+		// absence in store means watcher caught the deletion
+		c.log.Debugf("UsageKind %s not found, ignoring", name)
+		return nil
+	default:
+		return errors.Wrapf(err, "while getting UsageKind %q", name)
+	}
+
+	if c.isDeletionCandidate(uk) {
+		return c.removeFinalizerIfNotUsed(uk, namespaceNameKey{})
+	}
+
+	if c.needToAddFinalizer(uk) {
+		return c.addFinalizer(uk)
+	}
+	return nil
+}
+
+func (c *ProtectionController) needToAddFinalizer(uk *v1alpha1.UsageKind) bool {
+	return uk.ObjectMeta.DeletionTimestamp == nil && !containsString(uk.ObjectMeta.Finalizers, finalizerName)
+}
+
+func (c *ProtectionController) addFinalizer(uk *v1alpha1.UsageKind) error {
+	if c.testHookAddFinalizerDone != nil {
+		defer c.testHookAddFinalizerDone()
+	}
+
+	ukCopy := uk.DeepCopy()
+	ukCopy.ObjectMeta.Finalizers = append(ukCopy.ObjectMeta.Finalizers, finalizerName)
+	_, err := c.ukClient.UsageKinds().Update(ukCopy)
+	if err != nil {
+		return errors.Wrapf(err, "while adding finalizer to UsageKind %s", uk.Name)
+	}
+	c.log.Debugf("Added protection finalizer to UK %s", uk.Name)
+	return nil
+}
+
+func (c *ProtectionController) isDeletionCandidate(uk *v1alpha1.UsageKind) bool {
+	return uk.ObjectMeta.DeletionTimestamp != nil && containsString(uk.ObjectMeta.Finalizers, finalizerName)
+}
+
+func (c *ProtectionController) removeFinalizerIfNotUsed(uk *v1alpha1.UsageKind, key namespaceNameKey) error {
+	if c.testHookProcessDeletionDone != nil {
+		defer c.testHookProcessDeletionDone()
+	}
+
+	isUsed, err := c.isBeingUsedBySBU(uk, key)
+	if err != nil {
+		return errors.Wrap(err, "while checking if UsageKind is used by any SBU")
+	}
+	if !isUsed {
+		return c.removeFinalizer(uk)
+	}
+	return nil
+}
+
+//TODO (implement-sbu-finalizer): after implementing sbu finalizer keyToSkip arg is not needed
+func (c *ProtectionController) isBeingUsedBySBU(uk *v1alpha1.UsageKind, keyToSkip namespaceNameKey) (bool, error) {
+	sbuList, err := c.bindingUsageInformer.GetIndexer().ByIndex(indexKind, uk.Name)
+	if err != nil {
+		return false, errors.Wrapf(err, "while getting Service Binding Usages for UsageKind %s", uk.Name)
+	}
+
+	// TODO (implement-sbu-finalizer): filtering should be removed when SBU has finalizer
+	filtered := make([]interface{}, 0)
+	for _, obj := range sbuList {
+		sbu, ok := obj.(*v1alpha1.ServiceBindingUsage)
+		if !ok {
+			continue
+		}
+		key := namespaceNameKey{Namespace: sbu.Namespace, Name: sbu.Name}
+		if keyToSkip != key {
+			filtered = append(filtered, sbu)
+		}
+	}
+	return len(filtered) > 0, nil
+}
+
+func (c *ProtectionController) removeFinalizer(uk *v1alpha1.UsageKind) error {
+	ukCopy := uk.DeepCopy()
+	ukCopy.ObjectMeta.Finalizers = removeString(ukCopy.ObjectMeta.Finalizers, finalizerName)
+	_, err := c.ukClient.UsageKinds().Update(ukCopy)
+	if err != nil {
+		return errors.Wrapf(err, "while removing finalizer from UsageKind %s", uk.Name)
+	}
+	c.log.Debugf("Removed protection finalizer from UsageKind %s", uk.Name)
+	return nil
+}
+
+func containsString(slice []string, s string) bool {
+	for _, item := range slice {
+		if item == s {
+			return true
+		}
+	}
+	return false
+}
+
+func removeString(slice []string, s string) []string {
+	newSlice := make([]string, 0)
+	for _, item := range slice {
+		if item == s {
+			continue
+		}
+		newSlice = append(newSlice, item)
+	}
+	if len(newSlice) == 0 {
+		// no need to store empty slice
+		newSlice = nil
+	}
+	return newSlice
+}

--- a/components/binding-usage-controller/internal/controller/usagekind/protection_controller_export_test.go
+++ b/components/binding-usage-controller/internal/controller/usagekind/protection_controller_export_test.go
@@ -1,0 +1,9 @@
+package usagekind
+
+const FinalizerName = finalizerName
+
+func (c *ProtectionController) WithTestHookOnAsyncOpDone(addHook func(), deletionHook func()) *ProtectionController {
+	c.testHookAddFinalizerDone = addHook
+	c.testHookProcessDeletionDone = deletionHook
+	return c
+}

--- a/components/binding-usage-controller/internal/controller/usagekind/protection_controller_test.go
+++ b/components/binding-usage-controller/internal/controller/usagekind/protection_controller_test.go
@@ -1,0 +1,143 @@
+package usagekind_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	metaV1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/kyma-project/kyma/components/binding-usage-controller/internal/controller/usagekind"
+	"github.com/kyma-project/kyma/components/binding-usage-controller/internal/platform/logger/spy"
+	"github.com/kyma-project/kyma/components/binding-usage-controller/pkg/apis/servicecatalog/v1alpha1"
+	"github.com/kyma-project/kyma/components/binding-usage-controller/pkg/client/clientset/versioned/fake"
+	informers "github.com/kyma-project/kyma/components/binding-usage-controller/pkg/client/informers/externalversions"
+)
+
+func TestProtectionControllerAddsFinalizer(t *testing.T) {
+	// GIVEN
+	tc := newProtectionControllerTestCase()
+	defer tc.TearDown()
+	tc.RunController()
+
+	// WHEN
+	tc.AddUsageKind(t, fixUsageKind())
+	tc.WaitForAddFinalizer(t, 3*time.Second)
+
+	// THEN
+	uk := tc.GetUsageKind(t, fixUsageKind().Name)
+	assert.Contains(t, uk.Finalizers, usagekind.FinalizerName)
+
+	// WHEN
+	tc.MarkRemoval(t, uk.Name)
+	tc.WaitForProcessDeletionDone(t, 3*time.Second)
+
+	// THEN
+	uk = tc.GetUsageKind(t, fixUsageKind().Name)
+	assert.NotContains(t, uk.Finalizers, usagekind.FinalizerName)
+}
+
+func TestProtectionControllerProtectsUsageKindUsedBySBU(t *testing.T) {
+	// GIVEN
+	tc := newProtectionControllerTestCase()
+	defer tc.TearDown()
+	tc.RunController()
+
+	tc.AddSBU(t, fixSBU(fixUsageKind().Name))
+	tc.AddUsageKind(t, fixUsageKind())
+	tc.WaitForAddFinalizer(t, 3*time.Second)
+
+	// WHEN
+	tc.MarkRemoval(t, fixUsageKind().Name)
+	tc.WaitForProcessDeletionDone(t, 3*time.Second)
+
+	// THEN
+	uk := tc.GetUsageKind(t, fixUsageKind().Name)
+	assert.Contains(t, uk.Finalizers, usagekind.FinalizerName)
+
+	// WHEN
+	tc.RemoveSBU(t, fixSBU(fixUsageKind().Name))
+	tc.WaitForProcessDeletionDone(t, 3*time.Second)
+
+	// THEN
+	uk = tc.GetUsageKind(t, fixUsageKind().Name)
+	assert.NotContains(t, uk.Finalizers, usagekind.FinalizerName)
+}
+
+func fixSBU(kind string) *v1alpha1.ServiceBindingUsage {
+	return &v1alpha1.ServiceBindingUsage{
+		ObjectMeta: metaV1.ObjectMeta{
+			Namespace: "production",
+			Name:      "sbu-",
+			UID:       "uid-123",
+		},
+		Spec: v1alpha1.ServiceBindingUsageSpec{
+			UsedBy: v1alpha1.LocalReferenceByKindAndName{
+				Name: "redis-client",
+				Kind: kind,
+			},
+			ServiceBindingRef: v1alpha1.LocalReferenceByName{
+				Name: "redis-client",
+			},
+		},
+	}
+}
+
+type protectionTestCase struct {
+	*testCase
+
+	addFinalizerOpDone    chan struct{}
+	processDeletionOpDone chan struct{}
+}
+
+func newProtectionControllerTestCase() *protectionTestCase {
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+
+	addFinalizerDone := make(chan struct{})
+	addFinalizerOpHook := func() {
+		addFinalizerDone <- struct{}{}
+	}
+
+	processDeletionDone := make(chan struct{})
+	processDeletionOpHook := func() {
+		processDeletionDone <- struct{}{}
+	}
+
+	cs := fake.NewSimpleClientset()
+	informersFactory := informers.NewSharedInformerFactory(cs, 0)
+
+	ctrl := usagekind.NewProtectionController(informersFactory.Servicecatalog().V1alpha1().UsageKinds(),
+		informersFactory.Servicecatalog().V1alpha1().ServiceBindingUsages(),
+		cs.ServicecatalogV1alpha1(),
+		spy.NewLogSink().Logger).
+		WithTestHookOnAsyncOpDone(addFinalizerOpHook, processDeletionOpHook)
+
+	informersFactory.Start(ctx.Done())
+
+	return &protectionTestCase{
+		testCase: &testCase{
+			ctrl:           ctrl,
+			cancel:         cancel,
+			timeoutContext: ctx,
+			clientSet:      cs,
+		},
+		addFinalizerOpDone:    addFinalizerDone,
+		processDeletionOpDone: processDeletionDone,
+	}
+}
+
+func (tc *protectionTestCase) MarkRemoval(t *testing.T, name string) {
+	uk := tc.GetUsageKind(t, name)
+	copy := uk.DeepCopy()
+	copy.DeletionTimestamp = &metaV1.Time{Time: time.Now()}
+	tc.UpdateUsageKind(t, copy)
+}
+
+func (tc *protectionTestCase) WaitForAddFinalizer(t *testing.T, timeout time.Duration) {
+	tc.WaitForChan(t, tc.addFinalizerOpDone, timeout)
+}
+
+func (tc *protectionTestCase) WaitForProcessDeletionDone(t *testing.T, timeout time.Duration) {
+	tc.WaitForChan(t, tc.processDeletionOpDone, timeout)
+}

--- a/components/binding-usage-controller/pkg/apis/servicecatalog/v1alpha1/types.go
+++ b/components/binding-usage-controller/pkg/apis/servicecatalog/v1alpha1/types.go
@@ -124,7 +124,7 @@ type UsageKind struct {
 	Spec UsageKindSpec `json:"spec"`
 }
 
-// ServiceBindingTargetSpec represents a description of the ServiceBindingTarget
+// UsageKindSpec represents a description of the ServiceBindingTarget
 type UsageKindSpec struct {
 	DisplayName string             `json:"displayName"`
 	Resource    *ResourceReference `json:"resource"`


### PR DESCRIPTION
Confirm these statements before you submit your pull request:

- [x] I have read and submitted the required [Contributor Licence Agreements](https://github.com/kyma-project/community/blob/master/CONTRIBUTING.md#agreements-and-licenses).
- [x] This pull request follows the contributing guidelines, recommended Git workflow, and templates.
- [x] I have tested my changes.
- [x] I have updated the relevant documentation.
---

**Description**

Changes proposed in this pull request:

- Added ProtectionController which manages finalizer on UsageKind resources. Such finalizer blocks UsageKind deletion if such UsageKind is used by any ServiceBindingUsage
- main binding usage controller triggers protection controller (which creates/deletes finalizers) to prevent UsageKind deleteion before SBU deletion processing. This is temporary solution, finally, ProtectionController will be triggered by K8S (SBU removal)


**Issue link**

<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
