### PR TITLE
exclude sample- pods from alerting

### DIFF
--- a/resources/monitoring/charts/alert-rules/templates/unhealthy-pods-rules.yaml
+++ b/resources/monitoring/charts/alert-rules/templates/unhealthy-pods-rules.yaml
@@ -3,7 +3,7 @@ groups:
 - name: pod-not-running-rule
   rules:
   - alert: SystemPodNotRunning
-    expr: (kube_pod_container_status_running { namespace=~"kyma-.*|kube-.*|istio-.*", pod!~"((test|dummy)-.*)|(.*(docs|backup|test)-.*)|(.*-(tests|dummy))" } == 0)
+    expr: (kube_pod_container_status_running { namespace=~"kyma-.*|kube-.*|istio-.*", pod!~"((test|dummy|sample)-.*)|(.*(docs|backup|test)-.*)|(.*-(tests|dummy))" } == 0)
     for: 30s
     labels:
       severity: critical

--- a/resources/monitoring/charts/alert-rules/templates/unhealthy-pods-rules.yaml
+++ b/resources/monitoring/charts/alert-rules/templates/unhealthy-pods-rules.yaml
@@ -3,8 +3,8 @@ groups:
 - name: pod-not-running-rule
   rules:
   - alert: SystemPodNotRunning
-    expr: (kube_pod_container_status_running { namespace=~"kyma-.*|kube-.*|istio-.*", pod!~"((test|dummy|sample)-.*)|(.*(docs|backup|test)-.*)|(.*-(tests|dummy))" } == 0)
-    for: 30s
+    expr: (kube_pod_container_status_running { namespace=~"kyma-.*|kube-.*|istio-.*", pod!~"(test.*)|((dummy|sample)-.*)|(.*(docs|backup|test)-.*)|(.*-(tests|dummy))" } == 0)
+    for: 60s
     labels:
       severity: critical
     annotations:


### PR DESCRIPTION
The standard alert rule for system pods not running is reporting for a completed test pod which is currently very annoying.
I addressed the problem already in #1890 but we need a quick fix to reduce the false alerts.
So I adjusted the current pod selection pattern to exclude pods starting with "sample-"