### PR TITLE
Enable dynamic versioning

### DIFF
--- a/resources/core/charts/event-bus/charts/publish/templates/deployment.yaml
+++ b/resources/core/charts/event-bus/charts/publish/templates/deployment.yaml
@@ -24,7 +24,7 @@ spec:
     spec:
       containers:
         - name: {{ .Chart.Name }}
-          image: "{{ .Values.global.containerRegistry.path }}/{{ .Values.global.environments.dir }}event-bus-publish:f832e878"
+          image: "{{ .Values.global.containerRegistry.path }}/{{ .Values.global.event_bus.dir }}event-bus-publish:{{ .Values.global.event_bus.version }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           args:
             - --client_id=$(POD_NAME)

--- a/resources/core/charts/event-bus/charts/push/templates/deployment.yaml
+++ b/resources/core/charts/event-bus/charts/push/templates/deployment.yaml
@@ -51,7 +51,7 @@ spec:
     spec:
       containers:
         - name: {{ .Chart.Name }}
-          image: "{{ .Values.global.containerRegistry.path }}/{{ .Values.global.environments.dir }}event-bus-push:f832e878"
+          image: "{{ .Values.global.containerRegistry.path }}/{{ .Values.global.event_bus.dir }}event-bus-push:{{ .Values.global.event_bus.version }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           args:
             - --client_id=$(POD_NAME)

--- a/resources/core/charts/event-bus/charts/sub-validator/templates/deployment.yaml
+++ b/resources/core/charts/event-bus/charts/sub-validator/templates/deployment.yaml
@@ -69,7 +69,7 @@ spec:
     spec:
       containers:
         - name: {{ .Chart.Name }}
-          image: "{{ .Values.global.containerRegistry.path }}/{{ .Values.global.environments.dir }}event-bus-sub-validator:f832e878"
+          image: "{{ .Values.global.containerRegistry.path }}/{{ .Values.global.event_bus.dir }}event-bus-sub-validator:{{ .Values.global.event_bus.version }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           args:
             - --resyncPeriod={{ .Values.global.subValidator.resyncPeriod }}

--- a/resources/core/charts/event-bus/templates/tests/test-e2e-tester.yaml
+++ b/resources/core/charts/event-bus/templates/tests/test-e2e-tester.yaml
@@ -98,9 +98,9 @@ metadata:
 spec:
   serviceAccount: {{ .Values.e2eTests.nameTester }}
   containers:
-  - image: "{{ .Values.global.containerRegistry.path }}/{{ .Values.global.environments.dir }}event-bus-e2e-tester:564b7bb1"
+  - image: "{{ .Values.global.containerRegistry.path }}/{{ .Values.global.event_bus_tests.dir }}event-bus-e2e-tester:{{ .Values.global.event_bus_tests.version }}"
     imagePullPolicy: IfNotPresent
     name: {{ .Values.e2eTests.nameTester }}
     args:
-      - -subscriber-image={{ .Values.global.containerRegistry.path }}/{{ .Values.global.environments.dir }}event-bus-e2e-subscriber:564b7bb1
+      - -subscriber-image={{ .Values.global.containerRegistry.path }}/{{ .Values.global.event_bus_tests.dir }}event-bus-e2e-subscriber:{{ .Values.global.event_bus_tests.version }}
   restartPolicy: Never

--- a/resources/remote-environments/templates/deployment.yaml
+++ b/resources/remote-environments/templates/deployment.yaml
@@ -77,7 +77,7 @@ spec:
     spec:
       containers:
       - name: {{ .Release.Name }}-event-service
-        image: "{{ .Values.global.containerRegistry.path }}/{{ .Values.global.environments.dir }}event-service:f832e878"
+        image: "{{ .Values.global.containerRegistry.path }}/{{ .Values.global.event_service.dir }}event-service:{{ .Values.global.event_service.version }}"
         imagePullPolicy: {{ .Values.eventService.deployment.image.pullPolicy }}
         args:
         - "/eventservice"

--- a/resources/remote-environments/templates/tests/test-acceptance.yaml
+++ b/resources/remote-environments/templates/tests/test-acceptance.yaml
@@ -9,7 +9,7 @@ metadata:
 spec:
   containers:
     - name: test-{{.Release.Name }}-event-service-acceptance
-      image: "{{ .Values.global.containerRegistry.path }}/{{ .Values.acceptanceTest.image.name }}:{{ .Values.acceptanceTest.image.tag }}"
+      image: "{{ .Values.global.containerRegistry.path }}/{{ .Values.global.gateway_tests.dir }}gateway-acceptance-tests:{{ .Values.global.gateway_tests.version }}"
       imagePullPolicy: {{ .Values.acceptanceTest.image.pullPolicy }}
       resources:
         limits:

--- a/resources/remote-environments/values.yaml
+++ b/resources/remote-environments/values.yaml
@@ -31,8 +31,6 @@ ingress:
 
 acceptanceTest:
   image:
-    name: gateway-acceptance-tests
-    tag: 0.2.19
     pullPolicy: IfNotPresent
 
 eventService:


### PR DESCRIPTION
**Description**

Enable dynamic versioning in charts:
- event-bus (publish, push and subscription-validator)
- event-service
- event-bus e2e-tests
- event-service acceptance-tests

**Related issue(s)**
#855 
