### PR TITLE
Metadata Service returns correct error code when RE does not exist

### DIFF
--- a/components/metadata-service/internal/apperrors/apperrors.go
+++ b/components/metadata-service/internal/apperrors/apperrors.go
@@ -41,7 +41,6 @@ func WrongInput(format string, a ...interface{}) AppError {
 	return errorf(CodeWrongInput, format, a...)
 }
 
-
 func UpstreamServerCallFailed(format string, a ...interface{}) AppError {
 	return errorf(CodeUpstreamServerCallFailed, format, a...)
 }

--- a/components/metadata-service/internal/apperrors/apperrors.go
+++ b/components/metadata-service/internal/apperrors/apperrors.go
@@ -11,6 +11,7 @@ const (
 )
 
 type AppError interface {
+	Append(string, ...interface{}) AppError
 	Code() int
 	Error() string
 }
@@ -40,8 +41,14 @@ func WrongInput(format string, a ...interface{}) AppError {
 	return errorf(CodeWrongInput, format, a...)
 }
 
+
 func UpstreamServerCallFailed(format string, a ...interface{}) AppError {
 	return errorf(CodeUpstreamServerCallFailed, format, a...)
+}
+
+func (ae appError) Append(additionalFormat string, a ...interface{}) AppError {
+	format := additionalFormat + ", " + ae.message
+	return errorf(ae.code, format, a...)
 }
 
 func (ae appError) Code() int {

--- a/components/metadata-service/internal/apperrors/apperrors_test.go
+++ b/components/metadata-service/internal/apperrors/apperrors_test.go
@@ -38,18 +38,21 @@ func TestAppError(t *testing.T) {
 		createdNotFoundErr := NotFound("Some NotFound apperror, %s", "Some pkg err")
 		createdAlreadyExistsErr := AlreadyExists("Some AlreadyExists apperror, %s", "Some pkg err")
 		createdWrongInputErr := WrongInput("Some WrongInput apperror, %s", "Some pkg err")
+		createdUpstreamServerCallFailedErr := UpstreamServerCallFailed("Some UpstreamServerCallFailed apperror, %s", "Some pkg err")
 
 		//when
 		appendedInternalErr := createdInternalErr.Append("Some additional message")
 		appendedNotFoundErr := createdNotFoundErr.Append("Some additional message")
 		appendedAlreadyExistsErr := createdAlreadyExistsErr.Append("Some additional message")
 		appendedWrongInputErr := createdWrongInputErr.Append("Some additional message")
+		appendedUpstreamServerCallFailedErr := createdUpstreamServerCallFailedErr.Append("Some additional message")
 
 		//then
 		assert.Equal(t, CodeInternal, appendedInternalErr.Code())
 		assert.Equal(t, CodeNotFound, appendedNotFoundErr.Code())
 		assert.Equal(t, CodeAlreadyExists, appendedAlreadyExistsErr.Code())
 		assert.Equal(t, CodeWrongInput, appendedWrongInputErr.Code())
+		assert.Equal(t, CodeUpstreamServerCallFailed, appendedUpstreamServerCallFailedErr.Code())
 	})
 
 	t.Run("should append apperrors and chain messages correctly", func(t *testing.T) {
@@ -58,17 +61,20 @@ func TestAppError(t *testing.T) {
 		createdNotFoundErr := NotFound("Some NotFound apperror, %s", "Some pkg err")
 		createdAlreadyExistsErr := AlreadyExists("Some AlreadyExists apperror, %s", "Some pkg err")
 		createdWrongInputErr := WrongInput("Some WrongInput apperror, %s", "Some pkg err")
+		createdUpstreamServerCallFailedErr := UpstreamServerCallFailed("Some UpstreamServerCallFailed apperror, %s", "Some pkg err")
 
 		//when
 		appendedInternalErr := createdInternalErr.Append("Some additional message: %s", "error")
 		appendedNotFoundErr := createdNotFoundErr.Append("Some additional message: %s", "error")
 		appendedAlreadyExistsErr := createdAlreadyExistsErr.Append("Some additional message: %s", "error")
 		appendedWrongInputErr := createdWrongInputErr.Append("Some additional message: %s", "error")
+		appendedUpstreamServerCallFailedErr := createdUpstreamServerCallFailedErr.Append("Some additional message: %s", "error")
 
 		//then
 		assert.Equal(t, "Some additional message: error, Some Internal apperror, Some pkg err", appendedInternalErr.Error())
 		assert.Equal(t, "Some additional message: error, Some NotFound apperror, Some pkg err", appendedNotFoundErr.Error())
 		assert.Equal(t, "Some additional message: error, Some AlreadyExists apperror, Some pkg err", appendedAlreadyExistsErr.Error())
 		assert.Equal(t, "Some additional message: error, Some WrongInput apperror, Some pkg err", appendedWrongInputErr.Error())
+		assert.Equal(t, "Some additional message: error, Some UpstreamServerCallFailed apperror, Some pkg err", appendedUpstreamServerCallFailedErr.Error())
 	})
 }

