### PR TITLE
Change the support URL for redis bundle

### DIFF
--- a/resources/helm-broker-repo/bundles/redis-0.0.3/meta.yaml
+++ b/resources/helm-broker-repo/bundles/redis-0.0.3/meta.yaml
@@ -8,6 +8,6 @@ tags: database, cache
 providerDisplayName: bitnami
 longDescription: Redis is an advanced key-value cache and store
 documentationURL: https://github.com/bitnami/bitnami-docker-redis
-supportURL: http://slack.oss.bitnami.com/
+supportURL: https://bitnami.com/support
 imageURL: https://azure.microsoft.com/svghandler/redis-cache/
 bindable: true


### PR DESCRIPTION
**Description**

Current URL is broken and looks like there is no official open slack channel any more

Changes proposed in this pull request:

- Change the support URL for redis bundle