### PR TITLE
Add initial function size config to lambda-ui configmap

### DIFF
--- a/docs/kyma/docs/030-inst-local-installation-from-release.md
+++ b/docs/kyma/docs/030-inst-local-installation-from-release.md
@@ -141,6 +141,26 @@ See the example of the website address:
 http://192.168.64.44:30000
 ```
 
+## Enable Horizontal Pod Autoscaler (HPA)
+
+By default, the Horizontal Pod Autoscaler is not enabled in your local Kyma installation, so you need to enable it manually.
+
+Kyma uses the autoscaling/v1 stable version, which only provides support for CPU autoscaling. Once enabled, HPA automatically scales the number of lambda function Pods based on observed CPU utilization.
+
+>**NOTE:** The autoscaling/v1 version does not support custom metrics. To use such metrics, you need the autoscaling/v2beta2 version.
+
+To enable Horizontal Pod Autoscaler, follow these steps:
+
+1. Enable the metrics server for resource metrics by running the following command:
+    ```
+    $ minikube addons enable metrics-server
+    ```
+
+2. Verify if the metrics server is active by checking the list of addons:
+    ```
+    $ minikube addons list
+    ```
+
 ## Troubleshooting
 
 If the installer does not respond as expected, check the installation status using the `is-installed.sh` script with the `--verbose` flag added. Run:

--- a/resources/core/charts/kubeless/charts/lambdas-ui/README.md
+++ b/resources/core/charts/kubeless/charts/lambdas-ui/README.md
@@ -1,0 +1,118 @@
+# Lambdas
+
+## Overview
+
+**Lambdas** is a web-based UI component which is a part of the Console UI.
+It allows you to manage lambda functions, which are the key part of Kyma capabilities.
+
+## Details
+
+**Lambdas** allow you to:
+- Create and modify lambda functions.
+- Expose a function as API.
+- Bind a function to a service.
+- Write the code of the function. This option is available only through node.js.
+- Manage dependencies.
+- Add and remove labels.
+- Enable API security.
+- Select the function size.
+
+### Configuration
+
+**Lambdas** UI is deployed with the use of a [ConfigMap](templates/configmap.yaml).
+The **ConfigMap**  includes the `config.js` file that is mounted as the asset of the Console application and injected as a configuration file.
+Use this mechanism to overwrite the default configuration with custom values resulting from the Helm chart installation.
+
+### Function size
+
+You can modify the function size when you either create or update a function using  **Lambdas** UI.
+
+The [ConfigMap](templates/configmap.yaml) contains a set of configurations for a function size, including:
+- **resources** configuration with the following parameters: **requests** and **limits**.  
+- **horizontalPodAutoscaler** configuration with the following parameters: **minReplicas**, **maxReplicas** and **targetAverageUtilization**.
+
+- The basic **requests** configuration for a function is as follows:
+
+```
+resources:
+  requests:
+    cpu: '100m'
+    memory: '100Mi'
+```
+
+- You can configure the sizes using the following parameters: 
+1. S: `{memory: '128Mi', cpu: '100m', minReplicas: 1, maxReplicas: 2}`
+2. M: `{memory: '256Mi', cpu: '500m', minReplicas: 2, maxReplicas: 5}`
+3. L: `{memory: '512Mi', cpu: '1.0',  minReplicas: 5, maxReplicas: 10}`
+4. XL:`{memory: '1024Mi', cpu: '2.0', minReplicas: 10, maxReplicas: 20}`
+
+>**NOTE:** The size of the function may exhaust the resources of the Environment. When creating a function, keep in mind the configured resource quotas.
+
+The yaml file shows a sample M size function. 
+
+The function includes the container **test** with the `spec.deployment.spec.containers[0].resources` configuration, as well as the configuration for the **horizontalPodAutoscaler**.
+
+```yaml
+apiVersion: kubeless.io/v1beta1
+kind: Function
+metadata:
+  annotations:
+    function-size: M
+  finalizers:
+  - kubeless.io/function
+  generation: 1
+  name: test
+  namespace: stage
+spec:
+  checksum: ""
+  deployment:
+    spec:
+      replicas: 2
+      template:
+        spec:
+          containers:
+          - name: test
+            resources:
+              limits:
+                cpu: 500m
+                memory: 256Mi
+              requests:
+                cpu: 100m
+                memory: 100Mi
+  deps: ""
+  function: |-
+    module.exports = { main: function (event, context) {
+        return "test";
+    } }
+  function-content-type: text
+  handler: handler.main
+  horizontalPodAutoscaler:
+    metadata:
+      labels:
+        function: test
+      name: test
+      namespace: stage
+    spec:
+      maxReplicas: 5
+      metrics:
+      - resource:
+          name: cpu
+          targetAverageUtilization: 40
+        type: Resource
+      minReplicas: 2
+      scaleTargetRef:
+        apiVersion: apps/v1beta1
+        kind: Deployment
+        name: test
+  runtime: nodejs8
+  service:
+    ports:
+    - name: http-function-port
+      port: 8080
+      protocol: TCP
+      targetPort: 8080
+    selector:
+      created-by: kubeless
+      function: test
+  timeout: ""
+```

--- a/resources/core/charts/kubeless/charts/lambdas-ui/templates/configmap.yaml
+++ b/resources/core/charts/kubeless/charts/lambdas-ui/templates/configmap.yaml
@@ -10,6 +10,13 @@ data:
   config.js: |
     window.clusterConfig = {
       domain: '{{ .Values.global.domainName }}',
-      graphqlApiUrl: 'https://ui-api.{{ .Values.global.domainName }}/graphql'
+      graphqlApiUrl: 'https://ui-api.{{ .Values.global.domainName }}/graphql',
+      hpaCpuTargetAverageUtilization: 50,
+      functionResources:{requests:{cpu: '100m', memory: '100Mi'}},
+      functionSizes: [
+          {size:{ name: 'S', memory: '128Mi', cpu: '100m', minReplicas: 1, maxReplicas: 2, description: '' }},
+          {size:{ name: 'M', memory: '256Mi', cpu: '500m', minReplicas: 2, maxReplicas: 5, description: '' }},
+          {size:{ name: 'L', memory: '512Mi', cpu: '1.0',  minReplicas: 5, maxReplicas: 10, description: '' }},
+          {size:{ name: 'XL', memory: '1024Mi', cpu: '2.0', minReplicas: 10, maxReplicas: 20, description: '' }}
+        ]
     };
-    


### PR DESCRIPTION
**Description**
* Add initial function size config to lambda-ui configmap
* Updating related documentation for enabling `metric-server`

**Related issue(s)**
See https://github.com/kyma-project/kyma/issues/716
