### PR TITLE
Add helm chart for PodPreset admission controller installation

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -13,8 +13,11 @@
 # The `cluster-prerequisites` subdirectory
 /resources/cluster-prerequisites @Tomasz-Smelcerz-SAP @strekm @jakkab @crabtree @aszecowka @PK85 @mszostok @piotrmiskiewicz @polskikiel @piotrmsc
 
-# The `cluster-essentials` subchart
+# The `cluster-essentials` chart
 /resources/cluster-essentials/ @damianpacierpnikatsap @damjatsap @PK85
+
+# The `pod-preset` subchart
+/resources/cluster-essentials/charts/pod-preset @mszostok @PK85 @aszecowka @piotrmiskiewicz @polskikiel
 
 # The `api-controller` subchart
 /resources/core/charts/api-controller/ @piotrmsc @kubadz

--- a/resources/cluster-essentials/charts/pod-preset/.helmignore
+++ b/resources/cluster-essentials/charts/pod-preset/.helmignore
@@ -1,0 +1,21 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj

--- a/resources/cluster-essentials/charts/pod-preset/Chart.yaml
+++ b/resources/cluster-essentials/charts/pod-preset/Chart.yaml
@@ -1,0 +1,4 @@
+name: pod-preset
+description: A Helm chart for PodPreset resource that's implemented via a CRD that is paired with a mutating webhook in order to modify pod specs on the fly
+version: 0.1.0
+appVersion: "0.1.0"

