### PR TITLE
Make Catalog UI to be more resilient on empty creating schemas

### DIFF
--- a/components/ui-api-layer/internal/domain/servicecatalog/serviceplan_converter.go
+++ b/components/ui-api-layer/internal/domain/servicecatalog/serviceplan_converter.go
@@ -8,6 +8,7 @@ import (
 	"github.com/kyma-project/kyma/components/ui-api-layer/internal/gqlschema"
 	"github.com/kyma-project/kyma/components/ui-api-layer/internal/resource"
 	"github.com/pkg/errors"
+	"bytes"
 )
 
 type servicePlanConverter struct{}
@@ -32,7 +33,9 @@ func (p *servicePlanConverter) ToGQL(item *v1beta1.ServicePlan) (*gqlschema.Serv
 		if err != nil {
 			return nil, errors.Wrapf(err, "while unpacking service instance create parameter schema from ServicePlan [%s]", item.Name)
 		}
-		instanceCreateParameterSchema = &unpackedSchema
+		if unpackedSchema != nil && len(unpackedSchema) != 0 {
+			instanceCreateParameterSchema = &unpackedSchema
+		}
 	}
 	var bindingCreateParameterSchema *gqlschema.JSON
 	if item.Spec.ServiceBindingCreateParameterSchema != nil {
@@ -40,7 +43,9 @@ func (p *servicePlanConverter) ToGQL(item *v1beta1.ServicePlan) (*gqlschema.Serv
 		if err != nil {
 			return nil, errors.Wrapf(err, "while unpacking service binding create parameter schema from ServicePlan [%s]", item.Name)
 		}
-		bindingCreateParameterSchema = &unpackedSchema
+		if unpackedSchema != nil && len(unpackedSchema) != 0 {
+			bindingCreateParameterSchema = &unpackedSchema
+		}
 	}
 
 	displayName := resource.ToStringPtr(externalMetadata["displayName"])
@@ -92,12 +97,28 @@ func (p *servicePlanConverter) unpackCreateParameterSchema(raw []byte) (gqlschem
 }
 
 func (p *servicePlanConverter) extractCreateSchema(raw []byte) (map[string]interface{}, error) {
+	raw = bytes.Trim(raw, "\x00")
 	extracted := make(map[string]interface{})
 
 	err := json.Unmarshal(raw, &extracted)
 	if err != nil {
 		return nil, errors.Wrap(err, "while extracting creation parameter schema")
 	}
+	if p.isEmptyCreateParameterSchema(extracted) {
+		return nil, nil
+	}
 
 	return extracted, nil
+}
+
+func (p *servicePlanConverter) isEmptyCreateParameterSchema(schema map[string]interface{}) bool {
+	properties := schema["properties"]
+	if properties != nil && len(properties.(map[string]interface{})) != 0 {
+		return false
+	}
+	ref := schema["$ref"]
+	if ref != nil && ref.(string) != "" {
+		return false
+	}
+	return true
 }


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/master/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:
- Return empty `InstanceCreateParameterSchema` and/or `BindingCreateParameterSchema` when it has a empty `$ref` or `properties`,
- Update relevant unit tests.

**Related issue(s)**
See also https://github.com/kyma-project/console/issues/356