### PR TITLE
fix propagation of boolean values in configmaps

### DIFF
--- a/components/installer/pkg/installation/controller.go
+++ b/components/installer/pkg/installation/controller.go
@@ -179,7 +179,7 @@ func (c *Controller) syncHandler(key string) error {
 		return overridesErr
 	}
 
-	domainName, exists := overrides.FindOverrideValue(overrideProvider.Common(), "global.domainName")
+	domainName, exists := overrides.FindOverrideStringValue(overrideProvider.Common(), "global.domainName")
 	if !exists || domainName == "" {
 		runtime.HandleError(errors.New("'global.domainName' override not found"))
 		return nil

--- a/components/installer/pkg/overrides/generic-overrides.go
+++ b/components/installer/pkg/overrides/generic-overrides.go
@@ -1,6 +1,7 @@
 package overrides
 
 import (
+	"strconv"
 	"strings"
 
 	"github.com/ghodss/yaml"
@@ -175,7 +176,14 @@ func mergeIntoMap(keys []string, value string, dstMap map[string]interface{}) {
 	currentKey := keys[0]
 	//Last key points directly to string value
 	if len(keys) == 1 {
-		dstMap[currentKey] = value
+
+		//Conversion to boolean to satisfy Helm requirements.yaml: "enable:true/false syntax" 
+		var vv interface{} = value
+		if value == "true" || value == "false" {
+			vv, _ = strconv.ParseBool(value) 
+		}
+
+		dstMap[currentKey] = vv
 		return
 	}
 

--- a/components/installer/pkg/overrides/generic-overrides.go
+++ b/components/installer/pkg/overrides/generic-overrides.go
@@ -100,10 +100,10 @@ func MergeMaps(baseMap, overridesMap Map) {
 func FindOverrideStringValue(overrides Map, flatName string) (string, bool) {
 
 	res, isString := findOverrideValue(overrides, flatName).(string)
-	if !isString {
-		return "", false
+	if isString {
+		return res, true
 	}
-	return res, true
+	return "", false
 }
 
 func findOverrideValue(overrides Map, flatName string) (interface{}) {
@@ -115,11 +115,11 @@ func findOverrideValue(overrides Map, flatName string) (interface{}) {
 		}
 
 		nestedMap, isMap := m[keys[0]].(map[string]interface{})
-		if !isMap {
-			return nil
+		if isMap {
+			return findOverride(nestedMap, keys[1:])
 		}
 
-		return findOverride(nestedMap, keys[1:])
+		return nil		
 	}
 
 	keys := strings.Split(flatName, ".")

--- a/components/installer/pkg/overrides/generic-overrides_test.go
+++ b/components/installer/pkg/overrides/generic-overrides_test.go
@@ -339,7 +339,7 @@ a:
 			})
 		})
 
-		Convey("FindOverrideValue function", func() {
+		Convey("findOverrideValue function", func() {
 
 			Convey("Should find non-empty value in a map", func() {
 				flatmap := map[string]string{}
@@ -347,7 +347,7 @@ a:
 
 				oMap := UnflattenToMap(flatmap)
 
-				val, exists := FindOverrideValue(oMap, "a.b.c.d")
+				val, exists := FindOverrideStringValue(oMap, "a.b.c.d")
 				So(exists, ShouldBeTrue)
 				So(val, ShouldEqual, "testval")
 			})
@@ -358,7 +358,7 @@ a:
 
 				oMap := UnflattenToMap(flatmap)
 
-				val, exists := FindOverrideValue(oMap, "a.b.c.d")
+				val, exists := FindOverrideStringValue(oMap, "a.b.c.d")
 				So(exists, ShouldBeTrue)
 				So(val, ShouldBeBlank)
 			})
@@ -369,7 +369,7 @@ a:
 
 				oMap := UnflattenToMap(flatmap)
 
-				_, exists := FindOverrideValue(oMap, "a.b.c")
+				_, exists := FindOverrideStringValue(oMap, "a.b.c")
 				So(exists, ShouldBeFalse)
 			})
 
@@ -379,8 +379,36 @@ a:
 
 				oMap := UnflattenToMap(flatmap)
 
-				_, exists := FindOverrideValue(oMap, "a.b.f")
+				_, exists := FindOverrideStringValue(oMap, "a.b.f")
 				So(exists, ShouldBeFalse)
+			})
+		})
+
+		Convey("UnflattenToMap function", func() {
+
+			Convey("Should unflatten the map", func() {
+				flatmap := map[string]string{}
+				flatmap["a.b.c"] = "testval"
+
+				oMap := UnflattenToMap(flatmap)
+
+				val, exists := FindOverrideStringValue(oMap, "a.b.c")
+				So(exists, ShouldBeTrue)
+				So(val, ShouldEqual, "testval")
+			})
+
+			Convey("Should convert any strings that contain booleans to booleans", func() {
+				flatmap := map[string]string{}
+				flatmap["a.b.c"] = "true"
+				flatmap["a.b.d"] = "false"
+
+				oMap := UnflattenToMap(flatmap)
+
+				val:= findOverrideValue(oMap, "a.b.c")
+				val2 := findOverrideValue(oMap, "a.b.d")
+
+				So(val, ShouldBeTrue)
+				So(val2, ShouldBeFalse)
 			})
 		})
 	})


### PR DESCRIPTION
Confirm these statements before you submit your pull request:

- [x] I have read and submitted the required [Contributor Licence Agreements](https://github.com/kyma-project/community/blob/master/CONTRIBUTING.md#agreements-and-licenses).
- [x] This pull request follows the contributing guidelines, recommended Git workflow, and templates.
- [x] I have tested my changes.
- [x] I have updated the relevant documentation.
---

**Description**

Changes proposed in this pull request:

- Values used to determine if a chart should be enabled (e.g. azure-broker.enabled: true) are translated to booleans before Helm consumes them.

**Issue link**

#422 
