### PR TITLE
Remove the "Overview" heading from documents in the kyma/docs folder

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,7 +1,5 @@
 # Documentation
 
-## Overview
-
 The `docs` folder contains end-to-end documentation on Kyma and its components.
 
 Start with the overarching [Kyma](kyma/docs) documentation where you can find the general information on Kyma and the Getting Started guides. Then, read about the product in more detail:   

--- a/docs/event-bus/docs/030-cli-reference.md
+++ b/docs/event-bus/docs/030-cli-reference.md
@@ -3,8 +3,6 @@ title: CLI reference
 type: CLI reference
 ---
 
-## Overview
-
  Management of the Event Bus is based on the custom resources specifically defined for Kyma. Manage all of these resources through [kubectl](https://kubernetes.io/docs/reference/kubectl/overview/).
 
 ## Details

--- a/docs/kyma/docs/028-details-deploy-private-registry.md
+++ b/docs/kyma/docs/028-details-deploy-private-registry.md
@@ -3,8 +3,6 @@ title: Deploy with a private Docker registry
 type: Details
 ---
 
-## Overview
-
 Docker is a free tool to deploy applications and servers. To run an application on Kyma, provide the application binary file as a Docker image located in a Docker registry. Use the `DockerHub` public registry to upload your Docker images for free access to the public. Use a private Docker registry to ensure privacy, increased security, and better availability.
 
 This document shows how to deploy a Docker image from your private Docker registry to the Kyma cluster.

--- a/docs/kyma/docs/031-gs-local-installation.md
+++ b/docs/kyma/docs/031-gs-local-installation.md
@@ -3,8 +3,6 @@ title: Local Kyma installation
 type: Getting Started
 ---
 
-## Overview
-
 This Getting Started guide shows developers how to quickly deploy Kyma locally on a Mac, Linux, or Windows. Kyma installs locally using a proprietary installer based on a [Kubernetes operator](https://coreos.com/operators/). The document provides prerequisites, instructions on how to install Kyma locally and verify the deployment, as well as the troubleshooting tips.
 
 ## Prerequisites

--- a/docs/kyma/docs/032-gs-cluster-installation.md
+++ b/docs/kyma/docs/032-gs-cluster-installation.md
@@ -3,8 +3,6 @@ title: Cluster Kyma installation
 type: Getting Started
 ---
 
-## Overview
-
 This Getting Started guide shows developers how to quickly deploy Kyma on a cluster. Kyma installs on a cluster using a proprietary installer based on a [Kubernetes operator](https://coreos.com/operators/). The document provides prerequisites, instructions on how to install Kyma on a cluster and verify the deployment, as well as the troubleshooting tips.
 
 >**NOTE:** To learn how to install Kyma on a [Gardener](https://github.com/gardener/gardener) cluster, see the **Install Kyma on Gardener** document.

--- a/docs/kyma/docs/033-gs-sample-service-deployment-to-local.md
+++ b/docs/kyma/docs/033-gs-sample-service-deployment-to-local.md
@@ -3,8 +3,6 @@ title: Sample service deployment on local
 type: Getting Started
 ---
 
-## Overview
-
 This Getting Started guide is intended for the developers who want to quickly learn how to deploy a sample service and test it with Kyma installed locally on Mac.
 
 This guide uses a standalone sample service written in the [Go](http://golang.org) language .

--- a/docs/kyma/docs/034-gs-sample-service-deployment-to-cluster.md
+++ b/docs/kyma/docs/034-gs-sample-service-deployment-to-cluster.md
@@ -3,8 +3,6 @@ title: Sample service deployment on a cluster
 type: Getting Started
 ---
 
-## Overview
-
 This Getting Started guide is intended for the developers who want to quickly learn how to deploy a sample service and test it with the Kyma cluster.
 
 This guide uses a standalone sample service written in the [Go](http://golang.org) language.

--- a/docs/kyma/docs/035-gs-local-develop-no-docker.md
+++ b/docs/kyma/docs/035-gs-local-develop-no-docker.md
@@ -3,8 +3,6 @@ title: Develop a service locally without using Docker
 type: Getting Started
 ---
 
-## Overview
-
 You can develop services in the local Kyma installation without extensive Docker knowledge or a need to build and publish a Docker image. The `minikube mount` feature allows you to mount a directory from your local disk into the local Kubernetes cluster.
 
 This guide shows how to use this feature, using the service example implemented in Golang.

--- a/docs/kyma/docs/036-gs-publish-service-image-and-deploy.md
+++ b/docs/kyma/docs/036-gs-publish-service-image-and-deploy.md
@@ -3,8 +3,6 @@ title: Publish a service Docker image and deploy it to Kyma
 type: Getting Started
 ---
 
-## Overview
-
 In the Getting Started guide for local development of a service, you can learn how to develop a service locally. You can immediately see all the changes made in the local Kyma installation based on Minikube, without building a Docker image and publishing it to a Docker registry, such as the Docker Hub.
 
 Using the same example service, this guide explains how to build a Docker image for your service, publish it to the Docker registry, and deploy it to the local Kyma installation. The instructions base on Minikube, but you can also use the image that you create, and the Kubernetes resource definitions that you use on the Kyma cluster.

--- a/docs/monitoring/docs/030-gs-monitoring-custom-metrics.md
+++ b/docs/monitoring/docs/030-gs-monitoring-custom-metrics.md
@@ -3,8 +3,6 @@ title: Expose Custom Metrics in Kyma
 type: Getting Started
 ---
 
-## Overview
-
 This Getting Started guide shows how to expose custom metrics to Prometheus with a Golang service in Kyma. To do so, follow these steps:
 
 1. Configure Istio.
@@ -58,9 +56,9 @@ This is a basic example where `Gauge` and `Counter` metrics are exported using t
 1. Deploy the sample metrics application.
     ```bash
     kubectl apply -f https://raw.githubusercontent.com/kyma-project/examples/master/monitoring-custom-metrics/deployment/deployment.yaml
-    
+
     kubectl apply -f https://raw.githubusercontent.com/kyma-project/examples/master/monitoring-custom-metrics/deployment/service-8080.yaml
-    
+
     kubectl apply -f https://raw.githubusercontent.com/kyma-project/examples/master/monitoring-custom-metrics/deployment/service-8081.yaml
 
     kubectl apply -f https://raw.githubusercontent.com/kyma-project/examples/master/monitoring-custom-metrics/deployment/service-monitor.yaml
@@ -80,7 +78,7 @@ This is a basic example where `Gauge` and `Counter` metrics are exported using t
     kubectl port-forward svc/sample-metrics-8081 8081:8081
     ```
     Open a browser and access [`http://localhost:8081/metrics`](http://localhost:8081/metrics)
-    
+
     ![metrics on port 8081](assets/sample-metrics-2.png)
 
 Find the source code for the sample application [here](https://github.com/kyma-project/examples/blob/master/monitoring-custom-metrics/main.go). See the [package prometheus](https://godoc.org/github.com/prometheus/client_golang/prometheus) for the reference documentation. Read [this](https://prometheus.io/docs/concepts/metric_types/) documentation to learn more about the Prometheus metric types.
@@ -88,7 +86,7 @@ Find the source code for the sample application [here](https://github.com/kyma-p
 ### Access the exposed metrics in Prometheus
 
  Run the `port-forward` command on the `core-prometheus` service:
-    
+
 ```bash
 kubectl port-forward svc/core-prometheus -n kyma-system 9090:9090
 Forwarding from 127.0.0.1:9090 -> 9090

--- a/docs/serverless/docs/030-architecture.md
+++ b/docs/serverless/docs/030-architecture.md
@@ -3,8 +3,6 @@ title: Architecture
 type: Architecture
 ---
 
-## Overview
-
 The term "serverless" refers to an architecture that is Internet-based. Application development that uses serverless technology relies solely on a combination of cloud-based, third-party services, client-side logic, and service-hosted remote procedure calls, also known as "Functions as a Service" or FaaS. Developers use lambdas to create this combination. As a result, this combination replaces the common use of a server. In the context of Kyma, lambda functions connect third-party services and Kyma. Developing with this serverless approach reduces the implementation and operation effort of an application to the absolute minimum.
 
 ## The Serverless architecture

--- a/docs/serverless/docs/035-programming-model.md
+++ b/docs/serverless/docs/035-programming-model.md
@@ -3,8 +3,6 @@ title: The Node.js Programming Model
 type: Model
 ---
 
-## Overview
-
 Kyma supports Node.js 6 and 8. The function interface is the same for both versions. It is still best practice to start with Node.js 8, as it supports Promises out of the box. The result is less complicated code.
 
 Please set the runtime version (Node.js 6 or 8) while creating a function.
@@ -40,8 +38,8 @@ event:
   data:                                         # Event data
     foo: "bar"                                  # The data is parsed as JSON when required
   extensions:                                   # Optional parameters
-    request: ...                                # Reference to the request received 
-    response: ...                               # Reference to the response to send 
+    request: ...                                # Reference to the request received
+    response: ...                               # Reference to the response to send
                                                 # (specific properties will depend on the function language)
 context:
     function-name: "pubsub-nodejs"

--- a/docs/serverless/docs/040-cli-reference.md
+++ b/docs/serverless/docs/040-cli-reference.md
@@ -3,8 +3,6 @@ title: CLI reference
 type: CLI reference
 ---
 
-## Overview
-
 This section provides you with useful command line examples used in Kyma.
 
 ## Prerequisites

--- a/docs/service-catalog/docs/012-details-provisioning-and-binding.md
+++ b/docs/service-catalog/docs/012-details-provisioning-and-binding.md
@@ -3,8 +3,6 @@ title: Provisioning and binding
 type: Details
 ---
 
-## Overview
-
 Provisioning a service means creating an instance of a service. When you consume a specific ClusterServiceClass and the system provisions a ServiceInstance, you need credentials for this service. To obtain credentials, create a ServiceBinding resource using the API of the Service Catalog. One instance can have numerous bindings to use in the Deployment or Function. When you raise a binding request, the system returns the credentials in the form of a Secret. The system creates a Secret in a given Environment.
 
 > **NOTE:** The security in Kyma relies on the Kubernetes concept of a [Namespace](https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/). Kyma Environment is a security boundary. If the Secret exists in the Environment, the administrator can inject it to any Deployment. The Service Broker cannot prevent other applications from consuming a created Secret. Therefore, to ensure a stronger level of isolation and security, use a dedicated Environment and request separate bindings for each Deployment.

--- a/docs/service-catalog/docs/014-details-etcd-database.md
+++ b/docs/service-catalog/docs/014-details-etcd-database.md
@@ -3,12 +3,10 @@ title: Etcd Database
 type: Details
 ---
 
-## Overview
-
-The Service Catalog requires an `etcd` database cluster for a production use. 
-It has a separate `etcd` cluster defined in the Service Catalog [etcd][sc-etcd-sub-chart] sub-chart. 
+The Service Catalog requires an `etcd` database cluster for a production use.
+It has a separate `etcd` cluster defined in the Service Catalog [etcd][sc-etcd-sub-chart] sub-chart.
 The [etcd-operator][etcd-operator] installs and manages the `etcd` clusters deployed to Kubernetes,
-and also automates tasks related to operating an `etcd` cluster, for example executing [backup][etcd-backups] and [restore][etcd-restores] procedures. 
+and also automates tasks related to operating an `etcd` cluster, for example executing [backup][etcd-backups] and [restore][etcd-restores] procedures.
 
 > **NOTE:** The [etcd-operator][etcd-operator] is Namespace-scoped and is installed only in `kyma-system` Namespace.
 
@@ -27,7 +25,7 @@ To execute the backup process, you must set the following values in the [core][c
 | **etcd-operator.backupOperator.abs.storageAccount** | The name of the storage account for the Azure Blob Storage (ABS). It stores the value for the **storage-account** Secret key. |
 | **etcd-operator.backupOperator.abs.storageKey**     | The key value of the storage account for the ABS. It stores the value for the **storage-key** Secret key. |
 
-> **NOTE:** If you set the **storageAccount**, **storageKey**, and **containerName** properties, the **global.etcdBackup.enabled** must be set to `true`. 
+> **NOTE:** If you set the **storageAccount**, **storageKey**, and **containerName** properties, the **global.etcdBackup.enabled** must be set to `true`.
 
 ### Restore
 
@@ -43,7 +41,7 @@ kubectl create -f assets/etcd-restore/operator-deploy.yaml
 
 2. Create the EtcdRestore Custom Resource Definition:
 ```bash
-kubectl create -f assets/etcd-restore/restore-crd.yaml 
+kubectl create -f assets/etcd-restore/restore-crd.yaml
 ```
 
 3. Export the **ABS_PATH** environment variable with the path to the last successful backup file.

--- a/docs/service-catalog/docs/030-cli-reference.md
+++ b/docs/service-catalog/docs/030-cli-reference.md
@@ -3,8 +3,6 @@ title: CLI reference
 type: CLI reference
 ---
 
-## Overview
-
 Management of the Service Catalog is based on Kubernetes resources and the custom resources specifically defined for Kyma. Manage all of these resources through [kubectl](https://kubernetes.io/docs/reference/kubectl/overview/).
 
 ## Details


### PR DESCRIPTION
Changes proposed in this pull request:

- Removed the "Overview" section from the kyma/docs folder, as agreed on the SIG Content

**Related issue(s)**
#503 