### PR TITLE
Add scripts to run acceptance tests on Minikube

### DIFF
--- a/components/connector-service/scripts/run-with-local-tests.sh
+++ b/components/connector-service/scripts/run-with-local-tests.sh
@@ -11,7 +11,7 @@ echo "------------------------"
 
 docker build $CURRENT_DIR/.. -t connector-service
 
-kubectl -n kyma-integration patch statefulset connector-service --patch 'spec:
+kubectl -n kyma-integration patch deployment connector-service --patch 'spec:
   template:
     spec:
       containers:

--- a/components/connector-service/scripts/run-with-local-tests.sh
+++ b/components/connector-service/scripts/run-with-local-tests.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+
+CURRENT_DIR="$( cd "$(dirname "$0")" ; pwd -P )"
+
+eval $(minikube docker-env)
+
+echo ""
+echo "------------------------"
+echo "Building component image"
+echo "------------------------"
+
+docker build $CURRENT_DIR/.. -t connector-service
+
+kubectl -n kyma-integration patch statefulset connector-service --patch 'spec:
+  template:
+    spec:
+      containers:
+      - name: connector-service
+        image: connector-service
+        imagePullPolicy: Never'
+
+kubectl -n kyma-integration delete po -l app=connector-service --now --wait=false
+
+$CURRENT_DIR/../../../tests/connector-service-tests/scripts/run-local-tests.sh

--- a/components/connector-service/scripts/run-with-local-tests.sh
+++ b/components/connector-service/scripts/run-with-local-tests.sh
@@ -11,6 +11,11 @@ echo "------------------------"
 
 docker build $CURRENT_DIR/.. -t connector-service
 
+echo ""
+echo "------------------------"
+echo "Updating deployment"
+echo "------------------------"
+
 kubectl -n kyma-integration patch deployment connector-service --patch 'spec:
   template:
     spec:
@@ -18,6 +23,11 @@ kubectl -n kyma-integration patch deployment connector-service --patch 'spec:
       - name: connector-service
         image: connector-service
         imagePullPolicy: Never'
+
+echo ""
+echo "------------------------"
+echo "Removing old pods"
+echo "------------------------"
 
 kubectl -n kyma-integration delete po -l app=connector-service --now --wait=false
 

--- a/components/metadata-service/scripts/run-with-local-tests.sh
+++ b/components/metadata-service/scripts/run-with-local-tests.sh
@@ -11,6 +11,11 @@ echo "------------------------"
 
 docker build $CURRENT_DIR/.. -t metadata-service
 
+echo ""
+echo "------------------------"
+echo "Updating deployment"
+echo "------------------------"
+
 kubectl -n kyma-integration patch deployment metadata-service --patch 'spec:
   template:
     spec:
@@ -18,6 +23,11 @@ kubectl -n kyma-integration patch deployment metadata-service --patch 'spec:
       - name: metadata-service
         image: metadata-service
         imagePullPolicy: Never'
+
+echo ""
+echo "------------------------"
+echo "Removing old pods"
+echo "------------------------"
 
 kubectl -n kyma-integration delete po -l app=metadata-service --now --wait=false
 

--- a/components/metadata-service/scripts/run-with-local-tests.sh
+++ b/components/metadata-service/scripts/run-with-local-tests.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+
+CURRENT_DIR="$( cd "$(dirname "$0")" ; pwd -P )"
+
+eval $(minikube docker-env)
+
+echo ""
+echo "------------------------"
+echo "Building component image"
+echo "------------------------"
+
+docker build $CURRENT_DIR/.. -t metadata-service
+
+kubectl -n kyma-integration patch deployment metadata-service --patch 'spec:
+  template:
+    spec:
+      containers:
+      - name: metadata-service
+        image: metadata-service
+        imagePullPolicy: Never'
+
+kubectl -n kyma-integration delete po -l app=metadata-service --now --wait=false
+
+$CURRENT_DIR/../../../tests/metadata-service-tests/scripts/run-local-tests.sh

--- a/components/remote-environment-controller/scripts/run-with-local-tests.sh
+++ b/components/remote-environment-controller/scripts/run-with-local-tests.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+
+CURRENT_DIR="$( cd "$(dirname "$0")" ; pwd -P )"
+
+eval $(minikube docker-env)
+
+echo ""
+echo "------------------------"
+echo "Building component image"
+echo "------------------------"
+
+docker build $CURRENT_DIR/.. -t remote-environment-controller
+
+kubectl -n kyma-integration patch statefulset remote-environment-controller --patch 'spec:
+  template:
+    spec:
+      containers:
+      - name: remote-environment-controller
+        image: remote-environment-controller
+        imagePullPolicy: Never'
+
+kubectl -n kyma-integration delete po -l control-plane=remote-environment-controller --now --wait=false
+
+$CURRENT_DIR/../../../tests/remote-environment-controller-tests/scripts/run-local-tests.sh

