### PR TITLE
Setup tiller as installer sidecar

### DIFF
--- a/installation/resources/installer.yaml
+++ b/installation/resources/installer.yaml
@@ -31,6 +31,19 @@ kind: ServiceAccount
 metadata:
   name: kyma-installer
 ---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: kyma-installer
+subjects:
+- kind: ServiceAccount
+  name: kyma-installer
+  namespace: kyma-installer
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cluster-admin
+---
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
@@ -42,10 +55,37 @@ spec:
         name: kyma-installer
     spec:
       serviceAccountName: kyma-installer
+      initContainers:
+      - name: init-tiller
+        image: eu.gcr.io/kyma-project/alpine-net:0.2.74
+        imagePullPolicy: IfNotPresent
+        command: ['sh', '-c', 'until nc -zv kube-dns.kube-system.svc.cluster.local 53; do echo waiting for k8s readiness; sleep 2; done;']
       containers:
-      - name: kyma-installer-container
+      - name: tiller
+        image: gcr.io/kubernetes-helm/tiller:v2.8.2
+        imagePullPolicy: IfNotPresent
+        env:
+        - name: TILLER_NAMESPACE
+          value: kyma-installer
+        ports:
+        - containerPort: 44134
+          name: tiller
+        livenessProbe:
+          httpGet:
+            path: /liveness
+            port: 44135
+          initialDelaySeconds: 1
+          timeoutSeconds: 1
+        readinessProbe:
+          httpGet:
+            path: /readiness
+            port: 44135
+          initialDelaySeconds: 1
+          timeoutSeconds: 1
+      - name: kyma-installer
         image: eu.gcr.io/kyma-project/installer:0.3.281
         imagePullPolicy: IfNotPresent
+        args: ["-helmhost=localhost:44134"]
         env:
           - name: AZURE_BROKER_SUBSCRIPTION_ID
             valueFrom:
@@ -137,21 +177,8 @@ spec:
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
-  name: kyma-installer-reader
+  name: kyma-installer
 rules:
 - apiGroups: ["*"]
   resources: ["*"]
   verbs: ["*"]
----
-kind: ClusterRoleBinding
-apiVersion: rbac.authorization.k8s.io/v1beta1
-metadata:
-  name: kyma-installer
-subjects:
-- kind: ServiceAccount
-  name: kyma-installer
-  namespace: kyma-installer
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: kyma-installer-reader

--- a/installation/scripts/copy-resource.ps1
+++ b/installation/scripts/copy-resource.ps1
@@ -2,6 +2,7 @@ $CURRENT_DIR = Split-Path $MyInvocation.MyCommand.Path
 $LOCAL_DIR = "${CURRENT_DIR}\..\..".Substring(2)
 $INSTALLER_NS = "kyma-installer"
 $INSTALLER_POD = "kyma-installer"
+$INSTALLER_CONTAINER = "kyma-installer"
 $REMOTE_DIR = "/kyma/injected"
 
 $cmd = "${CURRENT_DIR}\is-ready.ps1 -ns ${INSTALLER_NS} name ${INSTALLER_POD}"
@@ -12,19 +13,19 @@ $POD_NAME = (Invoke-Expression -Command $cmd | Out-String).ToString().Trim()
 
 Write-Output "Copying kyma sources from ${LOCAL_DIR} into ${POD_NAME}:${REMOTE_DIR} ..."
 
-$cmd = "kubectl.exe exec -n ${INSTALLER_NS} ${POD_NAME} -- /bin/rm -rf ${REMOTE_DIR}"
+$cmd = "kubectl.exe exec -n ${INSTALLER_NS} ${POD_NAME} -c ${INSTALLER_CONTAINER} -- /bin/rm -rf ${REMOTE_DIR}"
 Invoke-Expression -Command $cmd
 
-$cmd = "kubectl.exe exec -n ${INSTALLER_NS} ${POD_NAME} -- /bin/mkdir -p ${REMOTE_DIR}"
+$cmd = "kubectl.exe exec -n ${INSTALLER_NS} ${POD_NAME} -c ${INSTALLER_CONTAINER} -- /bin/mkdir -p ${REMOTE_DIR}"
 Invoke-Expression -Command $cmd
 
-$cmd = "kubectl.exe cp ${LOCAL_DIR}\resources ${INSTALLER_NS}/${POD_NAME}:${REMOTE_DIR}/resources"
+$cmd = "kubectl.exe cp ${LOCAL_DIR}\resources ${INSTALLER_NS}/${POD_NAME}:${REMOTE_DIR}/resources -c ${INSTALLER_CONTAINER}"
 Invoke-Expression -Command $cmd
 
-$cmd = "kubectl.exe cp ${LOCAL_DIR}\installation ${INSTALLER_NS}/${POD_NAME}:${REMOTE_DIR}/installation"
+$cmd = "kubectl.exe cp ${LOCAL_DIR}\installation ${INSTALLER_NS}/${POD_NAME}:${REMOTE_DIR}/installation -c ${INSTALLER_CONTAINER}"
 Invoke-Expression -Command $cmd
 
