### PR TITLE
Remove header kyma-topic when sending messages to subscribers

### DIFF
--- a/components/event-bus/api/push/eventing.kyma.cx/v1alpha1/types.go
+++ b/components/event-bus/api/push/eventing.kyma.cx/v1alpha1/types.go
@@ -19,7 +19,6 @@ type Subscription struct {
 type SubscriptionSpec struct {
 	Endpoint                      string `json:"endpoint"`
 	IncludeSubscriptionNameHeader bool   `json:"include_subscription_name_header"`
-	IncludeTopicHeader            bool   `json:"include_topic_header"`
 	MaxInflight                   int    `json:"max_inflight"`
 	PushRequestTimeoutMS          int64  `json:"push_request_timeout_ms"`
 	EventType                     string `json:"event_type"`

--- a/components/event-bus/cmd/event-bus-push/application/application.go
+++ b/components/event-bus/cmd/event-bus-push/application/application.go
@@ -24,7 +24,7 @@ type PushApplication struct {
 func NewPushApplication(pushOpts *pushOpts.Options, informer ...cache.SharedIndexInformer) *PushApplication {
 	log.Println("Push :: Initializing application")
 	tracer := trace.StartNewTracer(&pushOpts.Options)
-	subscriptionsSupervisor := actors.StartSubscriptionsSupervisor(pushOpts, &tracer)
+	subscriptionsSupervisor := actors.StartSubscriptionsSupervisor(pushOpts, &tracer, common.DefaultRequestProvider)
 	var subscriptionsController *controllers.SubscriptionsController
 	if len(informer) > 0 {
 		subscriptionsController = controllers.StartSubscriptionsControllerWithInformer(subscriptionsSupervisor, informer[0], pushOpts)

--- a/components/event-bus/internal/common/http.go
+++ b/components/event-bus/internal/common/http.go
@@ -1,0 +1,12 @@
+package common
+
+import (
+	"io"
+	"net/http"
+)
+
+type RequestProvider func(method, url string, body io.Reader) (*http.Request, error)
+
+func DefaultRequestProvider(method, url string, body io.Reader) (*http.Request, error) {
+	return http.NewRequest(method, url, body)
+}

--- a/components/event-bus/internal/push/controllers/eventactivation.go
+++ b/components/event-bus/internal/push/controllers/eventactivation.go
@@ -1,8 +1,10 @@
 package controllers
 
-import "log"
 import (
+	"log"
+
 	subApis "github.com/kyma-project/kyma/components/event-bus/api/push/eventing.kyma.cx/v1alpha1"
+	"github.com/kyma-project/kyma/components/event-bus/internal/common"
 	"github.com/kyma-project/kyma/components/event-bus/internal/push/actors"
 )
 
@@ -27,7 +29,7 @@ func getUpdateFnWithEventActivationCheck(supervisor actors.SubscriptionsSupervis
 
 		if newSub.HasCondition(subApis.SubscriptionCondition{Type: subApis.EventsActivated, Status: subApis.ConditionTrue}) {
 			log.Printf("Start NATS Subscription %+v", newSub)
-			supervisor.StartSubscriptionReq(newSub)
+			supervisor.StartSubscriptionReq(newSub, common.DefaultRequestProvider)
 		}
 	}
 }
@@ -41,7 +43,7 @@ func getAddFnWithEventActivationCheck(supervisor actors.SubscriptionsSupervisorI
 		}
 		if subscription.HasCondition(subApis.SubscriptionCondition{Type: subApis.EventsActivated, Status: subApis.ConditionTrue}) {
 			log.Printf("Subscription custom resource created %v", obj)
-			supervisor.StartSubscriptionReq(subscription)
+			supervisor.StartSubscriptionReq(subscription, common.DefaultRequestProvider)
 		}
 	}
 }

--- a/components/event-bus/internal/push/controllers/eventactivation_test.go
+++ b/components/event-bus/internal/push/controllers/eventactivation_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/kyma-project/kyma/components/event-bus/api/push/eventing.kyma.cx/v1alpha1"
+	"github.com/kyma-project/kyma/components/event-bus/internal/common"
 	"github.com/stretchr/testify/mock"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -25,7 +26,7 @@ func (m *MockSupervisior) IsRunning() bool { return true }
 
 func (m *MockSupervisior) IsNATSConnected() bool { return true }
 
-func (m *MockSupervisior) StartSubscriptionReq(sub *v1alpha1.Subscription) {
+func (m *MockSupervisior) StartSubscriptionReq(sub *v1alpha1.Subscription, requestProvider common.RequestProvider) {
 	m.Called(sub)
 }
 

--- a/components/event-bus/internal/push/controllers/noeventactivation.go
+++ b/components/event-bus/internal/push/controllers/noeventactivation.go
@@ -4,6 +4,7 @@ import (
 	"log"
 
 	subscriptionApis "github.com/kyma-project/kyma/components/event-bus/api/push/eventing.kyma.cx/v1alpha1"
+	"github.com/kyma-project/kyma/components/event-bus/internal/common"
 	"github.com/kyma-project/kyma/components/event-bus/internal/push/actors"
 )
 
@@ -12,7 +13,7 @@ func getAddFnWithoutEventActivationCheck(supervisor actors.SubscriptionsSupervis
 		subscription, ok := obj.(*subscriptionApis.Subscription)
 		if ok {
 			log.Printf("Added Subscription %+v", subscription)
-			supervisor.StartSubscriptionReq(subscription)
+			supervisor.StartSubscriptionReq(subscription, common.DefaultRequestProvider)
 		} else {
 			log.Printf("unknown object type added %+v", obj)
 		}

--- a/components/event-bus/internal/push/opts/opts.go
+++ b/components/event-bus/internal/push/opts/opts.go
@@ -67,7 +67,6 @@ type Options struct {
 	ConnectWait            time.Duration
 	QueueGroup             string
 	SubscriptionNameHeader string
-	TopicHeader            string
 	AckWait                time.Duration
 	MaxIdleConns           int
 	IdleConnTimeout        time.Duration
@@ -130,7 +129,6 @@ func configureOptions(fs *flag.FlagSet, args []string, printVersion, printHelp f
 	fs.StringVar(&opts.QueueGroup, "queue_group", defaultQueueGroup, "queue group name")
 	fs.BoolVar(&opts.TLSSkipVerify, "tls_skip_verify", false, "Skip TLS certificate verification, allow insecure connection")
 	fs.StringVar(&opts.SubscriptionNameHeader, "subscription_name_header", "", "Push Subscription name header")
-	fs.StringVar(&opts.TopicHeader, "topic_header", "", "Topic header")
 	fs.StringVar(&opts.APIURL, "trace_api_url", trace.DefaultTraceAPIURL, "Trace API URL")
 	fs.StringVar(&opts.HostPort, "trace_host_port", trace.DefaultTraceHostPort, "Trace host port")
 	fs.StringVar(&opts.ServiceName, "trace_service_name", trace.DefaultTraceServiceName, "Push service name")

--- a/components/event-bus/test/util/crd.go
+++ b/components/event-bus/test/util/crd.go
@@ -29,7 +29,6 @@ func NewSubscription(name string,
 		SubscriptionSpec: apiv1.SubscriptionSpec{
 			Endpoint:                      subscriberEventEndpointURL,
 			IncludeSubscriptionNameHeader: false,
-			IncludeTopicHeader:            false,
 			MaxInflight:                   100,
 			PushRequestTimeoutMS:          10,
 			Source:                        apiv1.Source{SourceEnvironment: sourceEnvironment, SourceNamespace: sourceNamespace, SourceType: sourceType},

--- a/docs/event-bus/docs/011-details-event-flow-requirements.md
+++ b/docs/event-bus/docs/011-details-event-flow-requirements.md
@@ -30,7 +30,6 @@ See the table for the explanation of parameters in the Subscription custom resou
 | Parameter | Description |
 |----------------|------|
 | **include_subscription_name_header** | It indicates whether the lambda or the service includes the name of the Subscription when receiving an Event. |
-| **include_topic_header** | It indicates whether the service or app includes the name of the topic when receiving an Event. |
 | **max_inflight** | It indicates the maximum number of Events which can be delivered concurrently. The final value is the **max_inflight** number multiplied by the number of the `push` applications. |
 | **push_request_timeout_ms** | It indicates the time for which the `push` waits for the response when delivering an Event to the lambda or the service. After the specified time passes, the request times out and the Event Bus retries delivering the Event. Setting the **minimum** parameter to `0` applies the default value of 1000ms. |
 | **event_type** | The name of the Event type. For example, `order-created`.|

--- a/docs/event-bus/docs/030-cli-reference.md
+++ b/docs/event-bus/docs/030-cli-reference.md
@@ -44,7 +44,6 @@ The following examples show how to create new Subscriptions, list them, and obta
      push_request_timeout_ms: 2000
      max_inflight: 400
      include_subscription_name_header: true
-     include_topic_header: true
      event_type: order_created
      event_type_version: v1
      source:

--- a/resources/cluster-essentials/templates/eventing-subscription.crd.yaml
+++ b/resources/cluster-essentials/templates/eventing-subscription.crd.yaml
@@ -23,8 +23,6 @@ spec:
               maxLength: 512
             include_subscription_name_header:
               type: boolean
-            include_topic_header:
-              type: boolean
             max_inflight:
               type: integer
               minimum: 1

--- a/resources/core/charts/event-bus/charts/push/templates/deployment.yaml
+++ b/resources/core/charts/event-bus/charts/push/templates/deployment.yaml
@@ -59,7 +59,6 @@ spec:
             - --cluster_id={{ .Values.global.natsStreaming.clusterID }}
             - --tls_skip_verify={{ .Values.http.tlsSkipVerify }}
             - --subscription_name_header={{ .Values.global.push.http.subscriptionNameHeader }}
-            - --topic_header={{ .Values.global.push.http.topicHeader }}
             - --trace_api_url={{ .Values.global.trace.apiURL }}
             - --trace_service_name={{ .Values.trace.serviceName }}
             - --trace_operation_name={{ .Values.trace.operationName }}

--- a/resources/core/charts/event-bus/values.yaml
+++ b/resources/core/charts/event-bus/values.yaml
@@ -22,7 +22,6 @@ global:
   push:
     http:
       subscriptionNameHeader: "Kyma-Subscription"
-      topicHeader: "Kyma-Topic"
     resources:
       limits:
         memory: "32M"

--- a/resources/core/charts/kubeless/templates/tests/k8s.yaml
+++ b/resources/core/charts/kubeless/templates/tests/k8s.yaml
@@ -49,7 +49,6 @@ spec:
   push_request_timeout_ms: 2000
   max_inflight: 400
   include_subscription_name_header: true
-  include_topic_header: true
   event_type: test
   event_type_version: v1
   source:


### PR DESCRIPTION
Confirm these statements before you submit your pull request:

- [x] I have read and submitted the required [Contributor Licence Agreements](https://github.com/kyma-project/community/blob/master/CONTRIBUTING.md#agreements-and-licenses).
- [x] This pull request follows the contributing guidelines, recommended Git workflow, and templates.
- [x] I have tested my changes.
- [x] I have updated the relevant documentation.
---

**Description**

Changes proposed in this pull request:

- remove `kyma-topic` header from sent messages to subscribers
- remove `include_topic_header` flag from `eventing-subscription` crd
- update the related documentation
- update tests to verify that the header is no longer sent

**Issue link**
#387