### PR TITLE
Fix kubeless documnetation

### DIFF
--- a/tests/kubeless-test-client/README.md
+++ b/tests/kubeless-test-client/README.md
@@ -4,4 +4,5 @@ The `kubeless-test-client` contains the following:
 * The [ns.yaml](ns.yaml) file, which specifies the `kubeless-test` namespace
 * The [k8s.yaml](k8s.yaml) file, which contains necessary resources for `test-event` and `test-hello`
 * The JavaScript files of `test-event` and `test-hello`
-* The [svcbind.yaml](svcbind.yaml) file, which specifies `test-svcbind` and its supporting Kubernetes resources, including a Redis service which the functions binds to.
+* The [svc-instance.yaml](svc-instance.yaml) file deploys the Redis service instance and service binding.
+* The [svcbind-lambda.yaml](svcbind-lambda.yaml) file, which specifies `test-svcbind` the lambda which would be used to test the service binding. This file also deploys the Service binding usage.

--- a/tests/kubeless-test-client/README.md
+++ b/tests/kubeless-test-client/README.md
@@ -5,4 +5,4 @@ The `kubeless-test-client` contains the following:
 * The [k8s.yaml](k8s.yaml) file, which contains necessary resources for `test-event` and `test-hello`
 * The JavaScript files of `test-event` and `test-hello`
 * The [svc-instance.yaml](svc-instance.yaml) file deploys the Redis service instance and service binding.
-* The [svcbind-lambda.yaml](svcbind-lambda.yaml) file, which specifies `test-svcbind` the lambda which would be used to test the service binding. This file also deploys the Service binding usage.
+* The [svcbind-lambda.yaml](svcbind-lambda.yaml) file specifies the test-svcbind lambda used to test the service binding. This file also deploys the service binding usage.


### PR DESCRIPTION
 - Fix the broken links in kubeless documentation

Confirm these statements before you submit your pull request:

- [x] I have read and submitted the required [Contributor Licence Agreements](https://github.com/kyma-project/community/blob/master/CONTRIBUTING.md#agreements-and-licenses).
- [x] This pull request follows the contributing guidelines, recommended Git workflow, and templates.
- [x] I have tested my changes.
- [x] I have updated the relevant documentation.