### PR TITLE
Adjust apiserver-proxy to allow k8s apiserver to be secured

### DIFF
--- a/components/apiserver-proxy/Gopkg.lock
+++ b/components/apiserver-proxy/Gopkg.lock
@@ -393,6 +393,7 @@
 [[projects]]
   name = "k8s.io/apiserver"
   packages = [
+    "pkg/apis/audit",
     "pkg/authentication/authenticator",
     "pkg/authentication/authenticatorfactory",
     "pkg/authentication/group",
@@ -406,6 +407,7 @@
     "pkg/authentication/user",
     "pkg/authorization/authorizer",
     "pkg/authorization/authorizerfactory",
+    "pkg/endpoints/request",
     "pkg/util/flag",
     "pkg/util/webhook",
     "pkg/util/wsstream",
@@ -503,6 +505,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "969aa333f3a52590cc7292fcd401a09fe476774b4fd4b0b9793c35b865b33729"
+  inputs-digest = "f6c0113c1f44b208252edb1ed2e522c9016a70b56fbc0d45269d489cc2ad1f6d"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/components/apiserver-proxy/cmd/proxy/main.go
+++ b/components/apiserver-proxy/cmd/proxy/main.go
@@ -285,8 +285,7 @@ func main() {
 // Returns intiliazed config, allows local usage (outside cluster) based on provided kubeconfig or in-cluter
 func initKubeConfig(kcLocation string) *rest.Config {
 
-	if kcLocation != "" {
-		println(kcLocation)
+	if kcLocation != "" {		
 		kubeConfig, err := clientcmd.BuildConfigFromFlags("", kcLocation)
 		if err != nil {
 			glog.Fatalf("unable to build rest config based on provided path to kubeconfig file %s", err.Error())

--- a/components/apiserver-proxy/internal/authz/auth.go
+++ b/components/apiserver-proxy/internal/authz/auth.go
@@ -1,19 +1,3 @@
-/*
-Copyright 2017 Frederic Branczyk Authors.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
-
 package authz
 
 import (


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/master/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**
As with the decision to adjust kube-rbac-proxy with our needs for securing k8s apiserver, this PR serves all required code changes on top of kube-rbac-proxy.
Changes proposed in this pull request:

- Code changes in the apiserver-proxy which allows k8s apiserver to be secured

**Related issue(s)**
See also #707 >
