### PR TITLE
Fix missing nginx tracing span

### DIFF
--- a/resources/core/charts/nginx-ingress/templates/controller-configmap.yaml
+++ b/resources/core/charts/nginx-ingress/templates/controller-configmap.yaml
@@ -10,12 +10,12 @@ metadata:
   name: {{ template "nginx-ingress.controller.fullname" . }}
 data:
   enable-vts-status: "{{ .Values.controller.stats.enabled }}"
+  enable-opentracing: "true"
+  zipkin-collector-host: zipkin.kyma-system
 {{- if .Values.controller.headers }}
   proxy-set-headers: {{ .Release.Namespace }}/{{ template "nginx-ingress.fullname" . }}-custom-headers
   server-tokens: "false"
   hide-headers: "Server,Via"
-  enable-opentracing: "true"
-  zipkin-collector-host: zipkin.kyma-system
   use-geoip: "false"
 {{- end }}
 {{- if .Values.controller.config }}


### PR DESCRIPTION
The nginx tracing span was missing since the controller-configmap.yaml has an if condition in the helm chart and the flags to enable the tracing were inside the if block. Moving them out of the if block as enabling tracing does not depend upon the controller.headers flag

Confirm these statements before you submit your pull request:

- [x] I have read and submitted the required [Contributor Licence Agreements](https://github.com/kyma-project/community/blob/master/CONTRIBUTING.md#agreements-and-licenses).
- [x] This pull request follows the contributing guidelines, recommended Git workflow, and templates.
- [x] I have tested my changes.
- [ ] I have updated the relevant documentation.
---

**Description**

Changes proposed in this pull request:

-
-
-

**Issue link**

See also #351 
