### PR TITLE
Validate minikube.sh, run.sh and installer.sh scripts input parameters

### DIFF
--- a/installation/cmd/run.sh
+++ b/installation/cmd/run.sh
@@ -12,9 +12,14 @@ if [ `uname -s` = "Darwin" ]; then
 fi
 
 function checkInputParameterValue() {
-    if [ -z "$1" ] || [ "${1:0:2}" == "--" ]; then
-        echo "Invalid parameter value:"
-        echo "${1}"
+    if [ -z "${2}" ]; then
+        echo "Value parameter for ${1} is empty"
+        echo "Make sure parameter value is neither empty nor start with two hyphens"
+        exit 1
+    fi
+    if [ "${2:0:2}" == "--" ]; then
+        echo "Invalid parameter value for ${1}:"
+        echo "${2}"
         echo "Make sure parameter value is neither empty nor start with two hyphens"
         exit 1
     fi
@@ -32,13 +37,13 @@ do
             shift # past argument
         ;;
         --cr)
-            checkInputParameterValue "$2"
+            checkInputParameterValue "$1" "$2"
             CR_PATH="$2"
             shift # past argument
             shift # past value
         ;;
         --vm-driver)
-            checkInputParameterValue "$2"
+            checkInputParameterValue "$1" "$2"
             VM_DRIVER="$2"
             shift
             shift

--- a/installation/cmd/run.sh
+++ b/installation/cmd/run.sh
@@ -11,9 +11,18 @@ if [ `uname -s` = "Darwin" ]; then
     VM_DRIVER="hyperkit"
 fi
 
+function checkInputParameterValue() {
+    if [ -z "$1" ] || [ "${1:0:2}" == "--" ]; then
+        echo "Invalid parameter value:"
+        echo "${1}"
+        echo "Make sure parameter value is neither empty nor start with two hyphens"
+    fi
+}
+
 POSITIONAL=()
 while [[ $# -gt 0 ]]
 do
+    
     key="$1"
 
     case ${key} in
@@ -22,11 +31,13 @@ do
             shift # past argument
         ;;
         --cr)
+            checkInputParameterValue "$2"
             CR_PATH="$2"
             shift # past argument
             shift # past value
         ;;
         --vm-driver)
+            checkInputParameterValue "$2"
             VM_DRIVER="$2"
             shift
             shift

--- a/installation/cmd/run.sh
+++ b/installation/cmd/run.sh
@@ -3,7 +3,7 @@
 set -o errexit
 
 CURRENT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-
+SCRIPTS_DIR="${CURRENT_DIR}/../scripts"
 DOMAIN="kyma.local"
 
 VM_DRIVER="virtualbox"
@@ -11,7 +11,7 @@ if [ `uname -s` = "Darwin" ]; then
     VM_DRIVER="hyperkit"
 fi
 
