### PR TITLE
disable istio sidecar injection for components explictly

### DIFF
--- a/resources/application-connector/charts/application-broker/templates/deployment.yaml
+++ b/resources/application-connector/charts/application-broker/templates/deployment.yaml
@@ -19,6 +19,8 @@ spec:
       maxUnavailable: 0
   template:
     metadata:
+      annotations:
+        sidecar.istio.io/inject: "false"
       labels:
         app: {{ .Chart.Name }}
         chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"

--- a/resources/application-connector/charts/application-operator/templates/controller.yaml
+++ b/resources/application-connector/charts/application-operator/templates/controller.yaml
@@ -14,6 +14,8 @@ spec:
   serviceName: {{ .Chart.Name }}-service
   template:
     metadata:
+      annotations:
+        sidecar.istio.io/inject: "false"
       labels:
         control-plane: {{ .Chart.Name }}
         controller-tools.k8s.io: "1.0"

--- a/resources/application-connector/charts/application-operator/templates/tests/test-acceptance.yaml
+++ b/resources/application-connector/charts/application-operator/templates/tests/test-acceptance.yaml
@@ -5,6 +5,7 @@ metadata:
   name: {{ .Chart.Name }}-tests
   namespace: {{ .Values.global.namespace }}
   annotations:
+    sidecar.istio.io/inject: "false"
     "helm.sh/hook": test-success
   labels:
     "helm-chart-test": "true"

--- a/resources/application-connector/charts/application-registry/templates/tests/test-acceptance.yaml
+++ b/resources/application-connector/charts/application-registry/templates/tests/test-acceptance.yaml
@@ -5,6 +5,7 @@ metadata:
   name: {{ .Chart.Name }}-tests
   namespace: {{ .Values.global.namespace }}
   annotations:
+    sidecar.istio.io/inject: "false"
     "helm.sh/hook": test-success
   labels:
     "helm-chart-test": "true"

--- a/resources/application-connector/charts/connection-token-handler/templates/deployment.yaml
+++ b/resources/application-connector/charts/connection-token-handler/templates/deployment.yaml
@@ -15,6 +15,8 @@ spec:
       maxUnavailable: 0
   template:
     metadata:
+      annotations:
+        sidecar.istio.io/inject: "false"
       labels:
         app: {{ .Chart.Name }}
         release: {{ .Chart.Name }}

--- a/resources/application-connector/charts/connector-service/templates/tests/test-acceptance.yaml
+++ b/resources/application-connector/charts/connector-service/templates/tests/test-acceptance.yaml
@@ -5,6 +5,7 @@ metadata:
   name: {{ .Chart.Name }}-tests
   namespace: {{ .Values.global.namespace }}
   annotations:
+    sidecar.istio.io/inject: "false"
     "helm.sh/hook": test-success
   labels:
     "helm-chart-test": "true"

--- a/resources/application-connector/charts/nginx-ingress/values.yaml
+++ b/resources/application-connector/charts/nginx-ingress/values.yaml
@@ -129,7 +129,8 @@ controller:
 
   ## Annotations to be added to controller pods
   ##
-  podAnnotations: {}
+  podAnnotations:
+    sidecar.istio.io/inject: "false"
 
   replicaCount: 1
 
@@ -320,7 +321,8 @@ defaultBackend:
 
   ## Annotations to be added to default backend pods
   ##
-  podAnnotations: {}
+  podAnnotations:
+    sidecar.istio.io/inject: "false"
 
   replicaCount: 1
 

--- a/resources/cluster-essentials/charts/pod-preset/templates/controller-manager/stateful-set.yaml
+++ b/resources/cluster-essentials/charts/pod-preset/templates/controller-manager/stateful-set.yaml
@@ -17,6 +17,8 @@ spec:
   serviceName: {{ template "pod-preset.fullname" . }}-controller
   template:
     metadata:
+      annotations:
+        sidecar.istio.io/inject: "false"
       labels:
         app: {{ template "pod-preset.name" . }}-controller
         release: {{ .Release.Name }}

--- a/resources/cluster-essentials/charts/pod-preset/templates/webhook/deploy.yaml
+++ b/resources/cluster-essentials/charts/pod-preset/templates/webhook/deploy.yaml
@@ -17,7 +17,8 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: {{ include (print $.Template.BasePath "/webhook/webhook.yaml") . | sha256sum }}      
+        sidecar.istio.io/inject: "false"
+        checksum/config: {{ include (print $.Template.BasePath "/webhook/webhook.yaml") . | sha256sum }}
       labels:
         app: {{ template "pod-preset.name" . }}-webhook
         release: {{ .Release.Name }}

