### PR TITLE
Connector test skip verify

### DIFF
--- a/resources/application-connector/charts/connector-service/templates/tests/test-acceptance.yaml
+++ b/resources/application-connector/charts/connector-service/templates/tests/test-acceptance.yaml
@@ -21,7 +21,7 @@ spec:
     - name: GATEWAY_URL
       value: https://gateway.{{ .Values.global.domainName }}
     - name: SKIP_SSL_VERIFY
-      value: "{{ .Values.tests.skipSslVerify }}"
+      value: "true"
 
   restartPolicy: Never
 {{ end }}


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Connector Service tests will always run with SKIP_SSL_VERIFY

