### PR TITLE
Add Ark monitoring

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -28,6 +28,9 @@
 # The `values.yaml` file for `application-connector` chart
 /resources/application-connector/values.yaml @kyma-project/developers
 
+# The `heptio ark` chart
+/resources/ark/ @mwieczorek @joek @rakesh-garimella @sayanh @venturasr @lilitgh
+
 # The `api-controller` subchart
 /resources/core/charts/api-controller/ @piotrmsc @kubadz @sjanota
 

--- a/resources/ark/templates/configmap.yaml
+++ b/resources/ark/templates/configmap.yaml
@@ -55,11 +55,17 @@ data:
     - namespaces
     - persistentvolumes
     - persistentvolumeclaims
+    - remoteenvironments # added
+    - environmentmappings #
+    - servicebrokers #
+    - serviceclasses #
+    - serviceinstances #
+    - servicebindings #
     - secrets
     - configmaps
     - serviceaccounts
     - limitranges
-    - podpresets # added in compare to default priorities
+    - podpresets # added
     - pods
     - replicaset
 {{- end }}

--- a/resources/ark/templates/deployment.yaml
+++ b/resources/ark/templates/deployment.yaml
@@ -35,6 +35,9 @@ spec:
         - name: ark
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - name: metrics
+              containerPort: 8085
           command:
             - /ark
           args:

--- a/resources/ark/templates/service-monitor.yaml
+++ b/resources/ark/templates/service-monitor.yaml
@@ -1,0 +1,20 @@
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  labels:
+    prometheus: core
+    app: {{ template "ark.name" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+  name: {{ template "ark.fullname" . }}
+spec:
+  endpoints:
+  - interval: 30s
+    port: metrics
+  namespaceSelector:
+    matchNames:
+    - "{{ .Release.Namespace }}"
+  selector:
+    matchLabels:
+      app: {{ template "ark.name" . }}

--- a/resources/ark/templates/service.yaml
+++ b/resources/ark/templates/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: "{{ template "ark.fullname" . }}-metrics"
+  labels:
+    app: {{ template "ark.name" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+spec:
+  ports:
+  - port: 8085
+    name: metrics
+  selector:
+    app: {{ template "ark.name" . }}

--- a/resources/ark/values.yaml
+++ b/resources/ark/values.yaml
@@ -1,6 +1,6 @@
 image:
   repository: gcr.io/heptio-images/ark
-  tag: v0.9.7
+  tag: v0.9.8
   pullPolicy: IfNotPresent
 
 # A docker image with kubectl installed

--- a/resources/ark/values.yaml
+++ b/resources/ark/values.yaml
@@ -1,6 +1,6 @@
 image:
   repository: gcr.io/heptio-images/ark
-  tag: v0.9.8
+  tag: v0.9.9
   pullPolicy: IfNotPresent
 
 # A docker image with kubectl installed


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- bump ark's version 
- add restore priorities for ark 
- add service monitor for ark (+ expose port in ark pod, create service etc)
- add an entry in codeowners file for resources/ark chart

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
