### PR TITLE
Increase memory limit for core catalog apiserver

### DIFF
--- a/resources/core/charts/service-catalog/charts/catalog/values.yaml
+++ b/resources/core/charts/service-catalog/charts/catalog/values.yaml
@@ -103,7 +103,7 @@ apiserver:
       memory: 20Mi
     limits:
       cpu: 100m
-      memory: 30Mi
+      memory: 96Mi
 controllerManager:
   # annotations is a collection of annotations to add to the controllerManager pod.
   annotations: {}


### PR DESCRIPTION
Confirm these statements before you submit your pull request:

- [x] I have read and submitted the required [Contributor Licence Agreements](https://github.com/kyma-project/community/blob/master/CONTRIBUTING.md#agreements-and-licenses).
- [x] This pull request follows the contributing guidelines, recommended Git workflow, and templates.
- [x] I have tested my changes.
- [ ] I have updated the relevant documentation.
---

**Description**
Service Catalog APIServer restarts during tests execution with OOMKilled status. Recently on etcd cluster, TLS was enabled which can cause increased memory usage for core-catalog-apiserver.  Currently, we have memory limit set to 30MB. . In this PR we increase it to 96MB.

**Issue link**

<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
