### PR TITLE
Enable Source-Id as a header field

### DIFF
--- a/components/event-bus/.gitignore
+++ b/components/event-bus/.gitignore
@@ -10,3 +10,4 @@
 bin/
 docker/
 vendor/
+/unit-tests.xml

--- a/components/event-bus/Jenkinsfile
+++ b/components/event-bus/Jenkinsfile
@@ -50,8 +50,12 @@ podTemplate(label: label) {
                             + "./...")
                         }
 
-                        stage("build and test - event-bus-publish") {
-                            execute("/cmd/event-bus-publish", "make clean build")
+                        stage("test - event-bus") {
+                            execute("/", "make test")
+                        }
+
+                        stage("build - event-bus-publish") {
+                            execute("/cmd/event-bus-publish", "make clean compile")
                         }
 
                         stage("build image - event-bus-publish") {
@@ -60,8 +64,8 @@ podTemplate(label: label) {
                             }
                         }
 
-                        stage("build and test - event-bus-push") {
-                            execute("/cmd/event-bus-push", "make clean build")
+                        stage("build - event-bus-push") {
+                            execute("/cmd/event-bus-push", "make clean compile")
                         }
 
                         stage("build image - event-bus-push") {
@@ -70,8 +74,8 @@ podTemplate(label: label) {
                             }
                         }
 
-                        stage("build and test - event-bus-sub-validator") {
-                            execute("/cmd/event-bus-sv", "make clean build")
+                        stage("build - event-bus-sub-validator") {
+                            execute("/cmd/event-bus-sv", "make clean compile")
                         }
 
                         stage("build image - event-bus-sub-validator") {

--- a/components/event-bus/Makefile
+++ b/components/event-bus/Makefile
@@ -1,9 +1,18 @@
-.PHONY: all vet test
+.PHONY: all resolve test test-report validate vet
 
-all: vet test
+all: resolve test validate vet
 
-vet:
-	go list ./... | grep -v generated | xargs go vet
+resolve:
+	dep ensure -vendor-only -v
 
 test:
 	go list ./... | grep -v generated | xargs go test -v
+
+test-report:
+	2>&1 go test -v ./... | go2xunit -fail -output unit-tests.xml
+
+validate:
+	gometalinter --skip=generated --vendor --deadline=2m --disable-all --enable=vet ./...
+
+vet:
+	go list ./... | grep -v generated | xargs go vet

--- a/components/event-bus/Makefile
+++ b/components/event-bus/Makefile
@@ -1,0 +1,9 @@
+.PHONY: all vet test
+
+all: vet test
+
+vet:
+	go list ./... | grep -v generated | xargs go vet
+
+test:
+	go list ./... | grep -v generated | xargs go test -v

--- a/components/event-bus/api/publish/api.go
+++ b/components/event-bus/api/publish/api.go
@@ -9,24 +9,25 @@ const ( //TODO Check how to access struct tags
 	FieldSourceId         = "source-id"
 	FieldTraceContext     = "trace-context"
 
-	//AllowedIDChars
-	AllowedIdChars      = `^[a-zA-Z0-9_\-]+$`
 	AllowedEventIDChars = `^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$`
 
 	// fully-qualified topic name components
 	AllowedSourceIdChars         = `^[a-zA-Z]+([_\-\.]?[a-zA-Z0-9]+)*$`
 	AllowedEventTypeChars        = `^[a-zA-Z]+([_\-\.]?[a-zA-Z0-9]+)*$`
 	AllowedEventTypeVersionChars = `^[a-zA-Z0-9]+$`
+
+	HeaderSourceId = "Source-Id"
 )
 
 // PublishRequest represents a publish request
 type PublishRequest struct {
-	SourceID         string   `json:"source-id"`
-	EventType        string   `json:"event-type"`
-	EventTypeVersion string   `json:"event-type-version"`
-	EventID          string   `json:"event-id"`
-	EventTime        string   `json:"event-time"`
-	Data             AnyValue `json:"data"`
+	SourceID           string   `json:"source-id"`
+	EventType          string   `json:"event-type"`
+	EventTypeVersion   string   `json:"event-type-version"`
+	EventID            string   `json:"event-id"`
+	EventTime          string   `json:"event-time"`
+	Data               AnyValue `json:"data"`
+	SourceIdFromHeader bool
 }
 
 // AnyValue implements the service definition of AnyValue

--- a/components/event-bus/api/publish/validators.go
+++ b/components/event-bus/api/publish/validators.go
@@ -6,12 +6,13 @@ import (
 )
 
 var (
-	isValidID1     = regexp.MustCompile(AllowedIdChars).MatchString
 	isValidEventID = regexp.MustCompile(AllowedEventIDChars).MatchString
 
 	// fully-qualified topic name components
 	isValidEventType        = regexp.MustCompile(AllowedEventTypeChars).MatchString
 	isValidEventTypeVersion = regexp.MustCompile(AllowedEventTypeVersionChars).MatchString
+
+	isValidSourceId = regexp.MustCompile(AllowedSourceIdChars).MatchString
 )
 
 //ValidatePublish validates a publish POST request
@@ -35,6 +36,9 @@ func ValidatePublish(r *PublishRequest) *Error {
 	}
 
 	// validate the fully-qualified topic name components
+	if !isValidSourceId(r.SourceID){
+		return ErrorResponseWrongSourceId(r.SourceIdFromHeader)
+	}
 	if !isValidEventType(r.EventType) {
 		return ErrorResponseWrongEventType()
 	}

--- a/components/event-bus/api/publish/validators_test.go
+++ b/components/event-bus/api/publish/validators_test.go
@@ -11,9 +11,10 @@ func Test_ValidatePublish_MissingSourceId(t *testing.T) {
 	publishRequest := buildTestPublishRequest()
 	publishRequest.SourceID = ""
 	err := ValidatePublish(&publishRequest)
-	assert.NotEqual(t, len(err.Details), 0)
+	assert.Equal(t, len(err.Details), 1)
 	assert.Equal(t, http.StatusBadRequest, err.Status)
-	assert.Equal(t, FieldSourceId, err.Details[0].Field)
+	assert.Equal(t, ErrorMessageMissingSourceId, err.Message)
+	assert.Equal(t, ErrorTypeMissingFieldOrHeader, err.Details[0].Type)
 }
 
 func Test_ValidatePublish_MissingEventType(t *testing.T) {
@@ -95,6 +96,28 @@ func Test_ValidatePublish_InvalidEventID(t *testing.T) {
 	assert.NotEqual(t, len(err.Details), 0)
 	assert.Equal(t, http.StatusBadRequest, err.Status)
 	assert.Equal(t, FieldEventId, err.Details[0].Field)
+}
+
+func Test_ValidatePublish_InvalidSourceId_In_Payload(t *testing.T) {
+	publishRequest := buildTestPublishRequest()
+	publishRequest.SourceIdFromHeader = false
+	publishRequest.SourceID = "invalid/sourceId"
+	err := ValidatePublish(&publishRequest)
+	assert.NotEqual(t, len(err.Details), 0)
+	assert.Equal(t, http.StatusBadRequest, err.Status)
+	assert.Equal(t, FieldSourceId, err.Details[0].Field)
+	assert.Equal(t, ErrorTypeInvalidField, err.Details[0].Type)
+}
+
+func Test_ValidatePublish_InvalidSourceId_In_Header(t *testing.T) {
+	publishRequest := buildTestPublishRequest()
+	publishRequest.SourceIdFromHeader = true
+	publishRequest.SourceID = "invalid/sourceId"
+	err := ValidatePublish(&publishRequest)
+	assert.NotEqual(t, len(err.Details), 0)
+	assert.Equal(t, http.StatusBadRequest, err.Status)
+	assert.Equal(t, HeaderSourceId, err.Details[0].Field)
+	assert.Equal(t, ErrorTypeInvalidHeader, err.Details[0].Type)
 }
 
 func Test_ValidatePublish_Success(t *testing.T) {

--- a/components/event-bus/cmd/event-bus-publish/Makefile
+++ b/components/event-bus/cmd/event-bus-publish/Makefile
@@ -3,30 +3,19 @@ VERSION = 0.1.0
 COMPONENT = event-bus
 REGISTRY = eu.gcr.io
 
-.PHONY: all clean build tag push
+.PHONY: all clean compile docker-build tag
 
-all: clean build docker-build tag
+all: clean compile docker-build tag
 
 clean:
 	rm -rf bin/
 	rm -rf docker/
 
-build: vet test compile
-
 compile:
 	go build -o bin/event-bus-publish
-
-test:
-	go test github.com/kyma-project/kyma/components/event-bus/cmd/event-bus-publish -v
 
 docker-build:
 	./dockerBuild.sh  $(NAME) $(VERSION) $(COMPONENT)
 
 tag:
 	docker tag $(NAME):$(VERSION) $(REGISTRY)/$(NAME):$(VERSION)
-
-push:
-	docker push $(REGISTRY)/$(NAME):$(VERSION)
-
-vet:
-	go list ../../... | grep -v generated | xargs go vet

--- a/components/event-bus/cmd/event-bus-publish/handlers/handlers.go
+++ b/components/event-bus/cmd/event-bus-publish/handlers/handlers.go
@@ -90,6 +90,11 @@ func handlePublishRequest(w http.ResponseWriter, r *http.Request, publisher *con
 		return
 	}
 	publishRequest, err := parseRequest(body)
+
+	if len(publishRequest.SourceID) == 0 {
+		setSourceIdFromHeader(publishRequest, &r.Header)
+	}
+
 	if err != nil {
 		log.Printf("PublishHandler :: handlePublishRequest :: Error while parsing request :: Error: %v", err)
 		publish.SendJSONError(w, api.ErrorResponseBadPayload())
@@ -148,6 +153,15 @@ func parseRequest(b []byte) (*api.PublishRequest, error) {
 	var publishRequest api.PublishRequest
 	err := json.Unmarshal(b, &publishRequest)
 	return &publishRequest, err
+}
+
+func setSourceIdFromHeader(publishRequest *api.PublishRequest, header *http.Header) {
+	sourceId := header.Get(api.HeaderSourceId)
+	if len(sourceId) != 0 {
+		log.Println("Setting source id from header")
+		publishRequest.SourceID = sourceId
+		publishRequest.SourceIdFromHeader = true
+	}
 }
 
 func publishEvent(r *api.PublishRequest, body string, publisher *controllers.Publisher) (*api.PublishResponse, error) {

--- a/components/event-bus/cmd/event-bus-publish/handlers/handlers.go
+++ b/components/event-bus/cmd/event-bus-publish/handlers/handlers.go
@@ -91,16 +91,17 @@ func handlePublishRequest(w http.ResponseWriter, r *http.Request, publisher *con
 	}
 	publishRequest, err := parseRequest(body)
 
-	if len(publishRequest.SourceID) == 0 {
-		setSourceIdFromHeader(publishRequest, &r.Header)
-	}
-
 	if err != nil {
 		log.Printf("PublishHandler :: handlePublishRequest :: Error while parsing request :: Error: %v", err)
 		publish.SendJSONError(w, api.ErrorResponseBadPayload())
 		trace.TagSpanAsError(publishSpan, "error while parsing request", err.Error())
 		return
 	}
+
+	if len(publishRequest.SourceID) == 0 {
+		setSourceIdFromHeader(publishRequest, &r.Header)
+	}
+
 	errResponse := api.ValidatePublish(publishRequest)
 	if errResponse != nil {
 		log.Printf("PublishHandler :: handlePublishRequest :: Request validation failed. :: Error: %v", *errResponse)

--- a/components/event-bus/cmd/event-bus-publish/publish_test.go
+++ b/components/event-bus/cmd/event-bus-publish/publish_test.go
@@ -63,7 +63,8 @@ func TestPublishWithSourceIdInHeader(t *testing.T) {
 		msg = m
 	})
 	responseBody, statusCode := performPublishRequestWithHeaders(t, publishServer.URL, requestPayload, map[string]string{api.HeaderSourceId: testSourceID})
-	verifyPublish(t, statusCode, sub, responseBody, requestPayload)
+
+	verifyPublish(t, statusCode, sub, responseBody, buildDefaultTestPayload())
 }
 
 func TestPublishWithSourceIdInPayloadAndHeaderAndPayloadOneIsGivenPrecedence(t *testing.T) {

--- a/components/event-bus/cmd/event-bus-publish/test_helpers.go
+++ b/components/event-bus/cmd/event-bus-publish/test_helpers.go
@@ -198,7 +198,7 @@ func performPublishRequest(t *testing.T, publishURL string, payload string) ([]b
 }
 
 func performPublishRequestWithHeaders(t *testing.T, publishURL string, payload string, headers map[string]string) ([]byte, int) {
-	req, err := http.NewRequest("POST", publishURL+"/v1/events", strings.NewReader(payload))
+	req, _ := http.NewRequest("POST", publishURL+"/v1/events", strings.NewReader(payload))
 
 	req.Header.Set("Content-Type", "application/json")
 
@@ -233,11 +233,13 @@ func verifyReceivedMsg(t *testing.T, a string, b []byte) {
 		t.Error(err)
 	}
 	assert.Equal(t, aReq.EventID, bReq.EventID)
+	assert.Equal(t, aReq.SourceID, bReq.SourceID)
 }
 
 func assertExpectedError(t *testing.T, body []byte, actualStatusCode int, expectedStatusCode int, errorField interface{}, errorType interface{}) {
 	var responseError api.Error
 	err := json.Unmarshal(body, &responseError)
+	assert.Equal(t, actualStatusCode, expectedStatusCode)
 	assert.Nil(t, err)
 	if errorType != nil {
 		assert.Equal(t, errorType, responseError.Type)

--- a/components/event-bus/cmd/event-bus-push/Makefile
+++ b/components/event-bus/cmd/event-bus-push/Makefile
@@ -3,31 +3,19 @@ VERSION = 0.1.0
 COMPONENT = event-bus
 REGISTRY = eu.gcr.io
 
-.PHONY: all clean build tag push
+.PHONY: all clean compile docker-build tag
 
-all: clean build docker-build tag
+all: clean compile docker-build tag
 
 clean:
 	rm -rf bin/
 	rm -rf docker/
 
-build: vet test compile
-
 compile:
 	go build -o bin/event-bus-push
-
-test:
-	go test github.com/kyma-project/kyma/components/event-bus/internal/push/... -v
-	go test github.com/kyma-project/kyma/components/event-bus/test/acceptance/push -v
 
 docker-build:
 	./dockerBuild.sh $(NAME) $(VERSION) $(COMPONENT)
 
 tag:
 	docker tag $(NAME):$(VERSION) $(REGISTRY)/$(NAME):$(VERSION)
-
-push:
-	docker push $(REGISTRY)/$(NAME):$(VERSION)
-
-vet:
-	go list ../../... | grep -v generated | xargs go vet

--- a/components/event-bus/cmd/event-bus-sv/Makefile
+++ b/components/event-bus/cmd/event-bus-sv/Makefile
@@ -2,15 +2,13 @@ NAME = kyma-project/event-bus-sub-validator
 VERSION = 0.1.0
 REGISTRY = eu.gcr.io
 
-.PHONY: all clean build tag push
+.PHONY: all clean compile docker-build tag
 
-all: clean build docker-build tag
+all: clean compile docker-build tag
 
 clean:
 	rm -rf bin/
 	rm -rf docker/
-
-build: vet compile
 
 compile:
 	go build -o bin/event-bus-sub-validator 
@@ -28,10 +26,3 @@ docker-build:
 
 tag:
 	docker tag $(NAME):$(VERSION) $(REGISTRY)/$(NAME):$(VERSION)
-
-push:
-	docker push $(REGISTRY)/$(NAME):$(VERSION)
-
-vet:
-	go list ../../... | grep -v generated | xargs go vet
-

--- a/components/event-bus/docs/api.yaml
+++ b/components/event-bus/docs/api.yaml
@@ -1,7 +1,10 @@
 openapi: 3.0.0
 info:
   version: 1.0.0
-  title: Events API
+  title: Kyma Events API
+tags:
+- name: Kyma events
+  description: API to publish events from services inside Kyma
 paths:
   /v1/events:
     post:
@@ -9,6 +12,16 @@ paths:
       operationId: publishEvent
       tags:
         - publish
+      parameters:
+        - in: header
+          name: Source-Id
+          description: Identifier for the origin of the event. Either specify this or provide 'source-id' in the json payload.
+          schema:
+            type: string
+            pattern: '^[a-zA-Z]+([_\-\.]?[a-zA-Z0-9]+)*$'
+            example:
+              - "stage.commerce.kyma.local"
+          required: false
       requestBody:
         description: The event to be published
         required: true
@@ -53,8 +66,12 @@ components:
       type: object
       description: A Publish request
       properties:
-        source:
-          $ref: '#/components/schemas/EventSource'
+        source-id:
+          description: Identifier for the origin of the event. Either specify this or provide 'Source-Id' header value.
+          type: string
+          pattern: '^[a-zA-Z]+([_\-\.]?[a-zA-Z0-9]+)*$'
+          example:
+            - "stage.commerce.kyma.local"
         event-type:
           description: Type of the event.
           type: string
@@ -83,7 +100,6 @@ components:
         data:
           $ref: '#/components/schemas/AnyValue'
       required:
-        - source
         - event-type
         - event-type-version
         - event-time
@@ -102,41 +118,6 @@ components:
     AnyValue:
       nullable: false
       description: Can be any value but null.
-    EventSource:
-      description: This describes the software instance that emits the event at runtime (i.e. the producer).
-      type: object
-      properties:
-        source-namespace:
-          description: Identifier that uniquely identifies the organization publishing the event.
-          type: string
-          format: hostname
-          pattern: '^[a-zA-Z]+([_\-\.]?[a-zA-Z0-9]+)*$'
-          example:
-            - "kafka.apache.org"
-            - "com.microsoft.azure"
-            - "local.kyma.commerce"
-        source-type:
-          description: Type of the event source, within the namespace context.
-          type: string
-          format: hostname
-          pattern: '^[a-zA-Z]+([_\-\.]?[a-zA-Z0-9]+)*$'
-          example:
-            - "s3"
-            - "commerce"
-            - "marketing"
-        source-environment:
-          description: Environment of the event source.
-          type: string
-          format: hostname
-          pattern: '^[a-zA-Z]+([_\-\.]?[a-zA-Z0-9]+)*$'
-          example:
-            - "my.s3.bucket"
-            - "stage"
-            - "production"
-      required:
-        - source-namespace
-        - source-type
-        - source-environment
     APIError:
       type: object
       description: API Error response body

--- a/components/event-bus/test/acceptance/push/acceptance_test.go
+++ b/components/event-bus/test/acceptance/push/acceptance_test.go
@@ -253,7 +253,7 @@ func Test_pushRequestShouldNotIncludeKymaTopicHeader(t *testing.T) {
 		log.Printf("%v", respObj)
 
 		var ok bool
-		for i := 0; i < 10; i++ {
+		for i := 0; i < 20; i++ {
 			time.Sleep(1 * time.Second)
 			res, err := http.Get(subscriberServerV1.URL + util.SubServer1ResultsPath)
 			assert.Nil(t, err)


### PR DESCRIPTION
**Description**
- Adjust publish API to accept source id field from the header
- Add tests and validations for sourceid from payload and header
- Update Makefile to remove push as it is no longer possible to run
- Move vet and test targets to a common Makefile at the root
- Update Jenkins file accordingly.
- Add stages to run and vet the event-bus source code as first stages
- Ensure source id in the payload is given precedence when it is present in both header and payload
- Did minor clean up to remove some unwanted functions and variables
- Update the OpenAPI definition.
- Remove the source field. This was a miss in the api.yaml

**Related issue(s)**
See also #1048 
