### PR TITLE
Set sidecar injection annotations to false in Application Connector charts

### DIFF
--- a/resources/application-connector/charts/application-broker/templates/deployment.yaml
+++ b/resources/application-connector/charts/application-broker/templates/deployment.yaml
@@ -19,6 +19,8 @@ spec:
       maxUnavailable: 0
   template:
     metadata:
+      annotations:
+        sidecar.istio.io/inject: "false"
       labels:
         app: {{ .Chart.Name }}
         chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"

--- a/resources/application-connector/charts/application-operator/templates/controller.yaml
+++ b/resources/application-connector/charts/application-operator/templates/controller.yaml
@@ -14,6 +14,8 @@ spec:
   serviceName: {{ .Chart.Name }}-service
   template:
     metadata:
+      annotations:
+        sidecar.istio.io/inject: "false"
       labels:
         control-plane: {{ .Chart.Name }}
         controller-tools.k8s.io: "1.0"

--- a/resources/application-connector/charts/application-operator/templates/tests/test-acceptance.yaml
+++ b/resources/application-connector/charts/application-operator/templates/tests/test-acceptance.yaml
@@ -5,6 +5,7 @@ metadata:
   name: {{ .Chart.Name }}-tests
   namespace: {{ .Values.global.namespace }}
   annotations:
+    sidecar.istio.io/inject: "false"
     "helm.sh/hook": test-success
   labels:
     "helm-chart-test": "true"

--- a/resources/application-connector/charts/application-registry/templates/tests/test-acceptance.yaml
+++ b/resources/application-connector/charts/application-registry/templates/tests/test-acceptance.yaml
@@ -5,6 +5,7 @@ metadata:
   name: {{ .Chart.Name }}-tests
   namespace: {{ .Values.global.namespace }}
   annotations:
+    sidecar.istio.io/inject: "false"
     "helm.sh/hook": test-success
   labels:
     "helm-chart-test": "true"

--- a/resources/application-connector/charts/connection-token-handler/templates/deployment.yaml
+++ b/resources/application-connector/charts/connection-token-handler/templates/deployment.yaml
@@ -15,6 +15,8 @@ spec:
       maxUnavailable: 0
   template:
     metadata:
+      annotations:
+        sidecar.istio.io/inject: "false"
       labels:
         app: {{ .Chart.Name }}
         release: {{ .Chart.Name }}

--- a/resources/application-connector/charts/connector-service/templates/tests/test-acceptance.yaml
+++ b/resources/application-connector/charts/connector-service/templates/tests/test-acceptance.yaml
@@ -5,6 +5,7 @@ metadata:
   name: {{ .Chart.Name }}-tests
   namespace: {{ .Values.global.namespace }}
   annotations:
+    sidecar.istio.io/inject: "false"
     "helm.sh/hook": test-success
   labels:
     "helm-chart-test": "true"

--- a/resources/application-connector/charts/nginx-ingress/values.yaml
+++ b/resources/application-connector/charts/nginx-ingress/values.yaml
@@ -129,7 +129,8 @@ controller:
 
   ## Annotations to be added to controller pods
   ##
-  podAnnotations: {}
+  podAnnotations:
+    sidecar.istio.io/inject: "false"
 
   replicaCount: 1
 
@@ -320,7 +321,8 @@ defaultBackend:
 
   ## Annotations to be added to default backend pods
   ##
-  podAnnotations: {}
+  podAnnotations:
+    sidecar.istio.io/inject: "false"
 
   replicaCount: 1
 


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/master/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

For now, Istio injection is disabled by default.
We plan to switch the default condition to enabled.
To ensure everything is working as before, we have to add an annotation to all K8s Pods that would be in the scope of the change.
These are Pods that do not have "sidecar.istio.io/inject" label yet and exist in a namespace labeled with: "istio-injection: enabled"
Pods are created by K8s resources like: Pods (obvious), Deployments, StatefulSets, etc - everything that can spawn a Pod.

Changes proposed in this pull request:

- Add `sidecar.istio.io/inject: "false"` to the involved resources.

**Related issue(s)**
#2072 
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
