### PR TITLE
Do not allow nested hostnames in Api

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -17,7 +17,7 @@
 /resources/cluster-essentials/ @damianpacierpnikatsap @damjatsap @PK85
 
 # The `api-controller` subchart
-/resources/core/charts/api-controller/ @piotrmsc
+/resources/core/charts/api-controller/ @piotrmsc @kubadz
 
 # The `apiserver-proxy` subchart
 /resources/core/charts/apiserver-proxy/ @piotrmsc
@@ -114,7 +114,7 @@
 
 # Components
 # Api controller Component
-/components/api-controller/ @piotrmsc
+/components/api-controller/ @piotrmsc @kubadz
 
 # Binding usage controller Component
 /components/binding-usage-controller/ @aszecowka @PK85 @mszostok @piotrmiskiewicz @polskikiel

--- a/components/api-controller/cmd/controller/main.go
+++ b/components/api-controller/cmd/controller/main.go
@@ -35,10 +35,12 @@ func main() {
 
 	kubeConfig := initKubeConfig()
 
+	domainName := initDomainName()
+
 	apiExtensionsClientSet := apiExtensionsClient.NewForConfigOrDie(kubeConfig)
 
 	registerer := crd.NewRegistrar(apiExtensionsClientSet)
-	registerer.Register(v1alpha2.Crd())
+	registerer.Register(v1alpha2.Crd(domainName))
 
 	istioNetworkingClientSet := istioNetworkingClient.NewForConfigOrDie(kubeConfig)
 	istioNetworkingV1Interface := istioNetworkingV1.New(istioNetworkingClientSet, istioGateway)
@@ -105,4 +107,14 @@ func initJwtDefaultConfig() authenticationV2.JwtDefaultConfig {
 		Issuer:  issuer,
 		JwksUri: jwksURI,
 	}
+}
+
+func initDomainName() string {
+	domainName := os.Getenv("DOMAIN_NAME")
+
+	if domainName == "" {
+		log.Fatal("domain name not provided. Please provide env variable DOMAIN_NAME")
+	}
+
+	return domainName
 }

--- a/components/api-controller/cmd/controller/main.go
+++ b/components/api-controller/cmd/controller/main.go
@@ -56,7 +56,7 @@ func main() {
 	internalInformerFactory := kymaInformers.NewSharedInformerFactory(kymaClientSet, time.Second*30)
 	go internalInformerFactory.Start(stop)
 
-	v1alpha2Controller := v1alpha2.NewController(kymaClientSet, istioNetworkingV1Interface, serviceV1Interface, authenticationV2Interface, internalInformerFactory)
+	v1alpha2Controller := v1alpha2.NewController(kymaClientSet, istioNetworkingV1Interface, serviceV1Interface, authenticationV2Interface, internalInformerFactory, domainName)
 	v1alpha2Controller.Run(2, stop)
 }
 

--- a/components/api-controller/pkg/controller/v1alpha2/controller.go
+++ b/components/api-controller/pkg/controller/v1alpha2/controller.go
@@ -79,8 +79,8 @@ func NewController(
 			}
 
 			event := UpdateEvent{
-				newApi: newApiDef,
-				oldApi: oldApiDef,
+				newApi: newApiDef.DeepCopy(),
+				oldApi: oldApiDef.DeepCopy(),
 			}
 			c.queue.AddRateLimited(event)
 		},

