### PR TITLE
Change runtime representation of overrides from strings to map-of-maps

### DIFF
--- a/components/installer/Gopkg.lock
+++ b/components/installer/Gopkg.lock
@@ -587,6 +587,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "20f6c29fbdd2ab7c5ddfb89237d3c2a94d96009a3a854f9402827408aa8bfb61"
+  inputs-digest = "57278c7714fc81b8f54444ef460e0151acdb6961fb0884211cbd739c086f9fc9"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/components/installer/Gopkg.toml
+++ b/components/installer/Gopkg.toml
@@ -22,7 +22,7 @@ required = ["k8s.io/code-generator/cmd/client-gen"]
 
 [[constraint]]
   name = "k8s.io/helm"
-  version = "v2.8.1"  
+  version = "v2.8.1"
 
 [[constraint]]
   name = "github.com/smartystreets/goconvey"
@@ -35,6 +35,10 @@ required = ["k8s.io/code-generator/cmd/client-gen"]
 [[constraint]]
   name = "github.com/Azure/azure-sdk-for-go"
   version = "v15.0.1"
+
+[[constraint]]
+  name = "github.com/ghodss/yaml"
+  version = "v1.0.0"
 
 [[override]]
   name = "k8s.io/api"

--- a/components/installer/pkg/kymahelm/ysf-helm-client.go
+++ b/components/installer/pkg/kymahelm/ysf-helm-client.go
@@ -52,9 +52,6 @@ func (hc *Client) ReleaseStatus(rname string) (string, error) {
 
 // InstallReleaseFromChart .
 func (hc *Client) InstallReleaseFromChart(chartdir, ns, releaseName, overrides string) (*rls.InstallReleaseResponse, error) {
-	fmt.Println("########## InstallReleaseFromChart() overrides: ############")
-	fmt.Println(overrides)
-	fmt.Println("############################################################")
 	chart, err := chartutil.Load(chartdir)
 
 	if err != nil {
@@ -73,9 +70,6 @@ func (hc *Client) InstallReleaseFromChart(chartdir, ns, releaseName, overrides s
 
 // InstallRelease .
 func (hc *Client) InstallRelease(chartdir, ns, releasename, overrides string) (*rls.InstallReleaseResponse, error) {
-	fmt.Println("########## InstallRelease() overrides: #####################")
-	fmt.Println(overrides)
-	fmt.Println("############################################################")
 	return hc.helm.InstallRelease(
 		chartdir,
 		ns,
@@ -88,9 +82,6 @@ func (hc *Client) InstallRelease(chartdir, ns, releasename, overrides string) (*
 
 // InstallReleaseWithoutWait .
 func (hc *Client) InstallReleaseWithoutWait(chartdir, ns, releasename, overrides string) (*rls.InstallReleaseResponse, error) {
-	fmt.Println("########## InstallReleaseWithoutWait() overrides: ##########")
-	fmt.Println(overrides)
-	fmt.Println("############################################################")
 	return hc.helm.InstallRelease(
 		chartdir,
 		ns,
@@ -103,9 +94,6 @@ func (hc *Client) InstallReleaseWithoutWait(chartdir, ns, releasename, overrides
 
 // UpgradeRelease .
 func (hc *Client) UpgradeRelease(chartDir, releaseName, overrides string) (*rls.UpdateReleaseResponse, error) {
-	fmt.Println("########## UpgradeRelease() overrides: #####################")
-	fmt.Println(overrides)
-	fmt.Println("############################################################")
 	return hc.helm.UpdateRelease(
 		releaseName,
 		chartDir,

--- a/components/installer/pkg/kymahelm/ysf-helm-client.go
+++ b/components/installer/pkg/kymahelm/ysf-helm-client.go
@@ -52,6 +52,9 @@ func (hc *Client) ReleaseStatus(rname string) (string, error) {
 
 // InstallReleaseFromChart .
 func (hc *Client) InstallReleaseFromChart(chartdir, ns, releaseName, overrides string) (*rls.InstallReleaseResponse, error) {
+	fmt.Println("########## InstallReleaseFromChart() overrides: ############")
+	fmt.Println(overrides)
+	fmt.Println("############################################################")
 	chart, err := chartutil.Load(chartdir)
 
 	if err != nil {
@@ -70,6 +73,9 @@ func (hc *Client) InstallReleaseFromChart(chartdir, ns, releaseName, overrides s
 
 // InstallRelease .
 func (hc *Client) InstallRelease(chartdir, ns, releasename, overrides string) (*rls.InstallReleaseResponse, error) {
+	fmt.Println("########## InstallRelease() overrides: #####################")
+	fmt.Println(overrides)
+	fmt.Println("############################################################")
 	return hc.helm.InstallRelease(
 		chartdir,
 		ns,
@@ -82,6 +88,9 @@ func (hc *Client) InstallRelease(chartdir, ns, releasename, overrides string) (*
 
 // InstallReleaseWithoutWait .
 func (hc *Client) InstallReleaseWithoutWait(chartdir, ns, releasename, overrides string) (*rls.InstallReleaseResponse, error) {
+	fmt.Println("########## InstallReleaseWithoutWait() overrides: ##########")
+	fmt.Println(overrides)
+	fmt.Println("############################################################")
 	return hc.helm.InstallRelease(
 		chartdir,
 		ns,
@@ -94,6 +103,9 @@ func (hc *Client) InstallReleaseWithoutWait(chartdir, ns, releasename, overrides
 
 // UpgradeRelease .
 func (hc *Client) UpgradeRelease(chartDir, releaseName, overrides string) (*rls.UpdateReleaseResponse, error) {
+	fmt.Println("########## UpgradeRelease() overrides: #####################")
+	fmt.Println(overrides)
+	fmt.Println("############################################################")
 	return hc.helm.UpdateRelease(
 		releaseName,
 		chartDir,

--- a/components/installer/pkg/overrides/azure-broker.go
+++ b/components/installer/pkg/overrides/azure-broker.go
@@ -24,29 +24,29 @@ type azureParams struct {
 }
 
 // EnableAzureBroker provides Azure parameters from Vault
-func EnableAzureBroker(installationData *config.InstallationData) (string, error) {
+func EnableAzureBroker(installationData *config.InstallationData) (OverridesMap, error) {
 
 	if !hasAzureParams(installationData) {
-		return "", nil
+		return OverridesMap{}, nil
 	}
 
 	azureParams, err := getAzureParams(installationData)
 	if err != nil {
-		return "", err
+		return nil, err
 	}
 
 	tmpl, err := template.New("").Parse(tplStr)
 	if err != nil {
-		return "", err
+		return nil, err
 	}
 
 	buf := new(bytes.Buffer)
 	err = tmpl.Execute(buf, azureParams)
 	if err != nil {
-		return "", err
+		return nil, err
 	}
 
-	return buf.String(), nil
+	return ToMap(buf.String())
 }
 
 func getAzureParams(installationData *config.InstallationData) (*azureParams, error) {

--- a/components/installer/pkg/overrides/azure-broker.go
+++ b/components/installer/pkg/overrides/azure-broker.go
@@ -24,10 +24,10 @@ type azureParams struct {
 }
 
 // EnableAzureBroker provides Azure parameters from Vault
-func EnableAzureBroker(installationData *config.InstallationData) (OverridesMap, error) {
+func EnableAzureBroker(installationData *config.InstallationData) (Map, error) {
 
 	if !hasAzureParams(installationData) {
-		return OverridesMap{}, nil
+		return Map{}, nil
 	}
 
 	azureParams, err := getAzureParams(installationData)

--- a/components/installer/pkg/overrides/azure-broker_test.go
+++ b/components/installer/pkg/overrides/azure-broker_test.go
@@ -12,24 +12,27 @@ func TestEnableAzureBroker(t *testing.T) {
 		Convey("when InstallationData does not contain azure credentials overrides should be empty", func() {
 
 			installatioData := NewInstallationDataCreator().WithEmptyAzureCredentials().GetData()
-			overrides, err := EnableAzureBroker(&installatioData)
+			overridesMap, err := EnableAzureBroker(&installatioData)
+			So(err, ShouldBeNil)
 
+			overrides, err := ToYaml(overridesMap)
 			So(err, ShouldBeNil)
 			So(overrides, ShouldBeBlank)
 		})
 
 		Convey("when InstallationData contains azure credentials overrides should contain yaml", func() {
-			dummyOverridesForBroker := `
-azure-broker:
+			dummyOverridesForBroker := `azure-broker:
+  client_id: 37bb544f-8935-4a00-a934-3999577fb637
+  client_secret: ZGM3ZDlkYTgtZWMxMS00NTg4LTk5OGItOGU5YWJlNWUzYmE4DQo=
   enabled: true
   subscription_id: d5423a63-0ab6-4455-9efe-569c6e716625
   tenant_id: 7ffdff3c-daa6-420d-9cff-b04769031acf
-  client_id: 37bb544f-8935-4a00-a934-3999577fb637
-  client_secret: ZGM3ZDlkYTgtZWMxMS00NTg4LTk5OGItOGU5YWJlNWUzYmE4DQo=
 `
 			installatioData := NewInstallationDataCreator().WithDummyAzureCredentials().GetData()
-			overrides, err := EnableAzureBroker(&installatioData)
+			overridesMap, err := EnableAzureBroker(&installatioData)
+			So(err, ShouldBeNil)
 
+			overrides, err := ToYaml(overridesMap)
 			So(err, ShouldBeNil)
 			So(overrides, ShouldEqual, dummyOverridesForBroker)
 		})

--- a/components/installer/pkg/overrides/core.go
+++ b/components/installer/pkg/overrides/core.go
@@ -33,9 +33,9 @@ etcd-operator:
 `
 
 // GetCoreOverrides - returns values overrides for core installation basing on domain
-func GetCoreOverrides(installationData *config.InstallationData) (OverridesMap, error) {
+func GetCoreOverrides(installationData *config.InstallationData) (Map, error) {
 	if hasValidDomain(installationData) == false {
-		return OverridesMap{}, nil
+		return Map{}, nil
 	}
 
 	tmpl, err := template.New("").Parse(coreTplStr)

--- a/components/installer/pkg/overrides/core.go
+++ b/components/installer/pkg/overrides/core.go
@@ -33,23 +33,23 @@ etcd-operator:
 `
 
 // GetCoreOverrides - returns values overrides for core installation basing on domain
-func GetCoreOverrides(installationData *config.InstallationData) (string, error) {
+func GetCoreOverrides(installationData *config.InstallationData) (OverridesMap, error) {
 	if hasValidDomain(installationData) == false {
-		return "", nil
+		return OverridesMap{}, nil
 	}
 
 	tmpl, err := template.New("").Parse(coreTplStr)
 	if err != nil {
-		return "", err
+		return nil, err
 	}
 
 	buf := new(bytes.Buffer)
 	err = tmpl.Execute(buf, installationData)
 	if err != nil {
-		return "", err
+		return nil, err
 	}
 
-	return buf.String(), nil
+	return ToMap(buf.String())
 }
 
 func hasValidDomain(installationData *config.InstallationData) bool {

--- a/components/installer/pkg/overrides/core_test.go
+++ b/components/installer/pkg/overrides/core_test.go
@@ -12,70 +12,72 @@ func TestGetCoreOverrides(t *testing.T) {
 		Convey("when InstallationData does not contain domain name overrides should be empty", func() {
 
 			installationData := NewInstallationDataCreator().WithEmptyDomain().GetData()
-			overrides, err := GetCoreOverrides(&installationData)
+			overridesMap, err := GetCoreOverrides(&installationData)
+			So(err, ShouldBeNil)
 
+			overrides, err := ToYaml(overridesMap)
 			So(err, ShouldBeNil)
 			So(overrides, ShouldBeBlank)
 		})
 
 		Convey("when InstallationData contains domain name overrides should contain yaml", func() {
-			const dummyOverridesForCore = `
+			const dummyOverridesForCore = `cluster-users:
+  users:
+    adminGroup: testgroup
+configurations-generator:
+  kubeConfig:
+    ca: null
+    clusterName: kyma.local
+    url: null
+etcd-operator:
+  backupOperator:
+    abs:
+      storageAccount: ""
+      storageKey: ""
+    enabled: ""
 nginx-ingress:
   controller:
     service:
       loadBalancerIP: 1.1.1.1
-configurations-generator:
-  kubeConfig:
-    clusterName: kyma.local
-    url: 
-    ca: 
-cluster-users:
-  users:
-    adminGroup: testgroup
 test:
   auth:
-    username: ""
     password: ""
-etcd-operator:
-  backupOperator:
-    enabled: ""
-    abs:
-      storageAccount: ""
-      storageKey: ""
+    username: ""
 `
 			installationData := NewInstallationDataCreator().WithDomain("kyma.local").WithRemoteEnvIP("1.1.1.1").WithAdminGroup("testgroup").
 				GetData()
 
-			overrides, err := GetCoreOverrides(&installationData)
+			overridesMap, err := GetCoreOverrides(&installationData)
+			So(err, ShouldBeNil)
 
+			overrides, err := ToYaml(overridesMap)
 			So(err, ShouldBeNil)
 			So(overrides, ShouldEqual, dummyOverridesForCore)
 		})
 
 		Convey("when test properties are provided, auth.username and auth.password should exist", func() {
-			const dummyOverridesForCore = `
+			const dummyOverridesForCore = `cluster-users:
+  users:
+    adminGroup: null
+configurations-generator:
+  kubeConfig:
+    ca: null
+    clusterName: kyma.local
+    url: null
+etcd-operator:
+  backupOperator:
+    abs:
+      storageAccount: ""
+      storageKey: ""
+    enabled: ""
 nginx-ingress:
   controller:
     service:
       loadBalancerIP: 1.1.1.1
-configurations-generator:
-  kubeConfig:
-    clusterName: kyma.local
-    url: 
-    ca: 
-cluster-users:
-  users:
-    adminGroup: 
 test:
   auth:
-    username: "user1"
-    password: "p@ssw0rd"
-etcd-operator:
-  backupOperator:
-    enabled: ""
-    abs:
-      storageAccount: ""
-      storageKey: ""
+    password: p@ssw0rd
+    username: user1
 `
 			installationData := NewInstallationDataCreator().
 				WithDomain("kyma.local").
@@ -83,36 +85,37 @@ etcd-operator:
 				WithUITestCredentials("user1", "p@ssw0rd").
 				GetData()
 
-			overrides, err := GetCoreOverrides(&installationData)
+			overridesMap, err := GetCoreOverrides(&installationData)
+			So(err, ShouldBeNil)
 
+			overrides, err := ToYaml(overridesMap)
 			So(err, ShouldBeNil)
 			So(overrides, ShouldEqual, dummyOverridesForCore)
 		})
 
 		Convey("when etcd-operator properties are provided then enabled, abs.storageAccount and abs.storageKey should exist", func() {
-			const dummyOverridesForCore = `
+			const dummyOverridesForCore = `cluster-users:
+  users:
+    adminGroup: null
+configurations-generator:
+  kubeConfig:
+    ca: null
+    clusterName: kyma.local
+    url: null
+etcd-operator:
+  backupOperator:
+    abs:
+      storageAccount: pico-bello
+      storageKey: 123-456-3245-a23b
+    enabled: "true"
 nginx-ingress:
   controller:
     service:
       loadBalancerIP: 1.1.1.1
-configurations-generator:
-  kubeConfig:
-    clusterName: kyma.local
-    url: 
-    ca: 
-cluster-users:
-  users:
-    adminGroup: 
 test:
   auth:
-    username: ""
     password: ""
-etcd-operator:
-  backupOperator:
-    enabled: "true"
-    abs:
-      storageAccount: "pico-bello"
-      storageKey: "123-456-3245-a23b"
+    username: ""
 `
 			installationData := NewInstallationDataCreator().
 				WithDomain("kyma.local").
@@ -120,8 +123,10 @@ etcd-operator:
 				WithEtcdOperator("true", "pico-bello", "123-456-3245-a23b").
 				GetData()
 
-			overrides, err := GetCoreOverrides(&installationData)
+			overridesMap, err := GetCoreOverrides(&installationData)
+			So(err, ShouldBeNil)
 
+			overrides, err := ToYaml(overridesMap)
 			So(err, ShouldBeNil)
 			So(overrides, ShouldEqual, dummyOverridesForCore)
 		})

--- a/components/installer/pkg/overrides/generic-overrides.go
+++ b/components/installer/pkg/overrides/generic-overrides.go
@@ -6,12 +6,12 @@ import (
 	"github.com/ghodss/yaml"
 )
 
-//OverridesMap is a map of overrides. Values in the map can be nested maps (of the same type) or strings
-type OverridesMap map[string]interface{}
+//Map is a map of overrides. Values in the map can be nested maps (of the same type) or strings
+type Map map[string]interface{}
 
-//ToMap converts yaml to OverridesMap. Supports only map-like yamls (no lists!)
-func ToMap(value string) (OverridesMap, error) {
-	target := OverridesMap{}
+//ToMap converts yaml to Map. Supports only map-like yamls (no lists!)
+func ToMap(value string) (Map, error) {
+	target := Map{}
 
 	if value == "" {
 		//Otherwise, nil Map is returned by yaml.Unmarshal
@@ -25,8 +25,8 @@ func ToMap(value string) (OverridesMap, error) {
 	return target, nil
 }
 
-//ToYaml converts OverridesMap to YAML
-func ToYaml(oMap OverridesMap) (string, error) {
+//ToYaml converts Map to YAML
+func ToYaml(oMap Map) (string, error) {
 	if len(oMap) == 0 {
 		return "", nil
 	}
@@ -38,16 +38,16 @@ func ToYaml(oMap OverridesMap) (string, error) {
 	return string(res), nil
 }
 
-//Flattens an OverridesMap into a map of aggregated keys and value (to entries like, for example: "istio.ingress.service.gateway: xyz")
-func FlattenMap(oMap OverridesMap) map[string]string {
+//FlattenMap flattens an Map into a map of aggregated keys and value (to entries like, for example: "istio.ingress.service.gateway: xyz")
+func FlattenMap(oMap Map) map[string]string {
 	res := map[string]string{}
 	flattenMap(oMap, "", res)
 	return res
 }
 
-//UnflattenMap converts external "flat" overrides into OverridesMap. Opposite of FlattenMap function.
-func UnflattenMap(sourceMap map[string]string) OverridesMap {
-	mergedMap := OverridesMap{}
+//UnflattenMap converts external "flat" overrides into Map. Opposite of FlattenMap function.
+func UnflattenMap(sourceMap map[string]string) Map {
+	mergedMap := Map{}
 	if len(sourceMap) == 0 {
 		return mergedMap
 	}
@@ -63,7 +63,7 @@ func UnflattenMap(sourceMap map[string]string) OverridesMap {
 //MergeMaps merges all values from overridesMap map into baseMap, adding and/or overwriting final keys (string values) if both maps contain such entries.
 //baseMap WILL be modified during merge.
 //overridesMap won't be modified by future merges, since a deep-copy of it's nested maps are used for merging such nested maps.
-func MergeMaps(baseMap, overridesMap OverridesMap) {
+func MergeMaps(baseMap, overridesMap Map) {
 
 	//Helper function to deep-copy nested maps
 	putValueToMap := func(baseMap map[string]interface{}, key string, overrideVal interface{}) {
@@ -119,8 +119,8 @@ func deepCopyMap(src map[string]interface{}) map[string]interface{} {
 	return dst
 }
 
-// Flattens given OverridesMap. The keys in result map will contain all intermediate keys joined with dots, e.g.: "istio.ingress.service.gateway: xyz"
-func flattenMap(oMap OverridesMap, keys string, result map[string]string) {
+// Flattens given Map. The keys in result map will contain all intermediate keys joined with dots, e.g.: "istio.ingress.service.gateway: xyz"
+func flattenMap(oMap Map, keys string, result map[string]string) {
 
 	var prefix string
 
@@ -144,7 +144,7 @@ func flattenMap(oMap OverridesMap, keys string, result map[string]string) {
 }
 
 //Merges value into given map, introducing intermediate "nested" maps for every intermediate key.
-func mergeIntoMap(keys []string, value string, dstMap OverridesMap) {
+func mergeIntoMap(keys []string, value string, dstMap Map) {
 	currentKey := keys[0]
 	//Last key points directly to string value
 	if len(keys) == 1 {
@@ -153,10 +153,10 @@ func mergeIntoMap(keys []string, value string, dstMap OverridesMap) {
 	}
 
 	//All keys but the last one should point to a nested map
-	nestedMap, isMap := dstMap[currentKey].(OverridesMap)
+	nestedMap, isMap := dstMap[currentKey].(Map)
 
 	if !isMap {
-		nestedMap = OverridesMap{}
+		nestedMap = Map{}
 		dstMap[currentKey] = nestedMap
 	}
 

--- a/components/installer/pkg/overrides/generic-overrides.go
+++ b/components/installer/pkg/overrides/generic-overrides.go
@@ -1,0 +1,164 @@
+package overrides
+
+import (
+	"strings"
+
+	"github.com/ghodss/yaml"
+)
+
+//OverridesMap is a map of overrides. Values in the map can be nested maps (of the same type) or strings
+type OverridesMap map[string]interface{}
+
+//ToMap converts yaml to OverridesMap. Supports only map-like yamls (no lists!)
+func ToMap(value string) (OverridesMap, error) {
+	target := OverridesMap{}
+
+	if value == "" {
+		//Otherwise, nil Map is returned by yaml.Unmarshal
+		return target, nil
+	}
+
+	err := yaml.Unmarshal([]byte(value), &target)
+	if err != nil {
+		return nil, err
+	}
+	return target, nil
+}
+
+//ToYaml converts OverridesMap to YAML
+func ToYaml(oMap OverridesMap) (string, error) {
+	if len(oMap) == 0 {
+		return "", nil
+	}
+
+	res, err := yaml.Marshal(oMap)
+	if err != nil {
+		return "", err
+	}
+	return string(res), nil
+}
+
+//Flattens an OverridesMap into a map of aggregated keys and value (to entries like, for example: "istio.ingress.service.gateway: xyz")
+func FlattenMap(oMap OverridesMap) map[string]string {
+	res := map[string]string{}
+	flattenMap(oMap, "", res)
+	return res
+}
+
+//UnflattenMap converts external "flat" overrides into OverridesMap. Opposite of FlattenMap function.
+func UnflattenMap(sourceMap map[string]string) OverridesMap {
+	mergedMap := OverridesMap{}
+	if len(sourceMap) == 0 {
+		return mergedMap
+	}
+
+	for key, value := range sourceMap {
+		keys := strings.Split(key, ".")
+		mergeIntoMap(keys, value, mergedMap)
+	}
+
+	return mergedMap
+}
+
+//MergeMaps merges all values from overridesMap map into baseMap, adding and/or overwriting final keys (string values) if both maps contain such entries.
+//baseMap WILL be modified during merge.
+//overridesMap won't be modified by future merges, since a deep-copy of it's nested maps are used for merging such nested maps.
+func MergeMaps(baseMap, overridesMap OverridesMap) {
+
+	//Helper function to deep-copy nested maps
+	putValueToMap := func(baseMap map[string]interface{}, key string, overrideVal interface{}) {
+		overrideValMap, overrideIsMap := overrideVal.(map[string]interface{})
+		if overrideIsMap {
+			baseMap[key] = deepCopyMap(overrideValMap)
+		} else {
+			baseMap[key] = overrideVal
+		}
+	}
+
+	for key, overrideVal := range overridesMap {
+		//Can be nil
+		baseVal := baseMap[key]
+
+		baseMapVal, baseIsMap := baseVal.(map[string]interface{})
+		ovrrMapVal, newIsMap := overrideVal.(map[string]interface{})
+
+		if baseIsMap && newIsMap {
+			//Two maps case! Reccursion happens here!
+			MergeMaps(baseMapVal, ovrrMapVal)
+		} else {
+			//All other cases, even "pathological" one, when baseMap[key] is a map and overrideVal is a string.
+			putValueToMap(baseMap, key, overrideVal)
+		}
+	}
+
+}
+
+//Recursively copies the map. Used to ensure immutability of input maps when merging.
+func deepCopyMap(src map[string]interface{}) map[string]interface{} {
+	dst := map[string]interface{}{}
+
+	//Helper recursive function
+	var cp func(src map[string]interface{}, dst map[string]interface{})
+
+	cp = func(src map[string]interface{}, dst map[string]interface{}) {
+		for key, value := range src {
+
+			nestedMap, isMap := value.(map[string]interface{})
+			if isMap {
+				//Nested map!
+				nestedCopy := map[string]interface{}{}
+				cp(nestedMap, nestedCopy)
+				dst[key] = nestedCopy
+			} else {
+				dst[key] = value
+			}
+		}
+	}
+	cp(src, dst)
+
+	return dst
+}
+
+// Flattens given OverridesMap. The keys in result map will contain all intermediate keys joined with dots, e.g.: "istio.ingress.service.gateway: xyz"
+func flattenMap(oMap OverridesMap, keys string, result map[string]string) {
+
+	var prefix string
+
+	if len(keys) == 0 {
+		prefix = ""
+	} else {
+		prefix = keys + "."
+	}
+
+	for key, value := range oMap {
+
+		aString, isString := value.(string)
+		if isString {
+			result[prefix+key] = aString
+		} else {
+			//Nested map!
+			nestedMap := value.(map[string]interface{})
+			flattenMap(nestedMap, prefix+key, result)
+		}
+	}
+}
+
+//Merges value into given map, introducing intermediate "nested" maps for every intermediate key.
+func mergeIntoMap(keys []string, value string, dstMap OverridesMap) {
+	currentKey := keys[0]
+	//Last key points directly to string value
+	if len(keys) == 1 {
+		dstMap[currentKey] = value
+		return
+	}
+
+	//All keys but the last one should point to a nested map
+	nestedMap, isMap := dstMap[currentKey].(OverridesMap)
+
+	if !isMap {
+		nestedMap = OverridesMap{}
+		dstMap[currentKey] = nestedMap
+	}
+
+	mergeIntoMap(keys[1:], value, nestedMap)
+}

--- a/components/installer/pkg/overrides/generic-overrides_test.go
+++ b/components/installer/pkg/overrides/generic-overrides_test.go
@@ -1,0 +1,345 @@
+package overrides
+
+import (
+	"strings"
+	"testing"
+
+	. "github.com/smartystreets/goconvey/convey"
+)
+
+func TestGenericOverrides(t *testing.T) {
+
+	Convey("GenericOverrides", t, func() {
+
+		Convey("MergeMaps function", func() {
+
+			Convey("Should merge two maps with non-overlapping keys", func() {
+				const base = `
+a:
+  b:
+    j: "100"
+    k: "200"
+    l: "300"
+`
+				const override = `
+p:
+  q:
+    x1: "1100"
+    y1: "2100"
+    z1: "3100"
+`
+				const expected = `
+a:
+  b:
+    j: "100"
+    k: "200"
+    l: "300"
+p:
+  q:
+    x1: "1100"
+    y1: "2100"
+    z1: "3100"
+`
+				baseMap, err := ToMap(base)
+				So(err, ShouldBeNil)
+
+				overrideMap, err := ToMap(override)
+				So(err, ShouldBeNil)
+
+				MergeMaps(baseMap, overrideMap)
+				res, err := ToYaml(baseMap)
+				So(err, ShouldBeNil)
+				So(res, ShouldEqual, nlnl(expected))
+			})
+
+			Convey("Should merge two maps with overlapping keys", func() {
+				const base = `
+a:
+  b:
+    j: "100"
+    k: "200"
+    l: 300
+`
+				const override = `
+a:
+  b:
+    i: "1100"
+    j: 100
+    k:
+      x1: foo
+      y1:
+        z1: bar
+    l: "300"
+
+`
+				const expected = `
+a:
+  b:
+    i: "1100"
+    j: 100
+    k:
+      x1: foo
+      y1:
+        z1: bar
+    l: "300"
+`
+				baseMap, err := ToMap(base)
+				So(err, ShouldBeNil)
+
+				overrideMap, err := ToMap(override)
+				So(err, ShouldBeNil)
+
+				MergeMaps(baseMap, overrideMap)
+				res, err := ToYaml(baseMap)
+				So(err, ShouldBeNil)
+				So(res, ShouldEqual, nlnl(expected))
+			})
+
+			Convey("Should merge non-empty map with an empty one", func() {
+				const base = `
+a:
+  b:
+    j: "100"
+    k: 200
+    l: abc
+`
+				const expected = `
+a:
+  b:
+    j: "100"
+    k: 200
+    l: abc
+`
+				baseMap, err := ToMap(base)
+				So(err, ShouldBeNil)
+
+				emptyMap, err := ToMap("")
+				So(err, ShouldBeNil)
+				So(len(emptyMap), ShouldEqual, 0)
+
+				MergeMaps(baseMap, emptyMap)
+				res, err := ToYaml(baseMap)
+				So(err, ShouldBeNil)
+				So(res, ShouldEqual, nlnl(expected))
+			})
+
+			Convey("Should merge empty map with non-empty one", func() {
+				const override = `
+a:
+  b:
+    j: "100"
+    k: 200
+    l: abc
+`
+				const expected = `
+a:
+  b:
+    j: "100"
+    k: 200
+    l: abc
+`
+				baseMap, err := ToMap("")
+				So(err, ShouldBeNil)
+				So(len(baseMap), ShouldEqual, 0)
+
+				overrideMap, err := ToMap(override)
+				So(err, ShouldBeNil)
+
+				MergeMaps(baseMap, overrideMap)
+				res, err := ToYaml(baseMap)
+				So(err, ShouldBeNil)
+				So(res, ShouldEqual, nlnl(expected))
+			})
+		})
+
+		Convey("ToYaml function", func() {
+
+			Convey("Should not fail for empty map", func() {
+
+				inputMap := map[string]string{}
+				res, err := ToYaml(UnflattenMap(inputMap))
+				So(err, ShouldBeNil)
+				So(res, ShouldBeBlank)
+			})
+
+			Convey("Should merge several entries into one yaml", func() {
+
+				const expected = `
+a:
+  b:
+    c: "100"
+    d: "200"
+    e: "300"
+`
+				inputMap := map[string]string{}
+				inputMap["a.b.c"] = "100"
+				inputMap["a.b.d"] = "200"
+				inputMap["a.b.e"] = "300"
+				res, err := ToYaml(UnflattenMap(inputMap))
+				So(err, ShouldBeNil)
+				So(res, ShouldEqual, nlnl(expected))
+			})
+
+			Convey("Should handle multi-line string correctly", func() {
+
+				const expected = `
+a:
+  b:
+    c: "100"
+    d: "200"
+    e: |
+      300
+      400
+      500
+`
+				inputMap := map[string]string{}
+				inputMap["a.b.c"] = "100"
+				inputMap["a.b.d"] = "200"
+				inputMap["a.b.e"] = "300\n400\n500\n"
+
+				res, err := ToYaml(UnflattenMap(inputMap))
+				So(err, ShouldBeNil)
+				So(res, ShouldEqual, nlnl(expected))
+			})
+
+			Convey("Should handle global values", func() {
+
+				const expected = `
+a:
+  b:
+    c: "100"
+    d: "200"
+    e: "300"
+global:
+  foo: bar
+h:
+  o:
+    o: xyz
+`
+				inputMap := map[string]string{}
+				inputMap["a.b.c"] = "100"
+				inputMap["a.b.d"] = "200"
+				inputMap["a.b.e"] = "300"
+				inputMap["global.foo"] = "bar"
+				inputMap["h.o.o"] = "xyz"
+
+				res, err := ToYaml(UnflattenMap(inputMap))
+				So(err, ShouldBeNil)
+				So(res, ShouldEqual, nlnl(expected))
+			})
+
+		})
+
+		Convey("ToMap function", func() {
+			Convey("Should unmarshall yaml into a map", func() {
+				const value = `
+a:
+  b:
+    c: "100"
+    d: "200"
+    e: "300"
+`
+				res, err := ToMap(value)
+				So(err, ShouldBeNil)
+
+				a, ok := res["a"].(map[string]interface{})
+				So(ok, ShouldBeTrue)
+
+				b, ok := a["b"].(map[string]interface{})
+				So(ok, ShouldBeTrue)
+
+				c, ok := b["c"].(string)
+				So(ok, ShouldBeTrue)
+				So(c, ShouldEqual, "100")
+
+				d, ok := b["d"].(string)
+				So(ok, ShouldBeTrue)
+				So(d, ShouldEqual, "200")
+
+				e, ok := b["e"].(string)
+				So(ok, ShouldBeTrue)
+				So(e, ShouldEqual, "300")
+			})
+
+		})
+
+		Convey("FlattenMap function", func() {
+
+			Convey("Should flatten the map", func() {
+				const value = `
+a:
+  b:
+    c: "100"
+    d: "200"
+    e: "300"
+`
+				oMap, err := ToMap(value)
+				So(err, ShouldBeNil)
+
+				res := FlattenMap(oMap)
+				So(len(res), ShouldEqual, 3)
+				So(res["a.b.c"], ShouldEqual, "100")
+				So(res["a.b.d"], ShouldEqual, "200")
+				So(res["a.b.e"], ShouldEqual, "300")
+			})
+		})
+
+		Convey("copyMap function", func() {
+
+			Convey("Should copy nested map(s)", func() {
+				const value = `
+a:
+  b:
+    c: 100
+    d:
+      e: "200"
+`
+				src, err := ToMap(value)
+				So(err, ShouldBeNil)
+
+				srcA, isMap := src["a"].(map[string]interface{})
+				So(isMap, ShouldBeTrue)
+
+				srcB, isMap := srcA["b"].(map[string]interface{})
+				So(isMap, ShouldBeTrue)
+
+				srcD, isMap := srcB["d"].(map[string]interface{})
+				So(isMap, ShouldBeTrue)
+
+				copy := deepCopyMap(src)
+
+				copyA, isMap := copy["a"].(map[string]interface{})
+				So(isMap, ShouldBeTrue)
+
+				copyB, isMap := copyA["b"].(map[string]interface{})
+				So(isMap, ShouldBeTrue)
+
+				copyD, isMap := copyB["d"].(map[string]interface{})
+				So(isMap, ShouldBeTrue)
+
+				//copy and src should be equal
+				So(srcB["c"], ShouldEqual, 100)
+				So(copyB["c"], ShouldEqual, 100)
+
+				So(srcD["e"], ShouldEqual, "200")
+				So(copyD["e"], ShouldEqual, "200")
+
+				//once we modify the copy...
+				newD := map[string]interface{}{}
+				newD["e"] = 500
+				copyB["d"] = newD
+
+				//source shoud stay the same, copy should be changed
+				srcD, _ = srcB["d"].(map[string]interface{})
+				copyD, _ = copyB["d"].(map[string]interface{})
+				So(srcD["e"], ShouldEqual, "200")
+				So(copyD["e"], ShouldEqual, 500)
+			})
+		})
+	})
+}
+
+//nlnl == [n]o [l]eading [n]ew [l]ine
+func nlnl(s string) string {
+	return strings.TrimLeft(s, "\n")
+}

--- a/components/installer/pkg/overrides/global.go
+++ b/components/installer/pkg/overrides/global.go
@@ -31,7 +31,7 @@ global:
 `
 
 // GetGlobalOverrides .
-func GetGlobalOverrides(installationData *config.InstallationData) (OverridesMap, error) {
+func GetGlobalOverrides(installationData *config.InstallationData) (Map, error) {
 
 	tmpl, err := template.New("").Parse(globalsTplStr)
 	if err != nil {

--- a/components/installer/pkg/overrides/global.go
+++ b/components/installer/pkg/overrides/global.go
@@ -31,18 +31,18 @@ global:
 `
 
 // GetGlobalOverrides .
-func GetGlobalOverrides(installationData *config.InstallationData) (string, error) {
+func GetGlobalOverrides(installationData *config.InstallationData) (OverridesMap, error) {
 
 	tmpl, err := template.New("").Parse(globalsTplStr)
 	if err != nil {
-		return "", err
+		return nil, err
 	}
 
 	buf := new(bytes.Buffer)
 	err = tmpl.Execute(buf, installationData)
 	if err != nil {
-		return "", err
+		return nil, err
 	}
 
-	return buf.String(), nil
+	return ToMap(buf.String())
 }

--- a/components/installer/pkg/overrides/global_test.go
+++ b/components/installer/pkg/overrides/global_test.go
@@ -10,152 +10,160 @@ import (
 func TestGetGlobalOverrides(t *testing.T) {
 	Convey("GetGlobalOverrides", t, func() {
 		Convey("when IP address is not specified IsLocalEnv should be true", func() {
-			const dummyOverridesForGlobal = `
-global:
-  tlsCrt: ""
-  tlsKey: ""
-  isLocalEnv: true
-  domainName: "kyma.local"
-  remoteEnvCa: ""
-  remoteEnvCaKey: ""
-  istio:
-    tls:
-      secretName: "istio-ingress-certs"
-  etcdBackupABS:
-    containerName: ""
+
+			const dummyOverridesForGlobal = `global:
   alertTools:
     credentials:
-      victorOps:
-        routingkey: ""
-        apikey: ""
       slack:
-        channel: ""
         apiurl: ""
+        channel: ""
+      victorOps:
+        apikey: ""
+        routingkey: ""
+  domainName: kyma.local
+  etcdBackupABS:
+    containerName: ""
+  isLocalEnv: true
+  istio:
+    tls:
+      secretName: istio-ingress-certs
+  remoteEnvCa: ""
+  remoteEnvCaKey: ""
+  tlsCrt: ""
+  tlsKey: ""
 `
 
 			installData := NewInstallationDataCreator().WithDomain("kyma.local").WithLocalInstallation().GetData()
 
-			overrides, err := GetGlobalOverrides(&installData)
+			overridesMap, err := GetGlobalOverrides(&installData)
+			So(err, ShouldBeNil)
 
+			overrides, err := ToYaml(overridesMap)
 			So(err, ShouldBeNil)
 			So(overrides, ShouldEqual, dummyOverridesForGlobal)
 		})
 
 		Convey("when IP address is specified IsLocalEnv should be false", func() {
-			const dummyOverridesForGlobal = `
-global:
-  tlsCrt: ""
-  tlsKey: ""
-  isLocalEnv: false
-  domainName: "kyma.local"
-  remoteEnvCa: ""
-  remoteEnvCaKey: ""
-  istio:
-    tls:
-      secretName: "istio-ingress-certs"
-  etcdBackupABS:
-    containerName: ""
+
+			const dummyOverridesForGlobal = `global:
   alertTools:
     credentials:
-      victorOps:
-        routingkey: ""
-        apikey: ""
       slack:
-        channel: ""
         apiurl: ""
+        channel: ""
+      victorOps:
+        apikey: ""
+        routingkey: ""
+  domainName: kyma.local
+  etcdBackupABS:
+    containerName: ""
+  isLocalEnv: false
+  istio:
+    tls:
+      secretName: istio-ingress-certs
+  remoteEnvCa: ""
+  remoteEnvCaKey: ""
+  tlsCrt: ""
+  tlsKey: ""
 `
 			installData := NewInstallationDataCreator().WithDomain("kyma.local").WithIP("100.100.100.100").GetData()
 
-			overrides, err := GetGlobalOverrides(&installData)
+			overridesMap, err := GetGlobalOverrides(&installData)
+			So(err, ShouldBeNil)
 
+			overrides, err := ToYaml(overridesMap)
 			So(err, ShouldBeNil)
 			So(overrides, ShouldEqual, dummyOverridesForGlobal)
 		})
 
 		Convey("when cert properties are provided tlsCrt and tlsKey should exist", func() {
-			const dummyOverridesForGlobal = `
-global:
-  tlsCrt: "abc"
-  tlsKey: "def"
-  isLocalEnv: false
-  domainName: "kyma.local"
-  remoteEnvCa: ""
-  remoteEnvCaKey: ""
-  istio:
-    tls:
-      secretName: "istio-ingress-certs"
-  etcdBackupABS:
-    containerName: ""
+
+			const dummyOverridesForGlobal = `global:
   alertTools:
     credentials:
-      victorOps:
-        routingkey: ""
-        apikey: ""
       slack:
-        channel: ""
         apiurl: ""
+        channel: ""
+      victorOps:
+        apikey: ""
+        routingkey: ""
+  domainName: kyma.local
+  etcdBackupABS:
+    containerName: ""
+  isLocalEnv: false
+  istio:
+    tls:
+      secretName: istio-ingress-certs
+  remoteEnvCa: ""
+  remoteEnvCaKey: ""
+  tlsCrt: abc
+  tlsKey: def
 `
 			installData := NewInstallationDataCreator().WithDomain("kyma.local").WithIP("100.100.100.100").WithCert("abc", "def").GetData()
 
-			overrides, err := GetGlobalOverrides(&installData)
+			overridesMap, err := GetGlobalOverrides(&installData)
+			So(err, ShouldBeNil)
 
+			overrides, err := ToYaml(overridesMap)
 			So(err, ShouldBeNil)
 			So(overrides, ShouldEqual, dummyOverridesForGlobal)
 		})
 
 		Convey("when remote env CA property is provided remoteEnvCa should exist", func() {
-			const dummyOverridesForGlobal = `
-global:
-  tlsCrt: ""
-  tlsKey: ""
-  isLocalEnv: false
-  domainName: "kyma.local"
-  remoteEnvCa: "xyz"
-  remoteEnvCaKey: "abc"
-  istio:
-    tls:
-      secretName: "istio-ingress-certs"
-  etcdBackupABS:
-    containerName: ""
+
+			const dummyOverridesForGlobal = `global:
   alertTools:
     credentials:
-      victorOps:
-        routingkey: ""
-        apikey: ""
       slack:
-        channel: ""
         apiurl: ""
+        channel: ""
+      victorOps:
+        apikey: ""
+        routingkey: ""
+  domainName: kyma.local
+  etcdBackupABS:
+    containerName: ""
+  isLocalEnv: false
+  istio:
+    tls:
+      secretName: istio-ingress-certs
+  remoteEnvCa: xyz
+  remoteEnvCaKey: abc
+  tlsCrt: ""
+  tlsKey: ""
 `
 			installData := NewInstallationDataCreator().WithDomain("kyma.local").WithIP("100.100.100.100").WithRemoteEnvCa("xyz").WithRemoteEnvCaKey("abc").GetData()
 
-			overrides, err := GetGlobalOverrides(&installData)
+			overridesMap, err := GetGlobalOverrides(&installData)
+			So(err, ShouldBeNil)
 
+			overrides, err := ToYaml(overridesMap)
 			So(err, ShouldBeNil)
 			So(overrides, ShouldEqual, dummyOverridesForGlobal)
 		})
 
 		Convey("when EtcdBackupABSContainerName property is provided then etcdBackupABS.containerName should exist", func() {
-			const dummyOverridesForGlobal = `
-global:
-  tlsCrt: ""
-  tlsKey: ""
-  isLocalEnv: false
-  domainName: "kyma.local"
-  remoteEnvCa: ""
-  remoteEnvCaKey: ""
-  istio:
-    tls:
-      secretName: "istio-ingress-certs"
-  etcdBackupABS:
-    containerName: "abs/container/name"
+
+			const dummyOverridesForGlobal = `global:
   alertTools:
     credentials:
-      victorOps:
-        routingkey: ""
-        apikey: ""
       slack:
-        channel: ""
         apiurl: ""
+        channel: ""
+      victorOps:
+        apikey: ""
+        routingkey: ""
+  domainName: kyma.local
+  etcdBackupABS:
+    containerName: abs/container/name
+  isLocalEnv: false
+  istio:
+    tls:
+      secretName: istio-ingress-certs
+  remoteEnvCa: ""
+  remoteEnvCaKey: ""
+  tlsCrt: ""
+  tlsKey: ""
 `
 			installData := NewInstallationDataCreator().
 				WithDomain("kyma.local").
@@ -163,34 +171,35 @@ global:
 				WithEtcdBackupABSContainerName("abs/container/name").
 				GetData()
 
-			overrides, err := GetGlobalOverrides(&installData)
-
+			overridesMap, err := GetGlobalOverrides(&installData)
+			So(err, ShouldBeNil)
+			overrides, err := ToYaml(overridesMap)
 			So(err, ShouldBeNil)
 			So(overrides, ShouldEqual, dummyOverridesForGlobal)
 		})
 
 		Convey("when slack and victorops credentials are provided then alertTools.credentials.victorOps and alertTools.credentials.slack should exist", func() {
-			const dummyOverridesForGlobal = `
-global:
-  tlsCrt: ""
-  tlsKey: ""
-  isLocalEnv: false
-  domainName: "kyma.local"
-  remoteEnvCa: ""
-  remoteEnvCaKey: ""
-  istio:
-    tls:
-      secretName: "istio-ingress-certs"
-  etcdBackupABS:
-    containerName: ""
+
+			const dummyOverridesForGlobal = `global:
   alertTools:
     credentials:
-      victorOps:
-        routingkey: "victorops_routing_key"
-        apikey: "victorops_api_key"
       slack:
-        channel: "slack_channel"
-        apiurl: "slack_apiurl"
+        apiurl: slack_apiurl
+        channel: slack_channel
+      victorOps:
+        apikey: victorops_api_key
+        routingkey: victorops_routing_key
+  domainName: kyma.local
+  etcdBackupABS:
+    containerName: ""
+  isLocalEnv: false
+  istio:
+    tls:
+      secretName: istio-ingress-certs
+  remoteEnvCa: ""
+  remoteEnvCaKey: ""
+  tlsCrt: ""
+  tlsKey: ""
 `
 			installData := NewInstallationDataCreator().
 				WithDomain("kyma.local").
@@ -199,8 +208,10 @@ global:
 				WithSlackCredentials("slack_channel", "slack_apiurl").
 				GetData()
 
-			overrides, err := GetGlobalOverrides(&installData)
+			overridesMap, err := GetGlobalOverrides(&installData)
+			So(err, ShouldBeNil)
 
+			overrides, err := ToYaml(overridesMap)
 			So(err, ShouldBeNil)
 			So(overrides, ShouldEqual, dummyOverridesForGlobal)
 		})

--- a/components/installer/pkg/overrides/istio.go
+++ b/components/installer/pkg/overrides/istio.go
@@ -14,9 +14,9 @@ ingressgateway:
 `
 
 // GetIstioOverrides returns values overrides for istio ingressgateway
-func GetIstioOverrides(installationData *config.InstallationData) (OverridesMap, error) {
+func GetIstioOverrides(installationData *config.InstallationData) (Map, error) {
 	if hasIPAddress(installationData) == false {
-		return OverridesMap{}, nil
+		return Map{}, nil
 	}
 
 	tmpl, err := template.New("").Parse(istioTplStr)

--- a/components/installer/pkg/overrides/istio.go
+++ b/components/installer/pkg/overrides/istio.go
@@ -14,23 +14,23 @@ ingressgateway:
 `
 
 // GetIstioOverrides returns values overrides for istio ingressgateway
-func GetIstioOverrides(installationData *config.InstallationData) (string, error) {
+func GetIstioOverrides(installationData *config.InstallationData) (OverridesMap, error) {
 	if hasIPAddress(installationData) == false {
-		return "", nil
+		return OverridesMap{}, nil
 	}
 
 	tmpl, err := template.New("").Parse(istioTplStr)
 	if err != nil {
-		return "", err
+		return nil, err
 	}
 
 	buf := new(bytes.Buffer)
 	bErr := tmpl.Execute(buf, installationData)
 	if bErr != nil {
-		return "", err
+		return nil, err
 	}
 
-	return buf.String(), nil
+	return ToMap(buf.String())
 }
 
 func hasIPAddress(installationData *config.InstallationData) bool {

--- a/components/installer/pkg/overrides/istio_test.go
+++ b/components/installer/pkg/overrides/istio_test.go
@@ -19,14 +19,14 @@ func TestGetIstioOverrides(t *testing.T) {
 		})
 
 		Convey("when IP address is specified should contain yaml", func() {
-			const dummyOverridesForIstio = `
-ingressgateway:
+			const dummyOverridesForIstio = `ingressgateway:
   service:
     externalPublicIp: 100.100.100.100
 `
 			installationData := NewInstallationDataCreator().WithIP("100.100.100.100").GetData()
-			overrides, err := GetIstioOverrides(&installationData)
-
+			overridesMap, err := GetIstioOverrides(&installationData)
+			So(err, ShouldBeNil)
+			overrides, err := ToYaml(overridesMap)
 			So(err, ShouldBeNil)
 			So(overrides, ShouldEqual, dummyOverridesForIstio)
 		})

--- a/components/installer/pkg/overrides/remote-environment.go
+++ b/components/installer/pkg/overrides/remote-environment.go
@@ -19,11 +19,11 @@ service:
 `
 
 // GetHmcDefaultOverrides returns values overrides for hmc default remote environment
-func GetHmcDefaultOverrides() (OverridesMap, error) {
+func GetHmcDefaultOverrides() (Map, error) {
 	return ToMap(hmcDefault)
 }
 
 // GetEcDefaultOverrides returns values overrides for ec default remote environment
-func GetEcDefaultOverrides() (OverridesMap, error) {
+func GetEcDefaultOverrides() (Map, error) {
 	return ToMap(ecDefault)
 }

--- a/components/installer/pkg/overrides/remote-environment.go
+++ b/components/installer/pkg/overrides/remote-environment.go
@@ -19,11 +19,11 @@ service:
 `
 
 // GetHmcDefaultOverrides returns values overrides for hmc default remote environment
-func GetHmcDefaultOverrides() string {
-	return hmcDefault
+func GetHmcDefaultOverrides() (OverridesMap, error) {
+	return ToMap(hmcDefault)
 }
 
 // GetEcDefaultOverrides returns values overrides for ec default remote environment
-func GetEcDefaultOverrides() string {
-	return ecDefault
+func GetEcDefaultOverrides() (OverridesMap, error) {
+	return ToMap(ecDefault)
 }

--- a/components/installer/pkg/overrides/static-file.go
+++ b/components/installer/pkg/overrides/static-file.go
@@ -10,7 +10,7 @@ import (
 // StaticFile interface defines contract for overrides file representation
 type StaticFile interface {
 	HasOverrides() bool
-	GetOverrides() (*string, error)
+	GetOverrides() (OverridesMap, error)
 }
 
 // LocalStaticFile struct defines static file overrides for local
@@ -27,8 +27,8 @@ func (localStaticFile *LocalStaticFile) HasOverrides() bool {
 }
 
 // GetOverrides .
-func (localStaticFile *LocalStaticFile) GetOverrides() (*string, error) {
-	return nil, nil
+func (localStaticFile *LocalStaticFile) GetOverrides() (OverridesMap, error) {
+	return OverridesMap{}, nil
 }
 
 // ClusterStaticFile struct defines static file overrides for cluster
@@ -57,7 +57,7 @@ func (clusterStaticFile *ClusterStaticFile) HasOverrides() bool {
 }
 
 // GetOverrides function reads cluster overrides file and returns its content
-func (clusterStaticFile *ClusterStaticFile) GetOverrides() (*string, error) {
+func (clusterStaticFile *ClusterStaticFile) GetOverrides() (OverridesMap, error) {
 	fileBytes, err := ioutil.ReadFile(clusterStaticFile.getFilePath())
 
 	if err != nil {
@@ -68,9 +68,7 @@ func (clusterStaticFile *ClusterStaticFile) GetOverrides() (*string, error) {
 		return nil, err
 	}
 
-	overridesStr := string(fileBytes)
-
-	return &overridesStr, nil
+	return ToMap(string(fileBytes))
 }
 
 func (clusterStaticFile *ClusterStaticFile) getFilePath() string {

--- a/components/installer/pkg/overrides/static-file.go
+++ b/components/installer/pkg/overrides/static-file.go
@@ -10,7 +10,7 @@ import (
 // StaticFile interface defines contract for overrides file representation
 type StaticFile interface {
 	HasOverrides() bool
-	GetOverrides() (OverridesMap, error)
+	GetOverrides() (Map, error)
 }
 
 // LocalStaticFile struct defines static file overrides for local
@@ -27,8 +27,8 @@ func (localStaticFile *LocalStaticFile) HasOverrides() bool {
 }
 
 // GetOverrides .
-func (localStaticFile *LocalStaticFile) GetOverrides() (OverridesMap, error) {
-	return OverridesMap{}, nil
+func (localStaticFile *LocalStaticFile) GetOverrides() (Map, error) {
+	return Map{}, nil
 }
 
 // ClusterStaticFile struct defines static file overrides for cluster
@@ -57,7 +57,7 @@ func (clusterStaticFile *ClusterStaticFile) HasOverrides() bool {
 }
 
 // GetOverrides function reads cluster overrides file and returns its content
-func (clusterStaticFile *ClusterStaticFile) GetOverrides() (OverridesMap, error) {
+func (clusterStaticFile *ClusterStaticFile) GetOverrides() (Map, error) {
 	fileBytes, err := ioutil.ReadFile(clusterStaticFile.getFilePath())
 
 	if err != nil {

--- a/components/installer/pkg/steps/cluster-essentials.go
+++ b/components/installer/pkg/steps/cluster-essentials.go
@@ -3,7 +3,6 @@ package steps
 import (
 	"log"
 	"path"
-	"strings"
 
 	"github.com/kyma-project/kyma/components/installer/pkg/config"
 	"github.com/kyma-project/kyma/components/installer/pkg/consts"
@@ -17,7 +16,12 @@ func (steps *InstallationSteps) InstallClusterEssentials(installationData *confi
 	steps.statusManager.InProgress(stepName)
 
 	chartDir := path.Join(steps.chartDir, consts.ClusterEssentialsComponent)
-	clusterEssentialsOverrides := steps.getClusterEssentialsOverrides(installationData, chartDir)
+	clusterEssentialsOverrides, err := steps.getClusterEssentialsOverrides(installationData, chartDir)
+
+	if steps.errorHandlers.CheckError("Install Overrides Error: ", err) {
+		steps.statusManager.Error(stepName)
+		return err
+	}
 
 	installResp, installErr := steps.helmClient.InstallRelease(
 		chartDir,
@@ -43,7 +47,12 @@ func (steps *InstallationSteps) UpdateClusterEssentials(installationData *config
 	steps.statusManager.InProgress(stepName)
 
 	chartDir := path.Join(steps.chartDir, consts.ClusterEssentialsComponent)
-	clusterEssentailsOverrides := steps.getClusterEssentialsOverrides(installationData, chartDir)
+	clusterEssentailsOverrides, err := steps.getClusterEssentialsOverrides(installationData, chartDir)
+
+	if steps.errorHandlers.CheckError("Upgrade Overrides Error: ", err) {
+		steps.statusManager.Error(stepName)
+		return err
+	}
 
 	upgradeResp, upgradeErr := steps.helmClient.UpgradeRelease(
 		chartDir,
@@ -61,19 +70,19 @@ func (steps *InstallationSteps) UpdateClusterEssentials(installationData *config
 	return nil
 }
 
-func (steps *InstallationSteps) getClusterEssentialsOverrides(installationData *config.InstallationData, chartDir string) string {
-	var allOverrides []string
+func (steps *InstallationSteps) getClusterEssentialsOverrides(installationData *config.InstallationData, chartDir string) (string, error) {
+	allOverrides := overrides.OverridesMap{}
 
 	globalOverrides, err := overrides.GetGlobalOverrides(installationData)
 	steps.errorHandlers.LogError("Couldn't get global overrides: ", err)
-	allOverrides = append(allOverrides, globalOverrides)
+	overrides.MergeMaps(allOverrides, globalOverrides)
 
-	fileOverrides := steps.getStaticFileOverrides(installationData, chartDir)
-	if fileOverrides.HasOverrides() == true {
-		fileOverridesStr, err := fileOverrides.GetOverrides()
+	staticOverrides := steps.getStaticFileOverrides(installationData, chartDir)
+	if staticOverrides.HasOverrides() == true {
+		fileOverrides, err := staticOverrides.GetOverrides()
 		steps.errorHandlers.LogError("Couldn't get additional overrides: ", err)
-		allOverrides = append(allOverrides, *fileOverridesStr)
+		overrides.MergeMaps(allOverrides, fileOverrides)
 	}
 
-	return strings.Join(allOverrides, "\n")
+	return overrides.ToYaml(allOverrides)
 }

--- a/components/installer/pkg/steps/cluster-essentials.go
+++ b/components/installer/pkg/steps/cluster-essentials.go
@@ -71,7 +71,7 @@ func (steps *InstallationSteps) UpdateClusterEssentials(installationData *config
 }
 
 func (steps *InstallationSteps) getClusterEssentialsOverrides(installationData *config.InstallationData, chartDir string) (string, error) {
-	allOverrides := overrides.OverridesMap{}
+	allOverrides := overrides.Map{}
 
 	globalOverrides, err := overrides.GetGlobalOverrides(installationData)
 	steps.errorHandlers.LogError("Couldn't get global overrides: ", err)

--- a/components/installer/pkg/steps/core.go
+++ b/components/installer/pkg/steps/core.go
@@ -104,7 +104,7 @@ func logFailedResources(ns string) {
 }
 
 func (steps *InstallationSteps) getCoreOverrides(installationData *config.InstallationData, chartDir string) (string, error) {
-	allOverrides := overrides.OverridesMap{}
+	allOverrides := overrides.Map{}
 
 	globalOverrides, err := overrides.GetGlobalOverrides(installationData)
 	steps.errorHandlers.LogError("Couldn't get global overrides: ", err)

--- a/components/installer/pkg/steps/dex.go
+++ b/components/installer/pkg/steps/dex.go
@@ -78,7 +78,7 @@ func (steps *InstallationSteps) UpdateDex(installationData *config.InstallationD
 
 func (steps *InstallationSteps) getDexOverrides(installationData *config.InstallationData, chartDir string) (string, error) {
 
-	allOverrides := overrides.OverridesMap{}
+	allOverrides := overrides.Map{}
 
 	globalOverrides, err := overrides.GetGlobalOverrides(installationData)
 	steps.errorHandlers.LogError("Couldn't get global overrides: ", err)

--- a/components/installer/pkg/steps/istio.go
+++ b/components/installer/pkg/steps/istio.go
@@ -72,7 +72,7 @@ func (steps *InstallationSteps) UpdateIstio(installationData *config.Installatio
 }
 
 func (steps *InstallationSteps) getIstioOverrides(installationData *config.InstallationData, chartDir string) (string, error) {
-	allOverrides := overrides.OverridesMap{}
+	allOverrides := overrides.Map{}
 
 	globalOverrides, err := overrides.GetGlobalOverrides(installationData)
 	steps.errorHandlers.LogError("Couldn't get global overrides: ", err)

--- a/components/installer/pkg/steps/prometheus.go
+++ b/components/installer/pkg/steps/prometheus.go
@@ -3,10 +3,10 @@ package steps
 import (
 	"log"
 	"path"
-	"strings"
 
 	"github.com/kyma-project/kyma/components/installer/pkg/config"
 	"github.com/kyma-project/kyma/components/installer/pkg/consts"
+	"github.com/kyma-project/kyma/components/installer/pkg/overrides"
 )
 
 //InstallPrometheus .
@@ -15,7 +15,12 @@ func (steps *InstallationSteps) InstallPrometheus(installationData *config.Insta
 	const namespace = "kyma-system"
 
 	chartDir := path.Join(steps.chartDir, consts.PrometheusComponent)
-	overrides := steps.getPrometheusOverrides(installationData, chartDir)
+	overrides, err := steps.getPrometheusOverrides(installationData, chartDir)
+
+	if steps.errorHandlers.CheckError("Install Overrides Error: ", err) {
+		steps.statusManager.Error(stepName)
+		return err
+	}
 
 	steps.PrintInstallationStep(stepName)
 	steps.statusManager.InProgress(stepName)
@@ -43,7 +48,12 @@ func (steps *InstallationSteps) UpdatePrometheus(installationData *config.Instal
 	const namespace = "kyma-system"
 
 	chartDir := path.Join(steps.chartDir, consts.PrometheusComponent)
-	overrides := steps.getPrometheusOverrides(installationData, chartDir)
+	overrides, err := steps.getPrometheusOverrides(installationData, chartDir)
+
+	if steps.errorHandlers.CheckError("Upgrade Overrides Error: ", err) {
+		steps.statusManager.Error(stepName)
+		return err
+	}
 
 	steps.PrintInstallationStep(stepName)
 	steps.statusManager.InProgress(stepName)
@@ -63,15 +73,16 @@ func (steps *InstallationSteps) UpdatePrometheus(installationData *config.Instal
 
 	return nil
 }
-func (steps *InstallationSteps) getPrometheusOverrides(installationData *config.InstallationData, chartDir string) string {
-	var allOverrides []string
+func (steps *InstallationSteps) getPrometheusOverrides(installationData *config.InstallationData, chartDir string) (string, error) {
+	//TODO: this does not get globalOverrides... Is that a problem if global will carry all external ones (overrides.yaml + from configMaps/secrets?)
+	allOverrides := overrides.OverridesMap{}
 
-	fileOverrides := steps.getStaticFileOverrides(installationData, chartDir)
-	if fileOverrides.HasOverrides() == true {
-		fileOverridesStr, err := fileOverrides.GetOverrides()
+	staticOverrides := steps.getStaticFileOverrides(installationData, chartDir)
+	if staticOverrides.HasOverrides() == true {
+		fileOverrides, err := staticOverrides.GetOverrides()
 		steps.errorHandlers.LogError("Couldn't get additional overrides: ", err)
-		allOverrides = append(allOverrides, *fileOverridesStr)
+		overrides.MergeMaps(allOverrides, fileOverrides)
 	}
 
-	return strings.Join(allOverrides, "\n")
+	return overrides.ToYaml(allOverrides)
 }

--- a/components/installer/pkg/steps/prometheus.go
+++ b/components/installer/pkg/steps/prometheus.go
@@ -75,7 +75,7 @@ func (steps *InstallationSteps) UpdatePrometheus(installationData *config.Instal
 }
 func (steps *InstallationSteps) getPrometheusOverrides(installationData *config.InstallationData, chartDir string) (string, error) {
 	//TODO: this does not get globalOverrides... Is that a problem if global will carry all external ones (overrides.yaml + from configMaps/secrets?)
-	allOverrides := overrides.OverridesMap{}
+	allOverrides := overrides.Map{}
 
 	staticOverrides := steps.getStaticFileOverrides(installationData, chartDir)
 	if staticOverrides.HasOverrides() == true {

--- a/components/installer/pkg/steps/remote-environment.go
+++ b/components/installer/pkg/steps/remote-environment.go
@@ -3,7 +3,6 @@ package steps
 import (
 	"log"
 	"path"
-	"strings"
 
 	"github.com/kyma-project/kyma/components/installer/pkg/config"
 	"github.com/kyma-project/kyma/components/installer/pkg/consts"
@@ -22,7 +21,12 @@ func (steps *InstallationSteps) InstallHmcDefaultRemoteEnvironments(installation
 
 	steps.statusManager.InProgress(stepName)
 	chartDir := path.Join(steps.chartDir, consts.RemoteEnvironments)
-	hmcOverrides := steps.getHmcOverrides(installationData, chartDir)
+	hmcOverrides, err := steps.getHmcOverrides(installationData, chartDir)
+
+	if steps.errorHandlers.CheckError("Install Overrides Error: ", err) {
+		steps.statusManager.Error(stepName)
+		return err
+	}
 
 	installErr := steps.installRemoteEnvironment(hmcRemoteEnvironmentComponent, chartDir, hmcOverrides)
 
@@ -44,7 +48,11 @@ func (steps *InstallationSteps) UpdateHmcDefaultRemoteEnvironments(installationD
 	steps.statusManager.InProgress(stepName)
 
 	chartDir := path.Join(steps.chartDir, consts.RemoteEnvironments)
-	hmcOverrides := steps.getHmcOverrides(installationData, chartDir)
+	hmcOverrides, err := steps.getHmcOverrides(installationData, chartDir)
+	if steps.errorHandlers.CheckError("Update Overrides Error: ", err) {
+		steps.statusManager.Error(stepName)
+		return err
+	}
 
 	upgradeErr := steps.updateRemoteEnvironment(hmcRemoteEnvironmentComponent, chartDir, hmcOverrides)
 
@@ -65,7 +73,12 @@ func (steps *InstallationSteps) InstallEcDefaultRemoteEnvironments(installationD
 
 	steps.statusManager.InProgress(stepName)
 	chartDir := path.Join(steps.chartDir, consts.RemoteEnvironments)
-	ecOverrides := steps.getEcOverrides(installationData, chartDir)
+	ecOverrides, err := steps.getEcOverrides(installationData, chartDir)
+
+	if steps.errorHandlers.CheckError("Install Overrides Error: ", err) {
+		steps.statusManager.Error(stepName)
+		return err
+	}
 
 	installErr := steps.installRemoteEnvironment(ecRemoteEnvironmentComponent, chartDir, ecOverrides)
 
@@ -86,7 +99,12 @@ func (steps *InstallationSteps) UpdateEcDefaultRemoteEnvironments(installationDa
 
 	steps.statusManager.InProgress(stepName)
 	chartDir := path.Join(steps.chartDir, consts.RemoteEnvironments)
-	ecOverrides := steps.getEcOverrides(installationData, chartDir)
+	ecOverrides, err := steps.getEcOverrides(installationData, chartDir)
+
+	if steps.errorHandlers.CheckError("Update Error: ", err) {
+		steps.statusManager.Error(stepName)
+		return err
+	}
 
 	upgradeErr := steps.updateRemoteEnvironment(ecRemoteEnvironmentComponent, chartDir, ecOverrides)
 
@@ -100,46 +118,47 @@ func (steps *InstallationSteps) UpdateEcDefaultRemoteEnvironments(installationDa
 	return nil
 }
 
-func (steps *InstallationSteps) getHmcOverrides(installationData *config.InstallationData, chartDir string) string {
-	var allOverrides []string
+func (steps *InstallationSteps) getHmcOverrides(installationData *config.InstallationData, chartDir string) (string, error) {
+	allOverrides := overrides.OverridesMap{}
 
 	globalOverrides, err := overrides.GetGlobalOverrides(installationData)
 	steps.errorHandlers.LogError("Couldn't get global overrides: ", err)
-	allOverrides = append(allOverrides, globalOverrides)
+	overrides.MergeMaps(allOverrides, globalOverrides)
 
-	hmcDefaultOverride := overrides.GetHmcDefaultOverrides()
+	hmcDefaultOverride, err := overrides.GetHmcDefaultOverrides()
+
 	steps.errorHandlers.LogError("Couldn't get Hmc default overrides: ", err)
-	allOverrides = append(allOverrides, hmcDefaultOverride)
+	overrides.MergeMaps(allOverrides, hmcDefaultOverride)
 
-	fileOverrides := steps.getStaticFileOverrides(installationData, chartDir)
-	if fileOverrides.HasOverrides() == true {
-		fileOverridesStr, err := fileOverrides.GetOverrides()
+	staticOverrides := steps.getStaticFileOverrides(installationData, chartDir)
+	if staticOverrides.HasOverrides() == true {
+		fileOverrides, err := staticOverrides.GetOverrides()
 		steps.errorHandlers.LogError("Couldn't get additional overrides: ", err)
-		allOverrides = append(allOverrides, *fileOverridesStr)
+		overrides.MergeMaps(allOverrides, fileOverrides)
 	}
 
-	return strings.Join(allOverrides, "\n")
+	return overrides.ToYaml(allOverrides)
 }
 
-func (steps *InstallationSteps) getEcOverrides(installationData *config.InstallationData, chartDir string) string {
-	var allOverrides []string
+func (steps *InstallationSteps) getEcOverrides(installationData *config.InstallationData, chartDir string) (string, error) {
+	allOverrides := overrides.OverridesMap{}
 
 	globalOverrides, err := overrides.GetGlobalOverrides(installationData)
 	steps.errorHandlers.LogError("Couldn't get global overrides: ", err)
-	allOverrides = append(allOverrides, globalOverrides)
+	overrides.MergeMaps(allOverrides, globalOverrides)
 
-	ecDefaultOverride := overrides.GetEcDefaultOverrides()
+	ecDefaultOverride, err := overrides.GetEcDefaultOverrides()
 	steps.errorHandlers.LogError("Couldn't get Ec default overrides: ", err)
-	allOverrides = append(allOverrides, ecDefaultOverride)
+	overrides.MergeMaps(allOverrides, ecDefaultOverride)
 
-	fileOverrides := steps.getStaticFileOverrides(installationData, chartDir)
-	if fileOverrides.HasOverrides() == true {
-		fileOverridesStr, err := fileOverrides.GetOverrides()
+	staticOverrides := steps.getStaticFileOverrides(installationData, chartDir)
+	if staticOverrides.HasOverrides() == true {
+		fileOverrides, err := staticOverrides.GetOverrides()
 		steps.errorHandlers.LogError("Couldn't get additional overrides: ", err)
-		allOverrides = append(allOverrides, *fileOverridesStr)
+		overrides.MergeMaps(allOverrides, fileOverrides)
 	}
 
-	return strings.Join(allOverrides, "\n")
+	return overrides.ToYaml(allOverrides)
 }
 
 func (steps *InstallationSteps) installRemoteEnvironment(installationName, chartDir, overrides string) error {

--- a/components/installer/pkg/steps/remote-environment.go
+++ b/components/installer/pkg/steps/remote-environment.go
@@ -119,7 +119,7 @@ func (steps *InstallationSteps) UpdateEcDefaultRemoteEnvironments(installationDa
 }
 
 func (steps *InstallationSteps) getHmcOverrides(installationData *config.InstallationData, chartDir string) (string, error) {
-	allOverrides := overrides.OverridesMap{}
+	allOverrides := overrides.Map{}
 
 	globalOverrides, err := overrides.GetGlobalOverrides(installationData)
 	steps.errorHandlers.LogError("Couldn't get global overrides: ", err)
@@ -141,7 +141,7 @@ func (steps *InstallationSteps) getHmcOverrides(installationData *config.Install
 }
 
 func (steps *InstallationSteps) getEcOverrides(installationData *config.InstallationData, chartDir string) (string, error) {
-	allOverrides := overrides.OverridesMap{}
+	allOverrides := overrides.Map{}
 
 	globalOverrides, err := overrides.GetGlobalOverrides(installationData)
 	steps.errorHandlers.LogError("Couldn't get global overrides: ", err)

--- a/installation/resources/installer.yaml
+++ b/installation/resources/installer.yaml
@@ -71,7 +71,7 @@ spec:
                 name: azure-broker
                 key: azure_broker_client_secret
                 optional: true
-          - name: TLS_CERT          
+          - name: TLS_CERT
             valueFrom:
               configMapKeyRef:
                 name: cluster-certificate

--- a/installation/resources/installer.yaml
+++ b/installation/resources/installer.yaml
@@ -44,7 +44,7 @@ spec:
       serviceAccountName: kyma-installer
       containers:
       - name: kyma-installer-container
-        image: eu.gcr.io/kyma-project/snapshot/installer:PR-240
+        image: eu.gcr.io/kyma-project/installer:0.3.195
         imagePullPolicy: IfNotPresent
         env:
           - name: AZURE_BROKER_SUBSCRIPTION_ID
@@ -71,7 +71,7 @@ spec:
                 name: azure-broker
                 key: azure_broker_client_secret
                 optional: true
-          - name: TLS_CERT
+          - name: TLS_CERT          
             valueFrom:
               configMapKeyRef:
                 name: cluster-certificate

--- a/installation/resources/installer.yaml
+++ b/installation/resources/installer.yaml
@@ -44,7 +44,7 @@ spec:
       serviceAccountName: kyma-installer
       containers:
       - name: kyma-installer-container
-        image: eu.gcr.io/kyma-project/installer:0.3.195
+        image: eu.gcr.io/kyma-project/snapshot/installer:PR-240
         imagePullPolicy: IfNotPresent
         env:
           - name: AZURE_BROKER_SUBSCRIPTION_ID


### PR DESCRIPTION
Confirm these statements before you submit your pull request:

- [x] I have read and submitted the required [Contributor Licence Agreements](https://github.com/kyma-project/community/blob/master/CONTRIBUTING.md#agreements-and-licenses).
- [x] This pull request follows the contributing guidelines, recommended Git workflow, and templates.
- [x] I have tested my changes.
- [x] I have updated the relevant documentation.
---

**Description**

This PR changes internal representation of overrides in Kyma Installer from strings to map-of-maps.
This allows deep-merges of overrides necessary to provide generic overrides mechanism.
Previous, string-based representation only allowed to concatenate strings, which resulted in entire "sub-tree" of overrides being overwritten in case of overlapping overrides.