--- a/resources/core/charts/api-controller/templates/deployment.yaml
+++ b/resources/core/charts/api-controller/templates/deployment.yaml
@@ -5,11 +5,13 @@ metadata:
   name: api-controller
   namespace:  {{ .Release.Namespace }}
   labels:
-    app: api-controller    
+    app: api-controller
 spec:
   replicas: 1
   template:
     metadata:
+      annotations:
+        sidecar.istio.io/inject: "false"
       labels:
         app: api-controller
     spec:

--- a/resources/core/charts/api-controller/templates/tests/test-api-controller.yaml
+++ b/resources/core/charts/api-controller/templates/tests/test-api-controller.yaml
@@ -13,6 +13,7 @@ kind: Pod
 metadata:
   name: test-api-controller-acceptance
   annotations:
+    sidecar.istio.io/inject: "false"
     "helm.sh/hook": test-success
   labels:
     "helm-chart-test": "true"

--- a/resources/core/charts/azure-broker/charts/redis/templates/deployment.yaml
+++ b/resources/core/charts/azure-broker/charts/redis/templates/deployment.yaml
@@ -10,6 +10,8 @@ metadata:
 spec:
   template:
     metadata:
+      annotations:
+        sidecar.istio.io/inject: "false"
       labels:
         app: {{ template "redis.fullname" . }}
     spec:

--- a/resources/core/charts/azure-broker/templates/azure-service-classes-docu.yaml
+++ b/resources/core/charts/azure-broker/templates/azure-service-classes-docu.yaml
@@ -11,6 +11,8 @@ spec:
   template:
     metadata:
       name: {{ template "fullname" . }}-docs
+      annotations:
+        sidecar.istio.io/inject: "false"
       labels:
         inject: docs-upload-config
     spec:

--- a/resources/core/charts/azure-broker/templates/deployment.yaml
+++ b/resources/core/charts/azure-broker/templates/deployment.yaml
@@ -14,6 +14,8 @@ spec:
       app: {{ template "fullname" . }}
   template:
     metadata:
+      annotations:
+        sidecar.istio.io/inject: "false"
       labels:
         app: {{ template "fullname" . }}
         chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"

--- a/resources/core/charts/console/templates/deployment.yaml
+++ b/resources/core/charts/console/templates/deployment.yaml
@@ -11,6 +11,8 @@ spec:
   replicas: {{ .Values.replicaCount }}
   template:
     metadata:
+      annotations:
+        sidecar.istio.io/inject: "false"
       labels:
         app: {{ template "name" . }}
         release: {{ .Release.Name }}

--- a/resources/core/charts/docs/charts/content-ui/templates/deployment.yaml
+++ b/resources/core/charts/docs/charts/content-ui/templates/deployment.yaml
@@ -11,6 +11,8 @@ spec:
   replicas: {{ .Values.replicaCount }}
   template:
     metadata:
+      annotations:
+        sidecar.istio.io/inject: "false"
       labels:
         app: {{ template "name" . }}
         release: {{ .Release.Name }}

--- a/resources/core/charts/docs/charts/documentation/templates/docs-gcp-service-classes.yaml
+++ b/resources/core/charts/docs/charts/documentation/templates/docs-gcp-service-classes.yaml
@@ -11,6 +11,8 @@ spec:
   template:
     metadata:
       name: {{ template "fullname" . }}-docs
+      annotations:
+        sidecar.istio.io/inject: "false"
       labels:
         inject: docs-upload-config
     spec:

--- a/resources/core/charts/docs/charts/documentation/templates/docs-hb-service-classes.yaml
+++ b/resources/core/charts/docs/charts/documentation/templates/docs-hb-service-classes.yaml
@@ -11,6 +11,8 @@ spec:
   template:
     metadata:
       name: {{ template "fullname" . }}-docs
+      annotations:
+        sidecar.istio.io/inject: "false"
       labels:
         inject: docs-upload-config
     spec:

--- a/resources/core/charts/docs/charts/documentation/templates/docs-job.yaml
+++ b/resources/core/charts/docs/charts/documentation/templates/docs-job.yaml
@@ -11,6 +11,8 @@ spec:
   template:
     metadata:
       name: {{ template "fullname" . }}-docs
+      annotations:
+        sidecar.istio.io/inject: "false"
       labels:
         inject: docs-upload-config
     spec:

--- a/resources/core/charts/etcd-operator/templates/backup-deployment.yaml
+++ b/resources/core/charts/etcd-operator/templates/backup-deployment.yaml
@@ -17,6 +17,8 @@ spec:
   template:
     metadata:
       name: {{ template "name" . }}-backup
