### PR TITLE
Enable heapster addon for Windows

### DIFF
--- a/installation/scripts/minikube.ps1
+++ b/installation/scripts/minikube.ps1
@@ -15,7 +15,7 @@ Write-Output @"
 function CheckIfMinikubeIsInitialized() {
     $cmd = "minikube status --format '{{.MinikubeStatus}}'"
     $minikubeStatus = (Invoke-Expression -Command $cmd) | Out-String
-    
+
     if ($minikubeStatus -ne "") {
         Write-Output "Minikube is already initialized"
         $deleteMinikube = Read-Host "Do you want to remove previous minikube cluster [y/N]"
@@ -32,6 +32,9 @@ function CheckIfMinikubeIsInitialized() {
 
 function InitializeMinikubeConfig () {
     $cmd = "minikube config unset ingress"
+    Invoke-Expression -Command $cmd
+
+    $cmd = "minikube addons enable heapster"
     Invoke-Expression -Command $cmd
 }
 
@@ -52,7 +55,7 @@ function StartMinikube() {
     if ($VM_DRIVER -eq "hyperv") {
         $cmd += " --hyperv-virtual-switch='${env.HYPERV_VIRTUAL_SW}'"
     }
-    
+
     Invoke-Expression -Command $cmd
 }
 
@@ -62,18 +65,18 @@ function WaitForMinikubeToBeUp() {
     $limit = 15
     $counter = 0
     $clusterStatus = ""
-    
+
     while ($counter -lt $limit) {
         $counter += 1
         Write-Output "Keep calm, there are ${limit} possibilities and so far it is attempt number ${counter}"
-      
+
         $cmd = "minikube status --format '{{.MinikubeStatus}}'"
         $clusterStatus = (Invoke-Expression -Command $cmd) | Out-String
         $clusterStatus = $clusterStatus.Trim()
         if ($clusterStatus -eq "Running") {
             break
         }
-      
+
         Start-Sleep -Seconds 1
     }
 }
@@ -88,8 +91,8 @@ function AddDevDomainsToEtcHosts([string[]]$hostnamesPrefixes) {
     $n = 6 # 7 hostnames in one line, others in next line. Windows can't read more than 9 hostnames in the same line.
     $hostnames = $hostnamesPrefixes | ForEach-Object {"$_.${DOMAIN}"} # for minikube ssh
     $hostnames1 = $hostnamesPrefixes[0..$n] | ForEach-Object {"$_.${DOMAIN}"}
-    $hostnames2 = $hostnamesPrefixes[ - ($n + 1)..-1] | ForEach-Object {"$_.${DOMAIN}"} 
-    
+    $hostnames2 = $hostnamesPrefixes[ - ($n + 1)..-1] | ForEach-Object {"$_.${DOMAIN}"}
+
     $cmd = "minikube ip"
     $minikubeIp = (Invoke-Expression -Command $cmd | Out-String).Trim()
 


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Added a command to enable heapster addon in the Minikube config. script for Windows. 

**Related issue(s)**
This is a follow-up to #1739 