-source $CURRENT_DIR/../scripts/utils.sh
+source $SCRIPTS_DIR/utils.sh
 
 POSITIONAL=()
 while [[ $# -gt 0 ]]
@@ -57,18 +57,18 @@ if [ -n "$KNATIVE" ]; then
 fi
 
 if [[ ! ${SKIP_MINIKUBE_START} ]]; then
-    bash ${CURRENT_DIR}/../scripts/minikube.sh --domain "${DOMAIN}" --vm-driver "${VM_DRIVER}" ${MINIKUBE_EXTRA_ARGS}
+    bash ${SCRIPTS_DIR}/minikube.sh --domain "${DOMAIN}" --vm-driver "${VM_DRIVER}" ${MINIKUBE_EXTRA_ARGS}
 fi
 
-bash ${CURRENT_DIR}/../scripts/build-kyma-installer.sh --vm-driver "${VM_DRIVER}"
+bash ${SCRIPTS_DIR}/build-kyma-installer.sh --vm-driver "${VM_DRIVER}"
 
 if [ -z "$CR_PATH" ]; then
 
     TMPDIR=`mktemp -d "${CURRENT_DIR}/../../temp-XXXXXXXXXX"`
     CR_PATH="${TMPDIR}/installer-cr-local.yaml"
-    bash ${CURRENT_DIR}/../scripts/create-cr.sh --output "${CR_PATH}" --domain "${DOMAIN}"
+    bash ${SCRIPTS_DIR}/create-cr.sh --output "${CR_PATH}" --domain "${DOMAIN}"
 
 fi
 
-bash ${CURRENT_DIR}/../scripts/installer.sh --local --cr "${CR_PATH}" "${KNATIVE}"
+bash ${SCRIPTS_DIR}/installer.sh --local --cr "${CR_PATH}" "${KNATIVE}"
 rm -rf $TMPDIR

--- a/installation/cmd/run.sh
+++ b/installation/cmd/run.sh
@@ -11,19 +11,7 @@ if [ `uname -s` = "Darwin" ]; then
     VM_DRIVER="hyperkit"
 fi
 
-function checkInputParameterValue() {
-    if [ -z "${2}" ]; then
-        echo "Value parameter for ${1} is empty"
-        echo "Make sure parameter value is neither empty nor start with two hyphens"
-        exit 1
-    fi
-    if [ "${2:0:2}" == "--" ]; then
-        echo "Invalid parameter value for ${1}:"
-        echo "${2}"
-        echo "Make sure parameter value is neither empty nor start with two hyphens"
-        exit 1
-    fi
-}
+source $CURRENT_DIR/../scripts/utils.sh
 
 POSITIONAL=()
 while [[ $# -gt 0 ]]

--- a/installation/cmd/run.sh
+++ b/installation/cmd/run.sh
@@ -16,6 +16,7 @@ function checkInputParameterValue() {
         echo "Invalid parameter value:"
         echo "${1}"
         echo "Make sure parameter value is neither empty nor start with two hyphens"
+        exit 1
     fi
 }
 

--- a/installation/scripts/installer.sh
+++ b/installation/scripts/installer.sh
@@ -13,6 +13,7 @@ function checkInputParameterValue() {
         echo "Invalid parameter value:"
         echo "${1}"
         echo "Make sure parameter value is neither empty nor start with two hyphens"
+        exit 1
     fi
 }
 

--- a/installation/scripts/installer.sh
+++ b/installation/scripts/installer.sh
@@ -8,9 +8,18 @@ INSTALLER="${RESOURCES_DIR}/installer.yaml"
 INSTALLER_CONFIG=""
 AZURE_BROKER_CONFIG=""
 
+function checkInputParameterValue() {
+    if [ -z "$1" ] || [ "${1:0:2}" == "--" ]; then
+        echo "Invalid parameter value:"
+        echo "${1}"
+        echo "Make sure parameter value is neither empty nor start with two hyphens"
+    fi
+}
+
 POSITIONAL=()
 while [[ $# -gt 0 ]]
 do
+    
     key="$1"
 
     case ${key} in
@@ -19,6 +28,7 @@ do
             shift
             ;;
         --cr)
+            checkInputParameterValue "$2"
             CR_PATH="$2"
             shift # past argument
             shift # past value

--- a/installation/scripts/installer.sh
+++ b/installation/scripts/installer.sh
@@ -9,9 +9,14 @@ INSTALLER_CONFIG=""
 AZURE_BROKER_CONFIG=""
 
 function checkInputParameterValue() {
-    if [ -z "$1" ] || [ "${1:0:2}" == "--" ]; then
-        echo "Invalid parameter value:"
-        echo "${1}"
+    if [ -z "${2}" ]; then
+        echo "Value parameter for ${1} is empty"
+        echo "Make sure parameter value is neither empty nor start with two hyphens"
+        exit 1
+    fi
+    if [ "${2:0:2}" == "--" ]; then
+        echo "Invalid parameter value for ${1}:"
+        echo "${2}"
         echo "Make sure parameter value is neither empty nor start with two hyphens"
         exit 1
     fi
@@ -29,7 +34,7 @@ do
             shift
             ;;
         --cr)
-            checkInputParameterValue "$2"
+            checkInputParameterValue "$1" "$2"
             CR_PATH="$2"
             shift # past argument
             shift # past value

--- a/installation/scripts/installer.sh
+++ b/installation/scripts/installer.sh
@@ -8,19 +8,7 @@ INSTALLER="${RESOURCES_DIR}/installer.yaml"
 INSTALLER_CONFIG=""
 AZURE_BROKER_CONFIG=""
 
-function checkInputParameterValue() {
-    if [ -z "${2}" ]; then
-        echo "Value parameter for ${1} is empty"
-        echo "Make sure parameter value is neither empty nor start with two hyphens"
-        exit 1
-    fi
-    if [ "${2:0:2}" == "--" ]; then
-        echo "Invalid parameter value for ${1}:"
-        echo "${2}"
-        echo "Make sure parameter value is neither empty nor start with two hyphens"
-        exit 1
-    fi
-}
+source $CURRENT_DIR/utils.sh
 
 POSITIONAL=()
 while [[ $# -gt 0 ]]

--- a/installation/scripts/minikube.sh
+++ b/installation/scripts/minikube.sh
@@ -20,6 +20,7 @@ function checkInputParameterValue() {
         echo "Invalid parameter value:"
         echo "${1}"
         echo "Make sure parameter value is neither empty nor start with two hyphens"
+        exit 1
     fi
 }
 

--- a/installation/scripts/minikube.sh
+++ b/installation/scripts/minikube.sh
@@ -15,20 +15,6 @@ MEMORY=8192
 
 source $CURRENT_DIR/utils.sh
 
-function checkInputParameterValue() {
-    if [ -z "${2}" ]; then
-        echo "Value parameter for ${1} is empty"
-        echo "Make sure parameter value is neither empty nor start with two hyphens"
-        exit 1
-    fi
-    if [ "${2:0:2}" == "--" ]; then
-        echo "Invalid parameter value for ${1}:"
-        echo "${2}"
-        echo "Make sure parameter value is neither empty nor start with two hyphens"
-        exit 1
-    fi
-}
-
 POSITIONAL=()
 while [[ $# -gt 0 ]]
 do

--- a/installation/scripts/minikube.sh
+++ b/installation/scripts/minikube.sh
@@ -15,28 +15,41 @@ MEMORY=8192
 
 source $CURRENT_DIR/utils.sh
 
+function checkInputParameterValue() {
+    if [ -z "$1" ] || [ "${1:0:2}" == "--" ]; then
+        echo "Invalid parameter value:"
+        echo "${1}"
+        echo "Make sure parameter value is neither empty nor start with two hyphens"
+    fi
+}
+
 POSITIONAL=()
 while [[ $# -gt 0 ]]
 do
+
     key="$1"
 
     case ${key} in
         --disk-size)
+            checkInputParameterValue "$2"
             DISK_SIZE=$2
             shift
             shift
             ;;
         --vm-driver)
+            checkInputParameterValue "$2"
             VM_DRIVER="$2"
             shift # past argument
             shift # past value
             ;;
         --memory)
+            checkInputParameterValue "$2"
             MEMORY=$2
             shift
             shift
             ;;
         --domain)
+            checkInputParameterValue "$2"
             MINIKUBE_DOMAIN="$2"
             shift # past argument
             shift # past value

--- a/installation/scripts/minikube.sh
+++ b/installation/scripts/minikube.sh
@@ -16,9 +16,14 @@ MEMORY=8192
 source $CURRENT_DIR/utils.sh
 
 function checkInputParameterValue() {
-    if [ -z "$1" ] || [ "${1:0:2}" == "--" ]; then
-        echo "Invalid parameter value:"
-        echo "${1}"
+    if [ -z "${2}" ]; then
+        echo "Value parameter for ${1} is empty"
+        echo "Make sure parameter value is neither empty nor start with two hyphens"
+        exit 1
+    fi
+    if [ "${2:0:2}" == "--" ]; then
+        echo "Invalid parameter value for ${1}:"
+        echo "${2}"
         echo "Make sure parameter value is neither empty nor start with two hyphens"
         exit 1
     fi
@@ -32,25 +37,25 @@ do
 
     case ${key} in
         --disk-size)
-            checkInputParameterValue "$2"
-            DISK_SIZE=$2
+            checkInputParameterValue "$1" "$2"
+            DISK_SIZE="$2"
             shift
             shift
             ;;
         --vm-driver)
-            checkInputParameterValue "$2"
+            checkInputParameterValue "$1" "$2"
             VM_DRIVER="$2"
             shift # past argument
             shift # past value
             ;;
         --memory)
-            checkInputParameterValue "$2"
-            MEMORY=$2
+            checkInputParameterValue "$1" "$2"
+            MEMORY="$2"
             shift
             shift
             ;;
         --domain)
-            checkInputParameterValue "$2"
+            checkInputParameterValue "$1" "$2"
             MINIKUBE_DOMAIN="$2"
             shift # past argument
             shift # past value

--- a/installation/scripts/utils.sh
+++ b/installation/scripts/utils.sh
@@ -95,3 +95,17 @@ function showFailedResources {
     done
   fi
 }
+
+function checkInputParameterValue() {
+    if [ -z "${2}" ]; then
+        echo "Value parameter for ${1} is empty"
+        echo "Make sure parameter value is neither empty nor start with two hyphens"
+        exit 1
+    fi
+    if [ "${2:0:2}" == "--" ]; then
+        echo "Invalid parameter value for ${1}:"
+        echo "${2}"
+        echo "Make sure parameter value is neither empty nor start with two hyphens"
+        exit 1
+    fi
+}


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/master/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- Scripts listed below will now log error and exit on wrong parameter input:
  - minikube.sh
  - installer.sh
  - run.sh

**Related issue(s)**
#1469
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