+      annotations:
+        sidecar.istio.io/inject: "false"
       labels:
         app: {{ template "name" . }}-backup
         release: {{ .Release.Name }}

--- a/resources/core/charts/event-bus/charts/push/templates/deployment.yaml
+++ b/resources/core/charts/event-bus/charts/push/templates/deployment.yaml
@@ -64,7 +64,7 @@ spec:
             - --trace_operation_name={{ .Values.trace.operationName }}
             - --check_events_activation={{ .Values.check.eventsActivation }}
           ports:
-            - name: http 
+            - name: http
               containerPort: {{ .Values.port }}
           livenessProbe:
             httpGet:

--- a/resources/core/charts/event-bus/templates/tests/test-e2e-tester.yaml
+++ b/resources/core/charts/event-bus/templates/tests/test-e2e-tester.yaml
@@ -3,14 +3,14 @@ kind: ServiceAccount
 metadata:
   name:  {{ .Values.e2eTests.nameTester }}
   labels:
-    helm-chart-test: "true"  
+    helm-chart-test: "true"
 ---
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: test-core-event-bus-subs
   labels:
-    helm-chart-test: "true"  
+    helm-chart-test: "true"
 rules:
 - apiGroups: ["eventing.kyma-project.io"]
   resources: ["subscriptions"]
@@ -36,7 +36,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: test-core-event-bus-eas
   labels:
-    helm-chart-test: "true"  
+    helm-chart-test: "true"
 rules:
 - apiGroups: ["applicationconnector.kyma-project.io"]
   resources: ["eventactivations"]
@@ -47,44 +47,44 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: test-core-event-bus-eas
   labels:
-    helm-chart-test: "true"  
+    helm-chart-test: "true"
 subjects:
 - kind: ServiceAccount
   name: {{ .Values.e2eTests.nameTester }}
-  namespace: {{ .Release.Namespace }}   
+  namespace: {{ .Release.Namespace }}
 roleRef:
   kind: ClusterRole
   name: test-core-event-bus-eas
-  apiGroup: rbac.authorization.k8s.io        
+  apiGroup: rbac.authorization.k8s.io
 ---
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: test-core-event-bus-k8s
   labels:
-    helm-chart-test: "true"  
+    helm-chart-test: "true"
 rules:
 - apiGroups: ["apps"]
   resources: ["deployments"]
   verbs: ["*"]
 - apiGroups: [""]
   resources: ["pods", "pods/status", "services"]
-  verbs: ["*"]  
+  verbs: ["*"]
 ---
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: test-core-event-bus-k8s
   labels:
-    helm-chart-test: "true"  
+    helm-chart-test: "true"
 subjects:
 - kind: ServiceAccount
   name: {{ .Values.e2eTests.nameTester }}
-  namespace: {{ .Release.Namespace }}   
+  namespace: {{ .Release.Namespace }}
 roleRef:
   kind: ClusterRole
   name: test-core-event-bus-k8s
-  apiGroup: rbac.authorization.k8s.io        
+  apiGroup: rbac.authorization.k8s.io
 ---
 apiVersion: v1
 kind: Pod
@@ -93,7 +93,7 @@ metadata:
   labels:
     helm-chart-test: "true"
   annotations:
-#    sidecar.istio.io/inject: "true"   # needed if the tester could run with side cars
+    sidecar.istio.io/inject: "false"   # needed if the tester could run with side cars
     helm.sh/hook: test-success
 spec:
   serviceAccount: {{ .Values.e2eTests.nameTester }}

--- a/resources/core/charts/helm-broker/charts/etcd-stateful/templates/03-statefulset.yaml
+++ b/resources/core/charts/helm-broker/charts/etcd-stateful/templates/03-statefulset.yaml
@@ -16,6 +16,8 @@ spec:
   template:
     metadata:
       name: {{ template "etcd-hb-fullname" . }}
+      annotations:
+        sidecar.istio.io/inject: "false"
       labels:
         app: {{ template "etcd-hb-fullname" . }}
         chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
@@ -23,7 +25,7 @@ spec:
         heritage: "{{ .Release.Service }}"
     spec:
       terminationGracePeriodSeconds: 60
-      restartPolicy: Always     
+      restartPolicy: Always
       containers:
       - name: "{{ template "etcd-hb-fullname" . }}"
         image: "{{.Values.etcd.image}}:{{.Values.etcd.imageTag}}"
