### PR TITLE
Enable addons needed for Horizontal Pod Autoscaler in local minikube

### DIFF
--- a/installation/scripts/minikube.ps1
+++ b/installation/scripts/minikube.ps1
@@ -78,6 +78,17 @@ function WaitForMinikubeToBeUp() {
     }
 }
 
+
+function EnableMinikubeAddons() {
+
+    Write-Output "Enabling minikube addons..."
+
+    minikube addons enable metrics-server
+    minikube addons enable heapster
+
+    minikube addons list
+}
+
 function IncreaseFsInotifyMaxUserInstances() {
     # Default value of 128 is not enough to perform “kubectl log -f” from pods, hence increased to 524288
     $cmd = "minikube ssh -- `"sudo sysctl -w fs.inotify.max_user_instances=524288`""
@@ -110,5 +121,6 @@ CheckIfMinikubeIsInitialized
 InitializeMinikubeConfig
 StartMinikube
 WaitForMinikubeToBeUp
+EnableMinikubeAddons
 AddDevDomainsToEtcHosts "apiserver", "console", "catalog", "instances", "dex", "docs", "lambdas-ui", "ui-api", "minio", "jaeger", "grafana", "configurations-generator", "gateway", "connector-service"
 IncreaseFsInotifyMaxUserInstances

--- a/installation/scripts/minikube.sh
+++ b/installation/scripts/minikube.sh
@@ -157,6 +157,16 @@ function increaseFsInotifyMaxUserInstances() {
     fi
 }
 
+function enableMinikubeAddons() {
+
+    log "Enabling minikube addons..." green
+
+    minikube addons enable metrics-server
+    minikube addons enable heapster
+
+    minikube addons list
+}
+
 function start() {
     checkMinikubeVersion
 
@@ -184,6 +194,8 @@ function start() {
     -b=localkube
 
     waitForMinikubeToBeUp
+
+    enableMinikubeAddons
 
     # Adding domains to /etc/hosts files
     addDevDomainsToEtcHosts "apiserver.${MINIKUBE_DOMAIN} console.${MINIKUBE_DOMAIN} catalog.${MINIKUBE_DOMAIN} instances.${MINIKUBE_DOMAIN} brokers.${MINIKUBE_DOMAIN} dex.${MINIKUBE_DOMAIN} docs.${MINIKUBE_DOMAIN} lambdas-ui.${MINIKUBE_DOMAIN} ui-api.${MINIKUBE_DOMAIN} minio.${MINIKUBE_DOMAIN} jaeger.${MINIKUBE_DOMAIN} grafana.${MINIKUBE_DOMAIN}  configurations-generator.${MINIKUBE_DOMAIN} gateway.${MINIKUBE_DOMAIN} connector-service.${MINIKUBE_DOMAIN}"


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

Enable minikube addons metrics-server and heapster for local minikube.

**Related issue(s)**
[Introduce Function Sizes #716](https://github.com/kyma-project/kyma/issues/716)
