### PR TITLE
Modify default etcd configuration (for service catalog)

### DIFF
--- a/installation/resources/installer-config-cluster.yaml.tpl
+++ b/installation/resources/installer-config-cluster.yaml.tpl
@@ -101,3 +101,14 @@ data:
 
   mixer.resources.limits.memory: 1Gi
   mixer.resources.requests.memory: 256Mi
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: service-catalog-overrides
+  namespace: kyma-installer
+  labels:
+    installer: overrides
+    component: service-catalog
+data:
+  etcd-stateful.resources.limits.memory: 512Mi

--- a/installation/resources/installer-config-cluster.yaml.tpl
+++ b/installation/resources/installer-config-cluster.yaml.tpl
@@ -111,4 +111,4 @@ metadata:
     installer: overrides
     component: service-catalog
 data:
-  etcd-stateful.resources.limits.memory: 512Mi
+  etcd.resources.limits.memory: 512Mi

--- a/installation/resources/installer-config-cluster.yaml.tpl
+++ b/installation/resources/installer-config-cluster.yaml.tpl
@@ -111,4 +111,4 @@ metadata:
     installer: overrides
     component: service-catalog
 data:
-  etcd.resources.limits.memory: 512Mi
+  etcd-stateful.etcd.resources.limits.memory: 512Mi

--- a/installation/resources/installer-config-local.yaml.tpl
+++ b/installation/resources/installer-config-local.yaml.tpl
@@ -83,3 +83,14 @@ data:
 
   mixer.resources.limits.memory: 256Mi
   mixer.resources.requests.memory: 128Mi
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: service-catalog-overrides
+  namespace: kyma-installer
+  labels:
+    installer: overrides
+    component: service-catalog
+data:
+  etcd-stateful.etcd.resources.limits.memory: 256Mi

--- a/resources/service-catalog/charts/etcd-stateful/templates/03-statefulset.yaml
+++ b/resources/service-catalog/charts/etcd-stateful/templates/03-statefulset.yaml
@@ -137,6 +137,7 @@ spec:
                 --initial-cluster-token etcd-cluster-1 \
                 --initial-cluster ${PEERS} \
                 --initial-cluster-state ${STATE} \
+                --snapshot-count=10000 \
                 --listen-metrics-urls http://${IP}:2381 \
                 --data-dir /var/run/etcd/default.etcd
             else
@@ -149,6 +150,7 @@ spec:
                 --initial-cluster-token etcd-cluster-1 \
                 --initial-cluster ${PEERS} \
                 --initial-cluster-state ${STATE} \
+                --snapshot-count=10000 \
                 --data-dir /var/run/etcd/default.etcd
             fi
 

--- a/resources/service-catalog/charts/etcd-stateful/templates/03-statefulset.yaml
+++ b/resources/service-catalog/charts/etcd-stateful/templates/03-statefulset.yaml
@@ -120,6 +120,10 @@ spec:
             # --client-cert-auth=true \
             # --trusted-ca-file=/etc/etcdtls/server/server-ca.crt \
 
+            # SNAPSHOT_COUNT parameter was introducet to mitigate the "out of memory" issue.
+            # More information here: https://github.com/kyma-project/kyma/issues/1802
+            SNAPSHOT_COUNT=10000
+
             if [ $(ETCD_TLS) = "true" ]; then
               exec etcd --name ${HOSTNAME} \
                 --listen-peer-urls https://${IP}:2380 \
@@ -137,7 +141,7 @@ spec:
                 --initial-cluster-token etcd-cluster-1 \
                 --initial-cluster ${PEERS} \
                 --initial-cluster-state ${STATE} \
-                --snapshot-count=10000 \
+                --snapshot-count=${SNAPSHOT_COUNT} \
                 --listen-metrics-urls http://${IP}:2381 \
                 --data-dir /var/run/etcd/default.etcd
             else
@@ -150,7 +154,7 @@ spec:
                 --initial-cluster-token etcd-cluster-1 \
                 --initial-cluster ${PEERS} \
                 --initial-cluster-state ${STATE} \
-                --snapshot-count=10000 \
+                --snapshot-count=${SNAPSHOT_COUNT} \
                 --data-dir /var/run/etcd/default.etcd
             fi
 


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:
- memory limit for non-local cluster increased to 512M (previously 256M)
- --snapshot-count is now set to 10 000 (default value: 100 000)

**Related issue(s)**
* #1802