@@ -154,8 +156,8 @@ spec:
             - /usr/local/bin/etcdctl
             {{ if .Values.etcd.secure }}
             - --endpoints=https://localhost:2379
-            - --cert=/etc/etcdtls/operator/etcd-tls/etcd-client.crt 
-            - --key=/etc/etcdtls/operator/etcd-tls/etcd-client.key 
+            - --cert=/etc/etcdtls/operator/etcd-tls/etcd-client.crt
+            - --key=/etc/etcdtls/operator/etcd-tls/etcd-client.key
             - --cacert=/etc/etcdtls/operator/etcd-tls/etcd-client-ca.crt
             {{ else }}
             - --endpoints=http://localhost:2379
@@ -166,7 +168,7 @@ spec:
           periodSeconds: 15
           timeoutSeconds: 5
           failureThreshold: 3
-        
+
       affinity:
         podAntiAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
@@ -174,7 +176,7 @@ spec:
                 matchExpressions:
                   - key: "app"
                     operator: In
-                    values: 
+                    values:
                     - {{ template "etcd-hb-fullname" . }}
               topologyKey: "kubernetes.io/hostname"
   volumeClaimTemplates:

--- a/resources/core/charts/helm-broker/templates/deploy.yaml
+++ b/resources/core/charts/helm-broker/templates/deploy.yaml
@@ -16,6 +16,8 @@ spec:
     type: Recreate
   template:
     metadata:
+      annotations:
+        sidecar.istio.io/inject: "false"
       labels:
         app: {{ template "fullname" . }}
         chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"

--- a/resources/core/charts/kubeless/charts/lambdas-ui/templates/deployment.yaml
+++ b/resources/core/charts/kubeless/charts/lambdas-ui/templates/deployment.yaml
@@ -11,6 +11,8 @@ spec:
   replicas: {{ .Values.replicaCount }}
   template:
     metadata:
+      annotations:
+        sidecar.istio.io/inject: "false"
       labels:
         app: {{ template "name" . }}
         release: {{ .Release.Name }}

--- a/resources/core/charts/kubeless/templates/kubeless-controller-deployment.yaml
+++ b/resources/core/charts/kubeless/templates/kubeless-controller-deployment.yaml
@@ -17,6 +17,8 @@ spec:
       kubeless: controller
   template:
     metadata:
+      annotations:
+        sidecar.istio.io/inject: "false"
       labels:
         kubeless: controller
         release: {{ .Release.Name }}

--- a/resources/core/charts/kubeless/templates/tests/test-kubeless.yaml
+++ b/resources/core/charts/kubeless/templates/tests/test-kubeless.yaml
@@ -63,6 +63,7 @@ metadata:
   labels:
     helm-chart-test: "true"
   annotations:
+    sidecar.istio.io/inject: "false"
     helm.sh/hook: test-success
 spec:
   serviceAccount: "test-{{ template "fullname" . }}"
@@ -161,6 +162,7 @@ metadata:
   labels:
     helm-chart-test: "true"
   annotations:
+    sidecar.istio.io/inject: "false"
     helm.sh/hook: test-success
 spec:
   serviceAccount: "test-{{ template "fullname" . }}-int"

--- a/resources/core/charts/minio/templates/deployment.yaml
+++ b/resources/core/charts/minio/templates/deployment.yaml
@@ -24,6 +24,8 @@ spec:
   template:
     metadata:
       name: {{ template "minio.fullname" . }}
+      annotations:
+        sidecar.istio.io/inject: "false"
       labels:
         app: {{ template "minio.name" . }}
         release: {{ .Release.Name }}