--- a/resources/cluster-essentials/charts/pod-preset/README.md
+++ b/resources/cluster-essentials/charts/pod-preset/README.md
@@ -1,0 +1,28 @@
+```
+  _____          _    _____                    _   
+ |  __ \        | |  |  __ \                  | |  
+ | |__) |__   __| |  | |__) | __ ___  ___  ___| |_ 
+ |  ___/ _ \ / _` |  |  ___/ '__/ _ \/ __|/ _ \ __|
+ | |  | (_) | (_| |  | |   | | |  __/\__ \  __/ |_ 
+ |_|   \___/ \__,_|  |_|   |_|  \___||___/\___|\__|
+                                               
+```
+
+## Overview
+
+The Pod Preset component allows injecting information such as Secrets, volume mounts, and environment variables during Pods creation.
+Using a PodPreset, you do not have to provide all information for every Pod.
+
+## Details
+
+This Helm chart installs the admission controller extracted from the main Kubernetes repository. Find the source code [here](https://github.com/jpeeler/podpreset-crd).
+This Helm chart is required because the managed cluster does not enable the core Kubernetes admission controller for PodPreset since it is in the alpha state.
+
+This chart also provides the controller-manager which is responsible for restarting the Deployments whenever the PodPreset changes. 
+This functionality is not present in the main Kubernetes implementation and by default is disabled in this Helm chart. If you want to enable the controller-manager, set the **controller.enabled** parameter to `true` in the [values.yaml](./values.yaml) file.
+
+### Images
+The Docker images are pushed to the [Docker Hub](https://hub.docker.com/) under the [mszostok](https://hub.docker.com/u/mszostok/) repository. This is a temporary solution until the official images are pushed from the [podpreset-crd](https://github.com/jpeeler/podpreset-crd) repository.
+
+The `mszostok/service-catalog-podpreset-controller` Docker image was build by executing the `make docker-build` command from the [podpreset-crd](https://github.com/jpeeler/podpreset-crd) repository. The `0.0.2` version is build from [this](https://github.com/jpeeler/podpreset-crd/commit/4d6e1a45dd59ac149a171f43dc1499d3ee4901a8) commit.
+The `mszostok/service-catalog-admission-webhook` Docker image was build by executing the `make docker-build-webhook` command from the [podpreset-crd](https://github.com/jpeeler/podpreset-crd) repository. The `0.0.2` version is build from [this](https://github.com/jpeeler/podpreset-crd/commit/4d6e1a45dd59ac149a171f43dc1499d3ee4901a8) commit.

--- a/resources/cluster-essentials/charts/pod-preset/templates/_helpers.tpl
+++ b/resources/cluster-essentials/charts/pod-preset/templates/_helpers.tpl
@@ -1,0 +1,32 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "pod-preset.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "pod-preset.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "pod-preset.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}

--- a/resources/cluster-essentials/charts/pod-preset/templates/controller-manager/cluster-role-binding.yaml
+++ b/resources/cluster-essentials/charts/pod-preset/templates/controller-manager/cluster-role-binding.yaml
@@ -2,13 +2,13 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: {{ template "pod-preset.fullname" . }}-manager
+  name: {{ template "pod-preset.fullname" . }}-controller
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: {{ template "pod-preset.fullname" . }}-manager
+  name: {{ template "pod-preset.fullname" . }}-controller
 subjects:
 - kind: ServiceAccount
-  name: {{ template "pod-preset.fullname" . }}-manager
+  name: {{ template "pod-preset.fullname" . }}-controller
   namespace: "{{ .Release.Namespace }}"
 {{- end -}}

--- a/resources/cluster-essentials/charts/pod-preset/templates/controller-manager/cluster-role-binding.yaml
+++ b/resources/cluster-essentials/charts/pod-preset/templates/controller-manager/cluster-role-binding.yaml
@@ -1,0 +1,14 @@
+{{- if .Values.controller.enabled }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ template "pod-preset.fullname" . }}-manager
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ template "pod-preset.fullname" . }}-manager
+subjects:
+- kind: ServiceAccount
+  name: {{ template "pod-preset.fullname" . }}-manager
+  namespace: "{{ .Release.Namespace }}"
+{{- end -}}

--- a/resources/cluster-essentials/charts/pod-preset/templates/controller-manager/cluster-role.yaml
+++ b/resources/cluster-essentials/charts/pod-preset/templates/controller-manager/cluster-role.yaml
@@ -2,17 +2,8 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: {{ template "pod-preset.fullname" . }}-manager
+  name: {{ template "pod-preset.fullname" . }}-controller
 rules:
-- apiGroups:
-  - apps
-  resources:
-  - deployments
-  verbs:
-  - get
-  - watch
-  - list
-  - update
 - apiGroups:
   - ""
   resources:
@@ -29,20 +20,13 @@ rules:
   - get
   - list
   - watch
-  - create
   - update
-  - patch
-  - delete
 - apiGroups:
-  - settings.servicecatalog.k8s.io
+  - settings.svcat.k8s.io
   resources:
   - podpresets
   verbs:
   - get
   - list
   - watch
-  - create
-  - update
-  - patch
-  - delete
 {{- end -}}

--- a/resources/cluster-essentials/charts/pod-preset/templates/controller-manager/cluster-role.yaml
+++ b/resources/cluster-essentials/charts/pod-preset/templates/controller-manager/cluster-role.yaml
@@ -1,0 +1,48 @@
+{{- if .Values.controller.enabled }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ template "pod-preset.fullname" . }}-manager
+rules:
+- apiGroups:
+  - apps
+  resources:
+  - deployments
+  verbs:
+  - get
+  - watch
+  - list
+  - update
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+  - update
+- apiGroups:
+  - apps
+  resources:
+  - deployments
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - settings.servicecatalog.k8s.io
+  resources:
+  - podpresets
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+{{- end -}}

--- a/resources/cluster-essentials/charts/pod-preset/templates/controller-manager/sa.yaml
+++ b/resources/cluster-essentials/charts/pod-preset/templates/controller-manager/sa.yaml
@@ -2,10 +2,10 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: {{ template "pod-preset.fullname" . }}-manager
+  name: {{ template "pod-preset.fullname" . }}-controller
   namespace: "{{ .Release.Namespace }}"
   labels:
-    app: {{ template "pod-preset.name" . }}-manager
+    app: {{ template "pod-preset.name" . }}-controller
     chart: {{ template "pod-preset.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}

--- a/resources/cluster-essentials/charts/pod-preset/templates/controller-manager/sa.yaml
+++ b/resources/cluster-essentials/charts/pod-preset/templates/controller-manager/sa.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.controller.enabled }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ template "pod-preset.fullname" . }}-manager
+  namespace: "{{ .Release.Namespace }}"
+  labels:
+    app: {{ template "pod-preset.name" . }}-manager
+    chart: {{ template "pod-preset.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+{{- end -}}

--- a/resources/cluster-essentials/charts/pod-preset/templates/controller-manager/stateful-set.yaml
+++ b/resources/cluster-essentials/charts/pod-preset/templates/controller-manager/stateful-set.yaml
@@ -1,0 +1,32 @@
+{{- if .Values.controller.enabled }}
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: {{ template "pod-preset.fullname" . }}-manager
+  namespace: "{{ .Release.Namespace }}"
+  labels:
+    app: {{ template "pod-preset.name" . }}-webhook
+    chart: {{ template "pod-preset.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  selector:
+    matchLabels:
+      app: {{ template "pod-preset.name" . }}-manager
+      release: {{ .Release.Name }}
+  serviceName: {{ template "pod-preset.fullname" . }}-manager
+  template:
+    metadata:
+      labels:
+        app: {{ template "pod-preset.name" . }}-manager
+        release: {{ .Release.Name }}
+    spec:
+      serviceAccountName: {{ template "pod-preset.fullname" . }}-manager
+      terminationGracePeriodSeconds: 10
+      containers:
+      - name: {{ .Chart.Name }}-manager
+        image: "{{ .Values.controller.image.repository }}:{{ .Values.controller.image.tag }}"
+        imagePullPolicy: {{ .Values.controller.image.pullPolicy }}
+        command:
+        - /root/manager
+{{- end -}}

--- a/resources/cluster-essentials/charts/pod-preset/templates/controller-manager/stateful-set.yaml
+++ b/resources/cluster-essentials/charts/pod-preset/templates/controller-manager/stateful-set.yaml
@@ -2,7 +2,7 @@
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
-  name: {{ template "pod-preset.fullname" . }}-manager
+  name: {{ template "pod-preset.fullname" . }}-controller
   namespace: "{{ .Release.Namespace }}"
   labels:
     app: {{ template "pod-preset.name" . }}-webhook
@@ -12,19 +12,19 @@ metadata:
 spec:
   selector:
     matchLabels:
-      app: {{ template "pod-preset.name" . }}-manager
+      app: {{ template "pod-preset.name" . }}-controller
       release: {{ .Release.Name }}
-  serviceName: {{ template "pod-preset.fullname" . }}-manager
+  serviceName: {{ template "pod-preset.fullname" . }}-controller
   template:
     metadata:
       labels:
-        app: {{ template "pod-preset.name" . }}-manager
+        app: {{ template "pod-preset.name" . }}-controller
         release: {{ .Release.Name }}
     spec:
-      serviceAccountName: {{ template "pod-preset.fullname" . }}-manager
+      serviceAccountName: {{ template "pod-preset.fullname" . }}-controller
       terminationGracePeriodSeconds: 10
       containers:
-      - name: {{ .Chart.Name }}-manager
+      - name: {{ .Chart.Name }}-controller
         image: "{{ .Values.controller.image.repository }}:{{ .Values.controller.image.tag }}"
         imagePullPolicy: {{ .Values.controller.image.pullPolicy }}
         command:

--- a/resources/cluster-essentials/charts/pod-preset/templates/podpreset-crd.yaml
+++ b/resources/cluster-essentials/charts/pod-preset/templates/podpreset-crd.yaml
@@ -1,10 +1,10 @@
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
-  name: podpresets.settings.servicecatalog.k8s.io
+  name: podpresets.settings.svcat.k8s.io
 spec:
   version: v1alpha1
-  group: settings.servicecatalog.k8s.io
+  group: settings.svcat.k8s.io
   names:
     kind: PodPreset
     plural: podpresets

--- a/resources/cluster-essentials/charts/pod-preset/templates/podpreset-crd.yaml
+++ b/resources/cluster-essentials/charts/pod-preset/templates/podpreset-crd.yaml
@@ -1,0 +1,46 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: podpresets.settings.servicecatalog.k8s.io
+spec:
+  version: v1alpha1
+  group: settings.servicecatalog.k8s.io
+  names:
+    kind: PodPreset
+    plural: podpresets
+  scope: Namespaced
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          type: string
+        kind:
+          type: string
+        metadata:
+          type: object
+        spec:
+          properties:
+            env:
+              items:
+                type: object
+              type: array
+            envFrom:
+              items:
+                type: object
+              type: array
+            selector:
+              type: object
+            volumeMounts:
+              items:
+                type: object
+              type: array
+            volumes:
+              items:
+                type: object
+              type: array
+          required:
+          - selector
+          type: object
+        status:
+          type: object
+      type: object

--- a/resources/cluster-essentials/charts/pod-preset/templates/webhook/cluster-role-binding.yaml
+++ b/resources/cluster-essentials/charts/pod-preset/templates/webhook/cluster-role-binding.yaml
@@ -1,0 +1,17 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ template "pod-preset.fullname" . }}-webhook
+  labels:
+    app: {{ template "pod-preset.name" . }}-webhook
+    chart: {{ template "pod-preset.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ template "pod-preset.fullname" . }}-webhook
+subjects:
+- kind: ServiceAccount
+  name: {{ template "pod-preset.fullname" . }}-webhook
+  namespace: "{{ .Release.Namespace }}"

--- a/resources/cluster-essentials/charts/pod-preset/templates/webhook/cluster-role.yaml
+++ b/resources/cluster-essentials/charts/pod-preset/templates/webhook/cluster-role.yaml
@@ -1,0 +1,18 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ template "pod-preset.fullname" . }}-webhook
+  labels:
+    app: {{ template "pod-preset.name" . }}-webhook
+    chart: {{ template "pod-preset.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+rules:
+- apiGroups:
+  - settings.servicecatalog.k8s.io
+  resources:
+  - podpresets
+  verbs:
+  - get
+  - list
+  - watch

--- a/resources/cluster-essentials/charts/pod-preset/templates/webhook/cluster-role.yaml
+++ b/resources/cluster-essentials/charts/pod-preset/templates/webhook/cluster-role.yaml
@@ -9,7 +9,7 @@ metadata:
     heritage: {{ .Release.Service }}
 rules:
 - apiGroups:
-  - settings.servicecatalog.k8s.io
+  - settings.svcat.k8s.io
   resources:
   - podpresets
   verbs:

--- a/resources/cluster-essentials/charts/pod-preset/templates/webhook/deploy.yaml
+++ b/resources/cluster-essentials/charts/pod-preset/templates/webhook/deploy.yaml
@@ -1,0 +1,48 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ template "pod-preset.fullname" . }}-webhook
+  namespace: "{{ .Release.Namespace }}"
+  labels:
+    app: {{ template "pod-preset.name" . }}-webhook
+    chart: {{ template "pod-preset.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  replicas: {{ .Values.webhook.replicaCount }}
+  selector:
+    matchLabels:
+      app: {{ template "pod-preset.name" . }}-webhook
+      release: {{ .Release.Name }}
+  template:
+    metadata:
+      labels:
+        app: {{ template "pod-preset.name" . }}-webhook
+        release: {{ .Release.Name }}
+    spec:
+      serviceAccountName: {{ template "pod-preset.fullname" . }}-webhook
+      containers:
+      - name: {{ .Chart.Name }}-webhook
+        image: "{{ .Values.webhook.image.repository }}:{{ .Values.webhook.image.tag }}"
+        imagePullPolicy: {{ .Values.webhook.image.pullPolicy }}
+        args:
+        - -tls-cert-file=/keys/webhook.crt
+        - -tls-private-key-file=/keys/webhook.key
+        - -alsologtostderr
+        - -v
+        - "{{ .Values.webhook.verbosity }}"
+        ports:
+        - containerPort: 443
+        volumeMounts:
+        - name: webhook-cert
+          mountPath: /keys
+          readOnly: true
+      volumes:
+      - name: webhook-cert
+        secret:
+          secretName: {{ template "pod-preset.fullname" . }}-webhook-cert
+          items:
+          - key: tls.crt
+            path: webhook.crt
+          - key: tls.key
+            path: webhook.key

--- a/resources/cluster-essentials/charts/pod-preset/templates/webhook/sa.yaml
+++ b/resources/cluster-essentials/charts/pod-preset/templates/webhook/sa.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ template "pod-preset.fullname" . }}-webhook
+  namespace: "{{ .Release.Namespace }}"
+  labels:
+    app: {{ template "pod-preset.name" . }}-webhook
+    chart: {{ template "pod-preset.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}

--- a/resources/cluster-essentials/charts/pod-preset/templates/webhook/service.yaml
+++ b/resources/cluster-essentials/charts/pod-preset/templates/webhook/service.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "pod-preset.fullname" . }}-webhook
+  namespace: "{{ .Release.Namespace }}"
+  labels:
+    app: {{ template "pod-preset.name" . }}-webhook
+    chart: {{ template "pod-preset.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  ports:
+  - port: 443
+    protocol: TCP
+    targetPort: 443
+  selector:
+    app: {{ template "pod-preset.name" . }}-webhook
+    release: {{ .Release.Name }}

--- a/resources/cluster-essentials/charts/pod-preset/templates/webhook/webhook.yaml
+++ b/resources/cluster-essentials/charts/pod-preset/templates/webhook/webhook.yaml
@@ -16,7 +16,7 @@ webhooks:
       namespace: "{{ .Release.Namespace }}"
       path: /mutating-pods
   failurePolicy: Ignore
-  name: podpresets.settings.servicecatalog.k8s.io
+  name: podpresets.settings.svcat.k8s.io
   rules:
   - apiGroups:
     - ""

--- a/resources/cluster-essentials/charts/pod-preset/templates/webhook/webhook.yaml
+++ b/resources/cluster-essentials/charts/pod-preset/templates/webhook/webhook.yaml
@@ -1,0 +1,39 @@
+{{- $ca := genCA "pod-preset-webhook-ca" 3650 }}
+{{- $cn := printf "%s-webhook" (include "pod-preset.fullname" .) }}
+{{- $altName1 := printf "%s.%s" $cn .Release.Namespace }}
+{{- $altName2 := printf "%s.%s.svc" $cn .Release.Namespace }}
+{{- $cert := genSignedCert $cn nil (list $altName1 $altName2) 3650 $ca }}
+apiVersion: admissionregistration.k8s.io/v1beta1
+kind: MutatingWebhookConfiguration
+metadata:
+  name: {{ template "pod-preset.fullname" . }}-webhook
+  namespace: "{{ .Release.Namespace }}"
+webhooks:
+- clientConfig:
+    caBundle: {{ b64enc $ca.Cert }}
+    service:
+      name: {{ template "pod-preset.fullname" . }}-webhook
+      namespace: "{{ .Release.Namespace }}"
+      path: /mutating-pods
+  failurePolicy: Ignore
+  name: podpresets.settings.servicecatalog.k8s.io
+  rules:
+  - apiGroups:
+    - ""
+    apiVersions:
+    - v1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - pods
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ template "pod-preset.fullname" . }}-webhook-cert
+  namespace: "{{ .Release.Namespace }}"
+type: Opaque
+data:
+  tls.crt: {{ b64enc $cert.Cert }}
+  tls.key: {{ b64enc $cert.Key }}

--- a/resources/cluster-essentials/charts/pod-preset/values.yaml
+++ b/resources/cluster-essentials/charts/pod-preset/values.yaml
@@ -1,0 +1,19 @@
+webhook:
+  replicaCount: 1
+  image:
+    repository: mszostok/service-catalog-admission-webhook
+    tag: 0.0.1
+    pullPolicy: IfNotPresent
+  verbosity: 6
+  service:
+    type: NodePort
+    port: 443
+
+controller:
+  enabled: false
+  image:
+    repository: mszostok/service-catalog-podpreset-controller
+    tag: 0.0.1
+    pullPolicy: IfNotPresent
+
+

--- a/resources/cluster-essentials/charts/pod-preset/values.yaml
+++ b/resources/cluster-essentials/charts/pod-preset/values.yaml
@@ -2,7 +2,7 @@ webhook:
   replicaCount: 1
   image:
     repository: mszostok/service-catalog-admission-webhook
-    tag: 0.0.1
+    tag: 0.0.2
     pullPolicy: IfNotPresent
   verbosity: 6
   service:
@@ -13,7 +13,7 @@ controller:
   enabled: false
   image:
     repository: mszostok/service-catalog-podpreset-controller
-    tag: 0.0.1
+    tag: 0.0.2
     pullPolicy: IfNotPresent
 
 


### PR DESCRIPTION
Confirm these statements before you submit your pull request:

- [x] I have read and submitted the required [Contributor Licence Agreements](https://github.com/kyma-project/community/blob/master/CONTRIBUTING.md#agreements-and-licenses).
- [x] This pull request follows the contributing guidelines, recommended Git workflow, and templates.
- [x] I have tested my changes.
- [x] I have updated the relevant documentation.
---

**Description**

Changes proposed in this pull request:

- Provide a helm chart which will install the admission controller for PodPresets.
This helm chart installs the controllers extracted from the main k8s repository. The source code you can find [here](https://github.com/jpeeler/podpreset-crd)

We need it because on the managed cluster we cannot enable the core k8s admission controllers for PodPreset because they are in the alpha state.

Additionally is worth to mention that Jeff Peeler implemented a new component called controller-manager which is responsible for restarting the Deployments when PodPreset was changed. This functionality is new and was not present in k8s implementation, so for now I disabled it.

**How to test**

Just install the Kyma locally or use the cluster (I've prepared the gopher cluster, you can download the kubeconfig from the **33** on-demand/gopher Jenkins Job)

_Steps_
1. Create a pod preset from API Group: **settings.svcat.k8s.io/v1alpha1**
```bash
kubectl create -f https://gist.github.com/mszostok/f56be101e7459c64ccb88c23cd23e777
```

2. Create a deployment.
```bash
kubectl create -f https://gist.github.com/mszostok/e5a68e6a9e9d743eed680a00d4612701/raw
```

3. Check that pod has annotation about the PodPreset action and has injected env and mounted volume.
```bash
kubectl describe po website
```


**NOTE:** _Still we need to clarify where to store the Docker images for the controller_

**Differences between this helm chart and source [repo](https://github.com/jpeeler/podpreset-crd)**
- create proper ClusterRoles, and introduce separate account for each deployment
- autogeneration of proper CA and TLS keys