### PR TITLE
Change deprecated destination.service to destination.service.host

### DIFF
--- a/components/metadata-service/internal/metadata/istio/repository.go
+++ b/components/metadata-service/internal/metadata/istio/repository.go
@@ -11,7 +11,7 @@ import (
 )
 
 const (
-	matchTemplateFormat = `(destination.service == "%s.%s.svc.cluster.local") && (source.labels["%s"] != "true")`
+	matchTemplateFormat = `(destination.service.host == "%s.%s.svc.cluster.local") && (source.labels["%s"] != "true")`
 )
 
 // RuleInterface allows to perform operations for Rules in kubernetes

--- a/components/metadata-service/internal/metadata/istio/repository_test.go
+++ b/components/metadata-service/internal/metadata/istio/repository_test.go
@@ -117,7 +117,7 @@ func TestRepository_Create(t *testing.T) {
 				},
 			},
 			Spec: &v1alpha2.RuleSpec{
-				Match: `(destination.service == "re-test-uuid1.testns.svc.cluster.local") && (source.labels["re-test-uuid1"] != "true")`,
+				Match: `(destination.service.host == "re-test-uuid1.testns.svc.cluster.local") && (source.labels["re-test-uuid1"] != "true")`,
 				Actions: []v1alpha2.RuleAction{{
 					Handler:   "re-test-uuid1.denier",
 					Instances: []string{"re-test-uuid1.checknothing"},
@@ -288,7 +288,7 @@ func TestRepository_Upsert(t *testing.T) {
 				},
 			},
 			Spec: &v1alpha2.RuleSpec{
-				Match: `(destination.service == "re-test-uuid1.testns.svc.cluster.local") && (source.labels["re-test-uuid1"] != "true")`,
+				Match: `(destination.service.host == "re-test-uuid1.testns.svc.cluster.local") && (source.labels["re-test-uuid1"] != "true")`,
 				Actions: []v1alpha2.RuleAction{{
 					Handler:   "re-test-uuid1.denier",
 					Instances: []string{"re-test-uuid1.checknothing"},

--- a/tests/acceptance/remote-environment/suite/istio.go
+++ b/tests/acceptance/remote-environment/suite/istio.go
@@ -41,7 +41,7 @@ metadata:
   name: {{.Service}}
   namespace: {{.Namespace}}
 spec:
-  match: (destination.service == "{{.Service}}.{{.Namespace}}.svc.cluster.local") && (source.labels["{{.AccessLabel}}"] != "true")
+  match: (destination.service.host == "{{.Service}}.{{.Namespace}}.svc.cluster.local") && (source.labels["{{.AccessLabel}}"] != "true")
   actions:
   - handler: gw.denier
     instances:

--- a/tests/metadata-service-tests/test/testkit/k8sresources_check.go
+++ b/tests/metadata-service-tests/test/testkit/k8sresources_check.go
@@ -113,7 +113,7 @@ func checkLabels(t *testing.T, expected, actual Labels) {
 }
 
 func makeMatchExpression(name, namespace string) string {
-	return `(destination.service == "` + name + "." + namespace + `.svc.cluster.local") && (source.labels["` + name + `"] != "true")`
+	return `(destination.service.host == "` + name + "." + namespace + `.svc.cluster.local") && (source.labels["` + name + `"] != "true")`
 }
 
 func findServiceInRemoteEnv(reServices []remoteenv.Service, searchedID string) *remoteenv.Service {


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/master/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

According to [isito docs](https://istio.io/docs/reference/config/policy-and-telemetry/attribute-vocabulary/#deprecated-attributes) attribute `destination.service` is deprecated and should be replaced with `destination.service.host`,

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
