### PR TITLE
Handle tls-enabled etcd clusters in backup tool

### DIFF
--- a/installation/resources/installer.yaml
+++ b/installation/resources/installer.yaml
@@ -163,11 +163,11 @@ spec:
                 name: installation-config
                 key: enable_etcd_backup_operator
                 optional: true
-          - name: ECTD_BACKUP_ABS_CONTAINER_NAME
+          - name: ETCD_BACKUP_ABS_CONTAINER_NAME
             valueFrom:
               configMapKeyRef:
                 name: installation-config
-                key: ectd_backup_abs_container_name
+                key: etcd_backup_abs_container_name
                 optional: true
           - name: VICTOR_OPS_API_KEY_VALUE
             valueFrom:

--- a/tools/etcd-backup/README.md
+++ b/tools/etcd-backup/README.md
@@ -31,6 +31,7 @@ export APP_BLOB_PREFIX={prefix_name}
 
 export APP_BACKUP_CONFIG_MAP_NAME_FOR_TRACING="sc-recorded-etcd-backup-data"
 export APP_BACKUP_ETCD_ENDPOINTS="{endpoints}"
+export APP_BACKUP_CLIENT_TLS_SECRET="core-service-catalog-etcd-etcd-client-tls" # If the TLS for the etcd is enabled.
 
 export APP_CLEANER_LEAVE_MIN_NEWEST_BACKUP_BLOBS="3"
 export APP_CLEANER_EXPIRATION_BLOB_TIME="24h"

--- a/tools/etcd-backup/internal/backup/config.go
+++ b/tools/etcd-backup/internal/backup/config.go
@@ -11,4 +11,9 @@ type Config struct {
 	// ConfigMapNameForTracing is the name of the ConfigMap where
 	// the path to the last successful ABS backup is saved.
 	ConfigMapNameForTracing string
+
+	// ClientTLSSecret is the name of the secret where
+	// client tls certificates are stored required for communication
+	// with etcd cluster to make a backup.
+	ClientTLSSecret string `envconfig:"optional"`
 }

--- a/tools/etcd-backup/internal/backup/executor.go
+++ b/tools/etcd-backup/internal/backup/executor.go
@@ -22,9 +22,10 @@ type Executor struct {
 	etcdBackupCli    etcdOpClient.EtcdBackupInterface
 	etcdBackupLister etcdOpLister.EtcdBackupNamespaceLister
 
-	absContainerName string
-	etcdEndpoints    []string
-	absSecretName    string
+	absContainerName    string
+	etcdEndpoints       []string
+	etcdClientTLSSecret string
+	absSecretName       string
 
 	idProvider idprovider.Fn
 }
@@ -32,13 +33,14 @@ type Executor struct {
 // NewExecutor returns new instance of Executor
 func NewExecutor(cfg Config, absSecretName, absContainerName string, etcdBackupCli etcdOpClient.EtcdBackupInterface, nsScopedLister etcdOpLister.EtcdBackupNamespaceLister, log logrus.FieldLogger) *Executor {
 	return &Executor{
-		log:              log,
-		etcdBackupCli:    etcdBackupCli,
-		etcdBackupLister: nsScopedLister,
-		absSecretName:    absSecretName,
-		etcdEndpoints:    cfg.EtcdEndpoints,
-		idProvider:       idprovider.New(),
-		absContainerName: removeSlashSuffixIfNeeded(absContainerName),
+		log:                 log,
+		etcdBackupCli:       etcdBackupCli,
+		etcdBackupLister:    nsScopedLister,
+		absSecretName:       absSecretName,
+		etcdEndpoints:       cfg.EtcdEndpoints,
+		etcdClientTLSSecret: cfg.ClientTLSSecret,
+		idProvider:          idprovider.New(),
+		absContainerName:    removeSlashSuffixIfNeeded(absContainerName),
 	}
 }
 
@@ -91,7 +93,8 @@ func (e *Executor) etcdBackup(blobPrefix string) (*etcdTypes.EtcdBackup, error) 
 			GenerateName: etcdBackupGenerateName, // used to generate a unique name
 		},
 		Spec: etcdTypes.BackupSpec{
-			EtcdEndpoints: e.etcdEndpoints,
+			EtcdEndpoints:   e.etcdEndpoints,
+			ClientTLSSecret: e.etcdClientTLSSecret,
 
 			StorageType: etcdTypes.BackupStorageTypeABS,
 			BackupSource: etcdTypes.BackupSource{


### PR DESCRIPTION
Confirm these statements before you submit your pull request:

- [x] I have read and submitted the required [Contributor Licence Agreements](https://github.com/kyma-project/community/blob/master/CONTRIBUTING.md#agreements-and-licenses).
- [x] This pull request follows the contributing guidelines, recommended Git workflow, and templates.
- [x] I have tested my changes.
- [x] I have updated the relevant documentation.
---

**Description**

Changes proposed in this pull request:

- Add new parameter for etcd-backup tool containing secret name which has tls certificates to access etcd-cluster (required to make backup of tls enabled etcd clusters). Value is passed to EtcdBackup CR
- fixes typos in env var for installer
-

**Issue link**

<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
