### PR TITLE
Add backoff retries in an errornous case in event bus test

### DIFF
--- a/tests/event-bus/e2e-tester/e2e-tester.go
+++ b/tests/event-bus/e2e-tester/e2e-tester.go
@@ -372,6 +372,7 @@ func checkSubscriberStatus(noOfRetries int) bool {
 			time.Sleep(time.Duration(i) * time.Second)
 		} else if !checkStatusCode(res, http.StatusOK) {
 			log.Printf("Subscriber Server Status request returns: %v; Retrying (%d/%d)\n", res, i, noOfRetries)
+			time.Sleep(time.Duration(i) * time.Second)
 		} else {
 			subscriberOK = true
 			break


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/master/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**
Add backoff retries in an errornous case in event bus test

Changes proposed in this pull request:

- Add backoff retries in an errornous case in event bus test

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