--- a/components/metadata-service/internal/apperrors/apperrors_test.go
+++ b/components/metadata-service/internal/apperrors/apperrors_test.go
@@ -31,4 +31,44 @@ func TestAppError(t *testing.T) {
 		assert.Equal(t, "code: 1, error: bug", WrongInput("code: %d, error: %s", 1, "bug").Error())
 		assert.Equal(t, "code: 1, error: bug", UpstreamServerCallFailed("code: %d, error: %s", 1, "bug").Error())
 	})
+
+	t.Run("should append apperrors without changing error code", func(t *testing.T) {
+		//given
+		createdInternalErr := Internal("Some Internal apperror, %s", "Some pkg err")
+		createdNotFoundErr := NotFound("Some NotFound apperror, %s", "Some pkg err")
+		createdAlreadyExistsErr := AlreadyExists("Some AlreadyExists apperror, %s", "Some pkg err")
+		createdWrongInputErr := WrongInput("Some WrongInput apperror, %s", "Some pkg err")
+
+		//when
+		appendedInternalErr := createdInternalErr.Append("Some additional message")
+		appendedNotFoundErr := createdNotFoundErr.Append("Some additional message")
+		appendedAlreadyExistsErr := createdAlreadyExistsErr.Append("Some additional message")
+		appendedWrongInputErr := createdWrongInputErr.Append("Some additional message")
+
+		//then
+		assert.Equal(t, CodeInternal, appendedInternalErr.Code())
+		assert.Equal(t, CodeNotFound, appendedNotFoundErr.Code())
+		assert.Equal(t, CodeAlreadyExists, appendedAlreadyExistsErr.Code())
+		assert.Equal(t, CodeWrongInput, appendedWrongInputErr.Code())
+	})
+
+	t.Run("should append apperrors and chain messages correctly", func(t *testing.T) {
+		//given
+		createdInternalErr := Internal("Some Internal apperror, %s", "Some pkg err")
+		createdNotFoundErr := NotFound("Some NotFound apperror, %s", "Some pkg err")
+		createdAlreadyExistsErr := AlreadyExists("Some AlreadyExists apperror, %s", "Some pkg err")
+		createdWrongInputErr := WrongInput("Some WrongInput apperror, %s", "Some pkg err")
+
+		//when
+		appendedInternalErr := createdInternalErr.Append("Some additional message: %s", "error")
+		appendedNotFoundErr := createdNotFoundErr.Append("Some additional message: %s", "error")
+		appendedAlreadyExistsErr := createdAlreadyExistsErr.Append("Some additional message: %s", "error")
+		appendedWrongInputErr := createdWrongInputErr.Append("Some additional message: %s", "error")
+
+		//then
+		assert.Equal(t, "Some additional message: error, Some Internal apperror, Some pkg err", appendedInternalErr.Error())
+		assert.Equal(t, "Some additional message: error, Some NotFound apperror, Some pkg err", appendedNotFoundErr.Error())
+		assert.Equal(t, "Some additional message: error, Some AlreadyExists apperror, Some pkg err", appendedAlreadyExistsErr.Error())
+		assert.Equal(t, "Some additional message: error, Some WrongInput apperror, Some pkg err", appendedWrongInputErr.Error())
+	})
 }

