### PR TITLE
Adding console title and logoUrl to installer overrides

### DIFF
--- a/installation/resources/installer-config-cluster.yaml.tpl
+++ b/installation/resources/installer-config-cluster.yaml.tpl
@@ -65,6 +65,19 @@ data:
 apiVersion: v1
 kind: ConfigMap
 metadata:
+  name: core-overrides
+  namespace: kyma-installer
+  labels:
+    installer: overrides
+    component: core
+data:
+  console.cluster.headerLogoUrl: "assets/logo.svg"
+  console.cluster.headerTitle: ""
+  console.cluster.faviconUrl: "favicon.ico"
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
   name: ec-default-overrides
   namespace: kyma-installer
   labels:

--- a/installation/resources/installer-config-local.yaml.tpl
+++ b/installation/resources/installer-config-local.yaml.tpl
@@ -61,6 +61,19 @@ data:
 apiVersion: v1
 kind: ConfigMap
 metadata:
+  name: core-overrides
+  namespace: kyma-installer
+  labels:
+    installer: overrides
+    component: core
+data:
+  console.cluster.headerLogoUrl: "assets/logo.svg"
+  console.cluster.headerTitle: ""
+  console.cluster.faviconUrl: "favicon.ico"
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
   name: ec-default-overrides
   namespace: kyma-installer
   labels:
@@ -69,7 +82,7 @@ metadata:
 data:
   deployment.args.sourceType: commerce
   service.externalapi.nodePort: "32001"
----
+---  
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/resources/core/charts/console/templates/configmap.yaml
+++ b/resources/core/charts/console/templates/configmap.yaml
@@ -17,6 +17,7 @@ data:
       orgName: '{{ js .Values.cluster.orgName }}',
       headerLogoUrl: '{{ js .Values.cluster.headerLogoUrl }}',
       headerTitle: '{{ js .Values.cluster.headerTitle }}',
+      faviconUrl: '{{ js .Values.cluster.faviconUrl }}',
       gateway_kyma_cx_api_version: 'v1alpha2'
     };
     

--- a/resources/core/charts/console/values.yaml
+++ b/resources/core/charts/console/values.yaml
@@ -3,7 +3,7 @@
 # Declare variables to be passed into your templates.
 replicaCount: 1
 image:
-  tag: 0.1.187
+  tag: 0.1.201
   pullPolicy: IfNotPresent
 service:
   name: nginx
@@ -29,5 +29,7 @@ cluster:
   orgName: 'My Organization'
   # Provide custom logo image url that should replace the default kyma logo in the console app header component
   headerLogoUrl: 'assets/logo.svg'
+  # Provide custom favicon for console app
+  faviconUrl: 'favicon.ico'
   # Provide custom title for the UI application that will be shown in the header component
   headerTitle: ''


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Make console title and logoUrl configurable via installer overrides

**Related issue(s)**
Fixes : https://github.com/kyma-project/console/issues/204
