### PR TITLE
Set as default http-metrics instead of https-metrics for exporter-kubelets

### DIFF
--- a/resources/core/charts/monitoring/charts/exporter-kubelets/templates/servicemonitor.yaml
+++ b/resources/core/charts/monitoring/charts/exporter-kubelets/templates/servicemonitor.yaml
@@ -44,7 +44,8 @@ spec:
   {{- else }}
   - port: http-metrics
     interval: 30s
-  - port: cadvisor
+  - path: /metrics/cadvisor
+    port: http-metrics
     interval: 30s
     honorLabels: true
   {{- end }}

--- a/resources/core/charts/monitoring/charts/exporter-kubelets/values.yaml
+++ b/resources/core/charts/monitoring/charts/exporter-kubelets/values.yaml
@@ -1,5 +1,5 @@
 # Set to false for GKE
-https: true
+https: false
 
 insecureSkipVerify: true
 


### PR DESCRIPTION
Set as default http-metrics instead of https-metrics for exporter-kubelets

**Description:**
It configures exporter-kubelets to expose metrics on port http-metrics by default. Service Monitor it  has been changed.

**Related issue(s)**
https://github.com/kyma-project/kyma/issues/1359
