### PR TITLE
Improve the bundle checker

### DIFF
--- a/components/helm-broker/cmd/checker/main.go
+++ b/components/helm-broker/cmd/checker/main.go
@@ -5,7 +5,6 @@ import (
 	"io/ioutil"
 	"os"
 
-	"github.com/kyma-project/kyma/components/helm-broker/internal"
 	"github.com/kyma-project/kyma/components/helm-broker/internal/ybundle"
 	"github.com/sirupsen/logrus"
 )
@@ -20,23 +19,20 @@ func main() {
 	if err != nil {
 		panic(err)
 	}
-	loader := ybundle.NewLoader(dir, logger.WithField("service", "bundle checker"))
+	loader := ybundle.NewLoader(dir, logger)
 
 	if len(os.Args) < 2 {
 		fmt.Println("Provide path to a bundle")
-		return
-	}
-
-	bundle, _, err := loader.LoadDir(os.Args[1])
-	if err != nil {
-		fmt.Println(err)
 		os.Exit(1)
 	}
-	printBundleInfo(bundle)
-}
+	bundleName := os.Args[1]
 
-func printBundleInfo(b *internal.Bundle) {
-	fmt.Printf("Bundle name: %s\n", b.Name)
-	fmt.Printf("Version: %s\n", b.Version.String())
-	fmt.Printf("Description: %s\n", b.Description)
+	fmt.Printf("==> Checking %s\n", bundleName)
+	_, _, err = loader.LoadDir(bundleName)
+	if err != nil {
+		fmt.Printf("[ERROR] %v\n", err)
+		os.Exit(1)
+	}
+
+	fmt.Print("Check OK")
 }

--- a/components/helm-broker/internal/ybundle/loader.go
+++ b/components/helm-broker/internal/ybundle/loader.go
@@ -40,11 +40,11 @@ type Loader struct {
 	tmpDir       string
 	loadChart    func(name string) (*chart.Chart, error)
 	createTmpDir func(dir, prefix string) (name string, err error)
-	log          *logrus.Entry
+	log          logrus.FieldLogger
 }
 
 // NewLoader returns new instance of Loader.
-func NewLoader(tmpDir string, log *logrus.Entry) *Loader {
+func NewLoader(tmpDir string, log logrus.FieldLogger) *Loader {
 	return &Loader{
 		tmpDir:       tmpDir,
 		loadChart:    chartutil.Load,


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Improve the bundle checker logging output


- Failure
  - previously
  ```
  $ checker ./bundles/stable/redis-0.0.3/
  while validating form: while validating "micro" plan: while validating plan meta: missing ID field
  ```
  - currently
  ```
  $ checker ./bundles/stable/redis-0.0.3/
  
  ==> Checking ./bundles/stable/redis-0.0.3/
  [ERROR] while validating form: while validating "micro" plan: while validating plan meta: missing ID field
  ```


- Failure
  - previously
  ```
  $ checker ./bundles/showcase/redis-0.0.3/                                                                                               1 
  Bundle name: redis
  Version: 0.0.3
  Description: Redis by Helm Broker (Experimental)

  ```
  - currently
  ```
  checker ./bundles/showcase/redis-0.0.3/
  ==> Checking ./bundles/showcase/redis-0.0.3/
  Check OK
  ```
**Related issue(s)**
- https://github.com/kyma-project/kyma/issues/592

