### PR TITLE
fix minikube version missmatch text

### DIFF
--- a/installation/scripts/minikube.sh
+++ b/installation/scripts/minikube.sh
@@ -96,7 +96,7 @@ function checkMinikubeVersion() {
     local version=$(minikube version | awk '{print  $3}')
 
     if [[ "${version}" != *"${MINIKUBE_VERSION}"* ]]; then
-        echo "Your minikube is in v${version}. v${MINIKUBE_VERSION} is supported version of minikube. Install supported version!"
+        echo "Your minikube is in ${version}. v${MINIKUBE_VERSION} is supported version of minikube. Install supported version!"
         exit -1
     fi
 }


### PR DESCRIPTION
MacOS error message:

"Your minikube is in vv0.27.0. v0.28.2 is supported version of minikube. Install supported version!"

