### PR TITLE
Add information on how to access Application Connector from local Kyma deployment

### DIFF
--- a/docs/application-connector/docs/009-details-access-ac-on-local.md
+++ b/docs/application-connector/docs/009-details-access-ac-on-local.md
@@ -1,0 +1,11 @@
+---
+title: Access Application Connector on local Kyma deployment
+type: Details
+---
+
+To access the Application Connector on a local deployment of Kyma, you must add the Kyma server certificate to the trusted certificate storage of your programming environment. This is necessary to connect the external solution to your local Kyma deployment, allow client certificate exchange, and API registration.
+
+For example, to access the Application Connector from a Java environment, run this command to add the Kyma server certificate to the Java Keystore:
+```
+sudo {JAVA_HOME}/bin/keytool -import -alias “Kyma” -keystore {JAVA_HOME}/jre/lib/security/cacerts -file <KYMA_HOME>/installation/certs/workspace/raw/server.crt
+```

--- a/docs/application-connector/docs/009-details-access-ac-on-local.md
+++ b/docs/application-connector/docs/009-details-access-ac-on-local.md
@@ -1,5 +1,5 @@
 ---
-title: Access Application Connector on local Kyma deployment
+title: Access the Application Connector on a local Kyma deployment
 type: Details
 ---
 

--- a/docs/kyma/docs/031-gs-local-installation.md
+++ b/docs/kyma/docs/031-gs-local-installation.md
@@ -39,8 +39,8 @@ Follow these steps to "always trust" the Kyma certificate on Mac:
   ```
 
 >**NOTE:**
-- "Always trusting" the certificate does not work with Mozilla Firefox.
-- To access the Application Connector and connect an external solution to the local deployment of Kyma, you must add the certificate to the trusted certificate storage of your programming environment. Read the **Access Application Connector on local Kyma** in the **Application Connector** topic to learn more.
+  - "Always trusting" the certificate does not work with Mozilla Firefox.
+  - To access the Application Connector and connect an external solution to the local deployment of Kyma, you must add the certificate to the trusted certificate storage of your programming environment. Read the **Access Application Connector on local Kyma** in the **Application Connector** topic to learn more.
 
 
 ## Install Kyma on Minikube

--- a/docs/kyma/docs/031-gs-local-installation.md
+++ b/docs/kyma/docs/031-gs-local-installation.md
@@ -40,7 +40,7 @@ Follow these steps to "always trust" the Kyma certificate on Mac:
 
 >**NOTE:** "Always trusting" the certificate does not work with Mozilla Firefox.
 
->**NOTE:** To access the Application Connector and connect an external solution to the local deployment of Kyma, you must add the certificate to the trusted certificate storage of your programming environment. Read the **Access Application Connector on local Kyma** in the **Application Connector** topic to learn more.
+To access the Application Connector and connect an external solution to the local deployment of Kyma, you must add the certificate to the trusted certificate storage of your programming environment. Read the **Access Application Connector on local Kyma** in the **Application Connector** topic to learn more.
 
 
 ## Install Kyma on Minikube

--- a/docs/kyma/docs/031-gs-local-installation.md
+++ b/docs/kyma/docs/031-gs-local-installation.md
@@ -38,9 +38,9 @@ Follow these steps to "always trust" the Kyma certificate on Mac:
   sudo security add-trusted-cert -d -r trustRoot -k /Library/Keychains/System.keychain certs/workspace/raw/server.crt
   ```
 
->**NOTE:**
-  - "Always trusting" the certificate does not work with Mozilla Firefox.
-  - To access the Application Connector and connect an external solution to the local deployment of Kyma, you must add the certificate to the trusted certificate storage of your programming environment. Read the **Access Application Connector on local Kyma** in the **Application Connector** topic to learn more.
+>**NOTE:** "Always trusting" the certificate does not work with Mozilla Firefox.
+
+>**NOTE:** To access the Application Connector and connect an external solution to the local deployment of Kyma, you must add the certificate to the trusted certificate storage of your programming environment. Read the **Access Application Connector on local Kyma** in the **Application Connector** topic to learn more.
 
 
 ## Install Kyma on Minikube

--- a/docs/kyma/docs/031-gs-local-installation.md
+++ b/docs/kyma/docs/031-gs-local-installation.md
@@ -38,7 +38,10 @@ Follow these steps to "always trust" the Kyma certificate on Mac:
   sudo security add-trusted-cert -d -r trustRoot -k /Library/Keychains/System.keychain certs/workspace/raw/server.crt
   ```
 
->**NOTE:** "Always trusting" the certificate does not work with Mozilla Firefox.
+>**NOTE:**
+- "Always trusting" the certificate does not work with Mozilla Firefox.
+- To access the Application Connector and connect an external solution to the local deployment of Kyma, you must add the certificate to the trusted certificate storage of your programming environment. Read the **Access Application Connector on local Kyma** in the **Application Connector** topic to learn more.
+
 
 ## Install Kyma on Minikube
 
@@ -71,7 +74,7 @@ $ ./scripts/install-tiller.sh
 $ kubectl apply -f https://github.com/kyma-project/kyma/releases/download/0.4.1/kyma-config-local.yaml
 ```
 
-6. To trigger the installation process, label the `kyma-installation` custom resource: 
+6. To trigger the installation process, label the `kyma-installation` custom resource:
 ```
 $ kubectl label installation/kyma-installation action=install
 ```


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Added a "details" document to Application Connector docs that uses Java as an example
- Added a note to local installation Getting Started guide

**Related issue(s)**
See #400 
