### PR TITLE
Adding checksum to enable pod restart

### DIFF
--- a/resources/cluster-essentials/charts/pod-preset/templates/webhook/deploy.yaml
+++ b/resources/cluster-essentials/charts/pod-preset/templates/webhook/deploy.yaml
@@ -16,6 +16,8 @@ spec:
       release: {{ .Release.Name }}
   template:
     metadata:
+      annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/webhook/webhook.yaml") . | sha256sum }}      
       labels:
         app: {{ template "pod-preset.name" . }}-webhook
         release: {{ .Release.Name }}


### PR DESCRIPTION
**Description**
Changes proposed in this pull request:
- Improvement to pod-preset webhook (deploy.yaml). On help upgrade the CA is rolled, but the Deployment is not. By adding the  template.metadata.annotations.checksum/config the webhook pod will be rolled in case of Change in the MutatingWebhookConfiguration CA.

**Related issue(s)**
Resolves #1827 for cluster-essentials/pod-preset helm chart.