### PR TITLE
Use NATS Streaming service object name instead of the HOST env var

### DIFF
--- a/resources/core/charts/event-bus/charts/publish/templates/deployment.yaml
+++ b/resources/core/charts/event-bus/charts/publish/templates/deployment.yaml
@@ -30,7 +30,7 @@ spec:
             - --client_id=$(POD_NAME)
             - --max_requests={{ .Values.global.publish.maxRequests }}
             - --nats_streaming_cluster_id={{ .Values.global.natsStreaming.clusterID }}
-            - --nats_url=nats://{{ printf "$(%s_NATS_STREAMING_SERVICE_HOST):%s" (upper .Release.Name| replace "-" "_") (toString .Values.global.natsStreaming.ports.client)}}
+            - --nats_url=nats://{{ template "nats-streaming.fullname" . }}:{{ toString .Values.global.natsStreaming.ports.client }}
             - --port={{ .Values.port }}
             - --trace_api_url={{ .Values.global.trace.apiURL }}
             - --trace_service_name={{ .Values.trace.serviceName }}

--- a/resources/core/charts/event-bus/charts/push/templates/deployment.yaml
+++ b/resources/core/charts/event-bus/charts/push/templates/deployment.yaml
@@ -55,7 +55,7 @@ spec:
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           args:
             - --client_id=$(POD_NAME)
-            - --nats_url=nats://{{ printf "$(%s_NATS_STREAMING_SERVICE_HOST):%s" (upper .Release.Name| replace "-" "_") (toString .Values.global.natsStreaming.ports.client)}}
+            - --nats_url=nats://{{ template "nats-streaming.fullname" . }}:{{ toString .Values.global.natsStreaming.ports.client }}
             - --cluster_id={{ .Values.global.natsStreaming.clusterID }}
             - --tls_skip_verify={{ .Values.http.tlsSkipVerify }}
             - --subscription_name_header={{ .Values.global.push.http.subscriptionNameHeader }}


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/master/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**
Use NATS Streaming service object name instead of the HOST env var

Changes proposed in this pull request:

- Change event-bus chart templates to pass NATS Streaming chart service object name to push and publish instead of using the NATS_STREAMING_SERVICE_HOST env var
**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
#1232 