### PR TITLE
Add RBAC rule - allow BUC to read serviceclass resources

### DIFF
--- a/resources/core/charts/service-catalog/charts/binding-usage-controller/templates/cluster-role.yaml
+++ b/resources/core/charts/service-catalog/charts/binding-usage-controller/templates/cluster-role.yaml
@@ -21,7 +21,7 @@ rules:
   resources: ["servicebindingusages", "usagekinds"]
   verbs: ["get", "list", "watch", "update"]
 - apiGroups: ["servicecatalog.k8s.io"]
-  resources: ["servicebindings","serviceinstances","clusterserviceclasses"]
+  resources: ["servicebindings","serviceinstances","clusterserviceclasses","serviceclasses"]
   verbs:     ["get","list","watch"]
 - apiGroups: [""]
   resources: ["events"]


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- add RBAC rule to allow BUC list/watch/get serviceclass resources.

**Related issue(s)**
#487 
