### PR TITLE
Adding env variable GF_USERS_DEFAULT_THEME to config light theme in G…

### DIFF
--- a/resources/core/charts/monitoring/charts/grafana/templates/grafana-deployment.yaml
+++ b/resources/core/charts/monitoring/charts/grafana/templates/grafana-deployment.yaml
@@ -58,6 +58,8 @@ spec:
           value: "{{ .Values.auth.anonymous.enabled }}"
         - name: GF_SERVER_ROOT_URL
           value: 'https://grafana.{{ .Values.global.domainName }}/'
+        - name: GF_USERS_DEFAULT_THEME
+          value: {{ .Values.users.default.theme }}
 {{- if .Values.extraVars }}
 {{ toYaml .Values.extraVars | indent 8 }}
 {{- end }}

--- a/resources/core/charts/monitoring/charts/grafana/values.yaml
+++ b/resources/core/charts/monitoring/charts/grafana/values.yaml
@@ -118,3 +118,8 @@ auth:
 ##Custom Labels to be added to Grafana ServiceMonitors
 ##
 additionalServiceMonitorLabels: {}
+
+# Possible theme values dark or light
+users:
+  default:
+    theme: "light"


### PR DESCRIPTION
Adding env variable GF_USERS_DEFAULT_THEME to config light theme in Grafana

Confirm these statements before you submit your pull request:

- [x] I have read and submitted the required [Contributor Licence Agreements](https://github.com/kyma-project/community/blob/master/CONTRIBUTING.md#agreements-and-licenses).
- [x] This pull request follows the contributing guidelines, recommended Git workflow, and templates.
- [x] I have tested my changes.
- [x] I have updated the relevant documentation.
---

**Description**

In order to enable grafana light theme a new env variable, GF_USERS_DEFAULT_THEME has been added to grafana-deployment.yaml. 