### PR TITLE
Treat succeeded pods as ready

### DIFF
--- a/tools/watch-pods/main.go
+++ b/tools/watch-pods/main.go
@@ -88,7 +88,7 @@ func createOnPodUpdateFunc(clusterState *tester.ClusterState) func(p *v1.Pod) {
 	return func(p *v1.Pod) {
 		for _, c := range p.Status.ContainerStatuses {
 			clusterState.UpdateState(tester.Container{Ns: p.Namespace, PodName: p.Name, ContainerName: c.Name}, tester.StateUpdate{
-				Ready:      c.Ready,
+				Ready:      c.Ready || p.Status.Phase == v1.PodSucceeded,
 				RestartCnt: c.RestartCount,
 			})
 		}


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/master/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- watch-pods treats pods in phase "Succeeded" as ready

**Related issue(s)**
Resolves #1253 
