### PR TITLE
Allow all console-dev domains access to ui-api-layer

### DIFF
--- a/resources/core/charts/ui-api/templates/deployment.yaml
+++ b/resources/core/charts/ui-api/templates/deployment.yaml
@@ -38,7 +38,7 @@ spec:
             value: "0.0.0.0"
           - name: APP_ALLOWED_ORIGINS
             {{- if .Values.global.isLocalEnv }}
-            value: "https://*.{{ .Values.global.domainName }},*.svc.cluster.local:44134,http://console-dev.{{ .Values.global.domainName }}:4200"
+            value: "https://*.{{ .Values.global.domainName }},*.svc.cluster.local:44134,http://console-dev.{{ .Values.global.domainName }}:*"
             {{- else }}
             value: "https://*.{{ .Values.global.domainName }},*.svc.cluster.local:44134"
             {{- end }}


### PR DESCRIPTION
Confirm these statements before you submit your pull request:

- [x] I have read and submitted the required [Contributor Licence Agreements](https://github.com/kyma-project/community/blob/master/CONTRIBUTING.md#agreements-and-licenses).
- [x] This pull request follows the contributing guidelines, recommended Git workflow, and templates.
- [x] I have tested my changes.
- [ ] I have updated the relevant documentation.
---

**Description**

Changes proposed in this pull request:
- Change `console-dev.kyma.local:4200` to `console-dev.kyma.local:*` for allowing all local domain from `console` module access to `ui-api-layer` running in local cluster.