### PR TITLE
Fix typo in webhook container start script

### DIFF
--- a/resources/istio-kyma-patch/templates/istio-webhook.yaml
+++ b/resources/istio-kyma-patch/templates/istio-webhook.yaml
@@ -26,7 +26,7 @@ spec:
         - containerPort: 5000
         args:
         - --script
-        - /istio-webhook/scripts/webhook.lua
+        - /istio-webhook/scripts/plugin.lua
         - --port
         - "5000"
         volumeMounts:


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/master/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**
Webhook in istio-patch has a typo in container start arguments. Webhook itself was running but was logging error with saying cannot open file.

Changes proposed in this pull request:

- fixed file name in the start argument

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