--- a/components/api-controller/pkg/controller/v1alpha2/controller.go
+++ b/components/api-controller/pkg/controller/v1alpha2/controller.go
@@ -19,7 +19,6 @@ import (
 	"github.com/kyma-project/kyma/components/api-controller/pkg/controller/meta"
 	networking "github.com/kyma-project/kyma/components/api-controller/pkg/controller/networking/v1"
 	service "github.com/kyma-project/kyma/components/api-controller/pkg/controller/service/v1"
-	apiErrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/tools/cache"
@@ -180,23 +179,9 @@ func (c *Controller) syncHandler(event BackendEvent) error {
 	return nil
 }
 
-func (c *Controller) onCreate(apiObj *kymaApi.Api) error {
+func (c *Controller) onCreate(api *kymaApi.Api) error {
 
-	log.Infof("Creating: %s/%s", apiObj.Namespace, apiObj.Name)
-
-	namespace := apiObj.Namespace
-	name := apiObj.Name
-
-	api, err := c.apisLister.Apis(namespace).Get(name)
-
-	if err != nil {
-
-		if apiErrors.IsNotFound(err) {
-			runtime.HandleError(fmt.Errorf("API '%+v' in work queue no longer exists", api))
-			return nil
-		}
-		return err
-	}
+	log.Infof("Creating: %s/%s", api.Namespace, api.Name)
 
 	if api.Spec.Authentication == nil {
 		api.Spec.Authentication = []kymaApi.AuthenticationRule{}

--- a/components/api-controller/pkg/controller/v1alpha2/controller_test.go
+++ b/components/api-controller/pkg/controller/v1alpha2/controller_test.go
@@ -1,0 +1,20 @@
+package v1alpha2
+
+import "testing"
+
+var fixHostnameTestCases = []struct{
+	hostname string
+	domainName string
+	expected string
+}{
+	{"my-service", "kyma.local", "my-service.kyma.local"},
+	{"my-service.kyma.local", "kyma.local", "my-service.kyma.local"},
+}
+
+func TestFixHostname(t *testing.T) {
+	for _, tc := range fixHostnameTestCases {
+		if fixHostname(tc.domainName, tc.hostname) != tc.expected {
+			t.Errorf("Fixed hostname %s should be: %s", tc.hostname, tc.expected)
+		}
+	}
+}

--- a/components/api-controller/pkg/controller/v1alpha2/crd.go
+++ b/components/api-controller/pkg/controller/v1alpha2/crd.go
@@ -100,7 +100,7 @@ func Crd() *k8sApiExtensions.CustomResourceDefinition {
 }
 
 const (
-	hostnamePattern = `^(([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]*[a-zA-Z0-9])\.)*([A-Za-z0-9]|[A-Za-z0-9][A-Za-z0-9\-]*[A-Za-z0-9])$`
+	hostnamePattern = `^([A-Za-z0-9]|[A-Za-z0-9][A-Za-z0-9\-]*[A-Za-z0-9])$`
 	urlPattern      = `^(?:https?:\/\/)?(?:[^@\/\n]+@)?(?:www\.)?([^:\/\n]+)`
 )
 

--- a/components/api-controller/pkg/controller/v1alpha2/crd.go
+++ b/components/api-controller/pkg/controller/v1alpha2/crd.go
@@ -100,7 +100,7 @@ func Crd(domainName string) *k8sApiExtensions.CustomResourceDefinition {
 }
 
 const (
-	hostnamePatternFormat = `^([A-Za-z0-9]|[A-Za-z0-9][A-Za-z0-9\-]*[A-Za-z0-9])(\.%s)?$`
+	hostnamePatternFormat = `^([A-Za-z0-9]|[A-Za-z0-9][A-Za-z0-9\-]{0,62}[A-Za-z0-9])(\.%s)?$`
 	urlPattern      = `^(?:https?:\/\/)?(?:[^@\/\n]+@)?(?:www\.)?([^:\/\n]+)`
 )
 

--- a/components/api-controller/pkg/controller/v1alpha2/crd.go
+++ b/components/api-controller/pkg/controller/v1alpha2/crd.go
@@ -9,7 +9,7 @@ import (
 	k8sMeta "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-func Crd() *k8sApiExtensions.CustomResourceDefinition {
+func Crd(domainName string) *k8sApiExtensions.CustomResourceDefinition {
 
 	kind := kymaApi.KindName
 	listKind := kymaApi.ListKindName
@@ -52,7 +52,7 @@ func Crd() *k8sApiExtensions.CustomResourceDefinition {
 								},
 								"hostname": {
 									Type:      "string",
-									Pattern:   hostnamePattern,
+									Pattern:   hostnamePattern(domainName),
 									MinLength: itoi64(3),
 									MaxLength: itoi64(256),
 								},
@@ -100,9 +100,13 @@ func Crd() *k8sApiExtensions.CustomResourceDefinition {
 }
 
 const (
-	hostnamePattern = `^([A-Za-z0-9]|[A-Za-z0-9][A-Za-z0-9\-]*[A-Za-z0-9])$`
+	hostnamePatternFormat = `^([A-Za-z0-9]|[A-Za-z0-9][A-Za-z0-9\-]*[A-Za-z0-9])(.%s)*$`
 	urlPattern      = `^(?:https?:\/\/)?(?:[^@\/\n]+@)?(?:www\.)?([^:\/\n]+)`
 )
+
+func hostnamePattern(domainName string) string {
+	return fmt.Sprintf(hostnamePatternFormat, domainName)
+}
 
 func itoi64(i int) *int64 {
 

--- a/components/api-controller/pkg/controller/v1alpha2/crd.go
+++ b/components/api-controller/pkg/controller/v1alpha2/crd.go
@@ -100,12 +100,13 @@ func Crd(domainName string) *k8sApiExtensions.CustomResourceDefinition {
 }
 
 const (
-	hostnamePatternFormat = `^([A-Za-z0-9]|[A-Za-z0-9][A-Za-z0-9\-]*[A-Za-z0-9])(.%s)*$`
+	hostnamePatternFormat = `^([A-Za-z0-9]|[A-Za-z0-9][A-Za-z0-9\-]*[A-Za-z0-9])(\.%s)?$`
 	urlPattern      = `^(?:https?:\/\/)?(?:[^@\/\n]+@)?(?:www\.)?([^:\/\n]+)`
 )
 
 func hostnamePattern(domainName string) string {
-	return fmt.Sprintf(hostnamePatternFormat, domainName)
+	escapedDomainName := strings.Replace(domainName, ".", "\\.", -1)
+	return fmt.Sprintf(hostnamePatternFormat, escapedDomainName)
 }
 
 func itoi64(i int) *int64 {

--- a/components/api-controller/pkg/controller/v1alpha2/crd_integration_test.go
+++ b/components/api-controller/pkg/controller/v1alpha2/crd_integration_test.go
@@ -24,7 +24,7 @@ func TestCrd_ShouldCreateCrd(t *testing.T) {
 		return
 	}
 
-	registrar.Register(Crd())
+	registrar.Register(Crd("kyma.local"))
 }
 
 func registrarFromDefaultConfig() (*crd.Registrar, error) {

--- a/components/api-controller/pkg/controller/v1alpha2/crd_test.go
+++ b/components/api-controller/pkg/controller/v1alpha2/crd_test.go
@@ -1,0 +1,22 @@
+package v1alpha2
+
+import (
+	"testing"
+	"regexp"
+)
+
+func TestMatchHostnameWithoutSubdomain(t *testing.T) {
+	re := regexp.MustCompile(hostnamePattern)
+	hostname := "my-service"
+	if !re.MatchString(hostname) {
+		t.Error("Hostname should match", hostname)
+	}
+}
+
+func TestMatchNotHostnameWithSubdomain(t *testing.T) {
+	re := regexp.MustCompile(hostnamePattern)
+	hostname := "my-service.my-division"
+	if re.MatchString(hostname) {
+		t.Error("Hostname shouldn't match:", hostname)
+	}
+}

--- a/components/api-controller/pkg/controller/v1alpha2/crd_test.go
+++ b/components/api-controller/pkg/controller/v1alpha2/crd_test.go
@@ -11,11 +11,13 @@ var hostnameCases = []struct {
 }{
 	{"my-service", true},
 	{"my-service.kyma.local", true},
-	{"my-service.kyma-local", false},
-	{"my-service.my-division", false},
-	{"my-service.my-division.kyma.local", false},
-	{"my-service.kima.locl", false},
-	{"my-service.kyma.local.kyma.local", false},
+	{"dot-is-escaped.kyma-local", false},
+	{"with-subdomain.my-division", false},
+	{"with-subdomain.my-division.kyma.local", false},
+	{"wrong-domain.kima.locl", false},
+	{"duplicated-domain.kyma.local.kyma.local", false},
+	{"my-special-very-too-long-hostname-that-is-not-compliant-with-relevant-rfc", false},
+	{"my-special-very-too-long-hostname-that-is-not-compliant-with-relevant-rfc.kyma.local", false},
 }
 
 func TestMatchHostname(t *testing.T) {

--- a/components/api-controller/pkg/controller/v1alpha2/crd_test.go
+++ b/components/api-controller/pkg/controller/v1alpha2/crd_test.go
@@ -1,62 +1,30 @@
 package v1alpha2
 
 import (
-	"testing"
 	"regexp"
+	"testing"
 )
 
-func TestMatchSimpleHostname(t *testing.T) {
-	re := regexp.MustCompile(hostnamePattern("kyma.local"))
-	hostname := "my-service"
-	if !re.MatchString(hostname) {
-		t.Error("Hostname should match:", hostname)
-	}
+var hostnameCases = []struct {
+	hostname string
+	valid    bool
+}{
+	{"my-service", true},
+	{"my-service.kyma.local", true},
+	{"my-service.kyma-local", false},
+	{"my-service.my-division", false},
+	{"my-service.my-division.kyma.local", false},
+	{"my-service.kima.locl", false},
+	{"my-service.kyma.local.kyma.local", false},
 }
 
-func TestMatchCompleteHostname(t *testing.T) {
+func TestMatchHostname(t *testing.T) {
 	re := regexp.MustCompile(hostnamePattern("kyma.local"))
-	hostname := "my-service.kyma.local"
-	if !re.MatchString(hostname) {
-		t.Error("Hostname should match:", hostname)
-	}
-}
-
-func TestMatchNotSimpleHostnameWithSubdomain(t *testing.T) {
-	re := regexp.MustCompile(hostnamePattern("kyma.local"))
-	hostname := "my-service.my-division"
-	if re.MatchString(hostname) {
-		t.Error("Hostname shouldn't match:", hostname)
-	}
-}
-
-func TestMatchNotCompleteHostnameWithSubdomain(t *testing.T) {
-	re := regexp.MustCompile(hostnamePattern("kyma.local"))
-	hostname := "my-service.my-division.kyma.local"
-	if re.MatchString(hostname) {
-		t.Error("Hostname shouldn't match:", hostname)
-	}
-}
-
-func TestMatchNotCompleteHostnameWithDifferentDomain(t *testing.T) {
-	re := regexp.MustCompile(hostnamePattern("kyma.local"))
-	hostname := "my-service.my-division.kima.locl"
-	if re.MatchString(hostname) {
-		t.Error("Hostname shouldn't match:", hostname)
-	}
-}
-
-func TestMatchNotCompleteHostnameWithDomainMultiplied(t *testing.T) {
-	re := regexp.MustCompile(hostnamePattern("kyma.local"))
-	hostname := "my-service.kyma.local.kyma.local"
-	if re.MatchString(hostname) {
-		t.Error("Hostname shouldn't match:", hostname)
-	}
-}
-
-func TestMatchExactDomainName(t *testing.T) {
-	re := regexp.MustCompile(hostnamePattern("kyma.local"))
-	hostname := "my-service.kyma-local"
-	if re.MatchString(hostname) {
-		t.Error("Hostname shouldn't match:", hostname)
+	for _, tc := range hostnameCases {
+		t.Run(tc.hostname, func(t *testing.T) {
+			if re.MatchString(tc.hostname) != tc.valid {
+				t.Errorf("Hostname '%s' should match: %v", tc.hostname, tc.valid)
+			}
+		})
 	}
 }

--- a/components/api-controller/pkg/controller/v1alpha2/crd_test.go
+++ b/components/api-controller/pkg/controller/v1alpha2/crd_test.go
@@ -44,3 +44,19 @@ func TestMatchNotCompleteHostnameWithDifferentDomain(t *testing.T) {
 		t.Error("Hostname shouldn't match:", hostname)
 	}
 }
+
+func TestMatchNotCompleteHostnameWithDomainMultiplied(t *testing.T) {
+	re := regexp.MustCompile(hostnamePattern("kyma.local"))
+	hostname := "my-service.kyma.local.kyma.local"
+	if re.MatchString(hostname) {
+		t.Error("Hostname shouldn't match:", hostname)
+	}
+}
+
+func TestMatchExactDomainName(t *testing.T) {
+	re := regexp.MustCompile(hostnamePattern("kyma.local"))
+	hostname := "my-service.kyma-local"
+	if re.MatchString(hostname) {
+		t.Error("Hostname shouldn't match:", hostname)
+	}
+}

--- a/components/api-controller/pkg/controller/v1alpha2/crd_test.go
+++ b/components/api-controller/pkg/controller/v1alpha2/crd_test.go
@@ -5,17 +5,41 @@ import (
 	"regexp"
 )
 
-func TestMatchHostnameWithoutSubdomain(t *testing.T) {
-	re := regexp.MustCompile(hostnamePattern)
+func TestMatchSimpleHostname(t *testing.T) {
+	re := regexp.MustCompile(hostnamePattern("kyma.local"))
 	hostname := "my-service"
 	if !re.MatchString(hostname) {
-		t.Error("Hostname should match", hostname)
+		t.Error("Hostname should match:", hostname)
 	}
 }
 
-func TestMatchNotHostnameWithSubdomain(t *testing.T) {
-	re := regexp.MustCompile(hostnamePattern)
+func TestMatchCompleteHostname(t *testing.T) {
+	re := regexp.MustCompile(hostnamePattern("kyma.local"))
+	hostname := "my-service.kyma.local"
+	if !re.MatchString(hostname) {
+		t.Error("Hostname should match:", hostname)
+	}
+}
+
+func TestMatchNotSimpleHostnameWithSubdomain(t *testing.T) {
+	re := regexp.MustCompile(hostnamePattern("kyma.local"))
 	hostname := "my-service.my-division"
+	if re.MatchString(hostname) {
+		t.Error("Hostname shouldn't match:", hostname)
+	}
+}
+
+func TestMatchNotCompleteHostnameWithSubdomain(t *testing.T) {
+	re := regexp.MustCompile(hostnamePattern("kyma.local"))
+	hostname := "my-service.my-division.kyma.local"
+	if re.MatchString(hostname) {
+		t.Error("Hostname shouldn't match:", hostname)
+	}
+}
+
+func TestMatchNotCompleteHostnameWithDifferentDomain(t *testing.T) {
+	re := regexp.MustCompile(hostnamePattern("kyma.local"))
+	hostname := "my-service.my-division.kima.locl"
 	if re.MatchString(hostname) {
 		t.Error("Hostname shouldn't match:", hostname)
 	}

--- a/resources/core/charts/api-controller/templates/deployment.yaml
+++ b/resources/core/charts/api-controller/templates/deployment.yaml
@@ -18,6 +18,8 @@ spec:
       - image: {{ .Values.global.containerRegistry.path }}/{{ .Values.image.name }}:{{ .Values.image.tag }}
         name: api-controller
         env:
+        - name: DOMAIN_NAME
+          value: {{ .Values.global.domainName }}
         - name: DEFAULT_ISSUER
           value: https://dex.{{ .Values.global.domainName }}
         - name: DEFAULT_JWKS_URI


### PR DESCRIPTION
Confirm these statements before you submit your pull request:

- [x] I have read and submitted the required [Contributor Licence Agreements](https://github.com/kyma-project/community/blob/master/CONTRIBUTING.md#agreements-and-licenses).
- [x] This pull request follows the contributing guidelines, recommended Git workflow, and templates.
- [x] I have tested my changes.
- [ ] I have updated the relevant documentation.
---

**Description**

Changes proposed in this pull request:
- api-controller:
  * [x] CRD hostname validation is changed: hostname can be complete address (with domain) or simply first part of it. For example CRD should accept both 'my-service' and 'my-service.kyma.local'
  * [x] Controller reads DOMAIN_NAME env variable and adds it to hostname if it's provided in simple form
  * [x] CRD validates hostname against DOMAIN_NAME
  * [x] DOMAIN_NAME is set in deployment template
  * [x] [cosmetic] Remove getting Api object from kubernetes twice in onCreate 

**Issue link**

<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
