### PR TITLE
Skip Application charts installation in acceptance tests if not needed

### DIFF
--- a/tests/acceptance/application/suite/application.go
+++ b/tests/acceptance/application/suite/application.go
@@ -67,8 +67,9 @@ func fixApplication(name, accessLabel, serviceId, gatewayUrl, displayName string
 			Name: name,
 		},
 		Spec: appTypes.ApplicationSpec{
-			AccessLabel: "re-access-label",
-			Description: "Application used by application acceptance test",
+			AccessLabel:      "re-access-label",
+			Description:      "Application used by application acceptance test",
+			SkipInstallation: true,
 			Services: []appTypes.Service{
 				{
 					ID:   serviceId,

--- a/tests/acceptance/application/suite/application.go
+++ b/tests/acceptance/application/suite/application.go
@@ -67,7 +67,7 @@ func fixApplication(name, accessLabel, serviceId, gatewayUrl, displayName string
 			Name: name,
 		},
 		Spec: appTypes.ApplicationSpec{
-			AccessLabel:      "re-access-label",
+			AccessLabel:      "app-access-label",
 			Description:      "Application used by application acceptance test",
 			SkipInstallation: true,
 			Services: []appTypes.Service{

--- a/tests/acceptance/servicecatalog/binding_usage_test.go
+++ b/tests/acceptance/servicecatalog/binding_usage_test.go
@@ -191,8 +191,9 @@ func (ts *TestSuite) fixApplication() *appTypes.Application {
 			Name: ts.applicationName,
 		},
 		Spec: appTypes.ApplicationSpec{
-			AccessLabel: "app-access-label",
-			Description: "Application used by acceptance test",
+			AccessLabel:      "app-access-label",
+			Description:      "Application used by acceptance test",
+			SkipInstallation: true,
 			Services: []appTypes.Service{
 				{
 					ID:   ts.appSvcNameA,

--- a/tests/acceptance/servicecatalog/servicecatalog_test.go
+++ b/tests/acceptance/servicecatalog/servicecatalog_test.go
@@ -130,8 +130,9 @@ func fixApplication() *appTypes.Application {
 			Name: "test-acc-app",
 		},
 		Spec: appTypes.ApplicationSpec{
-			Description: "Application used by acceptance test",
-			AccessLabel: "fix-access",
+			Description:      "Application used by acceptance test",
+			AccessLabel:      "fix-access",
+			SkipInstallation: true,
 			Services: []appTypes.Service{
 				{
 					ID:   "id-00000-1234-test",

--- a/tests/application-operator-tests/test/testkit/k8sresources_client.go
+++ b/tests/application-operator-tests/test/testkit/k8sresources_client.go
@@ -74,12 +74,9 @@ func (c *k8sResourcesClient) GetService(name string, options v1.GetOptions) (int
 
 func (c *k8sResourcesClient) CreateDummyApplication(name string, accessLabel string, skipInstallation bool) (*v1alpha1.Application, error) {
 	spec := v1alpha1.ApplicationSpec{
-		Services:    []v1alpha1.Service{},
-		AccessLabel: accessLabel,
-	}
-
-	if skipInstallation {
-		spec.SkipInstallation = true
+		Services:         []v1alpha1.Service{},
+		AccessLabel:      accessLabel,
+		SkipInstallation: skipInstallation,
 	}
 
 	dummyApp := &v1alpha1.Application{

--- a/tests/application-operator-tests/test/testkit/k8sresources_client.go
+++ b/tests/application-operator-tests/test/testkit/k8sresources_client.go
@@ -82,13 +82,13 @@ func (c *k8sResourcesClient) CreateDummyApplication(name string, accessLabel str
 		spec.SkipInstallation = true
 	}
 
-	dummyRe := &v1alpha1.Application{
+	dummyApp := &v1alpha1.Application{
 		TypeMeta:   v1.TypeMeta{Kind: "Application", APIVersion: v1alpha1.SchemeGroupVersion.String()},
 		ObjectMeta: v1.ObjectMeta{Name: name, Namespace: c.namespace},
 		Spec:       spec,
 	}
 
-	return c.applicationClient.ApplicationconnectorV1alpha1().Applications().Create(dummyRe)
+	return c.applicationClient.ApplicationconnectorV1alpha1().Applications().Create(dummyApp)
 }
 
 func (c *k8sResourcesClient) DeleteApplication(name string, options *v1.DeleteOptions) error {

--- a/tests/application-registry-tests/Gopkg.lock
+++ b/tests/application-registry-tests/Gopkg.lock
@@ -238,6 +238,7 @@
     "pkg/util/intstr",
     "pkg/util/json",
     "pkg/util/net",
+    "pkg/util/rand",
     "pkg/util/runtime",
     "pkg/util/sets",
     "pkg/util/validation",
@@ -305,6 +306,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "79faa1a1fb1d50ee7e17dfffab901d600cf09029a9469394893d2d0b15dc9e05"
+  inputs-digest = "163ec51fe838e89e1becade9287b39a739a637ef2d286ec163645453cd786c21"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/tests/application-registry-tests/test/apitests/apispec_test.go
+++ b/tests/application-registry-tests/test/apitests/apispec_test.go
@@ -18,7 +18,7 @@ func TestApiSpec(t *testing.T) {
 	k8sResourcesClient, err := testkit.NewK8sInClusterResourcesClient(config.Namespace)
 	require.NoError(t, err)
 
-	dummyApp, err := k8sResourcesClient.CreateDummyApplication("dummy-app", v1.GetOptions{}, true)
+	dummyApp, err := k8sResourcesClient.CreateDummyApplication("appapispectest0", v1.GetOptions{}, true)
 	require.NoError(t, err)
 
 	t.Run("Application Connector Metadata", func(t *testing.T) {

--- a/tests/application-registry-tests/test/apitests/apispec_test.go
+++ b/tests/application-registry-tests/test/apitests/apispec_test.go
@@ -18,7 +18,7 @@ func TestApiSpec(t *testing.T) {
 	k8sResourcesClient, err := testkit.NewK8sInClusterResourcesClient(config.Namespace)
 	require.NoError(t, err)
 
-	dummyApp, err := k8sResourcesClient.CreateDummyApplication("dummy-app", v1.GetOptions{})
+	dummyApp, err := k8sResourcesClient.CreateDummyApplication("dummy-app", v1.GetOptions{}, true)
 	require.NoError(t, err)
 
 	t.Run("Application Connector Metadata", func(t *testing.T) {

--- a/tests/application-registry-tests/test/apitests/metadata_test.go
+++ b/tests/application-registry-tests/test/apitests/metadata_test.go
@@ -24,7 +24,7 @@ func TestApiMetadata(t *testing.T) {
 	k8sResourcesClient, err := testkit.NewK8sInClusterResourcesClient(config.Namespace)
 	require.NoError(t, err)
 
-	dummyApp, err := k8sResourcesClient.CreateDummyApplication("dummy-app", v1.GetOptions{})
+	dummyApp, err := k8sResourcesClient.CreateDummyApplication("dummy-app", v1.GetOptions{}, true)
 	require.NoError(t, err)
 
 	metadataServiceClient := testkit.NewMetadataServiceClient(config.MetadataServiceUrl + "/" + dummyApp.Name + "/v1/metadata/services")

--- a/tests/application-registry-tests/test/k8stests/k8sresource_test.go
+++ b/tests/application-registry-tests/test/k8stests/k8sresource_test.go
@@ -24,7 +24,7 @@ func TestK8sResources(t *testing.T) {
 	k8sResourcesClient, err := testkit.NewK8sInClusterResourcesClient(config.Namespace)
 	require.NoError(t, err)
 
-	dummyApp, err := k8sResourcesClient.CreateDummyApplication("dummy-app", v1.GetOptions{})
+	dummyApp, err := k8sResourcesClient.CreateDummyApplication("dummy-app", v1.GetOptions{}, true)
 	require.NoError(t, err)
 
 	metadataServiceClient := testkit.NewMetadataServiceClient(config.MetadataServiceUrl + "/" + dummyApp.Name + "/v1/metadata/services")

--- a/tests/application-registry-tests/test/k8stests/k8sresource_test.go
+++ b/tests/application-registry-tests/test/k8stests/k8sresource_test.go
@@ -24,7 +24,7 @@ func TestK8sResources(t *testing.T) {
 	k8sResourcesClient, err := testkit.NewK8sInClusterResourcesClient(config.Namespace)
 	require.NoError(t, err)
 
-	dummyApp, err := k8sResourcesClient.CreateDummyApplication("dummy-app", v1.GetOptions{}, true)
+	dummyApp, err := k8sResourcesClient.CreateDummyApplication("appk8srestest0", v1.GetOptions{}, true)
 	require.NoError(t, err)
 
 	metadataServiceClient := testkit.NewMetadataServiceClient(config.MetadataServiceUrl + "/" + dummyApp.Name + "/v1/metadata/services")

--- a/tests/application-registry-tests/test/testkit/k8sresources_check.go
+++ b/tests/application-registry-tests/test/testkit/k8sresources_check.go
@@ -84,19 +84,19 @@ func CheckK8sChecknothing(t *testing.T, checknothing *istio.Checknothing, name s
 	checkLabels(t, labels, checknothing.Labels)
 }
 
-func CheckK8sApplication(t *testing.T, re *application.Application, name string, expectedServiceData ServiceData) {
-	require.Equal(t, name, re.Name)
+func CheckK8sApplication(t *testing.T, app *application.Application, name string, expectedServiceData ServiceData) {
+	require.Equal(t, name, app.Name)
 
-	reService := findServiceInApp(re.Spec.Services, expectedServiceData.ServiceId)
-	require.NotNil(t, reService)
+	appService := findServiceInApp(app.Spec.Services, expectedServiceData.ServiceId)
+	require.NotNil(t, appService)
 
-	require.Equal(t, expectedServiceData.ServiceId, reService.ID)
-	require.Equal(t, expectedServiceData.DisplayName, reService.DisplayName)
-	require.Equal(t, expectedServiceData.ProviderDisplayName, reService.ProviderDisplayName)
-	require.Equal(t, expectedServiceData.LongDescription, reService.LongDescription)
+	require.Equal(t, expectedServiceData.ServiceId, appService.ID)
+	require.Equal(t, expectedServiceData.DisplayName, appService.DisplayName)
+	require.Equal(t, expectedServiceData.ProviderDisplayName, appService.ProviderDisplayName)
+	require.Equal(t, expectedServiceData.LongDescription, appService.LongDescription)
 
 	if expectedServiceData.HasAPI {
-		apiEntry := findEntryOfType(reService.Entries, "API")
+		apiEntry := findEntryOfType(appService.Entries, "API")
 		require.NotNil(t, apiEntry)
 
 		if apiEntry.Type == "OAuth" {
@@ -109,7 +109,7 @@ func CheckK8sApplication(t *testing.T, re *application.Application, name string,
 	}
 
 	if expectedServiceData.HasEvents {
-		eventsEntry := findEntryOfType(reService.Entries, "Events")
+		eventsEntry := findEntryOfType(appService.Entries, "Events")
 		require.NotNil(t, eventsEntry)
 	}
 }

--- a/tests/application-registry-tests/test/testkit/k8sresources_client.go
+++ b/tests/application-registry-tests/test/testkit/k8sresources_client.go
@@ -19,7 +19,7 @@ type K8sResourcesClient interface {
 	GetRule(name string, options v1.GetOptions) (*v1alpha2.Rule, error)
 	GetChecknothing(name string, options v1.GetOptions) (*v1alpha2.Checknothing, error)
 	GetApplicationServices(name string, options v1.GetOptions) (*v1alpha1.Application, error)
-	CreateDummyApplication(name string, options v1.GetOptions) (*v1alpha1.Application, error)
+	CreateDummyApplication(name string, options v1.GetOptions, skipInstallation bool) (*v1alpha1.Application, error)
 	DeleteApplication(name string, options *v1.DeleteOptions) error
 }
 
@@ -88,13 +88,16 @@ func (c *k8sResourcesClient) GetApplicationServices(name string, options v1.GetO
 	return c.applicationClient.ApplicationconnectorV1alpha1().Applications().Get(name, options)
 }
 
-func (c *k8sResourcesClient) CreateDummyApplication(name string, options v1.GetOptions) (*v1alpha1.Application, error) {
+func (c *k8sResourcesClient) CreateDummyApplication(name string, options v1.GetOptions, skipInstallation bool) (*v1alpha1.Application, error) {
+	spec := v1alpha1.ApplicationSpec{
+		Services:         []v1alpha1.Service{},
+		SkipInstallation: skipInstallation,
+	}
+
 	dummyApp := &v1alpha1.Application{
 		TypeMeta:   v1.TypeMeta{Kind: "Application", APIVersion: v1alpha1.SchemeGroupVersion.String()},
 		ObjectMeta: v1.ObjectMeta{Name: name},
-		Spec: v1alpha1.ApplicationSpec{
-			Services: []v1alpha1.Service{},
-		},
+		Spec:       spec,
 	}
 
 	return c.applicationClient.ApplicationconnectorV1alpha1().Applications().Create(dummyApp)

--- a/tests/application-registry-tests/test/testkit/k8sresources_client.go
+++ b/tests/application-registry-tests/test/testkit/k8sresources_client.go
@@ -1,12 +1,14 @@
 package testkit
 
 import (
+	"fmt"
 	"github.com/kyma-project/kyma/components/application-operator/pkg/apis/applicationconnector/v1alpha1"
 	"github.com/kyma-project/kyma/components/application-operator/pkg/client/clientset/versioned"
 	"github.com/kyma-project/kyma/components/metadata-service/pkg/apis/istio/v1alpha2"
 	istioclient "github.com/kyma-project/kyma/components/metadata-service/pkg/client/clientset/versioned"
 	v1core "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/rand"
 
 	"k8s.io/client-go/kubernetes"
 	restclient "k8s.io/client-go/rest"
@@ -19,7 +21,7 @@ type K8sResourcesClient interface {
 	GetRule(name string, options v1.GetOptions) (*v1alpha2.Rule, error)
 	GetChecknothing(name string, options v1.GetOptions) (*v1alpha2.Checknothing, error)
 	GetApplicationServices(name string, options v1.GetOptions) (*v1alpha1.Application, error)
-	CreateDummyApplication(name string, options v1.GetOptions, skipInstallation bool) (*v1alpha1.Application, error)
+	CreateDummyApplication(namePrefix string, options v1.GetOptions, skipInstallation bool) (*v1alpha1.Application, error)
 	DeleteApplication(name string, options *v1.DeleteOptions) error
 }
 
@@ -88,19 +90,26 @@ func (c *k8sResourcesClient) GetApplicationServices(name string, options v1.GetO
 	return c.applicationClient.ApplicationconnectorV1alpha1().Applications().Get(name, options)
 }
 
-func (c *k8sResourcesClient) CreateDummyApplication(name string, options v1.GetOptions, skipInstallation bool) (*v1alpha1.Application, error) {
+func (c *k8sResourcesClient) CreateDummyApplication(namePrefix string, options v1.GetOptions, skipInstallation bool) (*v1alpha1.Application, error) {
 	spec := v1alpha1.ApplicationSpec{
 		Services:         []v1alpha1.Service{},
 		SkipInstallation: skipInstallation,
 	}
 
+	dummyAppName := addRandomPostfix(namePrefix)
+	//dummyAppName := namePrefix
+
 	dummyApp := &v1alpha1.Application{
 		TypeMeta:   v1.TypeMeta{Kind: "Application", APIVersion: v1alpha1.SchemeGroupVersion.String()},
-		ObjectMeta: v1.ObjectMeta{Name: name},
+		ObjectMeta: v1.ObjectMeta{Name: dummyAppName},
 		Spec:       spec,
 	}
 
 	return c.applicationClient.ApplicationconnectorV1alpha1().Applications().Create(dummyApp)
+}
+
+func addRandomPostfix(s string) string {
+	return fmt.Sprintf(s + "-%s", rand.String(5))
 }
 
 func (c *k8sResourcesClient) DeleteApplication(name string, options *v1.DeleteOptions) error {

--- a/tests/application-registry-tests/test/testkit/k8sresources_client.go
+++ b/tests/application-registry-tests/test/testkit/k8sresources_client.go
@@ -97,7 +97,6 @@ func (c *k8sResourcesClient) CreateDummyApplication(namePrefix string, options v
 	}
 
 	dummyAppName := addRandomPostfix(namePrefix)
-	//dummyAppName := namePrefix
 
 	dummyApp := &v1alpha1.Application{
 		TypeMeta:   v1.TypeMeta{Kind: "Application", APIVersion: v1alpha1.SchemeGroupVersion.String()},
@@ -109,7 +108,7 @@ func (c *k8sResourcesClient) CreateDummyApplication(namePrefix string, options v
 }
 
 func addRandomPostfix(s string) string {
-	return fmt.Sprintf(s + "-%s", rand.String(5))
+	return fmt.Sprintf(s+"-%s", rand.String(5))
 }
 
 func (c *k8sResourcesClient) DeleteApplication(name string, options *v1.DeleteOptions) error {

--- a/tests/connector-service-tests/Gopkg.lock
+++ b/tests/connector-service-tests/Gopkg.lock
@@ -2,171 +2,136 @@
 
 
 [[projects]]
-  digest = "1:a2c1d0e43bd3baaa071d1b9ed72c27d78169b2b269f71c105ac4ba34b1be4a39"
   name = "github.com/davecgh/go-spew"
   packages = ["spew"]
-  pruneopts = "UT"
   revision = "346938d642f2ec3594ed81d874461961cd0faa76"
   version = "v1.1.0"
 
 [[projects]]
-  digest = "1:2cd7915ab26ede7d95b8749e6b1f933f1c6d5398030684e6505940a10f31cfda"
   name = "github.com/ghodss/yaml"
   packages = ["."]
-  pruneopts = "UT"
   revision = "0ca9ea5df5451ffdf184b4428c902747c2c11cd7"
   version = "v1.0.0"
 
 [[projects]]
-  digest = "1:34e709f36fd4f868fb00dbaf8a6cab4c1ae685832d392874ba9d7c5dec2429d1"
   name = "github.com/gogo/protobuf"
   packages = [
     "proto",
-    "sortkeys",
+    "sortkeys"
   ]
-  pruneopts = "UT"
   revision = "636bf0302bc95575d69441b25a2603156ffdddf1"
   version = "v1.1.1"
 
 [[projects]]
   branch = "master"
-  digest = "1:1ba1d79f2810270045c328ae5d674321db34e3aae468eb4233883b473c5c0467"
   name = "github.com/golang/glog"
   packages = ["."]
-  pruneopts = "UT"
   revision = "23def4e6c14b4da8ac2ed8007337bc5eb5007998"
 
 [[projects]]
-  digest = "1:4c0989ca0bcd10799064318923b9bc2db6b4d6338dd75f3f2d86c3511aaaf5cf"
   name = "github.com/golang/protobuf"
   packages = [
     "proto",
     "ptypes",
     "ptypes/any",
     "ptypes/duration",
-    "ptypes/timestamp",
+    "ptypes/timestamp"
   ]
-  pruneopts = "UT"
   revision = "aa810b61a9c79d51363740d207bb46cf8e620ed5"
   version = "v1.2.0"
 
 [[projects]]
   branch = "master"
-  digest = "1:3ee90c0d94da31b442dde97c99635aaafec68d0b8a3c12ee2075c6bdabeec6bb"
   name = "github.com/google/gofuzz"
   packages = ["."]
-  pruneopts = "UT"
   revision = "24818f796faf91cd76ec7bddd72458fbced7a6c1"
 
 [[projects]]
-  digest = "1:65c4414eeb350c47b8de71110150d0ea8a281835b1f386eacaa3ad7325929c21"
   name = "github.com/googleapis/gnostic"
   packages = [
     "OpenAPIv2",
     "compiler",
-    "extensions",
+    "extensions"
   ]
-  pruneopts = "UT"
   revision = "7c663266750e7d82587642f65e60bc4083f1f84e"
   version = "v0.2.0"
 
 [[projects]]
-  digest = "1:3e551bbb3a7c0ab2a2bf4660e7fcad16db089fdcfbb44b0199e62838038623ea"
   name = "github.com/json-iterator/go"
   packages = ["."]
-  pruneopts = "UT"
   revision = "1624edc4454b8682399def8740d46db5e4362ba4"
   version = "v1.1.5"
 
 [[projects]]
-  digest = "1:2c169cdfcf2e3b2e6b9c2bc8797f942e7e34d3c1a7e5f8f3a26d04aae400894e"
   name = "github.com/kyma-project/kyma"
   packages = [
     "components/application-operator/pkg/apis/applicationconnector/v1alpha1",
     "components/application-operator/pkg/client/clientset/versioned",
     "components/application-operator/pkg/client/clientset/versioned/scheme",
-    "components/application-operator/pkg/client/clientset/versioned/typed/applicationconnector/v1alpha1",
+    "components/application-operator/pkg/client/clientset/versioned/typed/applicationconnector/v1alpha1"
   ]
-  pruneopts = "UT"
   revision = "d6ba814ef8b42b4c7c65f478e51f46f01387e1df"
 
 [[projects]]
-  digest = "1:33422d238f147d247752996a26574ac48dcf472976eda7f5134015f06bf16563"
   name = "github.com/modern-go/concurrent"
   packages = ["."]
-  pruneopts = "UT"
   revision = "bacd9c7ef1dd9b15be4a9909b8ac7a4e313eec94"
   version = "1.0.3"
 
 [[projects]]
-  digest = "1:e32bdbdb7c377a07a9a46378290059822efdce5c8d96fe71940d87cb4f918855"
   name = "github.com/modern-go/reflect2"
   packages = ["."]
-  pruneopts = "UT"
   revision = "4b7aa43c6742a2c18fdef89dd197aaae7dac7ccd"
   version = "1.0.1"
 
 [[projects]]
-  digest = "1:0028cb19b2e4c3112225cd871870f2d9cf49b9b4276531f03438a88e94be86fe"
   name = "github.com/pmezard/go-difflib"
   packages = ["difflib"]
-  pruneopts = "UT"
   revision = "792786c7400a136282c1664665ae0a8db921c6c2"
   version = "v1.0.0"
 
 [[projects]]
-  digest = "1:c1b1102241e7f645bc8e0c22ae352e8f0dc6484b6cb4d132fa9f24174e0119e2"
   name = "github.com/spf13/pflag"
   packages = ["."]
-  pruneopts = "UT"
   revision = "298182f68c66c05229eb03ac171abe6e309ee79a"
   version = "v1.0.3"
 
 [[projects]]
-  digest = "1:c40d65817cdd41fac9aa7af8bed56927bb2d6d47e4fea566a74880f5c2b1c41e"
   name = "github.com/stretchr/testify"
   packages = [
     "assert",
-    "require",
+    "require"
   ]
-  pruneopts = "UT"
   revision = "f35b8ab0b5a2cef36673838d662e249dd9c94686"
   version = "v1.2.2"
 
 [[projects]]
   branch = "master"
-  digest = "1:3f3a05ae0b95893d90b9b3b5afdb79a9b3d96e4e36e099d841ae602e4aca0da8"
   name = "golang.org/x/crypto"
   packages = ["ssh/terminal"]
-  pruneopts = "UT"
   revision = "e4dc69e5b2fd71dcaf8bd5d054eb936deb78d1fa"
 
 [[projects]]
   branch = "master"
-  digest = "1:67c2a615ba674115933f3ee56daa132974de340a9573937a97d14039f8544e8b"
   name = "golang.org/x/net"
   packages = [
     "http/httpguts",
     "http2",
     "http2/hpack",
-    "idna",
+    "idna"
   ]
-  pruneopts = "UT"
   revision = "03003ca0c849e57b6ea29a4bab8d3cb6e4d568fe"
 
 [[projects]]
   branch = "master"
-  digest = "1:6a875550c3b582f6c2d7e2ce44aba792511f00016d7c46b0a4fb26f730ef3058"
   name = "golang.org/x/sys"
   packages = [
     "unix",
-    "windows",
+    "windows"
   ]
-  pruneopts = "UT"
   revision = "66b7b1311ac80bbafcd2daeef9a5e6e2cd1e2399"
 
 [[projects]]
-  digest = "1:a2ab62866c75542dd18d2b069fec854577a20211d7c0ea6ae746072a1dccdd18"
   name = "golang.org/x/text"
   packages = [
     "collate",
@@ -182,39 +147,31 @@
     "unicode/bidi",
     "unicode/cldr",
     "unicode/norm",
-    "unicode/rangetable",
+    "unicode/rangetable"
   ]
-  pruneopts = "UT"
   revision = "f21a4dfb5e38f5895301dc265a8def02365cc3d0"
   version = "v0.3.0"
 
 [[projects]]
   branch = "master"
-  digest = "1:9fdc2b55e8e0fafe4b41884091e51e77344f7dc511c5acedcfd98200003bff90"
   name = "golang.org/x/time"
   packages = ["rate"]
-  pruneopts = "UT"
   revision = "85acf8d2951cb2a3bde7632f9ff273ef0379bcbd"
 
 [[projects]]
-  digest = "1:2d1fbdc6777e5408cabeb02bf336305e724b925ff4546ded0fa8715a7267922a"
   name = "gopkg.in/inf.v0"
   packages = ["."]
-  pruneopts = "UT"
   revision = "d2d2541c53f18d2a059457998ce2876cc8e67cbf"
   version = "v0.9.1"
 
 [[projects]]
-  digest = "1:342378ac4dcb378a5448dd723f0784ae519383532f5e70ade24132c4c8693202"
   name = "gopkg.in/yaml.v2"
   packages = ["."]
-  pruneopts = "UT"
   revision = "5420a8b6744d3b0345ab293f6fcba19c978f1183"
   version = "v2.2.1"
 
 [[projects]]
   branch = "master"
-  digest = "1:2a659714683e4f746bd99049735056c1b5b3b1d8ba0a26ca49e460771bc20f54"
   name = "k8s.io/api"
   packages = [
     "admissionregistration/v1alpha1",
@@ -244,13 +201,11 @@
     "settings/v1alpha1",
     "storage/v1",
     "storage/v1alpha1",
-    "storage/v1beta1",
+    "storage/v1beta1"
   ]
-  pruneopts = "UT"
   revision = "eee84a6322ca58a1557657a70bd3f5eda27e9c2a"
 
 [[projects]]
-  digest = "1:19a9cb1de67179abb85a98244431eaa4d5c918ab28a7276bba44bad6dfc9ca84"
   name = "k8s.io/apimachinery"
   packages = [
     "pkg/api/errors",
@@ -288,14 +243,12 @@
     "pkg/util/yaml",
     "pkg/version",
     "pkg/watch",
-    "third_party/forked/golang/reflect",
+    "third_party/forked/golang/reflect"
   ]
-  pruneopts = "UT"
   revision = "302974c03f7e50f16561ba237db776ab93594ef6"
   version = "kubernetes-1.10.1"
 
 [[projects]]
-  digest = "1:92324f90099c6d2ac027672116218f99989bb71e84307784d88034c7bf3deeff"
   name = "k8s.io/client-go"
   packages = [
     "discovery",
@@ -311,23 +264,14 @@
     "transport",
     "util/cert",
     "util/flowcontrol",
-    "util/integer",
+    "util/integer"
   ]
-  pruneopts = "UT"
   revision = "989be4278f353e42f26c416c53757d16fcff77db"
   version = "kubernetes-1.10.1"
 
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  input-imports = [
-    "github.com/kyma-project/kyma/components/application-operator/pkg/apis/applicationconnector/v1alpha1",
-    "github.com/kyma-project/kyma/components/application-operator/pkg/client/clientset/versioned",
-    "github.com/stretchr/testify/require",
-    "gopkg.in/yaml.v2",
-    "k8s.io/apimachinery/pkg/apis/meta/v1",
-    "k8s.io/apimachinery/pkg/util/rand",
-    "k8s.io/client-go/rest",
-  ]
+  inputs-digest = "75105789b7d626340ad28b0ef0f51f374a9ef0bbaf22622a7d5acbaf941510d3"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/tests/connector-service-tests/Gopkg.lock
+++ b/tests/connector-service-tests/Gopkg.lock
@@ -2,136 +2,171 @@
 
 
 [[projects]]
+  digest = "1:a2c1d0e43bd3baaa071d1b9ed72c27d78169b2b269f71c105ac4ba34b1be4a39"
   name = "github.com/davecgh/go-spew"
   packages = ["spew"]
+  pruneopts = "UT"
   revision = "346938d642f2ec3594ed81d874461961cd0faa76"
   version = "v1.1.0"
 
 [[projects]]
+  digest = "1:2cd7915ab26ede7d95b8749e6b1f933f1c6d5398030684e6505940a10f31cfda"
   name = "github.com/ghodss/yaml"
   packages = ["."]
+  pruneopts = "UT"
   revision = "0ca9ea5df5451ffdf184b4428c902747c2c11cd7"
   version = "v1.0.0"
 
 [[projects]]
+  digest = "1:34e709f36fd4f868fb00dbaf8a6cab4c1ae685832d392874ba9d7c5dec2429d1"
   name = "github.com/gogo/protobuf"
   packages = [
     "proto",
-    "sortkeys"
+    "sortkeys",
   ]
+  pruneopts = "UT"
   revision = "636bf0302bc95575d69441b25a2603156ffdddf1"
   version = "v1.1.1"
 
 [[projects]]
   branch = "master"
+  digest = "1:1ba1d79f2810270045c328ae5d674321db34e3aae468eb4233883b473c5c0467"
   name = "github.com/golang/glog"
   packages = ["."]
+  pruneopts = "UT"
   revision = "23def4e6c14b4da8ac2ed8007337bc5eb5007998"
 
 [[projects]]
+  digest = "1:4c0989ca0bcd10799064318923b9bc2db6b4d6338dd75f3f2d86c3511aaaf5cf"
   name = "github.com/golang/protobuf"
   packages = [
     "proto",
     "ptypes",
     "ptypes/any",
     "ptypes/duration",
-    "ptypes/timestamp"
+    "ptypes/timestamp",
   ]
+  pruneopts = "UT"
   revision = "aa810b61a9c79d51363740d207bb46cf8e620ed5"
   version = "v1.2.0"
 
 [[projects]]
   branch = "master"
+  digest = "1:3ee90c0d94da31b442dde97c99635aaafec68d0b8a3c12ee2075c6bdabeec6bb"
   name = "github.com/google/gofuzz"
   packages = ["."]
+  pruneopts = "UT"
   revision = "24818f796faf91cd76ec7bddd72458fbced7a6c1"
 
 [[projects]]
+  digest = "1:65c4414eeb350c47b8de71110150d0ea8a281835b1f386eacaa3ad7325929c21"
   name = "github.com/googleapis/gnostic"
   packages = [
     "OpenAPIv2",
     "compiler",
-    "extensions"
+    "extensions",
   ]
+  pruneopts = "UT"
   revision = "7c663266750e7d82587642f65e60bc4083f1f84e"
   version = "v0.2.0"
 
 [[projects]]
+  digest = "1:3e551bbb3a7c0ab2a2bf4660e7fcad16db089fdcfbb44b0199e62838038623ea"
   name = "github.com/json-iterator/go"
   packages = ["."]
+  pruneopts = "UT"
   revision = "1624edc4454b8682399def8740d46db5e4362ba4"
   version = "v1.1.5"
 
 [[projects]]
+  digest = "1:2c169cdfcf2e3b2e6b9c2bc8797f942e7e34d3c1a7e5f8f3a26d04aae400894e"
   name = "github.com/kyma-project/kyma"
   packages = [
     "components/application-operator/pkg/apis/applicationconnector/v1alpha1",
     "components/application-operator/pkg/client/clientset/versioned",
     "components/application-operator/pkg/client/clientset/versioned/scheme",
-    "components/application-operator/pkg/client/clientset/versioned/typed/applicationconnector/v1alpha1"
+    "components/application-operator/pkg/client/clientset/versioned/typed/applicationconnector/v1alpha1",
   ]
+  pruneopts = "UT"
   revision = "d6ba814ef8b42b4c7c65f478e51f46f01387e1df"
 
 [[projects]]
+  digest = "1:33422d238f147d247752996a26574ac48dcf472976eda7f5134015f06bf16563"
   name = "github.com/modern-go/concurrent"
   packages = ["."]
+  pruneopts = "UT"
   revision = "bacd9c7ef1dd9b15be4a9909b8ac7a4e313eec94"
   version = "1.0.3"
 
 [[projects]]
+  digest = "1:e32bdbdb7c377a07a9a46378290059822efdce5c8d96fe71940d87cb4f918855"
   name = "github.com/modern-go/reflect2"
   packages = ["."]
+  pruneopts = "UT"
   revision = "4b7aa43c6742a2c18fdef89dd197aaae7dac7ccd"
   version = "1.0.1"
 
 [[projects]]
+  digest = "1:0028cb19b2e4c3112225cd871870f2d9cf49b9b4276531f03438a88e94be86fe"
   name = "github.com/pmezard/go-difflib"
   packages = ["difflib"]
+  pruneopts = "UT"
   revision = "792786c7400a136282c1664665ae0a8db921c6c2"
   version = "v1.0.0"
 
 [[projects]]
+  digest = "1:c1b1102241e7f645bc8e0c22ae352e8f0dc6484b6cb4d132fa9f24174e0119e2"
   name = "github.com/spf13/pflag"
   packages = ["."]
+  pruneopts = "UT"
   revision = "298182f68c66c05229eb03ac171abe6e309ee79a"
   version = "v1.0.3"
 
 [[projects]]
+  digest = "1:c40d65817cdd41fac9aa7af8bed56927bb2d6d47e4fea566a74880f5c2b1c41e"
   name = "github.com/stretchr/testify"
   packages = [
     "assert",
-    "require"
+    "require",
   ]
+  pruneopts = "UT"
   revision = "f35b8ab0b5a2cef36673838d662e249dd9c94686"
   version = "v1.2.2"
 
 [[projects]]
   branch = "master"
+  digest = "1:3f3a05ae0b95893d90b9b3b5afdb79a9b3d96e4e36e099d841ae602e4aca0da8"
   name = "golang.org/x/crypto"
   packages = ["ssh/terminal"]
+  pruneopts = "UT"
   revision = "e4dc69e5b2fd71dcaf8bd5d054eb936deb78d1fa"
 
 [[projects]]
   branch = "master"
+  digest = "1:67c2a615ba674115933f3ee56daa132974de340a9573937a97d14039f8544e8b"
   name = "golang.org/x/net"
   packages = [
     "http/httpguts",
     "http2",
     "http2/hpack",
-    "idna"
+    "idna",
   ]
+  pruneopts = "UT"
   revision = "03003ca0c849e57b6ea29a4bab8d3cb6e4d568fe"
 
 [[projects]]
   branch = "master"
+  digest = "1:6a875550c3b582f6c2d7e2ce44aba792511f00016d7c46b0a4fb26f730ef3058"
   name = "golang.org/x/sys"
   packages = [
     "unix",
-    "windows"
+    "windows",
   ]
+  pruneopts = "UT"
   revision = "66b7b1311ac80bbafcd2daeef9a5e6e2cd1e2399"
 
 [[projects]]
+  digest = "1:a2ab62866c75542dd18d2b069fec854577a20211d7c0ea6ae746072a1dccdd18"
   name = "golang.org/x/text"
   packages = [
     "collate",
@@ -147,31 +182,39 @@
     "unicode/bidi",
     "unicode/cldr",
     "unicode/norm",
-    "unicode/rangetable"
+    "unicode/rangetable",
   ]
+  pruneopts = "UT"
   revision = "f21a4dfb5e38f5895301dc265a8def02365cc3d0"
   version = "v0.3.0"
 
 [[projects]]
   branch = "master"
+  digest = "1:9fdc2b55e8e0fafe4b41884091e51e77344f7dc511c5acedcfd98200003bff90"
   name = "golang.org/x/time"
   packages = ["rate"]
+  pruneopts = "UT"
   revision = "85acf8d2951cb2a3bde7632f9ff273ef0379bcbd"
 
 [[projects]]
+  digest = "1:2d1fbdc6777e5408cabeb02bf336305e724b925ff4546ded0fa8715a7267922a"
   name = "gopkg.in/inf.v0"
   packages = ["."]
+  pruneopts = "UT"
   revision = "d2d2541c53f18d2a059457998ce2876cc8e67cbf"
   version = "v0.9.1"
 
 [[projects]]
+  digest = "1:342378ac4dcb378a5448dd723f0784ae519383532f5e70ade24132c4c8693202"
   name = "gopkg.in/yaml.v2"
   packages = ["."]
+  pruneopts = "UT"
   revision = "5420a8b6744d3b0345ab293f6fcba19c978f1183"
   version = "v2.2.1"
 
 [[projects]]
   branch = "master"
+  digest = "1:2a659714683e4f746bd99049735056c1b5b3b1d8ba0a26ca49e460771bc20f54"
   name = "k8s.io/api"
   packages = [
     "admissionregistration/v1alpha1",
@@ -201,11 +244,13 @@
     "settings/v1alpha1",
     "storage/v1",
     "storage/v1alpha1",
-    "storage/v1beta1"
+    "storage/v1beta1",
   ]
+  pruneopts = "UT"
   revision = "eee84a6322ca58a1557657a70bd3f5eda27e9c2a"
 
 [[projects]]
+  digest = "1:19a9cb1de67179abb85a98244431eaa4d5c918ab28a7276bba44bad6dfc9ca84"
   name = "k8s.io/apimachinery"
   packages = [
     "pkg/api/errors",
@@ -234,6 +279,7 @@
     "pkg/util/intstr",
     "pkg/util/json",
     "pkg/util/net",
+    "pkg/util/rand",
     "pkg/util/runtime",
     "pkg/util/sets",
     "pkg/util/validation",
@@ -242,12 +288,14 @@
     "pkg/util/yaml",
     "pkg/version",
     "pkg/watch",
-    "third_party/forked/golang/reflect"
+    "third_party/forked/golang/reflect",
   ]
+  pruneopts = "UT"
   revision = "302974c03f7e50f16561ba237db776ab93594ef6"
   version = "kubernetes-1.10.1"
 
 [[projects]]
+  digest = "1:92324f90099c6d2ac027672116218f99989bb71e84307784d88034c7bf3deeff"
   name = "k8s.io/client-go"
   packages = [
     "discovery",
@@ -263,14 +311,23 @@
     "transport",
     "util/cert",
     "util/flowcontrol",
-    "util/integer"
+    "util/integer",
   ]
+  pruneopts = "UT"
   revision = "989be4278f353e42f26c416c53757d16fcff77db"
   version = "kubernetes-1.10.1"
 
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "6d7f2adbab73358dfe50efeaf1c70010cf6d26ae2d6fc5da4f67b3d591cffa33"
+  input-imports = [
+    "github.com/kyma-project/kyma/components/application-operator/pkg/apis/applicationconnector/v1alpha1",
+    "github.com/kyma-project/kyma/components/application-operator/pkg/client/clientset/versioned",
+    "github.com/stretchr/testify/require",
+    "gopkg.in/yaml.v2",
+    "k8s.io/apimachinery/pkg/apis/meta/v1",
+    "k8s.io/apimachinery/pkg/util/rand",
+    "k8s.io/client-go/rest",
+  ]
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/tests/connector-service-tests/test/apitests/connector_test.go
+++ b/tests/connector-service-tests/test/apitests/connector_test.go
@@ -32,7 +32,7 @@ func TestConnector(t *testing.T) {
 
 	k8sResourcesClient, err := testkit.NewK8sResourcesClient()
 	require.NoError(t, err)
-	_, e := k8sResourcesClient.CreateDummyApplication(appName, "")
+	_, e := k8sResourcesClient.CreateDummyApplication(appName, "", false)
 
 	client := testkit.NewConnectorClient(appName, config.InternalAPIUrl, config.ExternalAPIUrl, config.SkipSslVerify)
 
@@ -282,9 +282,9 @@ func TestCertificateValidation(t *testing.T) {
 
 	k8sResourcesClient, err := testkit.NewK8sResourcesClient()
 	require.NoError(t, err)
-	_, e := k8sResourcesClient.CreateDummyApplication(appName, "")
+	_, e := k8sResourcesClient.CreateDummyApplication(appName, "", false)
 	require.NoError(t, e)
-	_, e = k8sResourcesClient.CreateDummyApplication(forbiddenAppName, "")
+	_, e = k8sResourcesClient.CreateDummyApplication(forbiddenAppName, "", false)
 	require.NoError(t, e)
 
 	client := testkit.NewConnectorClient(appName, config.InternalAPIUrl, config.ExternalAPIUrl, config.SkipSslVerify)

--- a/tests/connector-service-tests/test/apitests/connector_test.go
+++ b/tests/connector-service-tests/test/apitests/connector_test.go
@@ -28,13 +28,11 @@ func TestConnector(t *testing.T) {
 	config, err := testkit.ReadConfig()
 	require.NoError(t, err)
 
-	appName := "dummy-app"
-
 	k8sResourcesClient, err := testkit.NewK8sResourcesClient()
 	require.NoError(t, err)
-	_, e := k8sResourcesClient.CreateDummyApplication(appName, "", false)
+	app, e := k8sResourcesClient.CreateDummyApplication("app-connector-test-0", "", false)
 
-	client := testkit.NewConnectorClient(appName, config.InternalAPIUrl, config.ExternalAPIUrl, config.SkipSslVerify)
+	client := testkit.NewConnectorClient(app.Name, config.InternalAPIUrl, config.ExternalAPIUrl, config.SkipSslVerify)
 
 	require.NoError(t, e)
 
@@ -51,7 +49,6 @@ func TestConnector(t *testing.T) {
 		certificates := testkit.DecodeAndParseCert(t, crtResponse)
 
 		// then
-
 		clientsCrt := certificates[0]
 		testkit.CheckIfSubjectEquals(t, infoResponse.Certificate.Subject, clientsCrt)
 	})
@@ -223,7 +220,7 @@ func TestConnector(t *testing.T) {
 		require.Equal(t, StatusBadRequest, err.ErrorResponse.Code)
 		require.Equal(t, "There was an error while parsing the base64 content. An incorrect value was provided.", err.ErrorResponse.Error)
 	})
-	k8sResourcesClient.DeleteApplication(appName, &v1.DeleteOptions{})
+	k8sResourcesClient.DeleteApplication(app.Name, &v1.DeleteOptions{})
 }
 
 func TestApiSpec(t *testing.T) {
@@ -277,24 +274,21 @@ func TestCertificateValidation(t *testing.T) {
 
 	gatewayUrlFormat := config.GatewayUrl + "/%s/v1/metadata/services"
 
-	appName := "dummy-app-1"
-	forbiddenAppName := "dummy-app-2"
-
 	k8sResourcesClient, err := testkit.NewK8sResourcesClient()
 	require.NoError(t, err)
-	_, e := k8sResourcesClient.CreateDummyApplication(appName, "", false)
-	require.NoError(t, e)
-	_, e = k8sResourcesClient.CreateDummyApplication(forbiddenAppName, "", false)
-	require.NoError(t, e)
+	testApp, err := k8sResourcesClient.CreateDummyApplication("app-connector-test-1", "", false)
+	require.NoError(t, err)
+	forbiddenApp, err := k8sResourcesClient.CreateDummyApplication("app-connector-test-2", "", false)
+	require.NoError(t, err)
 
-	client := testkit.NewConnectorClient(appName, config.InternalAPIUrl, config.ExternalAPIUrl, config.SkipSslVerify)
+	client := testkit.NewConnectorClient(testApp.Name, config.InternalAPIUrl, config.ExternalAPIUrl, config.SkipSslVerify)
 
 	clientKey := testkit.CreateKey(t)
 	tlsClient := createTLSClientWithCert(t, client, clientKey, config.SkipSslVerify)
 
 	t.Run("should access application", func(t *testing.T) {
 		// when
-		response, err := repeatUntilIngressIsCreated(tlsClient, gatewayUrlFormat, appName)
+		response, err := repeatUntilIngressIsCreated(tlsClient, gatewayUrlFormat, testApp.Name)
 
 		// then
 		require.NoError(t, err)
@@ -303,15 +297,15 @@ func TestCertificateValidation(t *testing.T) {
 
 	t.Run("should receive 403 when accessing RE with invalid CN", func(t *testing.T) {
 		// when
-		response, err := repeatUntilIngressIsCreated(tlsClient, gatewayUrlFormat, forbiddenAppName)
+		response, err := repeatUntilIngressIsCreated(tlsClient, gatewayUrlFormat, forbiddenApp.Name)
 
 		// then
 		require.NoError(t, err)
 		require.Equal(t, StatusForbidden, response.StatusCode)
 	})
 
-	k8sResourcesClient.DeleteApplication(appName, &v1.DeleteOptions{})
-	k8sResourcesClient.DeleteApplication(forbiddenAppName, &v1.DeleteOptions{})
+	k8sResourcesClient.DeleteApplication(testApp.Name, &v1.DeleteOptions{})
+	k8sResourcesClient.DeleteApplication(forbiddenApp.Name, &v1.DeleteOptions{})
 }
 
 func repeatUntilIngressIsCreated(tlsClient *Client, gatewayUrlFormat string, appName string) (*Response, error) {

--- a/tests/connector-service-tests/test/testkit/k8sClient.go
+++ b/tests/connector-service-tests/test/testkit/k8sClient.go
@@ -10,7 +10,7 @@ import (
 )
 
 type K8sResourcesClient interface {
-	CreateDummyApplication(name string, accessLabel string, skipInstallation bool) (*v1alpha1.Application, error)
+	CreateDummyApplication(namePrefix string, accessLabel string, skipInstallation bool) (*v1alpha1.Application, error)
 	DeleteApplication(name string, options *v1.DeleteOptions) error
 }
 type k8sResourcesClient struct {
@@ -54,7 +54,7 @@ func (c *k8sResourcesClient) CreateDummyApplication(namePrefix string, accessLab
 }
 
 func addRandomPostfix(s string) string {
-	return fmt.Sprintf(s + "-%s", rand.String(5))
+	return fmt.Sprintf(s+"-%s", rand.String(5))
 }
 
 func (c *k8sResourcesClient) DeleteApplication(name string, options *v1.DeleteOptions) error {

--- a/tests/connector-service-tests/test/testkit/k8sClient.go
+++ b/tests/connector-service-tests/test/testkit/k8sClient.go
@@ -1,9 +1,11 @@
 package testkit
 
 import (
+	"fmt"
 	"github.com/kyma-project/kyma/components/application-operator/pkg/apis/applicationconnector/v1alpha1"
 	"github.com/kyma-project/kyma/components/application-operator/pkg/client/clientset/versioned"
 	"k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/rand"
 	restclient "k8s.io/client-go/rest"
 )
 
@@ -22,6 +24,7 @@ func NewK8sResourcesClient() (K8sResourcesClient, error) {
 	}
 	return initClient(k8sConfig)
 }
+
 func initClient(k8sConfig *restclient.Config) (K8sResourcesClient, error) {
 	applicationsClientSet, err := versioned.NewForConfig(k8sConfig)
 	if err != nil {
@@ -32,20 +35,26 @@ func initClient(k8sConfig *restclient.Config) (K8sResourcesClient, error) {
 	}, nil
 }
 
-func (c *k8sResourcesClient) CreateDummyApplication(name string, accessLabel string, skipInstallation bool) (*v1alpha1.Application, error) {
+func (c *k8sResourcesClient) CreateDummyApplication(namePrefix string, accessLabel string, skipInstallation bool) (*v1alpha1.Application, error) {
 	spec := v1alpha1.ApplicationSpec{
 		Services:         []v1alpha1.Service{},
 		AccessLabel:      accessLabel,
 		SkipInstallation: skipInstallation,
 	}
 
+	dummyAppName := addRandomPostfix(namePrefix)
+
 	dummyApp := &v1alpha1.Application{
 		TypeMeta:   v1.TypeMeta{Kind: "Application", APIVersion: v1alpha1.SchemeGroupVersion.String()},
-		ObjectMeta: v1.ObjectMeta{Name: name},
+		ObjectMeta: v1.ObjectMeta{Name: dummyAppName},
 		Spec:       spec,
 	}
 
 	return c.applicationsClient.ApplicationconnectorV1alpha1().Applications().Create(dummyApp)
+}
+
+func addRandomPostfix(s string) string {
+	return fmt.Sprintf(s + "-%s", rand.String(5))
 }
 
 func (c *k8sResourcesClient) DeleteApplication(name string, options *v1.DeleteOptions) error {

--- a/tests/connector-service-tests/test/testkit/k8sClient.go
+++ b/tests/connector-service-tests/test/testkit/k8sClient.go
@@ -8,7 +8,7 @@ import (
 )
 
 type K8sResourcesClient interface {
-	CreateDummyApplication(name string, accessLabel string) (*v1alpha1.Application, error)
+	CreateDummyApplication(name string, accessLabel string, skipInstallation bool) (*v1alpha1.Application, error)
 	DeleteApplication(name string, options *v1.DeleteOptions) error
 }
 type k8sResourcesClient struct {
@@ -31,17 +31,23 @@ func initClient(k8sConfig *restclient.Config) (K8sResourcesClient, error) {
 		applicationsClient: applicationsClientSet,
 	}, nil
 }
-func (c *k8sResourcesClient) CreateDummyApplication(name string, accessLabel string) (*v1alpha1.Application, error) {
+
+func (c *k8sResourcesClient) CreateDummyApplication(name string, accessLabel string, skipInstallation bool) (*v1alpha1.Application, error) {
+	spec := v1alpha1.ApplicationSpec{
+		Services:         []v1alpha1.Service{},
+		AccessLabel:      accessLabel,
+		SkipInstallation: skipInstallation,
+	}
+
 	dummyApp := &v1alpha1.Application{
 		TypeMeta:   v1.TypeMeta{Kind: "Application", APIVersion: v1alpha1.SchemeGroupVersion.String()},
 		ObjectMeta: v1.ObjectMeta{Name: name},
-		Spec: v1alpha1.ApplicationSpec{
-			Services:    []v1alpha1.Service{},
-			AccessLabel: accessLabel,
-		},
+		Spec:       spec,
 	}
+
 	return c.applicationsClient.ApplicationconnectorV1alpha1().Applications().Create(dummyApp)
 }
+
 func (c *k8sResourcesClient) DeleteApplication(name string, options *v1.DeleteOptions) error {
 	return c.applicationsClient.ApplicationconnectorV1alpha1().Applications().Delete(name, options)
 }


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Skip Application charts installation in acceptance tests if not needed
- Add random postfix to test App names
- Allow applying finalizers to the App de-provisioning 

**Related issue(s)**

See also #1745 
