### PR TITLE
Fix GKE installation with dynamic IPs

### DIFF
--- a/installation/resources/installer-config-cluster.yaml.tpl
+++ b/installation/resources/installer-config-cluster.yaml.tpl
@@ -126,3 +126,4 @@ metadata:
     component: knative
 data:
   knative.ingressgateway.service.type: LoadBalancer
+  knative.domainName: "__DOMAIN__"

--- a/installation/resources/installer-config-cluster.yaml.tpl
+++ b/installation/resources/installer-config-cluster.yaml.tpl
@@ -32,7 +32,6 @@ data:
   global.isLocalEnv: "false"
   global.knative: "false"
   global.domainName: "__DOMAIN__"
-  global.loadBalancerIP: "__EXTERNAL_PUBLIC_IP__"
   global.etcdBackup.containerName: "__ETCD_BACKUP_ABS_CONTAINER_NAME__"
   global.etcdBackup.enabled: "__ENABLE_ETCD_BACKUP__"
   nginx-ingress.controller.service.loadBalancerIP: "__REMOTE_ENV_IP__"
@@ -95,9 +94,8 @@ data:
 
   security.enabled: "true"
 
-  # service type is later changed by isito patch
-  gateways.istio-ingressgateway.service.externalPublicIp: ""
-  gateways.istio-ingressgateway.type: "NodePort"
+  gateways.istio-ingressgateway.service.externalPublicIp: "__EXTERNAL_PUBLIC_IP__"
+  gateways.istio-ingressgateway.type: "LoadBalancer"
 
   pilot.resources.limits.memory: 2Gi
   pilot.resources.requests.memory: 512Mi
@@ -115,3 +113,14 @@ metadata:
     component: service-catalog
 data:
   etcd-stateful.etcd.resources.limits.memory: 512Mi
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: knative-overrides
+  namespace: kyma-installer
+  labels:
+    installer: overrides
+    component: knative
+data:
+  knative.ingressgateway.service.type: LoadBalancer

--- a/installation/resources/installer-config-local.yaml.tpl
+++ b/installation/resources/installer-config-local.yaml.tpl
@@ -95,3 +95,14 @@ metadata:
     component: service-catalog
 data:
   etcd-stateful.etcd.resources.limits.memory: 256Mi
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: knative-overrides
+  namespace: kyma-installer
+  labels:
+    installer: overrides
+    component: knative
+data:
+  knative.ingressgateway.service.type: NodePort

--- a/installation/resources/installer-config-local.yaml.tpl
+++ b/installation/resources/installer-config-local.yaml.tpl
@@ -106,3 +106,4 @@ metadata:
     component: knative
 data:
   knative.ingressgateway.service.type: NodePort
+  knative.domainName: "kyma.local"

--- a/resources/istio-kyma-patch/templates/configmap.yaml
+++ b/resources/istio-kyma-patch/templates/configmap.yaml
@@ -28,21 +28,6 @@ data:
       {{ end }}
     ]
 
-  {{ if .Values.global.loadBalancerIP }}
-  {{ $serviceName }}.service.patch.json: |
-    [
-      {
-        "op": "add",
-        "path": "/spec/loadBalancerIP",
-        "value": "{{ .Values.global.loadBalancerIP }}"
-      },{
-        "op": "replace",
-        "path": "/spec/type",
-        "value": "LoadBalancer"
-      }
-    ]
-  {{ end }}
-
   istio-egressgateway.deployment.patch.json: |
     [
       {

--- a/resources/knative/charts/knative/templates/serving.yaml
+++ b/resources/knative/charts/knative/templates/serving.yaml
@@ -1307,7 +1307,7 @@ metadata:
 ---
 apiVersion: v1
 data:
-  example.com: ""
+  {{ .Values.domainName }}: ""
 kind: ConfigMap
 metadata:
   name: config-domain

--- a/resources/knative/templates/tests/test-serving.yaml
+++ b/resources/knative/templates/tests/test-serving.yaml
@@ -17,7 +17,7 @@ spec:
     - name: INGRESSGATEWAY_ADDRESS
       value: knative-ingressgateway.istio-system.svc.cluster.local
     - name: DOMAIN_NAME
-      value: example.com
+      value: {{ .Values.global.domainName }}
     - name: TARGET
       value: {{ .Values.test.target }}
   restartPolicy: Never

--- a/resources/knative/values.yaml
+++ b/resources/knative/values.yaml
@@ -5,6 +5,7 @@ knative:
   gateway:
     tls:
       enabled: true
+  domainName: example.com
 
 global:
   containerRegistry:

--- a/resources/xip-patch/templates/job.yaml
+++ b/resources/xip-patch/templates/job.yaml
@@ -1,3 +1,4 @@
+{{- $serviceName := .Values.global.knative | ternary "knative-ingressgateway" "istio-ingressgateway" -}}
 apiVersion: batch/v1
 kind: Job
 metadata:
@@ -18,4 +19,6 @@ spec:
         env:
         - name: EXTERNAL_PUBLIC_IP
           value: {{ .Values.global.loadBalancerIP }}
+        - name: INGRESSGATEWAY_SERVICE_NAME
+          value: {{ $serviceName }}
           

--- a/resources/xip-patch/values.yaml
+++ b/resources/xip-patch/values.yaml
@@ -2,4 +2,4 @@ containerRegistry:
   path: eu.gcr.io/kyma-project
 xip_patch:
   dir: develop/
-  version: 7b8717d4
+  version: e9e635ea


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/master/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- istio-ingressgateway and knative-ingressgateway are LoadBalancers in cluster
- knative domain is set during installation
- xip-patch configures domain fo knative-ingressgateway if run with knative
- **knative does not work with EXTERNAL_PUBLIC_IP variable**

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
