### PR TITLE
Disable cache in ui tests

### DIFF
--- a/resources/core/templates/tests/test-ui-acceptance.yaml
+++ b/resources/core/templates/tests/test-ui-acceptance.yaml
@@ -10,8 +10,7 @@ spec:
   hostNetwork: true
   containers:
     - name: "test-{{ template "fullname" . }}-ui-acceptance"
-      # image: {{ .Values.global.containerRegistry.path }}/ui-tests:8c6eeaa2
-      image: eu.gcr.io/kyma-project/pr/ui-tests:PR-466
+      image: {{ .Values.global.containerRegistry.path }}/ui-tests:45f8be26
       imagePullPolicy: IfNotPresent
       resources:
          requests:

--- a/resources/core/templates/tests/test-ui-acceptance.yaml
+++ b/resources/core/templates/tests/test-ui-acceptance.yaml
@@ -10,7 +10,7 @@ spec:
   hostNetwork: true
   containers:
     - name: "test-{{ template "fullname" . }}-ui-acceptance"
-      image: {{ .Values.global.containerRegistry.path }}/ui-tests:45f8be26
+      image: {{ .Values.global.containerRegistry.path }}/ui-tests:1fa33546
       imagePullPolicy: IfNotPresent
       resources:
          requests:

--- a/resources/core/templates/tests/test-ui-acceptance.yaml
+++ b/resources/core/templates/tests/test-ui-acceptance.yaml
@@ -10,7 +10,8 @@ spec:
   hostNetwork: true
   containers:
     - name: "test-{{ template "fullname" . }}-ui-acceptance"
-      image: {{ .Values.global.containerRegistry.path }}/ui-tests:8c6eeaa2
+      # image: {{ .Values.global.containerRegistry.path }}/ui-tests:8c6eeaa2
+      image: eu.gcr.io/kyma-project/pr/ui-tests:PR-466
       imagePullPolicy: IfNotPresent
       resources:
          requests:

--- a/resources/core/templates/tests/test-ui-acceptance.yaml
+++ b/resources/core/templates/tests/test-ui-acceptance.yaml
@@ -10,7 +10,7 @@ spec:
   hostNetwork: true
   containers:
     - name: "test-{{ template "fullname" . }}-ui-acceptance"
-      image: {{ .Values.global.containerRegistry.path }}/ui-tests:1fa33546
+      image: {{ .Values.global.containerRegistry.path }}/ui-tests:6d0a328d
       imagePullPolicy: IfNotPresent
       resources:
          requests:


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Bump console-tests image to disable browser cache for ui tests execution
- Change default navigation timeout to 60 sec.

**Related issue(s)**
https://github.com/kyma-project/console/issues/456
