### PR TITLE
Added Helm hook for kyma-integration namespace installation

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -43,6 +43,9 @@
 # The `configurations-generator` subchart
 /resources/core/charts/configurations-generator @piotrmsc @kubadz
 
+# The `application-connector` chart
+/resources/application-connector/ @lszymik @akgalwas @janmedrek @Szymongib @franpog859 @Maladie
+
 # The `connector-service` subchart
 /resources/application-connector/charts/connector-service/ @lszymik @akgalwas @janmedrek @Szymongib @franpog859 @Maladie
 

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -44,7 +44,7 @@
 /resources/core/charts/configurations-generator @piotrmsc @kubadz
 
 # The `application-connector` chart
-/resources/application-connector/ @lszymik @akgalwas @janmedrek @Szymongib @franpog859 @Maladie
+/resources/application-connector/ @lszymik @akgalwas @janmedrek @Szymongib @franpog859 @Maladie @crabtree
 
 # The `connector-service` subchart
 /resources/application-connector/charts/connector-service/ @lszymik @akgalwas @janmedrek @Szymongib @franpog859 @Maladie

--- a/resources/application-connector/templates/kyma-integration-namespace.yaml
+++ b/resources/application-connector/templates/kyma-integration-namespace.yaml
@@ -1,6 +1,8 @@
 apiVersion: v1
 kind: Namespace
 metadata:
+  annotations:
+    "helm.sh/hook": "pre-install"
   name: {{ .Values.global.namespace }}
   labels:
     istio-injection: enabled


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Added `pre-install` Helm hook for `kyma-integration` namespace to ensure proper installation of Application Connector

**Related issue(s)**
#1319
