### PR TITLE
Restart ingressgateway pod during istio-patch

### DIFF
--- a/resources/core/charts/gateway/templates/gateway.yaml
+++ b/resources/core/charts/gateway/templates/gateway.yaml
@@ -3,6 +3,8 @@ kind: Gateway
 metadata:
   name: {{ .Values.global.istio.gateway.name }}
   namespace: {{.Release.Namespace }}
+  annotations:
+    "helm.sh/hook": "pre-install"  
 spec:
   selector:
     istio: ingressgateway # use istio default ingress gateway

--- a/resources/core/charts/gateway/templates/gateway.yaml
+++ b/resources/core/charts/gateway/templates/gateway.yaml
@@ -2,9 +2,7 @@ apiVersion: networking.istio.io/v1alpha3
 kind: Gateway
 metadata:
   name: {{ .Values.global.istio.gateway.name }}
-  namespace: {{.Release.Namespace }}
-  annotations:
-    "helm.sh/hook": "pre-install"  
+  namespace: {{.Release.Namespace }}  
 spec:
   selector:
     istio: ingressgateway # use istio default ingress gateway

--- a/resources/istio-kyma-patch/templates/configmap.yaml
+++ b/resources/istio-kyma-patch/templates/configmap.yaml
@@ -85,6 +85,7 @@ data:
     service jaeger-query
     service jaeger-agent
     service jaeger-collector
+    pod -lapp=istio-ingressgateway
 
   required-crds: |
     policies.authentication.istio.io

--- a/resources/istio-kyma-patch/templates/configmap.yaml
+++ b/resources/istio-kyma-patch/templates/configmap.yaml
@@ -16,26 +16,6 @@ data:
       }
     ]
 
-  istio-ingressgateway.deployment.patch.json: |
-    [
-      {
-        "op": "replace",
-        "path": "/spec/template/spec/containers/0/args/15",
-        "value": "zipkin.kyma-system:9411"
-      }
-      {{ if .Values.global.isLocalEnv }}
-      ,{
-        "op": "add",
-        "path": "/spec/template/spec/containers/0/ports/0/hostPort",
-        "value": 80
-      },{
-        "op": "add",
-        "path": "/spec/template/spec/containers/0/ports/1/hostPort",
-        "value": 443
-      }
-      {{ end }}
-    ]
-
   istio-pilot.deployment.patch.json: |
     [
       {
@@ -63,6 +43,25 @@ data:
       }
     ]
 
+  istio-ingressgateway.deployment.patch.json: |
+    [
+      {
+        "op": "replace",
+        "path": "/spec/template/spec/containers/0/args/15",
+        "value": "zipkin.kyma-system:9411"
+      }
+      {{ if .Values.global.isLocalEnv }}
+      ,{
+        "op": "add",
+        "path": "/spec/template/spec/containers/0/ports/0/hostPort",
+        "value": 80
+      },{
+        "op": "add",
+        "path": "/spec/template/spec/containers/0/ports/1/hostPort",
+        "value": 443
+      }
+      {{ end }}
+    ]
 
   delete: |
     deployment prometheus

--- a/resources/istio-kyma-patch/templates/configmap.yaml
+++ b/resources/istio-kyma-patch/templates/configmap.yaml
@@ -7,6 +7,26 @@ metadata:
     app: istio-kyma-patch
     chart: {{ .Chart.Name }}-{{ .Chart.Version }}
 data:
+  istio-ingressgateway.deployment.patch.json: |
+    [
+      {
+        "op": "replace",
+        "path": "/spec/template/spec/containers/0/args/15",
+        "value": "zipkin.kyma-system:9411"
+      }
+      {{ if .Values.global.isLocalEnv }}
+      ,{
+        "op": "add",
+        "path": "/spec/template/spec/containers/0/ports/0/hostPort",
+        "value": 80
+      },{
+        "op": "add",
+        "path": "/spec/template/spec/containers/0/ports/1/hostPort",
+        "value": 443
+      }
+      {{ end }}
+    ]
+    
   istio-egressgateway.deployment.patch.json: |
     [
       {
@@ -43,25 +63,6 @@ data:
       }
     ]
 
-  istio-ingressgateway.deployment.patch.json: |
-    [
-      {
-        "op": "replace",
-        "path": "/spec/template/spec/containers/0/args/15",
-        "value": "zipkin.kyma-system:9411"
-      }
-      {{ if .Values.global.isLocalEnv }}
-      ,{
-        "op": "add",
-        "path": "/spec/template/spec/containers/0/ports/0/hostPort",
-        "value": 80
-      },{
-        "op": "add",
-        "path": "/spec/template/spec/containers/0/ports/1/hostPort",
-        "value": 443
-      }
-      {{ end }}
-    ]
 
   delete: |
     deployment prometheus


### PR DESCRIPTION
Restarting istio ingress-gateway to verify if it's the root cause of connections being refused in DiD scenario.

**Description**

Changes proposed in this pull request:

-  restarting ingress-gateway in istio-patch by deleting pod

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
