### PR TITLE
Cluster overrides allow skipping TLS verification in Application Connector tests

### DIFF
--- a/installation/resources/installer-config-cluster.yaml.tpl
+++ b/installation/resources/installer-config-cluster.yaml.tpl
@@ -51,7 +51,7 @@ metadata:
     installer: overrides
     component: application-connector
 data:
-  connector-service.tests.skipSslVerify: "__SKIP__SLL_VERIFY__"
+  connector-service.tests.skipSslVerify: "__SKIP_SLL_VERIFY__"
 ---
 apiVersion: v1
 kind: ConfigMap

--- a/installation/resources/installer-config-cluster.yaml.tpl
+++ b/installation/resources/installer-config-cluster.yaml.tpl
@@ -51,7 +51,7 @@ metadata:
     installer: overrides
     component: application-connector
 data:
-  connector-service.tests.skipSslVerify: "__SKIP__SLL_VERIFICATION__"
+  connector-service.tests.skipSslVerify: "__SKIP__SLL_VERIFY__"
 ---
 apiVersion: v1
 kind: ConfigMap

--- a/installation/resources/installer-config-cluster.yaml.tpl
+++ b/installation/resources/installer-config-cluster.yaml.tpl
@@ -45,6 +45,17 @@ data:
 apiVersion: v1
 kind: ConfigMap
 metadata:
+  name: connector-service-overrides
+  namespace: kyma-installer
+  labels:
+    installer: overrides
+    component: application-connector
+data:
+  connector-service.tests.skipSslVerify: "__SKIP__SLL_VERIFICATION__"
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
   name: core-overrides
   namespace: kyma-installer
   labels:

--- a/installation/resources/installer-config-cluster.yaml.tpl
+++ b/installation/resources/installer-config-cluster.yaml.tpl
@@ -51,7 +51,7 @@ metadata:
     installer: overrides
     component: application-connector
 data:
-  connector-service.tests.skipSslVerify: "__SKIP_SLL_VERIFY__"
+  connector-service.tests.skipSslVerify: "__SKIP_SSL_VERIFY__"
 ---
 apiVersion: v1
 kind: ConfigMap


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Cluster overrides allow skipping TLS verification in Application Connector tests
- Add option do modify `skipSslVerify` flag on cluster

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
Resolves #1606 
