### PR TITLE
Update docs-job chart to finalize "Security" component name change

### DIFF
--- a/resources/core/charts/docs/charts/documentation/templates/docs-job.yaml
+++ b/resources/core/charts/docs/charts/documentation/templates/docs-job.yaml
@@ -86,8 +86,8 @@ spec:
              memory: {{ .Values.resources.documentation.requests.memory }}
            limits:
              memory: {{ .Values.resources.documentation.limits.memory }}
-      - name:  authorization-and-authentication
-        image: {{ .Values.global.containerRegistry.path }}/{{ .Values.global.docs.dir }}authorization-and-authentication-docs:{{ .Values.global.docs.version }}
+      - name:  security
+        image: {{ .Values.global.containerRegistry.path }}/{{ .Values.global.docs.dir }}security-docs:{{ .Values.global.docs.version }}
         resources:
            requests:
              memory: {{ .Values.resources.documentation.requests.memory }}

--- a/resources/core/values.yaml
+++ b/resources/core/values.yaml
@@ -53,7 +53,7 @@ global:
     version: 1bc49b46
   docs:
     dir: develop/
-    version: 43d564ee
+    version: 5c147f8e
   environments:
     dir: develop/
     version: 6e0a7fe2


### PR DESCRIPTION
Changes proposed in this pull request:

Switched from "authorization and authentication" to "security" in docs-job.yaml. This couldn't be done in PR #1219 - this update caused CI failures. 

**Related issue(s)**
This is a follow-up to:
- Issue #887 
- PR #1219 
