### PR TITLE
Pass token for subscriptions in UI API Layer acceptance tests the same way like on UI

### DIFF
--- a/resources/core/templates/tests/rbac-ui-api-acceptance.yaml
+++ b/resources/core/templates/tests/rbac-ui-api-acceptance.yaml
@@ -38,6 +38,9 @@ rules:
   - apiGroups: ["authentication.kyma-project.io"]
     resources: ["idppresets"]
     verbs: ["get"]
+  - apiGroups: ["applicationconnector.kyma-project.io"]
+    resources: ["remoteenvironments"]
+    verbs: ["create", "update", "delete"]
 
 ---
 kind: ClusterRoleBinding

--- a/resources/core/templates/tests/rbac-ui-api-acceptance.yaml
+++ b/resources/core/templates/tests/rbac-ui-api-acceptance.yaml
@@ -38,10 +38,6 @@ rules:
   - apiGroups: ["authentication.kyma-project.io"]
     resources: ["idppresets"]
     verbs: ["get"]
-  - apiGroups: ["applicationconnector.kyma-project.io"]
-    resources: ["remoteenvironments"]
-    verbs: ["create", "update", "delete"]
-
 ---
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1beta1

--- a/resources/core/templates/tests/rbac-ui-api-acceptance.yaml
+++ b/resources/core/templates/tests/rbac-ui-api-acceptance.yaml
@@ -38,6 +38,7 @@ rules:
   - apiGroups: ["authentication.kyma-project.io"]
     resources: ["idppresets"]
     verbs: ["get"]
+
 ---
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1beta1

--- a/tests/ui-api-layer-acceptance-tests/Dockerfile
+++ b/tests/ui-api-layer-acceptance-tests/Dockerfile
@@ -25,7 +25,7 @@ RUN mkdir -p /app
 RUN cd ${BASE_APP_DIR}/domain && \
     for dir in $(ls -1FA | grep / | tr -d /); do \
     echo "Building test package ${dir}..."; \
-    go test -tags=acceptance ./${dir} -c \
+    go test -tags=acceptance ./${dir} -c || exit 1 \
     ; done
 
 FROM alpine:3.8

--- a/tests/ui-api-layer-acceptance-tests/Gopkg.lock
+++ b/tests/ui-api-layer-acceptance-tests/Gopkg.lock
@@ -108,11 +108,7 @@
     "components/idppreset/pkg/apis/authentication/v1alpha1",
     "components/idppreset/pkg/client/clientset/versioned",
     "components/idppreset/pkg/client/clientset/versioned/scheme",
-    "components/idppreset/pkg/client/clientset/versioned/typed/authentication/v1alpha1",
-    "components/remote-environment-broker/pkg/apis/applicationconnector/v1alpha1",
-    "components/remote-environment-broker/pkg/client/clientset/versioned",
-    "components/remote-environment-broker/pkg/client/clientset/versioned/scheme",
-    "components/remote-environment-broker/pkg/client/clientset/versioned/typed/applicationconnector/v1alpha1"
+    "components/idppreset/pkg/client/clientset/versioned/typed/authentication/v1alpha1"
   ]
   revision = "01af467a7485d695790da907f60d0e617ad65120"
 
