### PR TITLE
React to subscriptions updates

### DIFF
--- a/components/event-bus/api/push/eventing.kyma.cx/v1alpha1/register.go
+++ b/components/event-bus/api/push/eventing.kyma.cx/v1alpha1/register.go
@@ -33,7 +33,8 @@ func init() {
 func addKnownTypes(scheme *runtime.Scheme) error {
 	scheme.AddKnownTypes(SchemeGroupVersion,
 		&Subscription{},
-	)
+		&SubscriptionList{},)
+
 	metav1.AddToGroupVersion(scheme, SchemeGroupVersion)
 	return nil
 }

--- a/components/event-bus/internal/push/controllers/eventactivation_test.go
+++ b/components/event-bus/internal/push/controllers/eventactivation_test.go
@@ -57,6 +57,7 @@ func verifyStartSubCalledOnEventActivation(orgSub *v1alpha1.Subscription, mockSu
 	subWithEventsActivation := orgSub.DeepCopy()
 	subWithEventsActivation.Status = activeStatus
 	mockSupervisor.On("StartSubscriptionReq", subWithEventsActivation).Return()
+	mockSupervisor.On("StopSubscriptionReq", orgSub).Return()
 	updateFunction(orgSub, subWithEventsActivation)
 	mockSupervisor.AssertCalled(t, "StartSubscriptionReq", subWithEventsActivation)
 	return subWithEventsActivation
@@ -71,9 +72,10 @@ func verifyStopSubCalledOnEventDeactivation(orgSub *v1alpha1.Subscription, mockS
 			},
 		},
 	}
-	SubWithEventsDeactivation := orgSub.DeepCopy()
-	SubWithEventsDeactivation.Status = deactiveStatus
-	mockSupervisor.On("StopSubscriptionReq", SubWithEventsDeactivation).Return()
-	updateFunction(orgSub, SubWithEventsDeactivation)
-	mockSupervisor.AssertCalled(t, "StopSubscriptionReq", SubWithEventsDeactivation)
+	subWithEventsDeactivation := orgSub.DeepCopy()
+	subWithEventsDeactivation.Status = deactiveStatus
+	mockSupervisor.On("StopSubscriptionReq", orgSub).Return()
+	mockSupervisor.On("StopSubscriptionReq", subWithEventsDeactivation).Return()
+	updateFunction(orgSub, subWithEventsDeactivation)
+	mockSupervisor.AssertCalled(t, "StopSubscriptionReq", subWithEventsDeactivation)
 }

