### PR TITLE
increase prometheus memory limit to 2Gi

### DIFF
--- a/resources/core/charts/monitoring/charts/prometheus/values.yaml
+++ b/resources/core/charts/monitoring/charts/prometheus/values.yaml
@@ -126,7 +126,7 @@ resources:
   requests:
     memory: 200Mi
   limits:
-    memory: 800Mi
+    memory: 2Gi
 
 ## How long to retain metrics
 ## Reduced to 6h from 24h as to limit Prometheus use a max of 800 Mb memory in nightly azure cluster

--- a/resources/core/templates/limit-range.yaml
+++ b/resources/core/templates/limit-range.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   limits:
   - max:
-      memory: 1024Mi # Maximum memory that a container can request
+      memory: 2Gi # Maximum memory that a container can request
     default:
       # If a container does not specify memory limit, this default value will be applied.
       # If a container tries to allocate more memory, container will be OOM killed.


### PR DESCRIPTION
Confirm these statements before you submit your pull request:

- [x] I have read and submitted the required [Contributor Licence Agreements](https://github.com/kyma-project/community/blob/master/CONTRIBUTING.md#agreements-and-licenses).
- [x] This pull request follows the contributing guidelines, recommended Git workflow, and templates.
- [x] I have tested my changes.
- [x] I have updated the relevant documentation.
---

**Description**

As Prometheus crashes regularly with out of memory. The memory limit has been increased to 2Gi,  where it runs stable.

Also the limitrange, kyma-default has been increased to 2Gi, where originally was 1Gi and this was preventing the creation of the Prometheus pod. 
