### PR TITLE
Fix raw content links in local deployment of sample service

### DIFF
--- a/docs/kyma/docs/033-gs-sample-service-deployment-to-local.md
+++ b/docs/kyma/docs/033-gs-sample-service-deployment-to-local.md
@@ -25,13 +25,13 @@ Follow these steps:
 1. Deploy the sample service to any of your Environments. Use the `stage` Environment for this guide:
 
    ```bash
-   kubectl create -n stage -f https://github.com/raw/kyma-project/examples/master/http-db-service/deployment/deployment.yaml
+   kubectl create -n stage -f https://raw.githubusercontent.com/kyma-project/examples/master/http-db-service/deployment/deployment.yaml
    ```
 
 2. Create an unsecured API for your example service:
 
    ```bash
-   kubectl apply -n stage -f https://github.com/raw/kyma-project/examples/master/gateway/service/api-without-auth.yaml
+   kubectl apply -n stage -f https://raw.githubusercontent.com/kyma-project/examples/master/gateway/service/api-without-auth.yaml
    ```
 
 3. Add the IP address of Minikube to the `hosts` file on your local machine for your APIs:
@@ -63,7 +63,7 @@ Follow these steps:
 Run the following command:
 
    ```bash
-   kubectl apply -n stage -f https://github.com/raw/kyma-project/examples/master/gateway/service/api-with-auth.yaml
+   kubectl apply -n stage -f https://raw.githubusercontent.com/kyma-project/examples/master/gateway/service/api-with-auth.yaml
    ```
 After you apply this update, you must include a valid bearer ID token in the Authorization header to access the service.
 


### PR DESCRIPTION
Confirm these statements before you submit your pull request:

- [x] I have read and submitted the required [Contributor Licence Agreements](https://github.com/kyma-project/community/blob/master/CONTRIBUTING.md#agreements-and-licenses).
- [x] This pull request follows the contributing guidelines, recommended Git workflow, and templates.
- [x] I have tested my changes.
- [x] I have updated the relevant documentation.
---

**Description**

Changes proposed in this pull request:
- our examples are using `httpa://github.com/raw` to access raw files on github. This is not working and recommended way is to use `https://raw.githubusercontent.com`. For example old link https://github.com/raw/kyma-project/examples/master/http-db-service/deployment/deployment.yaml leads to non existing page, while new one https://raw.githubusercontent.com/kyma-project/examples/master/http-db-service/deployment/deployment.yaml works perfectly fine


**Issue link**

<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