--- a/components/remote-environment-controller/scripts/run-with-local-tests.sh
+++ b/components/remote-environment-controller/scripts/run-with-local-tests.sh
@@ -11,6 +11,11 @@ echo "------------------------"
 
 docker build $CURRENT_DIR/.. -t remote-environment-controller
 
+echo ""
+echo "------------------------"
+echo "Updating stateful set"
+echo "------------------------"
+
 kubectl -n kyma-integration patch statefulset remote-environment-controller --patch 'spec:
   template:
     spec:
@@ -18,6 +23,11 @@ kubectl -n kyma-integration patch statefulset remote-environment-controller --pa
       - name: remote-environment-controller
         image: remote-environment-controller
         imagePullPolicy: Never'
+
+echo ""
+echo "------------------------"
+echo "Removing old pods"
+echo "------------------------"
 
 kubectl -n kyma-integration delete po -l control-plane=remote-environment-controller --now --wait=false
 

--- a/tests/connector-service-tests/scripts/run-local-tests.sh
+++ b/tests/connector-service-tests/scripts/run-local-tests.sh
@@ -21,6 +21,11 @@ docker build $CURRENT_DIR/.. -t connector-service-tests
 
 NODE_PORT=$(kubectl -n kyma-system get svc application-connector-nginx-ingress-controller -o 'jsonpath={.spec.ports[?(@.port==443)].nodePort}')
 
+echo ""
+echo "------------------------"
+echo "Creating test pod"
+echo "------------------------"
+
 cat <<EOF | kubectl -n kyma-integration apply -f -
 apiVersion: v1
 kind: Pod
@@ -47,6 +52,8 @@ echo ""
 echo "------------------------"
 echo "Waiting 5 seconds for pod to start..."
 echo "------------------------"
+echo ""
+
 sleep 5
 
 kubectl -n kyma-integration logs connector-service-tests -f

--- a/tests/connector-service-tests/scripts/run-local-tests.sh
+++ b/tests/connector-service-tests/scripts/run-local-tests.sh
@@ -26,12 +26,19 @@ echo "------------------------"
 echo "Creating test pod"
 echo "------------------------"
 
+MINIKUBE_IP=$(minikube ip)
+
 cat <<EOF | kubectl -n kyma-integration apply -f -
 apiVersion: v1
 kind: Pod
 metadata:
   name: connector-service-tests
 spec:
+  hostAliases:
+  - ip: "$MINIKUBE_IP"
+    hostnames:
+    - "connector-service.kyma.local"
+    - "gateway.kyma.local"
   containers:
   - name: connector-service-tests
     image: connector-service-tests

--- a/tests/connector-service-tests/scripts/run-local-tests.sh
+++ b/tests/connector-service-tests/scripts/run-local-tests.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+
+CURRENT_DIR="$( cd "$(dirname "$0")" ; pwd -P )"
+
+eval $(minikube docker-env)
+
+echo ""
+echo "------------------------"
+echo "Removing test pod"
+echo "------------------------"
+
+
+kubectl -n kyma-integration delete po connector-service-tests --now
+
+echo ""
+echo "------------------------"
+echo "Building tests image"
+echo "------------------------"
+
+docker build $CURRENT_DIR/.. -t connector-service-tests
+
+NODE_PORT=$(kubectl -n kyma-system get svc application-connector-nginx-ingress-controller -o 'jsonpath={.spec.ports[?(@.port==443)].nodePort}')
+
+cat <<EOF | kubectl -n kyma-integration apply -f -
+apiVersion: v1
+kind: Pod
+metadata:
+  name: connector-service-tests
+spec:
+  containers:
+  - name: connector-service-tests
+    image: connector-service-tests
+    imagePullPolicy: Never
+    env:
+    - name: INTERNAL_API_URL
+      value: http://connector-service-internal-api:8080
+    - name: EXTERNAL_API_URL
+      value: http://connector-service-external-api:8081
+    - name: GATEWAY_URL
+      value: https://gateway.kyma.local:$NODE_PORT
+    - name: SKIP_SSL_VERIFY
+      value: "true"
+  restartPolicy: Never
+EOF
+
+echo ""
+echo "------------------------"
+echo "Waiting 5 seconds for pod to start..."
+echo "------------------------"
+sleep 5
+
+kubectl -n kyma-integration logs connector-service-tests -f

