### PR TITLE
Remove subscription on UPDATE action from PodPreset configuration

### DIFF
--- a/resources/cluster-essentials/charts/pod-preset/templates/webhook/webhook.yaml
+++ b/resources/cluster-essentials/charts/pod-preset/templates/webhook/webhook.yaml
@@ -24,7 +24,6 @@ webhooks:
     - v1
     operations:
     - CREATE
-    - UPDATE
     resources:
     - pods
 ---


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/master/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

-  Remove subscription on UPDATE action from PodPreset configuration

#### Workflow overview:
<img width="1577" alt="screen shot 2018-12-04 at 18 19 31" src="https://user-images.githubusercontent.com/17568639/49460360-68aac080-f7f1-11e8-9bc1-a02aa80b28b2.png">

**NOTE:** Order of calling registered webhook is not deterministic. Please see below scenarios.

#### Reason:
Previously PodPreset was subscribed on CREATE and UPDATE action for Pod resources.

The PodPreset webhook is called on CREATE operation before Pod is written to etcd **(is important)**. 

The PodPreset webhook is called on UPDATE operation when Pod is already persisted in etcd.

In Kyma we have registered two webhooks: Istio and PodPreset.

Scenario 1:
1. Creating Pod 
2. Kube-apiserver calls the Istio webook
3. Istio webhook returns patch for that Pod with new section for adding `istio-proxy` container
4. Kube-apiservier calls the PodPreset webhook 
5. PodPreset webhook returns patch for that Pod with modified all containers where `envFrom` section was added
6. Pod is persisted in etcd

7. Kube-apiserver see update on Pod, so triggers the loggic one more time
2. Kube-apiserver calls the Istio webook
3. Istio webhook returns empty patch for that Pod because `istio-proxy` already exists
4. Kube-apiservier calls the PodPreset webhook 
5. PodPreset webhook returns empty patch for that Pod because all container are already configured with proper `envFrom` entry
6. Pod definition was not changed, nothing to update in `etcd`


Scenario 2 (error case):
1. Creating Pod 
4. Kube-apiservier calls the PodPreset webhook 
5. PodPreset webhook returns patch for that Pod with modified all containers where `envFrom` section was added
2. Kube-apiserver calls the Istio webook
3. Istio webhook returns patch for that Pod with a new section for adding `istio-proxy` container
6. Pod is persisted in etcd

7. Kube-apiserver see update on Pod, so triggers the logic one more time
4. Kube-apiservier calls the PodPreset webhook 
5. PodPreset webhook returns patch for that Pod with modification for `istio-proxy` container because there the `envFrom` was missing
2. Kube-apiserver calls the Istio webook
3. Istio webhook returns empty patch for that Pod because `istio-proxy` already exists
6. Pod definition was changed, k8s try to persist new pod definition but this operation is not allowed because we cannot modify the pod already persisted in etcd.

**Related issue(s)**

- https://github.com/kyma-project/kyma/issues/1807
