### PR TITLE
Improve CPU limits for minio

### DIFF
--- a/installation/resources/installer-config-cluster.yaml.tpl
+++ b/installation/resources/installer-config-cluster.yaml.tpl
@@ -43,6 +43,7 @@ data:
   minio.accessKey: "admin"
   minio.secretKey: "topSecretKey"
   minio.resources.limits.memory: 128Mi
+  minio.resources.limits.cpu: 250m
   acceptanceTest.remoteEnvironment.disabled: "true"
 ---
 apiVersion: v1


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Improve CPU limits. Grafana shows that minio has peaks in CPU consumption that come to around 130. Decided to set the recommended official limits https://github.com/helm/charts/blob/master/stable/minio/values.yaml#L124
