### PR TITLE
Fix broken link to Installer

### DIFF
--- a/docs/kyma/docs/048-gs-installation-overrides.md
+++ b/docs/kyma/docs/048-gs-installation-overrides.md
@@ -3,7 +3,7 @@ title: Helm overrides for Kyma installation
 type: Getting Started
 ---
 
-Kyma packages its components into [Helm](https://github.com/helm/helm/tree/master/docs) charts that the [Installer](../../../components/installer/README.md) uses.
+Kyma packages its components into [Helm](https://github.com/helm/helm/tree/master/docs) charts that the [Installer](https://github.com/kyma-project/kyma/tree/master/components/installer) uses.
 This document describes how to configure the Installer with override values for Helm [charts](https://github.com/helm/helm/blob/master/docs/charts.md).
 
 


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Fix broken link to Installer. Relative links from `kyma/docs` to directory other than `docs` are no-no