### PR TITLE
excluded test- pods from alerting

### DIFF
--- a/resources/monitoring/charts/alert-rules/templates/unhealthy-pods-rules.yaml
+++ b/resources/monitoring/charts/alert-rules/templates/unhealthy-pods-rules.yaml
@@ -3,7 +3,7 @@ groups:
 - name: pod-not-running-rule
   rules:
   - alert: SystemPodNotRunning
-    expr: (kube_pod_container_status_running { namespace=~"kyma-.*|kube-.*|istio-.*", pod!~".*-(docs|backup)-.*" } == 0)
+    expr: (kube_pod_container_status_running { namespace=~"kyma-.*|kube-.*|istio-.*", pod!~"(test-.*)|(.*(docs|backup)-.*)" } == 0)
     for: 30s
     labels:
       severity: critical

--- a/resources/monitoring/charts/exporter-node/templates/node.rules.yaml
+++ b/resources/monitoring/charts/exporter-node/templates/node.rules.yaml
@@ -38,7 +38,7 @@ groups:
         full within the next 24 hours (mounted at {{`{{$labels.mountpoint}}`}})
       summary: Node disk is running full within 24 hours
   - alert: NodeDiskRunningFull
-    expr: predict_linear(node_filesystem_free[30m], 3600 * 2) < 0
+    expr: (node:node_filesystem_usage: > 0.85) and (predict_linear(node:node_filesystem_free:[30m], 3600 * 2) < 0)
     for: 10m
     labels:
       severity: critical

--- a/resources/monitoring/charts/exporter-node/templates/node.rules.yaml
+++ b/resources/monitoring/charts/exporter-node/templates/node.rules.yaml
@@ -38,7 +38,7 @@ groups:
         full within the next 24 hours (mounted at {{`{{$labels.mountpoint}}`}})
       summary: Node disk is running full within 24 hours
   - alert: NodeDiskRunningFull
-    expr: (node:node_filesystem_usage: > 0.85) and (predict_linear(node:node_filesystem_free:[30m], 3600 * 2) < 0)
+    expr: (((node_filesystem_size-node_filesystem_free)/node_filesystem_size) > 0.85 ) AND (predict_linear(node_filesystem_free[30m], 3600 * 2) < 0)
     for: 10m
     labels:
       severity: critical


### PR DESCRIPTION
The standard alert rule for system pods not running is reporting for a completed test pod which is currently very annoying.
I addressed the problem already in #1890 but we need a quick fix to reduce the false alerts.
So I adjusted the current pod selection pattern to exclude pods starting with "test-"

Furthermore I improved the file size prediction rule to alarm only if we reached already a critical size of 0.85 as otherwise it is alarming directly after installation

