### PR TITLE
Fix concurrent map operations in watch-pods

### DIFF
--- a/tools/watch-pods/internal/tester/tester.go
+++ b/tools/watch-pods/internal/tester/tester.go
@@ -167,7 +167,7 @@ func (cs *ClusterState) UpdateState(c Container, update StateUpdate) {
 // GetUnstableContainers returns all Containers which are not ready or restarts in recent requiredStabilityPeriod
 func (cs *ClusterState) GetUnstableContainers(requiredStabilityPeriod time.Duration) []ContainerAndState {
 	cs.mtx.Lock()
-	cs.mtx.Unlock()
+	defer cs.mtx.Unlock()
 
 	unstable := make([]ContainerAndState, 0)
 


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/master/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- Fixed the tools/watch-pods concurrent map operations. Added missing defer to mutex.Unlock().

Resolves #621  