### PR TITLE
Added metrics.k8s.io to API groups of the kyma-admin role

### DIFF
--- a/installation/scripts/minikube.sh
+++ b/installation/scripts/minikube.sh
@@ -45,6 +45,8 @@ echo "
 function initializeMinikubeConfig() {
     # Disable default nginx ingress controller
     minikube config unset ingress
+    # Enable heapster addon
+    minikube addons enable heapster
 }
 
 #TODO refactor to use minikube status!

--- a/resources/core/charts/cluster-users/templates/rbac-roles.yaml
+++ b/resources/core/charts/cluster-users/templates/rbac-roles.yaml
@@ -30,7 +30,7 @@ metadata:
   annotations:
     "helm.sh/hook-weight": "0"
 rules:
-- apiGroups: ["", "api.kyma.cx", "apps", "authentication.kyma-project.io", "extensions", "gateway.kyma-project.io", "kubeless.io", "rbac.authorization.k8s.io", "applicationconnector.kyma-project.io", "servicecatalog.k8s.io", "servicecatalog.kyma.cx", "settings.k8s.io", "kyma.cx", "authentication.istio.io", "config.istio.io", "eventing.kyma.cx", "ui.kyma.cx", "ui.kyma-project.io"]
+- apiGroups: ["", "api.kyma.cx", "apps", "authentication.kyma-project.io", "extensions", "gateway.kyma-project.io", "kubeless.io", "rbac.authorization.k8s.io", "applicationconnector.kyma-project.io", "servicecatalog.k8s.io", "servicecatalog.kyma.cx", "settings.k8s.io", "kyma.cx", "authentication.istio.io", "config.istio.io", "eventing.kyma.cx", "ui.kyma.cx", "ui.kyma-project.io", "metrics.k8s.io"]
   resources: ["*"]
   verbs: ["get", "list"]
 - nonResourceURLs: ["*"] #give access to all non resource urls

--- a/resources/core/charts/cluster-users/templates/rbac-roles.yaml
+++ b/resources/core/charts/cluster-users/templates/rbac-roles.yaml
@@ -75,7 +75,7 @@ metadata:
   annotations:
     "helm.sh/hook-weight": "0"
 rules:
-- apiGroups: ["", "api.kyma.cx", "apps", "authentication.kyma-project.io", "extensions", "gateway.kyma-project.io", "kubeless.io", "rbac.authorization.k8s.io", "applicationconnector.kyma-project.io", "servicecatalog.k8s.io", "servicecatalog.kyma.cx", "settings.k8s.io", "kyma.cx", "authentication.istio.io", "config.istio.io", "eventing.kyma.cx", "ui.kyma.cx", "ui.kyma-project.io", "batch", "extensions", "autoscaling"]
+- apiGroups: ["", "api.kyma.cx", "apps", "authentication.kyma-project.io", "extensions", "gateway.kyma-project.io", "kubeless.io", "rbac.authorization.k8s.io", "applicationconnector.kyma-project.io", "servicecatalog.k8s.io", "servicecatalog.kyma.cx", "settings.k8s.io", "kyma.cx", "authentication.istio.io", "config.istio.io", "eventing.kyma.cx", "ui.kyma.cx", "ui.kyma-project.io", "metrics.k8s.io", "batch", "extensions", "autoscaling"]
   resources: ["*"]
   verbs: ["*"]
 - apiGroups: ["apiextensions.k8s.io"]


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Added `metrics.k8s.io` to API groups of the `kyma-admin` role (allows admin to run kubectl top)
- Updated `minikube.sh` to enable heapster addon

**Related issue(s)**
See #1499 