@@ -36,26 +38,26 @@ spec:
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           {{- if .Values.azuregateway.enabled }}
-          command: [ "/bin/sh", 
-          "-ce", 
-          "cp /tmp/config.json {{ .Values.configPath }} && 
+          command: [ "/bin/sh",
+          "-ce",
+          "cp /tmp/config.json {{ .Values.configPath }} &&
           /usr/bin/docker-entrypoint.sh minio -C {{ .Values.configPath }} gateway azure"]
           {{- else }}
           {{- if .Values.gcsgateway.enabled }}
-          command: [ "/bin/sh", 
-          "-ce", 
-          "cp /tmp/config.json {{ .Values.configPath }} && 
+          command: [ "/bin/sh",
+          "-ce",
+          "cp /tmp/config.json {{ .Values.configPath }} &&
           /usr/bin/docker-entrypoint.sh minio -C {{ .Values.configPath }} gateway gcs {{ .Values.gcsgateway.projectId }}"]
           {{- else }}
           {{- if .Values.nasgateway.enabled }}
-          command: [ "/bin/sh", 
-          "-ce", 
-          "cp /tmp/config.json {{ .Values.configPath }} && 
+          command: [ "/bin/sh",
+          "-ce",
+          "cp /tmp/config.json {{ .Values.configPath }} &&
           /usr/bin/docker-entrypoint.sh minio -C {{ .Values.configPath }} gateway nas {{ .Values.mountPath }}"]
           {{- else }}
-          command: [ "/bin/sh", 
-          "-ce", 
-          "cp /tmp/config.json {{ .Values.configPath }} && 
+          command: [ "/bin/sh",
+          "-ce",
+          "cp /tmp/config.json {{ .Values.configPath }} &&
           /usr/bin/docker-entrypoint.sh minio -C {{ .Values.configPath }} server {{ .Values.mountPath }}" ]
           {{- end }}
           {{- end }}

--- a/resources/core/charts/minio/templates/post-install-create-bucket-job.yaml
+++ b/resources/core/charts/minio/templates/post-install-create-bucket-job.yaml
@@ -15,6 +15,8 @@ metadata:
 spec:
   template:
     metadata:
+      annotations:
+        sidecar.istio.io/inject: "false"
       labels:
         app: {{ template "minio.name" . }}
         release: {{ .Release.Name }}

--- a/resources/core/charts/minio/templates/statefulset.yaml
+++ b/resources/core/charts/minio/templates/statefulset.yaml
@@ -19,6 +19,8 @@ spec:
   template:
     metadata:
       name: {{ template "minio.fullname" . }}
+      annotations:
+        sidecar.istio.io/inject: "false"
       labels:
         app: {{ template "minio.name" . }}
         release: {{ .Release.Name }}
@@ -30,8 +32,8 @@ spec:
         - name: {{ .Chart.Name }}
           image: {{ .Values.image.repository }}:{{ .Values.image.tag }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
-          command: [ "/bin/sh", 
-          "-ce", 
+          command: [ "/bin/sh",
+          "-ce",
           "cp /tmp/config.json {{ .Values.configPath }} &&
           /usr/bin/docker-entrypoint.sh minio -C {{ .Values.configPath }} server
           {{- range $i := until $nodeCount }}

--- a/resources/core/charts/namespace-controller/templates/4-deployment.yaml
+++ b/resources/core/charts/namespace-controller/templates/4-deployment.yaml
@@ -15,6 +15,8 @@ spec:
       maxUnavailable: 0
   template:
     metadata:
+      annotations:
+        sidecar.istio.io/inject: "false"
       labels:
         app: {{ template "name" . }}
         release: {{ .Release.Name }}

--- a/resources/core/charts/namespace-controller/templates/tests/test-namespace-controller.yaml
+++ b/resources/core/charts/namespace-controller/templates/tests/test-namespace-controller.yaml
@@ -39,6 +39,7 @@ kind: Pod
 metadata:
   name: test-{{ template "fullname" . }}
   annotations:
+    sidecar.istio.io/inject: "false"
     "helm.sh/hook": test-success
   labels:
       "helm-chart-test": "true"

--- a/resources/core/charts/service-catalog-addons/charts/brokers-ui/templates/deployment.yaml
+++ b/resources/core/charts/service-catalog-addons/charts/brokers-ui/templates/deployment.yaml
@@ -11,6 +11,8 @@ spec:
   replicas: {{ .Values.replicaCount }}
   template:
     metadata:
+      annotations:
+        sidecar.istio.io/inject: "false"
       labels:
         app: {{ template "name" . }}
         release: {{ .Release.Name }}

--- a/resources/core/charts/service-catalog-addons/charts/catalog-ui/templates/deployment.yaml
+++ b/resources/core/charts/service-catalog-addons/charts/catalog-ui/templates/deployment.yaml
@@ -11,6 +11,8 @@ spec:
   replicas: {{ .Values.replicaCount }}
   template:
     metadata:
+      annotations:
+        sidecar.istio.io/inject: "false"
       labels:
         app: {{ template "name" . }}
         release: {{ .Release.Name }}

--- a/resources/core/charts/service-catalog-addons/charts/instances-ui/templates/deployment.yaml
+++ b/resources/core/charts/service-catalog-addons/charts/instances-ui/templates/deployment.yaml
@@ -11,6 +11,8 @@ spec:
   replicas: {{ .Values.replicaCount }}
   template:
     metadata:
+      annotations:
+        sidecar.istio.io/inject: "false"
       labels:
         app: {{ template "name" . }}
         release: {{ .Release.Name }}

--- a/resources/core/templates/tests/test-core-acceptance.yaml
+++ b/resources/core/templates/tests/test-core-acceptance.yaml
@@ -4,6 +4,7 @@ kind: Pod
 metadata:
   name: test-{{ template "fullname" . }}-acceptance
   annotations:
+    sidecar.istio.io/inject: "false"
     "helm.sh/hook": test-success
   labels:
     "helm-chart-test": "true"

--- a/resources/core/templates/tests/test-ui-acceptance.yaml
+++ b/resources/core/templates/tests/test-ui-acceptance.yaml
@@ -3,6 +3,7 @@ kind: Pod
 metadata:
   name: "test-{{ template "fullname" . }}-ui-acceptance"
   annotations:
+    sidecar.istio.io/inject: "false"
     "helm.sh/hook": test-success
   labels:
     "helm-chart-test": "true"
@@ -37,7 +38,7 @@ spec:
       volumeMounts:
         - name: dex-config
           mountPath: /etc/dex/cfg
-  # Needed for detecting if static user is disabled 
+  # Needed for detecting if static user is disabled
   volumes:
     - name: dex-config
       configMap:
@@ -45,4 +46,4 @@ spec:
         items:
           - key: config.yaml
             path: config.yaml
-  restartPolicy: Never   
+  restartPolicy: Never

--- a/resources/core/templates/tests/test-ui-api-acceptance.yaml
+++ b/resources/core/templates/tests/test-ui-api-acceptance.yaml
@@ -3,6 +3,7 @@ kind: Pod
 metadata:
   name: "test-{{ template "fullname" . }}-ui-api-acceptance"
   annotations:
+    sidecar.istio.io/inject: "false"
     "helm.sh/hook": test-success
   labels:
     "helm-chart-test": "true"
@@ -33,7 +34,7 @@ spec:
       volumeMounts:
         - name: dex-config
           mountPath: /etc/dex/cfg
-  # Needed for detecting if SCI is enabled 
+  # Needed for detecting if SCI is enabled
   volumes:
     - name: dex-config
       configMap:

--- a/resources/dex/templates/dex-deployment.yaml
+++ b/resources/dex/templates/dex-deployment.yaml
@@ -12,8 +12,8 @@ spec:
   template:
     metadata:
     # temp disabled, looks like dex with sidecar have some problems affecting apiserver->dex communication used to verify id_tokens
-      # annotations:
-      #   sidecar.istio.io/inject: "true"
+      annotations:
+        sidecar.istio.io/inject: "false"
       labels:
         app: dex
         chart: {{ .Chart.Name }}-{{ .Chart.Version }}
@@ -42,7 +42,7 @@ spec:
           mountPath: /config/dst
         - name: config-tpl
           mountPath: /config/src
-        
+
       volumes:
       - name: config-tpl
         configMap:

--- a/resources/dex/templates/tests/test-dex-connection.yaml
+++ b/resources/dex/templates/tests/test-dex-connection.yaml
@@ -3,6 +3,7 @@ kind: Pod
 metadata:
   name: "test-{{ template "fullname" . }}-connection-dex"
   annotations:
+    sidecar.istio.io/inject: "false"
     "helm.sh/hook": test-success
   labels:
       "helm-chart-test": "true"

--- a/resources/istio/charts/grafana/templates/create-custom-resources-job.yaml
+++ b/resources/istio/charts/grafana/templates/create-custom-resources-job.yaml
@@ -58,6 +58,8 @@ spec:
   template:
     metadata:
       name: istio-grafana-post-install
+      annotations:
+        sidecar.istio.io/inject: "false"
       labels:
         app: istio-grafana
         release: {{ .Release.Name }}

--- a/resources/istio/charts/security/templates/cleanup-secrets.yaml
+++ b/resources/istio/charts/security/templates/cleanup-secrets.yaml
@@ -80,6 +80,8 @@ spec:
   template:
     metadata:
       name: istio-cleanup-secrets
+      annotations:
+        sidecar.istio.io/inject: "false"
       labels:
         app: {{ template "security.name" . }}
         release: {{ .Release.Name }}

--- a/resources/istio/charts/security/templates/create-custom-resources-job.yaml
+++ b/resources/istio/charts/security/templates/create-custom-resources-job.yaml
@@ -69,6 +69,8 @@ spec:
   template:
     metadata:
       name: istio-security-post-install
+      annotations:
+        sidecar.istio.io/inject: "false"
       labels:
         app: istio-security
         release: {{ .Release.Name }}

--- a/resources/logging/templates/daemonset.yaml
+++ b/resources/logging/templates/daemonset.yaml
@@ -6,6 +6,8 @@ metadata:
 spec:
   template:
     metadata:
+      annotations:
+        sidecar.istio.io/inject: "false"
       labels:
 {{ include "labels.standard" . | indent 8 }}
         component: logspout

--- a/resources/logging/templates/statefulset.yaml
+++ b/resources/logging/templates/statefulset.yaml
@@ -15,8 +15,10 @@ spec:
   template:
     metadata:
       name:  {{ template "name" . }}
+      annotations:
+        sidecar.istio.io/inject: "false"
       labels:
-{{ include "labels.standard" . | indent 8 }}        
+{{ include "labels.standard" . | indent 8 }}
         component: oklog
     spec:
       {{- if .Values.affinity }}

--- a/resources/logging/templates/tests/logging.yaml
+++ b/resources/logging/templates/tests/logging.yaml
@@ -42,6 +42,7 @@ metadata:
   labels:
     helm-chart-test: "true"
   annotations:
+    sidecar.istio.io/inject: "false"
     helm.sh/hook: test-success
 spec:
   serviceAccount: test-{{ template "fullname" . }}

--- a/resources/monitoring/charts/exporter-kube-state/templates/deployment.yaml
+++ b/resources/monitoring/charts/exporter-kube-state/templates/deployment.yaml
@@ -21,6 +21,8 @@ spec:
       app: {{ template "exporter-kube-state.fullname" . }}
   template:
     metadata:
+      annotations:
+        sidecar.istio.io/inject: "false"
       labels:
         app: {{ template "exporter-kube-state.fullname" . }}
         component: kube-state

--- a/resources/monitoring/charts/exporter-node/templates/daemonset.yaml
+++ b/resources/monitoring/charts/exporter-node/templates/daemonset.yaml
@@ -15,6 +15,8 @@ spec:
     type: RollingUpdate
   template:
     metadata:
+      annotations:
+        sidecar.istio.io/inject: "false"
       labels:
         app: {{ template "exporter-node.fullname" . }}
         component: node-exporter

--- a/resources/monitoring/templates/tests/test-kube-prometheus.yaml
+++ b/resources/monitoring/templates/tests/test-kube-prometheus.yaml
@@ -41,6 +41,7 @@ metadata:
   labels:
     helm-chart-test: "true"
   annotations:
+    sidecar.istio.io/inject: "false"
     helm.sh/hook: test-success
 spec:
   serviceAccount: test-{{ template "fullname" . }}

--- a/resources/prometheus-operator/templates/create-servicemonitor-job.yaml
+++ b/resources/prometheus-operator/templates/create-servicemonitor-job.yaml
@@ -13,6 +13,8 @@ metadata:
 spec:
   template:
     metadata:
+      annotations:
+        sidecar.istio.io/inject: "false"
       labels:
         app: {{ template "prometheus-operator.name" . }}
         release: {{ .Release.Name }}
@@ -24,8 +26,8 @@ spec:
           imagePullPolicy: "{{ .Values.global.hyperkube.pullPolicy }}"
           command:
             - ./kubectl
-            - apply 
-            - -f 
+            - apply
+            - -f
             - /tmp/servicemonitor/servicemonitor-operator.yaml
           volumeMounts:
             - mountPath: "/tmp/servicemonitor"

--- a/resources/prometheus-operator/templates/deployment.yaml
+++ b/resources/prometheus-operator/templates/deployment.yaml
@@ -16,6 +16,8 @@ spec:
       maxUnavailable: 0
   template:
     metadata:
+      annotations:
+        sidecar.istio.io/inject: "false"
       labels:
         app: {{ template "prometheus-operator.name" . }}
         operator: prometheus

--- a/resources/prometheus-operator/templates/get-crd-job.yaml
+++ b/resources/prometheus-operator/templates/get-crd-job.yaml
@@ -13,6 +13,8 @@ metadata:
 spec:
   template:
     metadata:
+      annotations:
+        sidecar.istio.io/inject: "false"
       labels:
         app: {{ template "prometheus-operator.name" . }}
         release: {{ .Release.Name }}

--- a/resources/service-catalog/charts/catalog/templates/apiserver-deployment.yaml
+++ b/resources/service-catalog/charts/catalog/templates/apiserver-deployment.yaml
@@ -27,8 +27,9 @@ spec:
         release: "{{ .Release.Name }}"
         releaseRevision: "{{ .Release.Revision }}"
         heritage: "{{ .Release.Service }}"
-      {{ if .Values.apiserver.annotations }}
       annotations:
+        sidecar.istio.io/inject: "false"
+      {{ if .Values.apiserver.annotations }}
 {{ toYaml .Values.apiserver.annotations | indent 8 }}
       {{- end }}
     spec:

--- a/resources/service-catalog/charts/catalog/templates/controller-manager-deployment.yaml
+++ b/resources/service-catalog/charts/catalog/templates/controller-manager-deployment.yaml
@@ -22,6 +22,7 @@ spec:
   template:
     metadata:
       annotations:
+        sidecar.istio.io/inject: "false"
         prometheus.io/scrape: "{{ .Values.controllerManager.enablePrometheusScrape }}"
       {{ if .Values.controllerManager.annotations }}
 {{ toYaml .Values.controllerManager.annotations | indent 8 }}

--- a/resources/service-catalog/charts/etcd-stateful/templates/00-etcd-tls-setup-job.yaml
+++ b/resources/service-catalog/charts/etcd-stateful/templates/00-etcd-tls-setup-job.yaml
@@ -14,6 +14,8 @@ spec:
   template:
     metadata:
       name: "{{ template "etcd-fullname" . }}-job"
+      annotations:
+        sidecar.istio.io/inject: "false"
       labels:
         heritage: {{.Release.Service | quote }}
         release: {{.Release.Name | quote }}

--- a/resources/service-catalog/charts/etcd-stateful/templates/03-statefulset.yaml
+++ b/resources/service-catalog/charts/etcd-stateful/templates/03-statefulset.yaml
@@ -16,6 +16,8 @@ spec:
   template:
     metadata:
       name: {{ template "etcd-fullname" . }}
+      annotations:
+        sidecar.istio.io/inject: "false"
       labels:
         app: {{ template "etcd-fullname" . }}
         chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
@@ -23,7 +25,7 @@ spec:
         heritage: "{{ .Release.Service }}"
     spec:
       terminationGracePeriodSeconds: 60
-      restartPolicy: Always     
+      restartPolicy: Always
       containers:
       - name: "{{ template "etcd-fullname" . }}"
         image: "{{.Values.etcd.image}}:{{.Values.etcd.imageTag}}"
@@ -164,8 +166,8 @@ spec:
             - /usr/local/bin/etcdctl
             {{ if .Values.etcd.secure }}
             - --endpoints=https://localhost:2379
-            - --cert=/etc/etcdtls/operator/etcd-tls/etcd-client.crt 
-            - --key=/etc/etcdtls/operator/etcd-tls/etcd-client.key 
+            - --cert=/etc/etcdtls/operator/etcd-tls/etcd-client.crt
+            - --key=/etc/etcdtls/operator/etcd-tls/etcd-client.key
             - --cacert=/etc/etcdtls/operator/etcd-tls/etcd-client-ca.crt
             {{ else }}
             - --endpoints=http://localhost:2379
@@ -176,7 +178,7 @@ spec:
           periodSeconds: 15
           timeoutSeconds: 5
           failureThreshold: 3
-        
+
       affinity:
         podAntiAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
@@ -184,10 +186,10 @@ spec:
                 matchExpressions:
                   - key: "app"
                     operator: In
-                    values: 
+                    values:
                     - {{ template "etcd-fullname" . }}
               topologyKey: "kubernetes.io/hostname"
-  
+
       volumes:
       - name: member-peer-tls
         secret:

--- a/resources/service-catalog/charts/etcd-stateful/templates/05-backup-job.yaml
+++ b/resources/service-catalog/charts/etcd-stateful/templates/05-backup-job.yaml
@@ -16,6 +16,9 @@ spec:
   jobTemplate:
     spec:
       template:
+        metadata:
+          annotations:
+            sidecar.istio.io/inject: "false"
         spec:
           serviceAccountName: {{ template "etcd-fullname" . }}-backup
           containers:


### PR DESCRIPTION
**Description**

**DO NOT MERGE**

For now, Istio injection is _disabled_ by default.
We plan to switch the default condition to _enabled_.
To ensure everything is working as before, we have to add an annotation to all K8s Pods that would be in the scope of the change.
These are Pods that do not have "sidecar.istio.io/inject" label yet and exist in a namespace labeled with: "istio-injection: enabled"

Pods are created by K8s resources like: Pods (obvious), Deployments, Jobs, StatefulSets, etc - everything that can spawn a Pod.

Changes proposed in this pull request:

- Add `sidecar.istio.io/inject: "false"` to the involved resources.

**Related issue(s)**
See #2072 