--- a/tests/metadata-service-tests/scripts/run-local-tests.sh
+++ b/tests/metadata-service-tests/scripts/run-local-tests.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+
+CURRENT_DIR="$( cd "$(dirname "$0")" ; pwd -P )"
+
+eval $(minikube docker-env)
+
+echo ""
+echo "------------------------"
+echo "Removing test pod"
+echo "------------------------"
+
+
+kubectl -n kyma-integration delete po metadata-service-tests --now
+
+echo ""
+echo "------------------------"
+echo "Building tests image"
+echo "------------------------"
+
+docker build $CURRENT_DIR/.. -t metadata-service-tests
+
+cat <<EOF | kubectl -n kyma-integration apply -f -
+apiVersion: v1
+kind: Pod
+metadata:
+  name: metadata-service-tests
+spec:
+  containers:
+  - name: metadata-service-tests
+    image: metadata-service-tests
+    imagePullPolicy: Never
+    env:
+    - name: METADATA_URL
+      value: http://metadata-service-external-api:8081
+    - name: NAMESPACE
+      value: kyma-integration
+  restartPolicy: Never
+EOF
+
+echo ""
+echo "------------------------"
+echo "Waiting 5 seconds for pod to start..."
+echo "------------------------"
+sleep 5
+
+kubectl -n kyma-integration logs metadata-service-tests -f

--- a/tests/metadata-service-tests/scripts/run-local-tests.sh
+++ b/tests/metadata-service-tests/scripts/run-local-tests.sh
@@ -19,6 +19,11 @@ echo "------------------------"
 
 docker build $CURRENT_DIR/.. -t metadata-service-tests
 
+echo ""
+echo "------------------------"
+echo "Creating test pod"
+echo "------------------------"
+
 cat <<EOF | kubectl -n kyma-integration apply -f -
 apiVersion: v1
 kind: Pod
@@ -41,6 +46,8 @@ echo ""
 echo "------------------------"
 echo "Waiting 5 seconds for pod to start..."
 echo "------------------------"
+echo ""
+
 sleep 5
 
 kubectl -n kyma-integration logs metadata-service-tests -f

--- a/tests/remote-environment-controller-tests/scripts/run-local-tests.sh
+++ b/tests/remote-environment-controller-tests/scripts/run-local-tests.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+
+CURRENT_DIR="$( cd "$(dirname "$0")" ; pwd -P )"
+
+eval $(minikube docker-env)
+
+echo ""
+echo "------------------------"
+echo "Removing test pod"
+echo "------------------------"
+
+
+kubectl -n kyma-integration delete po remote-environment-controller-tests --now
+
+echo ""
+echo "------------------------"
+echo "Building tests image"
+echo "------------------------"
+
+docker build $CURRENT_DIR/.. -t remote-environment-controller-tests
+
+cat <<EOF | kubectl -n kyma-integration apply -f -
+apiVersion: v1
+kind: Pod
+metadata:
+  name: remote-environment-controller-tests
+spec:
+  containers:
+  - name: remote-environment-controller-tests
+    image: remote-environment-controller-tests
+    imagePullPolicy: Never
+    env:
+    - name: TILLER_HOST
+      value: tiller-deploy.kube-system.svc.cluster.local:44134
+    - name: NAMESPACE
+      value: kyma-integration
+  restartPolicy: Never
+EOF
+
+echo ""
+echo "------------------------"
+echo "Waiting 5 seconds for pod to start..."
+echo "------------------------"
+sleep 5
+
+kubectl -n kyma-integration logs remote-environment-controller-tests -f

--- a/tests/remote-environment-controller-tests/scripts/run-local-tests.sh
+++ b/tests/remote-environment-controller-tests/scripts/run-local-tests.sh
@@ -19,6 +19,11 @@ echo "------------------------"
 
 docker build $CURRENT_DIR/.. -t remote-environment-controller-tests
 
+echo ""
+echo "------------------------"
+echo "Creating test pod"
+echo "------------------------"
+
 cat <<EOF | kubectl -n kyma-integration apply -f -
 apiVersion: v1
 kind: Pod
@@ -41,6 +46,8 @@ echo ""
 echo "------------------------"
 echo "Waiting 5 seconds for pod to start..."
 echo "------------------------"
+echo ""
+
 sleep 5
 
 kubectl -n kyma-integration logs remote-environment-controller-tests -f


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Added scripts for easily running acceptance tests for Application Connector components on Minikube

**Related issue(s)**
#1078 