--- a/components/metadata-service/internal/metadata/remoteenv/repository.go
+++ b/components/metadata-service/internal/metadata/remoteenv/repository.go
@@ -188,7 +188,7 @@ func (r *repository) getRemoteEnvironment(remoteEnvironment string) (*v1alpha1.R
 	if err != nil {
 		if k8serrors.IsNotFound(err) {
 			message := fmt.Sprintf("Remote Environment %s not found", remoteEnvironment)
-			return nil, apperrors.Internal(message)
+			return nil, apperrors.NotFound(message)
 		}
 
 		message := fmt.Sprintf("Getting Remote Environment %s failed, %s", remoteEnvironment, err.Error())

--- a/components/metadata-service/internal/metadata/remoteenv/repository_test.go
+++ b/components/metadata-service/internal/metadata/remoteenv/repository_test.go
@@ -97,7 +97,7 @@ func TestGetServices(t *testing.T) {
 
 		// then
 		require.Nil(t, services)
-		assert.Equal(t, apperrors.CodeInternal, err.Code())
+		assert.Equal(t, apperrors.CodeNotFound, err.Code())
 
 		// when
 		service, err := repository.Get("not_existent", "id1")
@@ -105,7 +105,7 @@ func TestGetServices(t *testing.T) {
 		// then
 		require.Error(t, err)
 		assert.Equal(t, remoteenv.Service{}, service)
-		assert.Equal(t, apperrors.CodeInternal, err.Code())
+		assert.Equal(t, apperrors.CodeNotFound, err.Code())
 	})
 
 	t.Run("should get service by id", func(t *testing.T) {
@@ -254,7 +254,7 @@ func TestCreateServices(t *testing.T) {
 		err := repository.Update("production", newService)
 
 		// then
-		assert.Equal(t, apperrors.CodeInternal, err.Code())
+		assert.Equal(t, apperrors.CodeNotFound, err.Code())
 	})
 }
 
@@ -335,7 +335,7 @@ func TestDeleteServices(t *testing.T) {
 		err := repository.Delete("production", "id1")
 
 		// then
-		assert.Equal(t, apperrors.CodeInternal, err.Code())
+		assert.Equal(t, apperrors.CodeNotFound, err.Code())
 	})
 }
 

