### PR TITLE
Adjust apiserver-proxy memory limits on cluster environments

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -23,7 +23,7 @@
 /resources/core/charts/api-controller/ @piotrmsc @kubadz
 
 # The `apiserver-proxy` subchart
-/resources/core/charts/apiserver-proxy/ @piotrmsc @kubadz
+/resources/core/charts/apiserver-proxy/ @piotrmsc @kubadz @sjanota
 
 # The `azure-broker` subchart
 /resources/core/charts/azure-broker/ @Tomasz-Smelcerz-SAP @strekm @jakkab @crabtree

--- a/resources/core/charts/apiserver-proxy/templates/deployment.yaml
+++ b/resources/core/charts/apiserver-proxy/templates/deployment.yaml
@@ -4,7 +4,13 @@ metadata:
   name: {{ template "name" . }}
   namespace: {{ .Release.Namespace }}
 spec:
-  replicas: 1
+  {{ if not .Values.global.isLocalEnv }}
+  replicas: 2
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 1  
+  {{ end }}
   template:
     metadata:
       annotations:
@@ -20,6 +26,13 @@ spec:
       containers:
       - image: {{ .Values.global.containerRegistry.path }}/{{ .Values.image.name }}:{{ .Values.image.tag }}
         name: kube-rbac-proxy
+        {{ if not .Values.global.isLocalEnv }}
+        resources:
+          limits:
+            memory: 256Mi
+          requests:
+            memory: 128Mi
+        {{ end }}
         imagePullPolicy: IfNotPresent
         args:
         - "--insecure-listen-address=0.0.0.0:{{ .Values.containerPort}}"

--- a/resources/core/charts/apiserver-proxy/templates/deployment.yaml
+++ b/resources/core/charts/apiserver-proxy/templates/deployment.yaml
@@ -10,6 +10,7 @@ spec:
     type: RollingUpdate
     rollingUpdate:
       maxUnavailable: 1  
+      maxSurge: 1
   {{ end }}
   template:
     metadata:


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/master/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Adjusted apiserver-proxy memory limits on cluster environments as they are fine for local, minikube development needs but not enough on multi node cluster environments with bigger load.
Changes proposed in this pull request:

- Added new codeowner for apiserver-proxy
- Modified memory configuration for proxy deployment on cluster env only
- Added RollingUpdate strategy for apiserver-deployment

**Related issue(s)**
#778 
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