@@ -358,6 +354,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "ace491ba8c78a2cf0b6f1dd1f524fa89c6f7ab8724dedd6219b37841ad249d0d"
+  inputs-digest = "0d3835c358fcd271ab4611b48bc5822c39311cdca5a7d3508e11491ccdde097f"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/tests/ui-api-layer-acceptance-tests/Gopkg.toml
+++ b/tests/ui-api-layer-acceptance-tests/Gopkg.toml
@@ -15,10 +15,6 @@ required = [
   version = "1.2.1"
 
 [[constraint]]
-  name = "k8s.io/helm"
-  version = "2.8.2"
-
-[[constraint]]
   name = "github.com/kubernetes-incubator/service-catalog"
   version = "v0.1.3"
 

--- a/tests/ui-api-layer-acceptance-tests/client/client.go
+++ b/tests/ui-api-layer-acceptance-tests/client/client.go
@@ -3,7 +3,6 @@ package client
 import (
 	scClientset "github.com/kubernetes-incubator/service-catalog/pkg/client/clientset_generated/clientset"
 	idpClientset "github.com/kyma-project/kyma/components/idppreset/pkg/client/clientset/versioned"
-	reClientset "github.com/kyma-project/kyma/components/remote-environment-broker/pkg/client/clientset/versioned"
 	"github.com/pkg/errors"
 	"k8s.io/client-go/kubernetes/typed/core/v1"
 	"k8s.io/client-go/rest"
@@ -49,18 +48,4 @@ func NewIDPPresetClientWithConfig() (*idpClientset.Clientset, *rest.Config, erro
 	}
 
 	return idpCli, k8sConfig, nil
-}
-
-func NewREClientWithConfig() (*reClientset.Clientset, *rest.Config, error) {
-	k8sConfig, err := NewRestClientConfigFromEnv()
-	if err != nil {
-		return nil, nil, errors.Wrap(err, "while creating new client with config")
-	}
-
-	reCli, err := reClientset.NewForConfig(k8sConfig)
-	if err != nil {
-		return nil, nil, errors.Wrap(err, "while creating new client with config")
-	}
-
-	return reCli, k8sConfig, nil
 }

--- a/tests/ui-api-layer-acceptance-tests/domain/authentication/idppreset_test.go
+++ b/tests/ui-api-layer-acceptance-tests/domain/authentication/idppreset_test.go
@@ -173,8 +173,8 @@ func queryMultipleIDPPresets(c *graphql.Client, resourceDetailsQuery string, exp
 
 func multipleResourcesQueryRequest(resourceDetailsQuery string, expectedResource IDPPreset) *graphql.Request {
 	query := fmt.Sprintf(`
-			query () {
-				IDPPresets() {
+			query {
+				IDPPresets {
 					%s
 				}
 			}

--- a/tests/ui-api-layer-acceptance-tests/domain/remoteenvironment/remoteenvironment_test.go
+++ b/tests/ui-api-layer-acceptance-tests/domain/remoteenvironment/remoteenvironment_test.go
@@ -235,7 +235,6 @@ func deleteREMutation(c *graphql.Client, reName string) (reDeleteMutationRespons
 	return response, err
 }
 
-
 func fixRE(name string, desc string, labels map[string]string) *remoteEnvironment {
 	return &remoteEnvironment{
 		Name:        name,

--- a/tests/ui-api-layer-acceptance-tests/domain/servicecatalog/clusterservicebroker_test.go
+++ b/tests/ui-api-layer-acceptance-tests/domain/servicecatalog/clusterservicebroker_test.go
@@ -47,13 +47,13 @@ func TestClusterServiceBrokerQueries(t *testing.T) {
 	resourceDetailsQuery := `
 		name
 		creationTimestamp
+    	url
+    	labels
     	status {
 			ready
     		reason
     		message
 		}
-    	url
-    	labels
 	`
 
 	t.Run("MultipleResources", func(t *testing.T) {

--- a/tests/ui-api-layer-acceptance-tests/domain/servicecatalog/clusterserviceclass_test.go
+++ b/tests/ui-api-layer-acceptance-tests/domain/servicecatalog/clusterserviceclass_test.go
@@ -70,6 +70,7 @@ func TestClusterServiceClassesQueries(t *testing.T) {
 		providerDisplayName
 		tags
 		labels
+		activated
 		plans {
 			name
 			displayName
@@ -78,7 +79,6 @@ func TestClusterServiceClassesQueries(t *testing.T) {
 			relatedClusterServiceClassName
 			instanceCreateParameterSchema
 		}
-		activated
 	`
 
 	t.Run("MultipleResources", func(t *testing.T) {

--- a/tests/ui-api-layer-acceptance-tests/domain/servicecatalog/servicebroker_test.go
+++ b/tests/ui-api-layer-acceptance-tests/domain/servicecatalog/servicebroker_test.go
@@ -49,13 +49,13 @@ func TestServiceBrokerQueries(t *testing.T) {
 		name
 		environment
 		creationTimestamp
+		url
+		labels
 		status {
 			ready
 			reason
 			message
 		}
-		url
-		labels
 	`
 
 	t.Run("MultipleResources", func(t *testing.T) {

--- a/tests/ui-api-layer-acceptance-tests/domain/servicecatalog/serviceclass_test.go
+++ b/tests/ui-api-layer-acceptance-tests/domain/servicecatalog/serviceclass_test.go
@@ -74,6 +74,7 @@ func TestServiceClassesQueries(t *testing.T) {
 		providerDisplayName
 		tags
 		labels
+		activated
 		plans {
 			name
 			displayName
@@ -83,7 +84,6 @@ func TestServiceClassesQueries(t *testing.T) {
 			instanceCreateParameterSchema
 			bindingCreateParameterSchema
 		}
-		activated
 	`
 
 	t.Run("MultipleResources", func(t *testing.T) {

--- a/tests/ui-api-layer-acceptance-tests/domain/servicecatalog/serviceinstance_test.go
+++ b/tests/ui-api-layer-acceptance-tests/domain/servicecatalog/serviceinstance_test.go
@@ -326,6 +326,9 @@ func instanceDetailsFields() string {
 		name
 		environment
 		planSpec
+		bindable
+		creationTimestamp
+		labels
 		classReference {
 			name
 			displayName
@@ -336,9 +339,6 @@ func instanceDetailsFields() string {
 			displayName
 			clusterWide
 		}
-		bindable
-		creationTimestamp
-		labels
 		status {
 			type
 			reason
@@ -374,7 +374,7 @@ func instanceDetailsFields() string {
 			relatedServiceClassName
 			instanceCreateParameterSchema
 			bindingCreateParameterSchema
-		}
+		 }
 		 serviceClass {
 			name
 			environment

--- a/tests/ui-api-layer-acceptance-tests/graphql/client.go
+++ b/tests/ui-api-layer-acceptance-tests/graphql/client.go
@@ -88,7 +88,7 @@ func (c *Client) Subscribe(req *Request) *Subscription {
 		return errorSubscription(err)
 	}
 
-	js, err := req.Json()
+	js, err := req.JSON()
 	if err != nil {
 		return errorSubscription(errors.Wrapf(err, "while converting request to json"))
 	}

--- a/tests/ui-api-layer-acceptance-tests/graphql/request.go
+++ b/tests/ui-api-layer-acceptance-tests/graphql/request.go
@@ -17,7 +17,7 @@ func NewRequest(q string) *Request {
 	query := strings.Replace(q, "\t", " ", -1)
 	return &Request{
 		query: query,
-		req:   graphql.NewRequest(q),
+		req:   graphql.NewRequest(query),
 		vars:  make(map[string]interface{}),
 	}
 }
@@ -31,7 +31,7 @@ func (r *Request) AddHeader(key, value string) {
 	r.req.Header.Add(key, value)
 }
 
-func (r *Request) Json() ([]byte, error) {
+func (r *Request) JSON() ([]byte, error) {
 	requestBodyObj := struct {
 		Query     string                 `json:"query"`
 		Variables map[string]interface{} `json:"variables"`

--- a/tests/ui-api-layer-acceptance-tests/graphql/request.go
+++ b/tests/ui-api-layer-acceptance-tests/graphql/request.go
@@ -2,6 +2,7 @@ package graphql
 
 import (
 	"encoding/json"
+	"strings"
 
 	"github.com/machinebox/graphql"
 )
@@ -13,8 +14,9 @@ type Request struct {
 }
 
 func NewRequest(q string) *Request {
+	query := strings.Replace(q, "\t", " ", -1)
 	return &Request{
-		query: q,
+		query: query,
 		req:   graphql.NewRequest(q),
 		vars:  make(map[string]interface{}),
 	}

--- a/tests/ui-api-layer-acceptance-tests/graphql/websocket.go
+++ b/tests/ui-api-layer-acceptance-tests/graphql/websocket.go
@@ -31,7 +31,9 @@ type operationMessage struct {
 }
 
 func newWebsocket(endpoint, token string, headers http.Header) (*clusterWebsocket, error) {
-	headers.Set("Authorization", fmt.Sprintf("Bearer %s", token))
+	// pass user token the same way like on UI
+	headers.Set("Sec-WebSocket-Protocol", fmt.Sprintf("graphql-ws, %s", token))
+
 	dialer := websocket.Dialer{
 		HandshakeTimeout: websocket.DefaultDialer.HandshakeTimeout,
 		TLSClientConfig:  &tls.Config{InsecureSkipVerify: true},


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Pass token for subscriptions in UI API Layer acceptance tests the same way like on UI
- Remove unused code from Remote Environments
- Remove tabs from queries/mutations in tests
- Prevent building wrong Docker image