### PR TITLE
Bump instances, catalog, core and tests images

### DIFF
--- a/resources/core/charts/console/values.yaml
+++ b/resources/core/charts/console/values.yaml
@@ -3,7 +3,7 @@
 # Declare variables to be passed into your templates.
 replicaCount: 1
 image:
-  tag: 0.1.146
+  tag: 0.1.151
   pullPolicy: IfNotPresent
 service:
   name: nginx

--- a/resources/core/charts/service-catalog/charts/catalog-ui/Chart.yaml
+++ b/resources/core/charts/service-catalog/charts/catalog-ui/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 name: catalog-ui
 description: Catalog Service UI for Kyma Console
 version: 0.1.0
-appVersion: 0.1.139
+appVersion: 0.1.151

--- a/resources/core/charts/service-catalog/charts/instances-ui/Chart.yaml
+++ b/resources/core/charts/service-catalog/charts/instances-ui/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 name: instances-ui
 description: Catalog Service Instances UI embedded in the Console
 version: 0.1.0
-appVersion: 0.1.142
+appVersion: 0.1.151

--- a/resources/core/templates/tests/test-ui-acceptance.yaml
+++ b/resources/core/templates/tests/test-ui-acceptance.yaml
@@ -10,7 +10,7 @@ spec:
   hostNetwork: true
   containers:
     - name: "test-{{ template "fullname" . }}-ui-acceptance"
-      image: {{ .Values.global.containerRegistry.path }}/ui-tests:0.1.114
+      image: {{ .Values.global.containerRegistry.path }}/ui-tests:0.1.151
       resources:
          requests:
            memory: {{ .Values.test.acceptance.ui.requests.memory }}


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/master/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:
- Bump `core` image to `0.1.151`:
  - restructure navigation for `Service Catalog` group (https://github.com/kyma-project/console/issues/78)
- Bump `catalog` image to `0.1.151`:
  - support link and tags,
  - one step provisioning (https://github.com/kyma-project/console/issues/80)
  - modify service catalog navigation (https://github.com/kyma-project/console/issues/70)
  - Luigi integration (https://github.com/kyma-project/console/issues/109)
- Bump `instances` image to `0.1.151`:
  - enrich details instance view: support link, documentation link, modal with content of `ServicePlanSpec`, labels (https://github.com/kyma-project/console/issues/89)
  - enrich instances list view: modal with content of `ServicePlanSpec`, tooltip with `status.message` (https://github.com/kyma-project/console/issues/86)
  - Luigi integration (https://github.com/kyma-project/console/issues/109)
- Bump `tests` image to `0.1.151`:
  - update tests for instances and catalog