### PR TITLE
Add a new document type

### DIFF
--- a/docs/kyma/docs/060-examples-try-out-kyma.md
+++ b/docs/kyma/docs/060-examples-try-out-kyma.md
@@ -1,11 +1,11 @@
 ---
-title: Examples
-type: Overview
+title: Kyma features and concepts in practice
+type: Examples
 ---
 
 The table contains a list of examples that demonstrate Kyma functionalities. You can run all of them locally or on a cluster. Examples are organized by a feature or concept they showcase. Each of them contains ready-to-use code snippets and the instructions in `README.md` documents.
 
-Follow the links to example code and content sources, and try them on your own.
+Follow the links to examples' code and content sources, and try them on your own.
 
 | Example | Description | Technology |
 |---|---|---|


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Removed the last Overview document that presented a list of available Kyma examples
- Moved the content to a new document of **Examples** type and changed the title

**Related issue(s)**
See also #1730 
