### PR TITLE
Fixing configuration-generator according to changed apiserver proxy. …

### DIFF
--- a/resources/core/charts/cluster-users/templates/rbac-roles.yaml
+++ b/resources/core/charts/cluster-users/templates/rbac-roles.yaml
@@ -34,6 +34,8 @@ rules:
 - apiGroups: ["", "api.kyma.cx", "apps", "extensions", "gateway.kyma.cx", "kubeless.io", "rbac.authorization.k8s.io", "remoteenvironment.kyma.cx", "servicecatalog.k8s.io", "servicecatalog.kyma.cx", "settings.k8s.io", "kyma.cx", "authentication.istio.io", "config.istio.io", "eventing.kyma.cx", "ui.kyma.cx"]
   resources: ["*"]
   verbs: ["get, list"]
+- nonResourceURLs: [ "/version", "/api", "/api/*", "/apis", "/apis/*"] #required permissions for kubectl when using KUBECONFIG generated from config-generator
+  verbs: ["get", "list"]   
 ---
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRoleBinding

--- a/resources/core/charts/cluster-users/templates/rbac-roles.yaml
+++ b/resources/core/charts/cluster-users/templates/rbac-roles.yaml
@@ -81,6 +81,8 @@ rules:
 - apiGroups: ["apiextensions.k8s.io"]
   resources: ["customresourcedefinitions"]
   verbs: ["get", "list"]
+- nonResourceURLs: [ "/version", "/api", "/api/*", "/apis", "/apis/*"] #required permissions for kubectl when using KUBECONFIG generated from config-generator
+  verbs: ["*"]  
 ---
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRoleBinding

--- a/resources/core/charts/configurations-generator/templates/deployment.yaml
+++ b/resources/core/charts/configurations-generator/templates/deployment.yaml
@@ -22,8 +22,8 @@ spec:
         command: [
           "/app",
           "-kube-config-custer-name={{ .Values.kubeConfig.clusterName }}",
-          "-kube-config-url={{ .Values.kubeConfig.url }}",
-          "-kube-config-ca={{ .Values.kubeConfig.ca }}"
+          "-kube-config-url=https://apiserver.{{ .Values.global.domainName }}",
+          "-kube-config-ca={{ .Values.global.tlsCrt }}"
         ]
         ports:
           - name: http


### PR DESCRIPTION
…Adjusted kyma-admin role

Confirm these statements before you submit your pull request:

- [ ] I have read and submitted the required [Contributor Licence Agreements](https://github.com/kyma-project/community/blob/master/CONTRIBUTING.md#agreements-and-licenses).
- [ ] This pull request follows the contributing guidelines, recommended Git workflow, and templates.
- [ ] I have tested my changes.
- [ ] I have updated the relevant documentation.
---

**Description**
Changes proposed in this pull request:

- Config-generator deployment was fixed so that generated kubeconfig now points to apiserver-proxy.
- Adjusted kyma-admin role
-

**Issue link**

<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
