### PR TITLE
Fix unhandled err checking in BUC project

### DIFF
--- a/components/binding-usage-controller/Gopkg.lock
+++ b/components/binding-usage-controller/Gopkg.lock
@@ -144,6 +144,23 @@
   version = "1.1.5"
 
 [[projects]]
+  name = "github.com/kisielk/errcheck"
+  packages = [
+    ".",
+    "internal/errcheck"
+  ]
+  revision = "1787c4bee836470bf45018cfbc783650db3c6501"
+
+[[projects]]
+  name = "github.com/kisielk/gotool"
+  packages = [
+    ".",
+    "internal/load"
+  ]
+  revision = "80517062f582ea3340cd4baf70e86d539ae7d84d"
+  version = "v1.0.0"
+
+[[projects]]
   name = "github.com/kubernetes-incubator/service-catalog"
   packages = [
     "pkg/apis/servicecatalog",
@@ -318,8 +335,10 @@
   packages = [
     "cmd/goimports",
     "go/ast/astutil",
+    "go/buildutil",
     "go/gcexportdata",
     "go/gcimporter15",
+    "go/loader",
     "go/types/typeutil",
     "imports"
   ]
@@ -577,6 +596,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "29b903989769e09200f6532dab8caa934294fd36f8fa5758338fb7e78fd5f7ee"
+  inputs-digest = "b1726b7efe50f5571394443bed5c5e882724bf4dfa6204aef3e94f7d4702b120"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/components/binding-usage-controller/Gopkg.toml
+++ b/components/binding-usage-controller/Gopkg.toml
@@ -27,6 +27,7 @@
 required = [
   "github.com/golang/lint/golint",
   "golang.org/x/tools/cmd/goimports",
+  "github.com/kisielk/errcheck",
 
   "k8s.io/code-generator/cmd/defaulter-gen",
   "k8s.io/code-generator/cmd/deepcopy-gen",
@@ -41,6 +42,10 @@ required = [
 [prune]
   unused-packages = true
   go-tests = true
+
+[[constraint]]
+  name = "github.com/kisielk/errcheck"
+  revision = "1787c4bee836470bf45018cfbc783650db3c6501"
 
 [[constraint]]
   name = "github.com/kubernetes-incubator/service-catalog"

--- a/components/binding-usage-controller/before-commit.sh
+++ b/components/binding-usage-controller/before-commit.sh
@@ -118,3 +118,22 @@ for vPackage in "${packagesToVet[@]}"; do
 	else echo -e "${GREEN}√ go vet ${vPackage} ${NC}"
 	fi
 done
+
+##
+# ERRCHECK
+##
+go build -o errcheck-vendored ./vendor/github.com/kisielk/errcheck
+buildErrCheckResult=$?
+if [[ ${buildErrCheckResult} != 0 ]]; then
+	echo -e "${RED}✗ go build errcheck${NC}\n${buildErrCheckResult}${NC}"
+	exit 1
+fi
+
+errCheckResult=$(./errcheck-vendored -ignoretests -blank -ignoregenerated ./...)
+rm errcheck-vendored
+
+if [[ $(echo ${#errCheckResult}) != 0 ]]; then
+	echo -e "${RED}✗ [errcheck] uncheck error in:${NC}\n${errCheckResult}${NC}"
+	exit 1
+else echo -e "${GREEN}√ errcheck ${NC}"
+fi

--- a/components/binding-usage-controller/cmd/controller/main.go
+++ b/components/binding-usage-controller/cmd/controller/main.go
@@ -82,12 +82,13 @@ func main() {
 		aggregator,
 		cp,
 		log)
-	ukProtectionController := usagekind.NewProtectionController(
+	ukProtectionController, err := usagekind.NewProtectionController(
 		bindingUsageInformerFactory.Servicecatalog().V1alpha1().UsageKinds(),
 		sbuInformer,
 		bindingUsageCli.ServicecatalogV1alpha1(),
 		log,
 	)
+	fatalOnError(err)
 
 	labelsFetcher := controller.NewBindingLabelsFetcher(scInformersGroup.ServiceInstances().Lister(),
 		scInformersGroup.ClusterServiceClasses().Lister(),
@@ -124,7 +125,9 @@ func runStatuszHTTPServer(stop <-chan struct{}, addr string, log logrus.FieldLog
 	mux := http.NewServeMux()
 	mux.HandleFunc("/statusz", func(w http.ResponseWriter, req *http.Request) {
 		w.WriteHeader(http.StatusOK)
-		fmt.Fprint(w, "OK")
+		if _, err := fmt.Fprint(w, "OK"); err != nil {
+			log.Errorf("Cannot write response body, got err: %v ", err)
+		}
 	})
 
 	srv := &http.Server{Addr: addr, Handler: mux}

--- a/components/binding-usage-controller/internal/controller/controller.go
+++ b/components/binding-usage-controller/internal/controller/controller.go
@@ -233,7 +233,12 @@ func (c *ServiceBindingUsageController) processNextWorkItem() bool {
 	if usageStatus != nil {
 		usageStatus.wrapMessageForFailed(fmt.Sprintf("Process error during %d attempts from %d", retry, c.maxRetires))
 
-		bindingUsage, _ := c.bindingUsageLister.ServiceBindingUsages(namespace).Get(name)
+		bindingUsage, err := c.bindingUsageLister.ServiceBindingUsages(namespace).Get(name)
+		if err != nil {
+			c.log.Errorf("Cannot get ServiceBindingUsage %s/%s, got error: %v", namespace, name, err)
+			return true
+		}
+
 		condition := sbuStatus.NewUsageCondition(usageStatus.sbuType, usageStatus.condition, usageStatus.reason, usageStatus.message)
 		if err := c.updateStatus(bindingUsage, *condition); err != nil {
 			c.log.Errorf("Error processing %q while updating sbu status with condition %+v", key, condition)

--- a/components/binding-usage-controller/internal/controller/errors.go
+++ b/components/binding-usage-controller/internal/controller/errors.go
@@ -18,7 +18,7 @@ func (NotFoundError) NotFound() bool { return true }
 
 // NewNotFoundError returns a new not found error with given message
 func NewNotFoundError(format string, args ...interface{}) NotFoundError {
-	return NotFoundError{msg: fmt.Sprintf(format, args)}
+	return NotFoundError{msg: fmt.Sprintf(format, args...)}
 }
 
 // IsNotFoundError checks if given error is NotFound error

--- a/components/binding-usage-controller/internal/controller/labels_fetcher.go
+++ b/components/binding-usage-controller/internal/controller/labels_fetcher.go
@@ -55,7 +55,7 @@ func (c *BindingLabelsFetcher) Fetch(svcBinding *scTypes.ServiceBinding) (map[st
 
 		labels, err := c.getBindingLabelsFromClassSpec(&svcClass.Spec.CommonServiceClassSpec)
 		if err != nil {
-			return nil, errors.Wrapf(err, "while getting labels from %", pretty.ClusterServiceClassName(svcClass))
+			return nil, errors.Wrapf(err, "while getting labels from %s", pretty.ClusterServiceClassName(svcClass))
 		}
 
 		return labels, nil
@@ -67,7 +67,7 @@ func (c *BindingLabelsFetcher) Fetch(svcBinding *scTypes.ServiceBinding) (map[st
 
 		labels, err := c.getBindingLabelsFromClassSpec(&svcClass.Spec.CommonServiceClassSpec)
 		if err != nil {
-			return nil, errors.Wrapf(err, "while getting labels from %", pretty.ServiceClassName(svcClass))
+			return nil, errors.Wrapf(err, "while getting labels from %s", pretty.ServiceClassName(svcClass))
 		}
 
 		return labels, nil

--- a/components/binding-usage-controller/internal/controller/usagekind/protection_controller.go
+++ b/components/binding-usage-controller/internal/controller/usagekind/protection_controller.go
@@ -54,9 +54,10 @@ func NewProtectionController(
 	sbuInformer sbuInformer.ServiceBindingUsageInformer,
 	usageKindInterface ukClient.ServicecatalogV1alpha1Interface,
 	log logrus.FieldLogger,
-) *ProtectionController {
+) (*ProtectionController, error) {
 	serviceBindingUsageInformer := sbuInformer.Informer()
-	serviceBindingUsageInformer.AddIndexers(cache.Indexers{
+
+	err := serviceBindingUsageInformer.AddIndexers(cache.Indexers{
 		indexKind: func(obj interface{}) ([]string, error) {
 			sbu, ok := obj.(*v1alpha1.ServiceBindingUsage)
 			if !ok {
@@ -65,6 +66,9 @@ func NewProtectionController(
 			return []string{sbu.Spec.UsedBy.Kind}, nil
 		},
 	})
+	if err != nil {
+		return nil, errors.Wrap(err, "while adding indexer for ServiceBindingUsage Informer")
+	}
 
 	c := &ProtectionController{
 		queue:                    workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "UsageKindProtection"),
@@ -92,7 +96,7 @@ func NewProtectionController(
 	//sbuInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
 	//	DeleteFunc: c.OnDeleteSBU,
 	//})
-	return c
+	return c, nil
 }
 
 func (c *ProtectionController) onAddOrUpdateUsageKind(obj interface{}) {


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Fix the unchecked error in BUC project.
- Add `errcheck` validator to prevent similar errors in the future
- Fix errors from `fmt.Errorf`, `fmt.Printf` funtions execution reported by new Go version. E.g. `Entry.Errorf format %s reads arg #1, but call has 0 args`


**Related issue(s)**

- https://github.com/kyma-project/kyma/issues/2011