### PR TITLE
Set the binding timeout to 10 sec

### DIFF
--- a/tests/acceptance/remote-environment/re_test.go
+++ b/tests/acceptance/remote-environment/re_test.go
@@ -45,7 +45,7 @@ func TestRemoteEnvironmentAPIAccess(t *testing.T) {
 	ts.ProvisionServiceInstance(10 * time.Second)
 
 	t.Logf("Binding")
-	ts.Bind(3 * time.Second)
+	ts.Bind(10 * time.Second)
 
 	ts.WaitForPodsAreRunning(45 * time.Second)
 	t.Logf("All pods are running")

--- a/tests/acceptance/remote-environment/suite/testsuite.go
+++ b/tests/acceptance/remote-environment/suite/testsuite.go
@@ -182,7 +182,7 @@ func (ts *TestSuite) Bind(timeout time.Duration) {
 		select {
 		case <-done:
 			if b != nil {
-				require.Fail(ts.t, fmt.Sprintf("timeout while waiting for service binding %s to be ready. Status: %v", b.Name, b.Status))
+				require.Fail(ts.t, fmt.Sprintf("timeout while waiting for service binding %s to be ready. Status: %+v", b.Name, b.Status))
 			} else {
 				require.Fail(ts.t, "timeout while waiting for service binding to be ready")
 			}


### PR DESCRIPTION
**Description**
- Set acceptance remote env test binding timeout to 10 seconds 

**Related issue(s)**
#501 
