### PR TITLE
Add feature gates support to installation scripts

### DIFF
--- a/components/installer/.gitignore
+++ b/components/installer/.gitignore
@@ -23,6 +23,7 @@
 # Binary created by ./before-commit.sh script
 /installer
 /main
+/deploy/installer/installer
 
 # "Local" kyma sources
 /kyma

--- a/components/installer/pkg/apis/installer/v1alpha1/types.go
+++ b/components/installer/pkg/apis/installer/v1alpha1/types.go
@@ -83,6 +83,7 @@ type KymaComponent struct {
 	Name        string `json:"name"`
 	ReleaseName string `json:"release"`
 	Namespace   string `json:"namespace"`
+	Feature	    string `json:"feature"`
 }
 
 // GetReleaseName returns release name for component

--- a/components/installer/pkg/feature_gates/feature_data.go
+++ b/components/installer/pkg/feature_gates/feature_data.go
@@ -1,0 +1,45 @@
+package feature_gates
+
+import (
+	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	"strings"
+)
+
+const (
+	namespace             = "kyma-installer"
+	configMapName         = "installer-feature-gates"
+	configMapPropertyName = "featureGates"
+)
+
+type Data interface {
+	IsEnabled(feature string) bool
+}
+
+func New(client *kubernetes.Clientset) (Data, error) {
+	configMap, err := client.CoreV1().ConfigMaps(namespace).Get(configMapName, meta_v1.GetOptions{})
+	if err != nil {
+		return nil, err
+	}
+
+	featuresString, ok := configMap.Data[configMapPropertyName]
+	if !ok || featuresString == "" {
+		return &featureData{features: make([]string, 0)}, nil
+	}
+
+	features := strings.Split(strings.Trim(featuresString, ", "), ",")
+	return &featureData{features: features}, nil
+}
+
+type featureData struct {
+	features []string
+}
+
+func (d *featureData) IsEnabled(feature string) bool {
+	for _, enabled := range d.features {
+		if enabled == feature {
+			return true
+		}
+	}
+	return false
+}

--- a/components/installer/pkg/installation/controller.go
+++ b/components/installer/pkg/installation/controller.go
@@ -1,6 +1,7 @@
 package installation
 
 import (
+	"github.com/kyma-project/kyma/components/installer/pkg/feature_gates"
 	"log"
 	"time"
 
@@ -197,13 +198,18 @@ func (c *Controller) syncHandler(key string) error {
 		if c.errorHandlers.CheckError("Error while building overrides: ", overridesErr) {
 			return overridesErr
 		}
+    
+		featuresProvider, err := feature_gates.New(c.kubeClientset)
+		if c.errorHandlers.CheckError("Error while building feature gates: ", overridesErr)  {
+			return err
+		}
 
 		err = c.conditionManager.InstallStart()
 		if c.errorHandlers.CheckError("Error starting install/update: ", err) {
 			return err
 		}
 
-		err = c.kymaSteps.InstallKyma(installationData, overrideProvider)
+		err = c.kymaSteps.InstallKyma(installationData, overrideProvider, featuresProvider)
 		if c.errorHandlers.CheckError("Error during install/update: ", err) {
 			c.conditionManager.InstallError()
 			return err

--- a/components/installer/pkg/steps/installation.go
+++ b/components/installer/pkg/steps/installation.go
@@ -1,6 +1,7 @@
 package steps
 
 import (
+	"github.com/kyma-project/kyma/components/installer/pkg/feature_gates"
 	"log"
 
 	actionmanager "github.com/kyma-project/kyma/components/installer/pkg/actionmanager"
@@ -51,7 +52,7 @@ func New(helmClient kymahelm.ClientInterface, kubeClientset *kubernetes.Clientse
 }
 
 //InstallKyma .
-func (steps *InstallationSteps) InstallKyma(installationData *config.InstallationData, overrideData overrides.OverrideData) error {
+func (steps *InstallationSteps) InstallKyma(installationData *config.InstallationData, overrideData overrides.OverrideData, featureData feature_gates.Data) error {
 
 	currentPackage, downloadKymaErr := steps.EnsureKymaSources(installationData)
 	if downloadKymaErr != nil {
@@ -69,6 +70,11 @@ func (steps *InstallationSteps) InstallKyma(installationData *config.Installatio
 	log.Println("Processing Kyma components")
 
 	for _, component := range installationData.Components {
+
+		if component.Feature != "" && !featureData.IsEnabled(component.Feature) {
+			log.Println("Skipping " + component.GetReleaseName() + ": feature '" + component.Feature + " is not enabled")
+			continue
+		}
 
 		stepName := "Processing component " + component.GetReleaseName()
 		steps.statusManager.InProgress(stepName)

--- a/installation/scripts/installer.sh
+++ b/installation/scripts/installer.sh
@@ -6,6 +6,7 @@ CURRENT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 RESOURCES_DIR="${CURRENT_DIR}/../resources"
 INSTALLER="${RESOURCES_DIR}/installer.yaml"
 INSTALLER_CONFIG=""
+FEATURE_GATES_CONFIG="${RESOURCES_DIR}/installer-feature-gates.yaml.tpl"
 
 POSITIONAL=()
 while [[ $# -gt 0 ]]
@@ -15,6 +16,11 @@ do
     case ${key} in
         --local)
             LOCAL=1
+            shift
+            ;;
+        --feature-gates)
+            FEATURE_GATES="$2"
+            shift
             shift
             ;;
         --cr)
@@ -60,8 +66,11 @@ if [ $CR_PATH ]; then
 
 fi
 
+
 echo -e "\nApplying installation combo yaml"
-bash ${CURRENT_DIR}/concat-yamls.sh ${INSTALLER} ${INSTALLER_CONFIG} ${CR_PATH} | kubectl apply -f -
+bash ${CURRENT_DIR}/concat-yamls.sh ${INSTALLER} ${INSTALLER_CONFIG} ${CR_PATH} ${FEATURE_GATES_CONFIG} \
+| sed 's/__FEATURE_GATES__/'${FEATURE_GATES}'/g' \
+| kubectl apply -f -
 
 echo -e "\nTriggering installation"
 kubectl label installation/kyma-installation action=install


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/master/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

Script `run.sh` accepts additional flag `--feature-gates`. Passed feature gates are added to `installer-feature-gates` ConfigMap which is read but installer (#1746)

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
Uses #1746