--- a/components/metadata-service/internal/metadata/servicedefservice.go
+++ b/components/metadata-service/internal/metadata/servicedefservice.go
@@ -57,7 +57,7 @@ func (sds *serviceDefinitionService) Create(remoteEnvironment string, serviceDef
 	if serviceDef.Identifier != "" {
 		apperr := sds.ensureUniqueIdentifier(serviceDef.Identifier, remoteEnvironment)
 		if apperr != nil {
-			return "", apperr
+			return "", apperr.Append("Creating service failed")
 		}
 	}
 
@@ -231,7 +231,7 @@ func convertServiceBaseInfo(service remoteenv.Service) model.ServiceDefinition {
 func (sds *serviceDefinitionService) ensureUniqueIdentifier(identifier, remoteEnvironment string) apperrors.AppError {
 	services, apperr := sds.GetAll(remoteEnvironment)
 	if apperr != nil {
-		return apperr
+		return apperr.Append("Checking identifier failed")
 	}
 
 	for _, service := range services {

--- a/components/metadata-service/internal/metadata/servicedefservice_test.go
+++ b/components/metadata-service/internal/metadata/servicedefservice_test.go
@@ -1317,16 +1317,13 @@ func TestServiceDefinitionService_Delete(t *testing.T) {
 
 	t.Run("should return an error if API deletion failed", func(t *testing.T) {
 		// given
-		serviceRepository := new(remoteenvmocks.ServiceRepository)
-		serviceRepository.On("Delete", "re", "uuid-1").Return(nil)
-
 		serviceAPIService := new(serviceapimocks.Service)
 		serviceAPIService.On("Delete", "re", "uuid-1").Return(apperrors.Internal("an error"))
 
 		uuidGenerator := new(uuidmocks.Generator)
 		uuidGenerator.On("NewUUID").Return("uuid-1")
 
-		service := NewServiceDefinitionService(uuidGenerator, serviceAPIService, serviceRepository, nil)
+		service := NewServiceDefinitionService(uuidGenerator, serviceAPIService, nil, nil)
 
 		// when
 		err := service.Delete("re", "uuid-1")

--- a/components/metadata-service/internal/metadata/servicedefservice_test.go
+++ b/components/metadata-service/internal/metadata/servicedefservice_test.go
@@ -339,9 +339,9 @@ func TestServiceDefinitionService_Create(t *testing.T) {
 		serviceID, err := service.Create("re", &serviceDefinition)
 
 		// then
-		assert.Empty(t, serviceID)
-		assert.Error(t, err)
+		require.Error(t, err)
 		assert.Contains(t, err.Error(), "some error")
+		assert.Empty(t, serviceID)
 
 		serviceAPIService.AssertExpectations(t)
 	})
@@ -376,7 +376,7 @@ func TestServiceDefinitionService_Create(t *testing.T) {
 		specService.AssertExpectations(t)
 	})
 
-	t.Run("should return error when creating service in remote environment fails", func(t *testing.T) {
+	t.Run("should return internal error when creating service in remote environment fails", func(t *testing.T) {
 		// given
 		serviceAPI := &model.API{
 			TargetUrl: "http://target.com",
@@ -423,9 +423,67 @@ func TestServiceDefinitionService_Create(t *testing.T) {
 		serviceID, err := service.Create("re", &serviceDefinition)
 
 		// then
-		assert.Empty(t, serviceID)
-		assert.Error(t, err)
+		require.Error(t, err)
 		assert.Contains(t, err.Error(), "some error")
+		assert.Equal(t, err.Code(), apperrors.CodeInternal)
+		assert.Empty(t, serviceID)
+
+		uuidGenerator.AssertExpectations(t)
+		serviceAPIService.AssertExpectations(t)
+		serviceRepository.AssertExpectations(t)
+		specService.AssertExpectations(t)
+	})
+
+	t.Run("should return not found error when creating service in remote environment that not exists", func(t *testing.T) {
+		// given
+		serviceAPI := &model.API{
+			TargetUrl: "http://target.com",
+		}
+		serviceDefinition := model.ServiceDefinition{
+			Name:        "Some service",
+			Description: "Some cool service",
+			Provider:    "Service Provider",
+			Api:         serviceAPI,
+		}
+		remoteEnvServiceAPI := &remoteenv.ServiceAPI{
+			TargetUrl:   "http://target.com",
+			AccessLabel: "access-label",
+			GatewayURL:  "gateway-url",
+			Credentials: remoteenv.Credentials{
+				AuthenticationUrl: "",
+				SecretName:        "",
+			},
+		}
+		remoteEnvService := remoteenv.Service{
+			ID:                  "uuid-1",
+			DisplayName:         "Some service",
+			LongDescription:     "Some cool service",
+			ShortDescription:    "Some cool service",
+			ProviderDisplayName: "Service Provider",
+			Labels:              map[string]string{"connected-app": "re"},
+			Tags:                make([]string, 0),
+			API:                 remoteEnvServiceAPI,
+			Events:              false,
+		}
+		uuidGenerator := new(uuidmocks.Generator)
+		uuidGenerator.On("NewUUID").Return("uuid-1")
+		serviceAPIService := new(serviceapimocks.Service)
+		serviceAPIService.On("New", "re", "uuid-1", serviceAPI).Return(remoteEnvServiceAPI, nil)
+		serviceRepository := new(remoteenvmocks.ServiceRepository)
+		serviceRepository.On("Create", "re", remoteEnvService).Return(apperrors.NotFound("some error"))
+		specService := new(specmocks.Service)
+		specService.On("PutSpec", &serviceDefinition, "gateway-url").Return(nil)
+
+		service := NewServiceDefinitionService(uuidGenerator, serviceAPIService, serviceRepository, specService)
+
+		// when
+		serviceID, err := service.Create("re", &serviceDefinition)
+
+		// then
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "some error")
+		assert.Equal(t, err.Code(), apperrors.CodeNotFound)
+		assert.Empty(t, serviceID)
 
 		uuidGenerator.AssertExpectations(t)
 		serviceAPIService.AssertExpectations(t)
@@ -466,9 +524,9 @@ func TestServiceDefinitionService_Create(t *testing.T) {
 		serviceID, err := service.Create("re", &serviceDefinition)
 
 		// then
-		require.Empty(t, serviceID)
 		require.Error(t, err)
 		assert.Equal(t, apperrors.CodeAlreadyExists, err.Code())
+		assert.Empty(t, serviceID)
 
 		serviceRepository.AssertExpectations(t)
 	})
@@ -511,9 +569,9 @@ func TestServiceDefinitionService_GetAll(t *testing.T) {
 
 		// when
 		result, err := service.GetAll("re")
-		require.NoError(t, err)
 
 		// then
+		require.NoError(t, err)
 		assert.Len(t, result, 2)
 		assert.Contains(t, result, model.ServiceDefinition{
 			ID:          "uuid-1",
@@ -540,10 +598,25 @@ func TestServiceDefinitionService_GetAll(t *testing.T) {
 
 		// when
 		result, err := service.GetAll("re")
-		require.NoError(t, err)
 
 		// then
+		require.NoError(t, err)
 		assert.Len(t, result, 0)
+	})
+
+	t.Run("should return not found error if cannot find Remote Environment", func(t *testing.T) {
+		// given
+		serviceRepository := new(remoteenvmocks.ServiceRepository)
+		serviceRepository.On("GetAll", "re").Return(nil, apperrors.NotFound("Remote Environment re not found"))
+
+		service := NewServiceDefinitionService(nil, nil, serviceRepository, nil)
+
+		// when
+		_, err := service.GetAll("re")
+
+		//then
+		require.Error(t, err)
+		assert.Equal(t, apperrors.CodeNotFound, err.Code())
 	})
 }
 
@@ -593,9 +666,9 @@ func TestServiceDefinitionService_GetById(t *testing.T) {
 
 		// when
 		result, err := service.GetByID("re", "uuid-1")
-		require.NoError(t, err)
 
 		// then
+		require.NoError(t, err)
 		assert.Equal(t, "uuid-1", result.ID)
 		assert.Equal(t, "Some service", result.Name)
 		assert.Equal(t, "Some cool service", result.Description)
@@ -611,7 +684,7 @@ func TestServiceDefinitionService_GetById(t *testing.T) {
 		specService.AssertExpectations(t)
 	})
 
-	t.Run("should return error when getting service from remote environment fails", func(t *testing.T) {
+	t.Run("should return internal error when getting service from remote environment fails", func(t *testing.T) {
 		// given
 		serviceRepository := new(remoteenvmocks.ServiceRepository)
 		serviceRepository.On("Get", "re", "uuid-1").Return(remoteenv.Service{}, apperrors.Internal("get error"))
@@ -622,8 +695,25 @@ func TestServiceDefinitionService_GetById(t *testing.T) {
 		_, err := service.GetByID("re", "uuid-1")
 
 		// then
-		assert.Error(t, err)
+		require.Error(t, err)
 		assert.Contains(t, err.Error(), "get error")
+		assert.Equal(t, err.Code(), apperrors.CodeInternal)
+	})
+
+	t.Run("should return not found error when getting service from remote environment that not exists", func(t *testing.T) {
+		// given
+		serviceRepository := new(remoteenvmocks.ServiceRepository)
+		serviceRepository.On("Get", "re", "uuid-1").Return(remoteenv.Service{}, apperrors.NotFound("get error"))
+
+		service := NewServiceDefinitionService(nil, nil, serviceRepository, nil)
+
+		// when
+		_, err := service.GetByID("re", "uuid-1")
+
+		// then
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "get error")
+		assert.Equal(t, err.Code(), apperrors.CodeNotFound)
 	})
 
 	t.Run("should return error when reading API fails", func(t *testing.T) {
@@ -661,7 +751,7 @@ func TestServiceDefinitionService_GetById(t *testing.T) {
 		_, err := service.GetByID("re", "uuid-1")
 
 		// then
-		assert.Error(t, err)
+		require.Error(t, err)
 		assert.Contains(t, err.Error(), "api error")
 	})
 
@@ -688,7 +778,7 @@ func TestServiceDefinitionService_GetById(t *testing.T) {
 		_, err := service.GetByID("re", "uuid-1")
 
 		// then
-		assert.Error(t, err)
+		require.Error(t, err)
 		assert.Contains(t, err.Error(), "error")
 
 		serviceRepository.AssertExpectations(t)
@@ -766,7 +856,7 @@ func TestServiceDefinitionService_Update(t *testing.T) {
 		_, err := service.Update("re", &serviceDefinition)
 
 		// then
-		assert.NoError(t, err)
+		require.NoError(t, err)
 
 		serviceAPIService.AssertExpectations(t)
 		serviceRepository.AssertExpectations(t)
@@ -822,7 +912,7 @@ func TestServiceDefinitionService_Update(t *testing.T) {
 		_, err := service.Update("re", &serviceDefinition)
 
 		// then
-		assert.Error(t, err)
+		require.Error(t, err)
 		assert.Equal(t, apperrors.CodeNotFound, err.Code())
 	})
 
@@ -871,7 +961,7 @@ func TestServiceDefinitionService_Update(t *testing.T) {
 		_, err := service.Update("re", &serviceDefinition)
 
 		// then
-		assert.NoError(t, err)
+		require.NoError(t, err)
 
 		serviceAPIService.AssertExpectations(t)
 		serviceRepository.AssertExpectations(t)
@@ -923,7 +1013,7 @@ func TestServiceDefinitionService_Update(t *testing.T) {
 		_, err := service.Update("re", &serviceDefinition)
 
 		// then
-		assert.NoError(t, err)
+		require.NoError(t, err)
 
 		serviceAPIService.AssertExpectations(t)
 		serviceRepository.AssertExpectations(t)
@@ -985,7 +1075,7 @@ func TestServiceDefinitionService_Update(t *testing.T) {
 		_, err := service.Update("re", &serviceDefinition)
 
 		// then
-		assert.Error(t, err)
+		require.Error(t, err)
 		assert.Equal(t, apperrors.CodeInternal, err.Code())
 		assert.NotEmpty(t, err.Error())
 
@@ -1047,7 +1137,7 @@ func TestServiceDefinitionService_Update(t *testing.T) {
 		_, err := service.Update("re", &serviceDefinition)
 
 		// then
-		assert.Error(t, err)
+		require.Error(t, err)
 		assert.Equal(t, apperrors.CodeInternal, err.Code())
 		assert.NotEmpty(t, err.Error())
 
@@ -1110,7 +1200,7 @@ func TestServiceDefinitionService_Update(t *testing.T) {
 		_, err := service.Update("re", &serviceDefinition)
 
 		// then
-		assert.Error(t, err)
+		require.Error(t, err)
 		assert.Equal(t, apperrors.CodeInternal, err.Code())
 		assert.NotEmpty(t, err.Error())
 
@@ -1186,7 +1276,7 @@ func TestServiceDefinitionService_Update(t *testing.T) {
 		_, err := service.Update("re", &serviceDefinition)
 
 		// then
-		assert.Error(t, err)
+		require.Error(t, err)
 		assert.Equal(t, apperrors.CodeInternal, err.Code())
 		assert.NotEmpty(t, err.Error())
 
@@ -1218,7 +1308,7 @@ func TestServiceDefinitionService_Delete(t *testing.T) {
 		err := service.Delete("re", "uuid-1")
 
 		// then
-		assert.NoError(t, err)
+		require.NoError(t, err)
 
 		serviceAPIService.AssertExpectations(t)
 		serviceRepository.AssertExpectations(t)
@@ -1227,23 +1317,48 @@ func TestServiceDefinitionService_Delete(t *testing.T) {
 
 	t.Run("should return an error if API deletion failed", func(t *testing.T) {
 		// given
+		serviceRepository := new(remoteenvmocks.ServiceRepository)
+		serviceRepository.On("Delete", "re", "uuid-1").Return(nil)
+
 		serviceAPIService := new(serviceapimocks.Service)
 		serviceAPIService.On("Delete", "re", "uuid-1").Return(apperrors.Internal("an error"))
 
 		uuidGenerator := new(uuidmocks.Generator)
 		uuidGenerator.On("NewUUID").Return("uuid-1")
 
-		service := NewServiceDefinitionService(uuidGenerator, serviceAPIService, nil, nil)
+		service := NewServiceDefinitionService(uuidGenerator, serviceAPIService, serviceRepository, nil)
 
 		// when
 		err := service.Delete("re", "uuid-1")
 
 		// then
-		assert.Error(t, err)
+		require.Error(t, err)
 		assert.Equal(t, apperrors.CodeInternal, err.Code())
 		assert.NotEmpty(t, err.Error())
 
 		serviceAPIService.AssertExpectations(t)
+	})
+
+	t.Run("should return an error when trying to delete service, but RE is not found", func(t *testing.T) {
+		// given
+		serviceRepository := new(remoteenvmocks.ServiceRepository)
+		serviceRepository.On("Delete", "re", "uuid-1").Return(apperrors.NotFound("A not found error"))
+
+		serviceAPIService := new(serviceapimocks.Service)
+		serviceAPIService.On("Delete", "re", "uuid-1").Return(nil)
+
+		uuidGenerator := new(uuidmocks.Generator)
+		uuidGenerator.On("NewUUID").Return("uuid-1")
+
+		service := NewServiceDefinitionService(uuidGenerator, serviceAPIService, serviceRepository, nil)
+
+		// when
+		err := service.Delete("re", "uuid-1")
+
+		// then
+		require.Error(t, err)
+		assert.Equal(t, apperrors.CodeNotFound, err.Code())
+		assert.NotEmpty(t, err.Error())
 	})
 
 	t.Run("should return an error if remoteenv delete failed", func(t *testing.T) {
@@ -1285,7 +1400,7 @@ func TestServiceDefinitionService_Delete(t *testing.T) {
 		err := service.Delete("re", "uuid-1")
 
 		// then
-		assert.Error(t, err)
+		require.Error(t, err)
 		assert.Equal(t, apperrors.CodeInternal, err.Code())
 		assert.NotEmpty(t, err.Error())
 
@@ -1316,7 +1431,6 @@ func TestServiceDefinitionService_GetAPI(t *testing.T) {
 
 		// then
 		require.NoError(t, err)
-
 		assert.Equal(t, serviceAPI, result)
 	})
 
@@ -1331,9 +1445,9 @@ func TestServiceDefinitionService_GetAPI(t *testing.T) {
 		result, err := service.GetAPI("re", "uuid-1")
 
 		// then
-		assert.Error(t, err)
-		assert.Nil(t, result)
+		require.Error(t, err)
 		assert.Equal(t, apperrors.CodeNotFound, err.Code())
+		assert.Nil(t, result)
 	})
 
 	t.Run("should return internal error if service does not exist", func(t *testing.T) {
@@ -1347,10 +1461,10 @@ func TestServiceDefinitionService_GetAPI(t *testing.T) {
 		result, err := service.GetAPI("re", "uuid-1")
 
 		// then
-		assert.Error(t, err)
-		assert.Nil(t, result)
+		require.Error(t, err)
 		assert.Equal(t, apperrors.CodeInternal, err.Code())
 		assert.Contains(t, err.Error(), "some error")
+		assert.Nil(t, result)
 	})
 
 	t.Run("should return bad request if service does not have API", func(t *testing.T) {
@@ -1364,9 +1478,9 @@ func TestServiceDefinitionService_GetAPI(t *testing.T) {
 		result, err := service.GetAPI("re", "uuid-1")
 
 		// then
-		assert.Error(t, err)
-		assert.Nil(t, result)
+		require.Error(t, err)
 		assert.Equal(t, apperrors.CodeWrongInput, err.Code())
+		assert.Nil(t, result)
 	})
 
 	t.Run("should return internal error if reading service API fails", func(t *testing.T) {
@@ -1386,9 +1500,9 @@ func TestServiceDefinitionService_GetAPI(t *testing.T) {
 		result, err := service.GetAPI("re", "uuid-1")
 
 		// then
-		assert.Error(t, err)
-		assert.Nil(t, result)
+		require.Error(t, err)
 		assert.Equal(t, apperrors.CodeInternal, err.Code())
 		assert.Contains(t, err.Error(), "some error")
+		assert.Nil(t, result)
 	})
 }

--- a/tests/metadata-service-tests/test/apitests/metadata_test.go
+++ b/tests/metadata-service-tests/test/apitests/metadata_test.go
@@ -80,11 +80,6 @@ func TestApiMetadata(t *testing.T) {
 		Spec:      testkit.SwaggerApiSpec,
 	}
 
-	invalidSpecUrlAPI := &testkit.API{
-		TargetUrl:        "http://service.com",
-		SpecificationUrl: "http://invalid-url-wit-spec.kyma.project.io/invalid",
-	}
-
 	t.Run("registration API", func(t *testing.T) {
 		t.Run("should register a service with OAuth credentials (with API, Events catalog, Documentation)", func(t *testing.T) {
 			// when
@@ -309,17 +304,6 @@ func TestApiMetadata(t *testing.T) {
 			initialServiceDefinition.Labels = map[string]string{}
 
 			require.Equal(t, http.StatusNoContent, statusCode)
-		})
-
-		t.Run("should return 502 when failed to fetch API spec", func(t *testing.T) {
-			// when
-			initialServiceDefinition := prepareServiceDetails("service-identifier-7", map[string]string{"connected-app": "dummy-re"}).WithAPI(invalidSpecUrlAPI)
-
-			statusCode, _, err := metadataServiceClient.CreateService(t, initialServiceDefinition)
-			require.NoError(t, err)
-
-			// then
-			require.Equal(t, http.StatusBadGateway, statusCode)
 		})
 
 		t.Run("should update service with OAuth credentials (with API, Events catalog, Documentation)", func(t *testing.T) {


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Metadata Service returns error with "not found" status when calling the Remote Environment service that does not exist
- Error message in this case says that RE does not exist
- There is an option to append error messages without creating new one with new error code `err.Append("Some additional message")` instead of `apperrors.Internal("Some additional message, %s", err.Error())`
- Error checking in the unit tests with the `require` function makes developer sure that single test will stop if error is unexpected

**Related issue(s)**

See also #1576 