--- a/components/event-bus/internal/push/controllers/subscriptions_controller.go
+++ b/components/event-bus/internal/push/controllers/subscriptions_controller.go
@@ -67,10 +67,8 @@ func (controller *SubscriptionsController) Stop() {
 
 func (controller *SubscriptionsController) startInformerWithoutEventActivationCheck() {
 	controller.informer.AddEventHandler(cache.ResourceEventHandlerFuncs{
-		AddFunc: getAddFnWithoutEventActivationCheck(controller.supervisor),
-		UpdateFunc: func(oldObj, newObj interface{}) {
-			//log.Print("Updated")
-		},
+		AddFunc:    getAddFnWithoutEventActivationCheck(controller.supervisor),
+		UpdateFunc: getUpdateFnWithoutEventActivationCheck(controller.supervisor),
 		DeleteFunc: controller.getDeleteFn(),
 	})
 

--- a/components/event-bus/internal/push/controllers/subsutil.go
+++ b/components/event-bus/internal/push/controllers/subsutil.go
@@ -1,0 +1,26 @@
+package controllers
+
+import (
+	"log"
+
+	subApis "github.com/kyma-project/kyma/components/event-bus/api/push/eventing.kyma.cx/v1alpha1"
+)
+
+func checkSubscriptions(oldObj, newObj interface{}) (*subApis.Subscription, *subApis.Subscription, bool) {
+	oldSub, oldSubOk := oldObj.(*subApis.Subscription)
+	newSub, newSubOK := newObj.(*subApis.Subscription)
+	if !oldSubOk || !newSubOK {
+		log.Printf("checkSubscriptions() failed: unknown object type either updated %+v or original +%v", newObj, oldObj)
+		return nil, nil, false
+	}
+	return oldSub, newSub, true
+}
+
+func checkSubscription(obj interface{}) (*subApis.Subscription, bool) {
+	sub, ok := obj.(*subApis.Subscription)
+	if !ok {
+		log.Printf("checkSubscription() failed: unknown object type %+v", obj)
+		return nil, false
+	}
+	return sub, true
+}

--- a/components/event-bus/test/integration/fake_k8s_client.go
+++ b/components/event-bus/test/integration/fake_k8s_client.go
@@ -1,0 +1,82 @@
+package integration
+
+import (
+	"context"
+	subApi "github.com/kyma-project/kyma/components/event-bus/api/push/eventing.kyma.cx/v1alpha1"
+	"github.com/kyma-project/kyma/components/event-bus/generated/push/clientset/versioned/fake"
+	"github.com/kyma-project/kyma/components/event-bus/generated/push/informers/externalversions"
+	"github.com/satori/go.uuid"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/tools/cache"
+	"time"
+)
+
+var (
+	client *fake.Clientset
+)
+
+func newFakeInformer(ctx context.Context) cache.SharedIndexInformer {
+
+	client = fake.NewSimpleClientset()
+
+	informers := externalversions.NewSharedInformerFactory(client, 0)
+
+	informer := informers.Eventing().V1alpha1().Subscriptions().Informer()
+
+	informers.Start(ctx.Done())
+
+	if !informer.HasSynced() {
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	return informer
+}
+
+func createNewSubscription(name string, namespace string, subscriberEventEndpointURL string, eventType string, eventTypeVersion string,
+	sourceID string) (*subApi.Subscription, error) {
+	uid := uuid.NewV4().String()
+	return client.EventingV1alpha1().Subscriptions(namespace).Create(getSubscriptionResource(name, namespace, uid, subscriberEventEndpointURL, sourceID, eventType, eventTypeVersion))
+}
+
+func updateSubscription(name string, namespace string, subscriberEventEndpointURL string, eventType string, eventTypeVersion string,
+	sourceID string) (*subApi.Subscription, error) {
+	uid := uuid.NewV4().String()
+	return client.EventingV1alpha1().Subscriptions(namespace).Update(getSubscriptionResource(name, namespace, uid, subscriberEventEndpointURL, sourceID, eventType, eventTypeVersion))
+}
+
+func getSubscriptionResource(name string, namespace string, uid string, subscriberEventEndpointURL string, sourceID string, eventType string, eventTypeVersion string) *subApi.Subscription {
+	return &subApi.Subscription{
+		TypeMeta: metav1.TypeMeta{APIVersion: subApi.SchemeGroupVersion.String()},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+			UID:       types.UID(uid),
+		},
+
+		SubscriptionSpec: subApi.SubscriptionSpec{
+			Endpoint:                      subscriberEventEndpointURL,
+			IncludeSubscriptionNameHeader: false,
+			MaxInflight:                   100,
+			PushRequestTimeoutMS:          10,
+			SourceID:                      sourceID,
+			EventType:                     eventType,
+			EventTypeVersion:              eventTypeVersion,
+		},
+
+		Status: subApi.SubscriptionStatus{
+			Conditions: []subApi.SubscriptionCondition{
+				{
+					Type:   subApi.EventsActivated,
+					Status: subApi.ConditionTrue,
+				},
+			},
+		},
+	}
+}
+
+func deleteSubscription(name string, namespace string) error {
+	return client.EventingV1alpha1().Subscriptions(namespace).Delete(name,
+		&metav1.DeleteOptions{TypeMeta: metav1.TypeMeta{APIVersion: subApi.SchemeGroupVersion.String()}},
+	)
+}

--- a/components/event-bus/test/integration/helpers.go
+++ b/components/event-bus/test/integration/helpers.go
@@ -1,0 +1,128 @@
+package integration
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"log"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	api "github.com/kyma-project/kyma/components/event-bus/api/publish"
+	"github.com/kyma-project/kyma/components/event-bus/generated/push/clientset/versioned/fake"
+	"github.com/kyma-project/kyma/components/event-bus/generated/push/informers/externalversions/eventing.kyma.cx/v1alpha1"
+	"github.com/stretchr/testify/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/tools/cache"
+	"context"
+	"github.com/nats-io/nats-streaming-server/server"
+)
+
+const (
+	clusterID               = "kyma-nats-streaming"
+	eventType               = "test-publish-push-success"
+	eventTypeVersion        = "v1"
+	sourceIDV1              = "test.local.kyma.commerce.ec"
+	eventDataV1             = "test-event-1"
+	sourceIDV2              = "test.local.kyma.commerce.ec"
+	eventDataV2             = "test-event-2"
+	publishServerStatusPath = "/v1/status/ready"
+	headerKymaTopic         = "kyma-topic"
+)
+
+func startNats() (*server.StanServer, error) {
+	return server.RunServer(clusterID)
+}
+
+func stopNats(stanServer *server.StanServer) {
+	stanServer.Shutdown()
+}
+
+func makePayload(sourceID, eventType, eventTypeVersion, eventData string) string {
+	return fmt.Sprintf(`{"source-id": "%s", "event-type": "%s","event-type-version": "%s","event-time": "2018-11-02T22:08:41+00:00","data": "%s"}`,
+		sourceID, eventType, eventTypeVersion, eventData)
+}
+
+//func newFakeInformer() cache.SharedIndexInformer {
+//	sub := util.NewSubscription(
+//		"test-sub",
+//		metav1.NamespaceDefault,
+//		subscriberServerV1.URL+util.SubServer1EventsPath,
+//		eventType,
+//		eventTypeVersion,
+//		sourceIDV1)
+//	clientSet := fake.NewSimpleClientset(sub)
+//	informer := v1alpha1.NewSubscriptionInformer(clientSet, metav1.NamespaceAll, 0, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
+//	informer.GetIndexer().Add(sub)
+//	return informer
+//}
+
+func newFakeInformer2() cache.SharedIndexInformer {
+	ctx, _ := context.WithTimeout(context.Background(), 5*time.Second)
+
+	client := fake.NewSimpleClientset()
+
+	informers := v1alpha1.NewSubscriptionInformer(client, metav1.NamespaceAll, 1*time.Minute, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
+
+	informers.Run(ctx.Done())
+
+	informer := v1alpha1.NewSubscriptionInformer(client, metav1.NamespaceAll, 0, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
+
+	if !informer.HasSynced() {
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	//client.EventingV1alpha1().Subscriptions("").Create()
+
+	return informer
+}
+
+func verifyStatusCode(res *http.Response, expectedStatusCode int, t *testing.T) {
+	if res.StatusCode != expectedStatusCode {
+		t.Errorf("Status code is wrong, have: %d, want: %d", res.StatusCode, expectedStatusCode)
+	}
+}
+
+func checkIfError(err error, t *testing.T) {
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func publishEvent(t *testing.T, publishServerURL string, payload string) {
+	res, err := http.Post(publishServerURL+"/v1/events", "application/json", strings.NewReader(payload))
+	checkIfError(err, t)
+	verifyStatusCode(res, 200, t)
+	log.Print(res)
+
+	respObj := &api.PublishResponse{}
+	body, err := ioutil.ReadAll(res.Body)
+	defer res.Body.Close()
+
+	err = json.Unmarshal(body, &respObj)
+	assert.NotNil(t, respObj.EventID)
+	assert.NotEmpty(t, respObj.EventID)
+	log.Printf("%v", respObj)
+}
+
+func verifyEndpointReceivedEvent(t *testing.T, endpoint, data string) {
+	var ok bool
+	for i := 0; i < 20; i++ {
+		time.Sleep(1 * time.Second)
+		res, err := http.Get(endpoint)
+		assert.Nil(t, err)
+		body, err := ioutil.ReadAll(res.Body)
+		var resp string
+		json.Unmarshal(body, &resp)
+		res.Body.Close()
+		if len(resp) == 0 {
+			continue
+		}
+		assert.Equal(t, data, resp)
+		ok = true
+		break
+	}
+	assert.True(t, ok)
+}

--- a/components/event-bus/test/integration/helpers.go
+++ b/components/event-bus/test/integration/helpers.go
@@ -11,13 +11,8 @@ import (
 	"time"
 
 	api "github.com/kyma-project/kyma/components/event-bus/api/publish"
-	"github.com/kyma-project/kyma/components/event-bus/generated/push/clientset/versioned/fake"
-	"github.com/kyma-project/kyma/components/event-bus/generated/push/informers/externalversions/eventing.kyma.cx/v1alpha1"
-	"github.com/stretchr/testify/assert"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/client-go/tools/cache"
-	"context"
 	"github.com/nats-io/nats-streaming-server/server"
+	"github.com/stretchr/testify/assert"
 )
 
 const (
@@ -43,40 +38,6 @@ func stopNats(stanServer *server.StanServer) {
 func makePayload(sourceID, eventType, eventTypeVersion, eventData string) string {
 	return fmt.Sprintf(`{"source-id": "%s", "event-type": "%s","event-type-version": "%s","event-time": "2018-11-02T22:08:41+00:00","data": "%s"}`,
 		sourceID, eventType, eventTypeVersion, eventData)
-}
-
-//func newFakeInformer() cache.SharedIndexInformer {
-//	sub := util.NewSubscription(
-//		"test-sub",
-//		metav1.NamespaceDefault,
-//		subscriberServerV1.URL+util.SubServer1EventsPath,
-//		eventType,
-//		eventTypeVersion,
-//		sourceIDV1)
-//	clientSet := fake.NewSimpleClientset(sub)
-//	informer := v1alpha1.NewSubscriptionInformer(clientSet, metav1.NamespaceAll, 0, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
-//	informer.GetIndexer().Add(sub)
-//	return informer
-//}
-
-func newFakeInformer2() cache.SharedIndexInformer {
-	ctx, _ := context.WithTimeout(context.Background(), 5*time.Second)
-
-	client := fake.NewSimpleClientset()
-
-	informers := v1alpha1.NewSubscriptionInformer(client, metav1.NamespaceAll, 1*time.Minute, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
-
-	informers.Run(ctx.Done())
-
-	informer := v1alpha1.NewSubscriptionInformer(client, metav1.NamespaceAll, 0, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
-
-	if !informer.HasSynced() {
-		time.Sleep(10 * time.Millisecond)
-	}
-
-	//client.EventingV1alpha1().Subscriptions("").Create()
-
-	return informer
 }
 
 func verifyStatusCode(res *http.Response, expectedStatusCode int, t *testing.T) {

--- a/components/event-bus/test/integration/publish_push_test.go
+++ b/components/event-bus/test/integration/publish_push_test.go
@@ -100,9 +100,9 @@ func Test_sameSubjectSubscribersInDifferentNamespacesShouldReceiveEventsOfThatSu
 	ns2 := "namespace-2"
 	eventData := "Test_sameSubjectSubscribersInDifferentNamespacesShouldReceiveEventsOfThatSubject"
 
-	doCreateSub(name, ns1, subscriberServerV1.URL+util.SubServer1EventsPath, eventType, eventTypeVersion, sourceIDV1, t)
+	triggerCreateSub(name, ns1, subscriberServerV1.URL+util.SubServer1EventsPath, eventType, eventTypeVersion, sourceIDV1, t)
 
-	doCreateSub(name, ns2, subscriberServerV2.URL+util.SubServer2EventsPath, eventType, eventTypeVersion, sourceIDV1, t)
+	triggerCreateSub(name, ns2, subscriberServerV2.URL+util.SubServer2EventsPath, eventType, eventTypeVersion, sourceIDV1, t)
 
 	time.Sleep(waitForSubscriptionToStart)
 
@@ -114,8 +114,8 @@ func Test_sameSubjectSubscribersInDifferentNamespacesShouldReceiveEventsOfThatSu
 	verifyEndpointReceivedEvent(t, subscriberServerV1.URL+util.SubServer1ResultsPath, eventData)
 	verifyEndpointReceivedEvent(t, subscriberServerV2.URL+util.SubServer2ResultsPath, eventData)
 
-	doDeleteSub(name, ns1, t)
-	doDeleteSub(name, ns2, t)
+	triggerDeleteSub(name, ns1, t)
+	triggerDeleteSub(name, ns2, t)
 }
 
 func Test_UpdateSubscriptionURL(t *testing.T) {
@@ -123,49 +123,49 @@ func Test_UpdateSubscriptionURL(t *testing.T) {
 	ns := "namespace-1"
 
 	preUpdateEvent := "test-pre-update"
-	doCreateSub(name, ns, subscriberServerV1.URL+util.SubServer1EventsPath, eventType, eventTypeVersion, sourceIDV1, t)
+	triggerCreateSub(name, ns, subscriberServerV1.URL+util.SubServer1EventsPath, eventType, eventTypeVersion, sourceIDV1, t)
 	time.Sleep(waitForSubscriptionToStart)
 
 	publishEvent(t, publishServer.URL, makePayload(sourceIDV1, eventType, eventTypeVersion, preUpdateEvent))
 	verifyEndpointReceivedEvent(t, subscriberServerV1.URL+util.SubServer1ResultsPath, preUpdateEvent)
 
-	doUpdate(name, ns, subscriberServerV2.URL+util.SubServer2EventsPath, eventType, eventTypeVersion, sourceIDV1, t)
+	triggerUpdateSub(name, ns, subscriberServerV2.URL+util.SubServer2EventsPath, eventType, eventTypeVersion, sourceIDV1, t)
 	time.Sleep(waitForSubscriptionToStart)
 
 	postUpdateEvent := "test-post-update"
 	publishEvent(t, publishServer.URL, makePayload(sourceIDV1, eventType, eventTypeVersion, postUpdateEvent))
 	verifyEndpointReceivedEvent(t, subscriberServerV2.URL+util.SubServer2ResultsPath, postUpdateEvent)
 
-	doDeleteSub(name, ns, t)
+	triggerDeleteSub(name, ns, t)
 
 }
 
 func verifyPublishPushFlow(eventData string, subscriptionName string, namespace string, t *testing.T) {
 	payloadV1 := makePayload(sourceIDV1, eventType, eventTypeVersion, eventData)
 
-	doCreateSub(subscriptionName, namespace, subscriberServerV1.URL+util.SubServer1EventsPath, eventType, eventTypeVersion, sourceIDV1, t)
+	triggerCreateSub(subscriptionName, namespace, subscriberServerV1.URL+util.SubServer1EventsPath, eventType, eventTypeVersion, sourceIDV1, t)
 
 	time.Sleep(waitForSubscriptionToStart)
 
 	publishEvent(t, publishServer.URL, payloadV1)
 	verifyEndpointReceivedEvent(t, subscriberServerV1.URL+util.SubServer1ResultsPath, eventData)
 
-	doDeleteSub(subscriptionName, namespace, t)
+	triggerDeleteSub(subscriptionName, namespace, t)
 
 }
 
-func doCreateSub(subscriptionName string, namespace string, subscriberEventEndpointURL string, eventType string, eventTypeVersion string,
+func triggerCreateSub(subscriptionName string, namespace string, subscriberEventEndpointURL string, eventType string, eventTypeVersion string,
 	sourceID string, t *testing.T) {
 	_, err := createNewSubscription(subscriptionName, namespace, subscriberEventEndpointURL, eventType, eventTypeVersion, sourceID)
 	checkIfError(err, t)
 }
 
-func doDeleteSub(subscriptionName string, namespace string, t *testing.T) {
+func triggerDeleteSub(subscriptionName string, namespace string, t *testing.T) {
 	err := deleteSubscription(subscriptionName, namespace)
 	checkIfError(err, t)
 }
 
-func doUpdate(subscriptionName string, namespace string, subscriberEventEndpointURL string, eventType string, eventTypeVersion string,
+func triggerUpdateSub(subscriptionName string, namespace string, subscriberEventEndpointURL string, eventType string, eventTypeVersion string,
 	sourceID string, t *testing.T) {
 	_, err := updateSubscription(subscriptionName, namespace, subscriberEventEndpointURL, eventType, eventTypeVersion, sourceID)
 	checkIfError(err, t)


### PR DESCRIPTION
Co-authored-by: abbi-gaurav <abbi.gaurav@gmail.com>

**Description**

Changes proposed in this pull request:

- Extend the controllers in push and subscription validator to react to all changes in a subscription CRD
- Extend the unit tests
- Create fake client and informers
- Add functions to create, update, delete subscription resources
- Apply code refactoring
- Update existing tests to use subscription resource creation
- Add a test to verify the update of a subscription

**Related issue(s)**
See also #365
