### PR TITLE
Fix #989 Multiple request in same trace

### DIFF
--- a/resources/core/charts/nginx-ingress/values.yaml
+++ b/resources/core/charts/nginx-ingress/values.yaml
@@ -5,7 +5,7 @@ controller:
   name: controller
   image:
     repository: quay.io/kubernetes-ingress-controller/nginx-ingress-controller
-    tag: "0.18.0"
+    tag: "0.19.0"
     pullPolicy: IfNotPresent
 
   config: {}


### PR DESCRIPTION
The upgrade 0.19.0 contains fix for an issue where multiple requests were clubbed in same trace. Refer https://github.com/kubernetes/ingress-nginx/blob/master/Changelog.md, https://github.com/kubernetes/ingress-nginx/pull/2955 and https://github.com/opentracing-contrib/nginx-opentracing/issues/52


Fixes #989 
Verified locally. For 20 events, we can see 20 different traces

![screen shot 2018-10-02 at 14 56 38](https://user-images.githubusercontent.com/4436741/46349851-80c85d00-c653-11e8-869b-7bfcb9602104.png)
