### PR TITLE
Added different limits for Nginx-Ingress on local and on cluster

### DIFF
--- a/resources/core/charts/nginx-ingress/templates/controller-deployment.yaml
+++ b/resources/core/charts/nginx-ingress/templates/controller-deployment.yaml
@@ -159,7 +159,12 @@ spec:
 {{ toYaml .Values.controller.extraVolumeMounts | indent 12}}
 {{- end }}
           resources:
-{{ toYaml .Values.controller.resources | indent 12 }}
+{{- if .Values.global.isLocalEnv }} # modified original chart to enable different memory limits for cluster and Minikube
+{{ toYaml .Values.controller.resources.local | indent 12 }}
+{{- end }}
+{{- if not .Values.global.isLocalEnv }}
+{{ toYaml .Values.controller.resources.cluster | indent 12 }}
+{{- end }}
 {{- if .Values.controller.extraContainers }}
 {{ toYaml .Values.controller.extraContainers | indent 8}}
 {{- end }}

--- a/resources/core/charts/nginx-ingress/values.yaml
+++ b/resources/core/charts/nginx-ingress/values.yaml
@@ -136,10 +136,16 @@ controller:
   minAvailable: 1
 
   resources:
-    limits:
-      memory: 256Mi
-    requests:
-      memory: 128Mi
+    cluster:
+      limits:
+        memory: 512Mi
+      requests:
+        memory: 128Mi
+    local:
+      limits:
+        memory: 256Mi
+      requests:
+        memory: 128Mi
 
   autoscaling:
     enabled: false


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Provided ability to configure different limits for Nginx-Ingress on cluster and on Minikube
- Increased memory limits for Nginx-Ingress for deployment on cluster

**Related issue(s)**
#1320 
