### PR TITLE
Fix command in gke installation doc

### DIFF
--- a/docs/kyma/docs/032-gs-gke-installation.md
+++ b/docs/kyma/docs/032-gs-gke-installation.md
@@ -150,7 +150,7 @@ Delegate the management of your domain to Google Cloud DNS. Follow these steps:
 4. Prepare the deployment file:
 
     ```
-    cat installation/resources/installer.yaml <(echo "---") installation/resources/installer-config-cluster.yaml.tpl  <(echo "---") installation/resources/installer-cr-cluster.yaml.tpl | sed -e "s/__DOMAIN__/$DOMAIN/g" |sed -e "s/__TLS_CERT__/$TLS_CERT/g" | sed -e "s/__TLS_KEY__/$TLS_KEY/g" | sed -e "s/__.*__//g" > my-kyma.yaml
+    cat installation/resources/installer.yaml <(echo -e "\n---") installation/resources/installer-config-cluster.yaml.tpl  <(echo -e "\n---") installation/resources/installer-cr-cluster.yaml.tpl | sed -e "s/__DOMAIN__/$DOMAIN/g" |sed -e "s/__TLS_CERT__/$TLS_CERT/g" | sed -e "s/__TLS_KEY__/$TLS_KEY/g" | sed -e "s/__.*__//g" > my-kyma.yaml
     ```
 
 5. The output of this operation is the `my_kyma.yaml` file. Modify it to fetch the proper image with the changes you made ([YOUR_DOCKER_LOGIN]/kyma-installer:latest). Use the modified file to deploy Kyma on your GKE cluster.


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Fix doc for installation on GKE. 
Without `\n` char the files are concatenated in such way:

```
...
  mixer.resources.requests.memory: 256Mi---
apiVersion: "installer.kyma-project.io/v1alpha1"
kind: Installation
...
```
- ...
- ...
which causes problems with applying such yaml

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
