### PR TITLE
Fix image name of Application Operator tests

### DIFF
--- a/tests/application-operator-tests/Makefile
+++ b/tests/application-operator-tests/Makefile
@@ -1,4 +1,4 @@
-APP_NAME = application-operator-test
+APP_NAME = application-operator-tests
 IMG = $(DOCKER_PUSH_REPOSITORY)$(DOCKER_PUSH_DIRECTORY)/$(APP_NAME)
 TAG = $(DOCKER_TAG)
 


### PR DESCRIPTION

**Description**

Changes proposed in this pull request:

- Fix image name of Application Operator tests

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
