### PR TITLE
Fix kubeless test based on changes to istio

### DIFF
--- a/resources/core/.helmignore
+++ b/resources/core/.helmignore
@@ -19,4 +19,3 @@
 .project
 .idea/
 *.tmproj
-charts/kubeless/templates/tests/

--- a/resources/core/.helmignore
+++ b/resources/core/.helmignore
@@ -19,3 +19,4 @@
 .project
 .idea/
 *.tmproj
+charts/kubeless/templates/tests/

--- a/resources/core/charts/kubeless/templates/tests/test-kubeless.yaml
+++ b/resources/core/charts/kubeless/templates/tests/test-kubeless.yaml
@@ -37,9 +37,7 @@ rules:
 - apiGroups: ["remoteenvironment.kyma.cx"]
   resources: ["eventactivations"]
   verbs: ["create", "delete", "get", "list"]
-- apiGroups: ["networking.istio.io"]
-  resources: ["virtualservices"]
-  verbs: ["get"]
+
 
 ---
 apiVersion: v1
@@ -69,7 +67,7 @@ kind: Pod
 metadata:
   name: test-{{ template "fullname" . }}
   labels:
-    helm-chart-test: "true"
+    helm-chart-test: "false"
   annotations:
     helm.sh/hook: test-success
 spec:

--- a/resources/core/charts/kubeless/templates/tests/test-kubeless.yaml
+++ b/resources/core/charts/kubeless/templates/tests/test-kubeless.yaml
@@ -37,6 +37,9 @@ rules:
 - apiGroups: ["remoteenvironment.kyma.cx"]
   resources: ["eventactivations"]
   verbs: ["create", "delete", "get", "list"]
+- apiGroups: ["networking.istio.io"]
+  resources: ["virtualservices"]
+  verbs: ["get"]
 
 ---
 apiVersion: v1

--- a/resources/core/charts/kubeless/templates/tests/test-kubeless.yaml
+++ b/resources/core/charts/kubeless/templates/tests/test-kubeless.yaml
@@ -66,7 +66,7 @@ kind: Pod
 metadata:
   name: test-{{ template "fullname" . }}
   labels:
-    helm-chart-test: "false"
+    helm-chart-test: "true"
   annotations:
     helm.sh/hook: test-success
 spec:

--- a/resources/core/charts/kubeless/values.yaml
+++ b/resources/core/charts/kubeless/values.yaml
@@ -1,7 +1,7 @@
 test:
   image:
     name: kubeless-test-client
-    tag: 0.2.51
+    tag: 0.2.52
 
 controller:
   deployment:

--- a/resources/core/charts/kubeless/values.yaml
+++ b/resources/core/charts/kubeless/values.yaml
@@ -1,7 +1,7 @@
 test:
   image:
     name: kubeless-test-client
-    tag: 0.2.52
+    tag: 0.2.51
 
 controller:
   deployment:

--- a/tests/kubeless-test-client/Dockerfile
+++ b/tests/kubeless-test-client/Dockerfile
@@ -15,7 +15,7 @@ RUN curl -Lo /tmp/kubeless.zip https://github.com/kubeless/kubeless/releases/dow
 #RUN curl -Lo /tmp/kubeless.zip "$(curl -s https://api.github.com/repos/kubeless/kubeless/releases/latest | jq -r '.assets[]|select(.name=="kubeless_linux-amd64.zip").browser_download_url')" && unzip -q /tmp/kubeless.zip -d /tmp/ && mv /tmp/bundles/kubeless_linux-amd64/kubeless /usr/bin/ && rm -r /tmp/kubeless.zip /tmp/bundles && chmod +x /usr/bin/kubeless
 
 RUN mkdir -p /root/.kube && touch /root/.kube/config
-COPY ns.yaml k8s.yaml dependencies.json hello.js event.js svcbind.yaml /
+COPY ns.yaml k8s.yaml dependencies.json hello.js event.js svcbind-lambda.yaml svc-instance.yaml /
 COPY bin/app /test-kubeless
 
 CMD ["/test-kubeless"]

--- a/tests/kubeless-test-client/svc-instance.yaml
+++ b/tests/kubeless-test-client/svc-instance.yaml
@@ -1,0 +1,22 @@
+apiVersion: servicecatalog.k8s.io/v1beta1
+kind: ServiceInstance
+metadata:
+  namespace: kubeless-test
+  name: redis
+spec:
+  clusterServiceClassExternalName: redis
+  clusterServicePlanExternalName: micro
+  parameters:
+    redisPassword: VXU3ZVRkY2tVdlFVMkNHYlYwM2gK
+    resources:
+      requests:
+        memory: 96Mi
+---
+apiVersion: servicecatalog.k8s.io/v1beta1
+kind: ServiceBinding
+metadata:
+  namespace: kubeless-test
+  name: redis-binding
+spec:
+  instanceRef:
+    name: redis

--- a/tests/kubeless-test-client/svcbind-lambda.yaml
+++ b/tests/kubeless-test-client/svcbind-lambda.yaml
@@ -56,5 +56,5 @@ spec:
  serviceBindingRef:
    name: redis-binding
  usedBy:
-   kind: Function
+   kind: function
    name: test-svcbind

--- a/tests/kubeless-test-client/svcbind-lambda.yaml
+++ b/tests/kubeless-test-client/svcbind-lambda.yaml
@@ -1,26 +1,3 @@
-apiVersion: servicecatalog.k8s.io/v1beta1
-kind: ServiceInstance
-metadata:
-  namespace: kubeless-test
-  name: redis
-spec:
-  clusterServiceClassExternalName: redis
-  clusterServicePlanExternalName: micro
-  parameters:
-    redisPassword: VXU3ZVRkY2tVdlFVMkNHYlYwM2gK
-    resources:
-      requests:
-        memory: 96Mi
----
-apiVersion: servicecatalog.k8s.io/v1beta1
-kind: ServiceBinding
-metadata:
-  namespace: kubeless-test
-  name: redis-binding
-spec:
-  instanceRef:
-    name: redis
----
 apiVersion: gateway.kyma.cx/v1alpha2
 kind: Api
 metadata:

--- a/tests/kubeless-test-client/test-kubeless.go
+++ b/tests/kubeless-test-client/test-kubeless.go
@@ -250,7 +250,7 @@ func ensureCorrectLog(namespace, funName string, pattern *regexp.Regexp, match s
 		log.Printf("Checking logs for pods: %v", pod)
 		select {
 		case <-timeout:
-			cmd := exec.Command("kubectl", "-n", namespace, "logs", pod)
+			cmd := exec.Command("kubectl", "-n", namespace, "logs", pod, "-c", funName)
 			stdoutStderr, _ := cmd.CombinedOutput()
 			log.Fatal("Timed out getting the correct log for ", funName, ":\n", string(stdoutStderr))
 		case <-tick:


### PR DESCRIPTION
 - Now we use golnag http clinet instead of curl
   for invoking.
 - Also improve the kubeless test
   - When we create a lambda with binding then
     there can be a case that when we check logs
     it would try to access the terminating pods.

Confirm these statements before you submit your pull request:

- [x] I have read and submitted the required [Contributor Licence Agreements](https://github.com/kyma-project/community/blob/master/CONTRIBUTING.md#agreements-and-licenses).
- [x] This pull request follows the contributing guidelines, recommended Git workflow, and templates.
- [x] I have tested my changes.
- [x] I have updated the relevant documentation.
---

<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
