### PR TITLE
Define BackendModule custom resources in Kyma components

### DIFF
--- a/resources/application-connector/templates/backendmodule.yaml
+++ b/resources/application-connector/templates/backendmodule.yaml
@@ -1,0 +1,4 @@
+apiVersion: ui.kyma-project.io/v1alpha1
+kind: BackendModule
+metadata:
+  name: application

--- a/resources/core/charts/api-controller/templates/backendmodule.yaml
+++ b/resources/core/charts/api-controller/templates/backendmodule.yaml
@@ -1,0 +1,4 @@
+apiVersion: ui.kyma-project.io/v1alpha1
+kind: BackendModule
+metadata:
+  name: apicontroller

--- a/resources/core/charts/console/templates/backendmodule.yaml
+++ b/resources/core/charts/console/templates/backendmodule.yaml
@@ -1,0 +1,4 @@
+apiVersion: ui.kyma-project.io/v1alpha1
+kind: BackendModule
+metadata:
+  name: authentication

--- a/resources/core/charts/kubeless/templates/backendmodule.yaml
+++ b/resources/core/charts/kubeless/templates/backendmodule.yaml
@@ -1,0 +1,4 @@
+apiVersion: ui.kyma-project.io/v1alpha1
+kind: BackendModule
+metadata:
+  name: kubeless

--- a/resources/core/charts/minio/templates/backendmodule.yaml
+++ b/resources/core/charts/minio/templates/backendmodule.yaml
@@ -1,0 +1,4 @@
+apiVersion: ui.kyma-project.io/v1alpha1
+kind: BackendModule
+metadata:
+  name: content

--- a/resources/core/charts/service-catalog-addons/templates/backendmodule.yaml
+++ b/resources/core/charts/service-catalog-addons/templates/backendmodule.yaml
@@ -1,0 +1,4 @@
+apiVersion: ui.kyma-project.io/v1alpha1
+kind: BackendModule
+metadata:
+  name: servicecatalogaddons

--- a/resources/service-catalog/templates/backendmodule.yaml
+++ b/resources/service-catalog/templates/backendmodule.yaml
@@ -1,0 +1,4 @@
+apiVersion: ui.kyma-project.io/v1alpha1
+kind: BackendModule
+metadata:
+  name: servicecatalog


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Define BackendModule custom resources in Kyma components

BackendModule CR is used for toggling modules in UI API Layer. For more details, see the related issue.

**Related issue(s)**
See #1883 
