### PR TITLE
Bump version of ui-api-layer and ui-api-acceptance-tests

### DIFF
--- a/resources/core/charts/ui-api/Chart.yaml
+++ b/resources/core/charts/ui-api/Chart.yaml
@@ -1,4 +1,4 @@
 name: ui-api
 description: GraphQL API for Kyma UIs
 version: 0.1.1
-appVersion: 0.3.302
+appVersion: 0.3.342

--- a/resources/core/templates/tests/test-ui-api-acceptance.yaml
+++ b/resources/core/templates/tests/test-ui-api-acceptance.yaml
@@ -10,7 +10,7 @@ spec:
   serviceAccountName:  "test-{{ template "fullname" . }}-ui-api-acceptance"
   containers:
     - name: "test-{{ template "fullname" . }}-ui-api-acceptance"
-      image: "{{ .Values.global.containerRegistry.path }}/ui-api-layer-acceptance-tests:0.3.232"
+      image: "{{ .Values.global.containerRegistry.path }}/ui-api-layer-acceptance-tests:0.3.342"
       env:
         - name: TILLER_HOST
           value: "tiller-deploy.kube-system.svc.cluster.local:44134"


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/master/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:
- Bump version of `ui-api-layer` to `0.3.342`: 
  - Add `supportUrl` and `servicePlanSpec` fields in QGLschema.
  - Possibility to query `supportUrl` in `ServiceClass` query and `servicePlanSpec` in `ServiceInstance` query.
  - Update relevant unit tests.
- Bump version of `ui-api-acceptance-tests` to `0.3.342`: 
  - Update relevant tests for new fields in queries, mostly tests for `ServiceInstance`.