### PR TITLE
Support self-signed certificate in the tests of Application Connector components

### DIFF
--- a/installation/resources/installer-config-cluster.yaml.tpl
+++ b/installation/resources/installer-config-cluster.yaml.tpl
@@ -48,6 +48,17 @@ data:
 apiVersion: v1
 kind: ConfigMap
 metadata:
+  name: connector-service-overrides
+  namespace: kyma-installer
+  labels:
+    installer: overrides
+    component: application-connector
+data:
+  connector-service.tests.skipSslVerify: "true"
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
   name: core-overrides
   namespace: kyma-installer
   labels:

--- a/installation/resources/installer-config-cluster.yaml.tpl
+++ b/installation/resources/installer-config-cluster.yaml.tpl
@@ -48,17 +48,6 @@ data:
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: connector-service-overrides
-  namespace: kyma-installer
-  labels:
-    installer: overrides
-    component: application-connector
-data:
-  connector-service.tests.skipSslVerify: "true"
----
-apiVersion: v1
-kind: ConfigMap
-metadata:
   name: core-overrides
   namespace: kyma-installer
   labels:

--- a/installation/resources/installer-config-local.yaml.tpl
+++ b/installation/resources/installer-config-local.yaml.tpl
@@ -39,6 +39,16 @@ data:
   global.alertTools.credentials.victorOps.apikey: ""
   nginx-ingress.controller.service.loadBalancerIP: ""
   cluster-users.users.adminGroup: ""
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: connector-service-overrides
+  namespace: kyma-installer
+  labels:
+    installer: overrides
+    component: application-connector
+data:
   connector-service.tests.skipSslVerify: "true"
 ---
 apiVersion: v1

--- a/installation/resources/installer-config-local.yaml.tpl
+++ b/installation/resources/installer-config-local.yaml.tpl
@@ -39,6 +39,7 @@ data:
   global.alertTools.credentials.victorOps.apikey: ""
   nginx-ingress.controller.service.loadBalancerIP: ""
   cluster-users.users.adminGroup: ""
+  connector-service.tests.skipSslVerify: "true"
 ---
 apiVersion: v1
 kind: ConfigMap

--- a/installation/resources/installer-config-local.yaml.tpl
+++ b/installation/resources/installer-config-local.yaml.tpl
@@ -44,7 +44,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: connector-service-overrides
-  namespace: kyma-integration
+  namespace: kyma-installer
   labels:
     installer: overrides
     component: application-connector

--- a/installation/resources/installer-config-local.yaml.tpl
+++ b/installation/resources/installer-config-local.yaml.tpl
@@ -44,7 +44,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: connector-service-overrides
-  namespace: kyma-installer
+  namespace: kyma-integration
   labels:
     installer: overrides
     component: application-connector

--- a/resources/application-connector/charts/connector-service/templates/tests/test-acceptance.yaml
+++ b/resources/application-connector/charts/connector-service/templates/tests/test-acceptance.yaml
@@ -1,3 +1,4 @@
+{{ if not .Values.global.isLocalEnv }}
 apiVersion: v1
 kind: Pod
 metadata:
@@ -23,3 +24,4 @@ spec:
       value: "{{ .Values.tests.skipSslVerify }}"
 
   restartPolicy: Never
+{{ end }}

--- a/resources/application-connector/charts/connector-service/templates/tests/test-acceptance.yaml
+++ b/resources/application-connector/charts/connector-service/templates/tests/test-acceptance.yaml
@@ -1,4 +1,4 @@
-{{ if not .Values.global.isLocalEnv }}
+{{ if (eq .Values.global.isLocalEnv false) }}
 apiVersion: v1
 kind: Pod
 metadata:
@@ -21,7 +21,6 @@ spec:
     - name: GATEWAY_URL
       value: https://gateway.{{ .Values.global.domainName }}
     - name: SKIP_SSL_VERIFY
-      value: "{{ .Values.global.isLocalEnv }}"
-
+      value: true
   restartPolicy: Never
 {{ end }}

--- a/resources/application-connector/charts/connector-service/templates/tests/test-acceptance.yaml
+++ b/resources/application-connector/charts/connector-service/templates/tests/test-acceptance.yaml
@@ -20,6 +20,6 @@ spec:
     - name: GATEWAY_URL
       value: https://gateway.{{ .Values.global.domainName }}
     - name: SKIP_SSL_VERIFY
-      value: {{ .Values.tests.skipSslVerify }}
+      value: "{{ .Values.tests.skipSslVerify }}"
 
   restartPolicy: Never

--- a/resources/application-connector/charts/connector-service/templates/tests/test-acceptance.yaml
+++ b/resources/application-connector/charts/connector-service/templates/tests/test-acceptance.yaml
@@ -1,4 +1,3 @@
-{{ if (eq .Values.global.isLocalEnv false) }}
 apiVersion: v1
 kind: Pod
 metadata:
@@ -21,6 +20,6 @@ spec:
     - name: GATEWAY_URL
       value: https://gateway.{{ .Values.global.domainName }}
     - name: SKIP_SSL_VERIFY
-      value: true
+      value: {{ .Values.tests.skipSslVerify }}
+
   restartPolicy: Never
-{{ end }}

--- a/resources/application-connector/charts/connector-service/values.yaml
+++ b/resources/application-connector/charts/connector-service/values.yaml
@@ -22,5 +22,6 @@ service:
     port: *internalAPIPort
 
 tests:
+  skipSslVerify: false
   image:
     pullPolicy: IfNotPresent


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Add configuration flag `skipSslVerify` to skip SSL verification in the Application Connector tests - enable self-signed certificate
- Skipping SSL verification is set to `false` by default on cluster. To enable self-signed certificate set the `.Values.tests.skipSslVerify` value to `true` in the connector-service-test

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
Resolves #1464 