-$cmd = "kubectl.exe cp ${LOCAL_DIR}\docs ${INSTALLER_NS}/${POD_NAME}:${REMOTE_DIR}/docs"
+$cmd = "kubectl.exe cp ${LOCAL_DIR}\docs ${INSTALLER_NS}/${POD_NAME}:${REMOTE_DIR}/docs -c ${INSTALLER_CONTAINER}"
 Invoke-Expression -Command $cmd
 
 $cmd = "kubectl.exe exec -n ${INSTALLER_NS} ${POD_NAME} -- /bin/chmod -R +x ${REMOTE_DIR}"

--- a/installation/scripts/copy-resources.sh
+++ b/installation/scripts/copy-resources.sh
@@ -2,6 +2,7 @@
 
 INSTALLER_NS_NAME=kyma-installer
 INSTALLER_POD_PATTERN=kyma-installer
+INSTALLER_CONTAINER=kyma-installer
 REMOTE_DIRECTORY=/kyma/injected
 CURRENT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 LOCAL_DIRECTORY="$( cd "$( dirname "${BASH_SOURCE[0]}" )/../.." && pwd )"
@@ -12,9 +13,9 @@ POD_NAME=$(kubectl -n ${INSTALLER_NS_NAME} get pods -l name=${INSTALLER_POD_PATT
 
 echo "Copying kyma sources from ${LOCAL_DIRECTORY} into ${POD_NAME}:${REMOTE_DIRECTORY} ..."
 
-kubectl -n ${INSTALLER_NS_NAME} exec ${POD_NAME} -- "/bin/rm" "-rf" "${REMOTE_DIRECTORY}"
-kubectl -n ${INSTALLER_NS_NAME} exec ${POD_NAME} -- "/bin/mkdir" "-p" "${REMOTE_DIRECTORY}"
+kubectl -n ${INSTALLER_NS_NAME} exec ${POD_NAME} -c ${INSTALLER_CONTAINER} -- "/bin/rm" "-rf" "${REMOTE_DIRECTORY}"
+kubectl -n ${INSTALLER_NS_NAME} exec ${POD_NAME} -c ${INSTALLER_CONTAINER} -- "/bin/mkdir" "-p" "${REMOTE_DIRECTORY}"
 
-kubectl cp "${LOCAL_DIRECTORY}/resources" "${INSTALLER_NS_NAME}/${POD_NAME}:${REMOTE_DIRECTORY}/resources"
-kubectl cp "${LOCAL_DIRECTORY}/installation" "${INSTALLER_NS_NAME}/${POD_NAME}:${REMOTE_DIRECTORY}/installation"
-kubectl cp "${LOCAL_DIRECTORY}/docs" "${INSTALLER_NS_NAME}/${POD_NAME}:${REMOTE_DIRECTORY}/docs"
+kubectl cp "${LOCAL_DIRECTORY}/resources" "${INSTALLER_NS_NAME}/${POD_NAME}:${REMOTE_DIRECTORY}/resources" -c ${INSTALLER_CONTAINER}
+kubectl cp "${LOCAL_DIRECTORY}/installation" "${INSTALLER_NS_NAME}/${POD_NAME}:${REMOTE_DIRECTORY}/installation" -c ${INSTALLER_CONTAINER}
+kubectl cp "${LOCAL_DIRECTORY}/docs" "${INSTALLER_NS_NAME}/${POD_NAME}:${REMOTE_DIRECTORY}/docs" -c ${INSTALLER_CONTAINER}

--- a/installation/scripts/is-installed.ps1
+++ b/installation/scripts/is-installed.ps1
@@ -21,10 +21,10 @@ while($true) {
     } elseif ($status -eq "Error") {
         Write-Output "kyma installation error... ${desc}"
         Write-Output "----------"
-        $cmd = "kubectl.exe get pods -n kyma-installer -o jsonpath='{.items[*].metadata.name}'"
+        $cmd = "kubectl.exe get pods -n kyma-installer -l name=kyma-installer --no-headers -o jsonpath='{.items[*].metadata.name}'"
         $podName = (Invoke-Expression -Command $cmd | Out-String).ToString().Trim()
         
-        $cmd = "kubectl.exe logs ${podName} -n kyma-installer"
+        $cmd = "kubectl.exe logs ${podName} -n kyma-installer -c kyma-installer"
         (Invoke-Expression -Command $cmd | Out-String).Trim() | Write-Output
         
         exit 1

--- a/installation/scripts/is-installed.sh
+++ b/installation/scripts/is-installed.sh
@@ -35,7 +35,7 @@ do
   then
     echo "kyma installation error... ${DESC}"
     echo "----------"
-    echo "$(kubectl logs -n kyma-installer $(kubectl get pods --all-namespaces -l name=kyma-installer --no-headers -o jsonpath='{.items[*].metadata.name}'))"
+    echo "$(kubectl logs -n kyma-installer -c kyma-installer $(kubectl get pods --all-namespaces -l name=kyma-installer --no-headers -o jsonpath='{.items[*].metadata.name}'))"
     echo "----------"
     exit 1
   else 


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/master/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

In this PR tiller is added as the installer sidecar. The installation of tiller is still a prerequisite because service catalog requires it.

When all dependencies to local tiller will be removed, tiller should be removed from local scripts and file installation/resources/tiller.yaml should be removed. Also manual step describing tiller installation in cluster deployment will no longer be valid.

Keep in mind that this change will block direct interaction with a cluster via helm. For example clean-up.sh script will stop working.

Changes proposed in this pull request:

- Move tiller to installer as a sidecar
- Scripts aligned

**Related issue(s)**

Resolves #498 
