### PR TITLE
Change bundle base URL in Helm Broker chart

### DIFF
--- a/resources/core/charts/helm-broker/values.yaml
+++ b/resources/core/charts/helm-broker/values.yaml
@@ -9,7 +9,7 @@ service:
   internalPort: 8080
 
 repository:
-  baseURL: "https://kyma-project.github.io/bundles/stable/"
+  baseURL: "https://github.com/kyma-project/bundles/releases/download/0.1.0/"
 
 config:
   storage:


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:
- Change bundle base URL in Helm Broker chart to point to the initial 0.1.1 release

**Related issue(s)**
- #1328