### PR TITLE
Fix ClusterRole bug

### DIFF
--- a/resources/core/charts/cluster-users/templates/rbac-roles.yaml
+++ b/resources/core/charts/cluster-users/templates/rbac-roles.yaml
@@ -3,6 +3,7 @@ kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
   name: kube-system-view
+  namespace: {{ .Release.Namespace }}
   labels:
     app: kyma
     chart: {{ .Chart.Name }}-{{ .Chart.Version }}
@@ -39,6 +40,7 @@ apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRoleBinding
 metadata:
   name: kyma-view-binding
+  namespace: {{ .Release.Namespace }}
   labels:
     app: kyma
     chart: {{ .Chart.Name }}-{{ .Chart.Version }}
@@ -86,6 +88,7 @@ apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRoleBinding
 metadata:
   name: kyma-admin-binding
+  namespace: {{ .Release.Namespace }}
   labels:
     app: kyma
     chart: {{ .Chart.Name }}-{{ .Chart.Version }}

--- a/resources/core/charts/cluster-users/templates/rbac-roles.yaml
+++ b/resources/core/charts/cluster-users/templates/rbac-roles.yaml
@@ -3,7 +3,6 @@ kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
   name: kube-system-view
-  namespace: {{ .Release.Namespace }}
   labels:
     app: kyma
     chart: {{ .Chart.Name }}-{{ .Chart.Version }}
@@ -24,7 +23,6 @@ apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRole
 metadata:
   name: kyma-view
-  namespace: {{ .Release.Namespace }}
   labels:
     app: kyma
     chart: {{ .Chart.Name }}-{{ .Chart.Version }}
@@ -33,15 +31,14 @@ metadata:
 rules:
 - apiGroups: ["", "api.kyma.cx", "apps", "authentication.kyma-project.io", "extensions", "gateway.kyma.cx", "kubeless.io", "rbac.authorization.k8s.io", "applicationconnector.kyma-project.io", "servicecatalog.k8s.io", "servicecatalog.kyma.cx", "settings.k8s.io", "kyma.cx", "authentication.istio.io", "config.istio.io", "eventing.kyma.cx", "ui.kyma.cx", "ui.kyma-project.io"]
   resources: ["*"]
-  verbs: ["get, list"]
-- nonResourceURLs: [ "*"] #give access to all non resource urls
-  verbs: ["get", "list"]   
+  verbs: ["get", "list"]
+- nonResourceURLs: ["*"] #give access to all non resource urls
+  verbs: ["get", "list"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRoleBinding
 metadata:
   name: kyma-view-binding
-  namespace: {{ .Release.Namespace }}
   labels:
     app: kyma
     chart: {{ .Chart.Name }}-{{ .Chart.Version }}
@@ -70,7 +67,6 @@ apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRole
 metadata:
   name: kyma-admin
-  namespace: {{ .Release.Namespace }}
   labels:
     app: kyma
     chart: {{ .Chart.Name }}-{{ .Chart.Version }}
@@ -83,14 +79,13 @@ rules:
 - apiGroups: ["apiextensions.k8s.io"]
   resources: ["customresourcedefinitions"]
   verbs: ["get", "list"]
-- nonResourceURLs: [ "*"] #give access to all non resource urls
-  verbs: ["*"]  
+- nonResourceURLs: ["*"] #give access to all non resource urls
+  verbs: ["*"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRoleBinding
 metadata:
   name: kyma-admin-binding
-  namespace: {{ .Release.Namespace }}
   labels:
     app: kyma
     chart: {{ .Chart.Name }}-{{ .Chart.Version }}
@@ -105,8 +100,7 @@ subjects:
   name: admin@kyma.cx
   apiGroup: rbac.authorization.k8s.io
 - kind: ServiceAccount
-  name: kube-rbac-proxy  
-  namespace: {{ .Release.Namespace }}  
+  name: kube-rbac-proxy
 {{ if .Values.users.adminGroup }}
 - kind: Group
   name: {{ .Values.users.adminGroup }}

--- a/resources/core/charts/cluster-users/templates/rbac-roles.yaml
+++ b/resources/core/charts/cluster-users/templates/rbac-roles.yaml
@@ -104,6 +104,7 @@ subjects:
   apiGroup: rbac.authorization.k8s.io
 - kind: ServiceAccount
   name: kube-rbac-proxy
+  namespace: {{ .Release.Namespace }}
 {{ if .Values.users.adminGroup }}
 - kind: Group
   name: {{ .Values.users.adminGroup }}


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Fix a bug in kyma-view ClusterRole definition that prevented the user with this role assigned from viewing/listing cluster resources
- Removed the "Namespace" field as it is redundant in the case of ClusterRoles/ClusterRoleBindings

**Related issue(s)**
none
