### PR TITLE
Set sidecar injection annotations to false in NS-controller, api-controller, azure-broker and dex

### DIFF
--- a/resources/core/charts/api-controller/templates/deployment.yaml
+++ b/resources/core/charts/api-controller/templates/deployment.yaml
@@ -5,11 +5,13 @@ metadata:
   name: api-controller
   namespace:  {{ .Release.Namespace }}
   labels:
-    app: api-controller    
+    app: api-controller
 spec:
   replicas: 1
   template:
     metadata:
+      annotations:
+        sidecar.istio.io/inject: "false"
       labels:
         app: api-controller
     spec:

--- a/resources/core/charts/api-controller/templates/tests/test-account-and-role.yaml
+++ b/resources/core/charts/api-controller/templates/tests/test-account-and-role.yaml
@@ -17,7 +17,7 @@ metadata:
     helm-chart-test: "true"
 rules:
   - apiGroups: [ "", "apps", "gateway.kyma-project.io", "networking.istio.io", "authentication.istio.io"]
-    resources: ["deployments", "services", "apis", "virtualservices", "policies"]
+    resources: ["deployments", "services", "apis", "virtualservices", "policies", "namespaces"]
     verbs: ["*"]
 ---
 kind: ClusterRoleBinding

--- a/resources/core/charts/api-controller/templates/tests/test-account-and-role.yaml
+++ b/resources/core/charts/api-controller/templates/tests/test-account-and-role.yaml
@@ -17,7 +17,7 @@ metadata:
     helm-chart-test: "true"
 rules:
   - apiGroups: [ "", "apps", "gateway.kyma-project.io", "networking.istio.io", "authentication.istio.io"]
-    resources: ["deployments", "services", "apis", "virtualservices", "policies", "namespaces"]
+    resources: ["deployments", "services", "apis", "virtualservices", "policies"]
     verbs: ["*"]
 ---
 kind: ClusterRoleBinding

--- a/resources/core/charts/api-controller/templates/tests/test-api-controller.yaml
+++ b/resources/core/charts/api-controller/templates/tests/test-api-controller.yaml
@@ -1,14 +1,6 @@
 {{- $serviceName := .Values.global.knative | ternary "knative-ingressgateway" "istio-ingressgateway" -}}
 ---
 apiVersion: v1
-kind: Namespace
-metadata:
-  labels:
-    istio-injection: enabled
-    "helm-chart-test": "true"
-  name: {{ .Values.global.api_controller_acceptance_tests.testNamespace }}
----
-apiVersion: v1
 kind: Pod
 metadata:
   name: test-api-controller-acceptance

--- a/resources/core/charts/api-controller/templates/tests/test-api-controller.yaml
+++ b/resources/core/charts/api-controller/templates/tests/test-api-controller.yaml
@@ -1,9 +1,19 @@
 {{- $serviceName := .Values.global.knative | ternary "knative-ingressgateway" "istio-ingressgateway" -}}
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  labels:
+    istio-injection: enabled
+    "helm-chart-test": "true"
+  name: {{ .Values.global.api_controller_acceptance_tests.testNamespace }}
+---
 apiVersion: v1
 kind: Pod
 metadata:
   name: test-api-controller-acceptance
   annotations:
+    sidecar.istio.io/inject: "false"
     "helm.sh/hook": test-success
   labels:
     "helm-chart-test": "true"
@@ -20,3 +30,4 @@ spec:
     - name: NAMESPACE
       value: {{ .Values.global.api_controller_acceptance_tests.testNamespace }}
   restartPolicy: Never
+---

--- a/resources/core/charts/azure-broker/charts/redis/templates/deployment.yaml
+++ b/resources/core/charts/azure-broker/charts/redis/templates/deployment.yaml
@@ -10,6 +10,8 @@ metadata:
 spec:
   template:
     metadata:
+      annotations:
+        sidecar.istio.io/inject: "false"
       labels:
         app: {{ template "redis.fullname" . }}
     spec:

--- a/resources/core/charts/azure-broker/templates/azure-service-classes-docu.yaml
+++ b/resources/core/charts/azure-broker/templates/azure-service-classes-docu.yaml
@@ -11,6 +11,8 @@ spec:
   template:
     metadata:
       name: {{ template "fullname" . }}-docs
+      annotations:
+        sidecar.istio.io/inject: "false"
       labels:
         inject: docs-upload-config
     spec:

--- a/resources/core/charts/azure-broker/templates/deployment.yaml
+++ b/resources/core/charts/azure-broker/templates/deployment.yaml
@@ -14,6 +14,8 @@ spec:
       app: {{ template "fullname" . }}
   template:
     metadata:
+      annotations:
+        sidecar.istio.io/inject: "false"
       labels:
         app: {{ template "fullname" . }}
         chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"

--- a/resources/core/charts/namespace-controller/templates/4-deployment.yaml
+++ b/resources/core/charts/namespace-controller/templates/4-deployment.yaml
@@ -15,6 +15,8 @@ spec:
       maxUnavailable: 0
   template:
     metadata:
+      annotations:
+        sidecar.istio.io/inject: "false"
       labels:
         app: {{ template "name" . }}
         release: {{ .Release.Name }}

--- a/resources/core/charts/namespace-controller/templates/tests/test-namespace-controller.yaml
+++ b/resources/core/charts/namespace-controller/templates/tests/test-namespace-controller.yaml
@@ -39,6 +39,7 @@ kind: Pod
 metadata:
   name: test-{{ template "fullname" . }}
   annotations:
+    sidecar.istio.io/inject: "false"
     "helm.sh/hook": test-success
   labels:
       "helm-chart-test": "true"

--- a/resources/dex/templates/dex-deployment.yaml
+++ b/resources/dex/templates/dex-deployment.yaml
@@ -12,8 +12,8 @@ spec:
   template:
     metadata:
     # temp disabled, looks like dex with sidecar have some problems affecting apiserver->dex communication used to verify id_tokens
-      # annotations:
-      #   sidecar.istio.io/inject: "true"
+      annotations:
+        sidecar.istio.io/inject: "false"
       labels:
         app: dex
         chart: {{ .Chart.Name }}-{{ .Chart.Version }}
@@ -42,7 +42,7 @@ spec:
           mountPath: /config/dst
         - name: config-tpl
           mountPath: /config/src
-        
+
       volumes:
       - name: config-tpl
         configMap:

--- a/resources/dex/templates/tests/test-dex-connection.yaml
+++ b/resources/dex/templates/tests/test-dex-connection.yaml
@@ -3,6 +3,7 @@ kind: Pod
 metadata:
   name: "test-{{ template "fullname" . }}-connection-dex"
   annotations:
+    sidecar.istio.io/inject: "false"
     "helm.sh/hook": test-success
   labels:
       "helm-chart-test": "true"


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/master/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

For now, Istio injection is disabled by default.
We plan to switch the default condition to enabled.
To ensure everything is working as before, we have to add an annotation to all K8s Pods that would be in the scope of the change.
These are Pods that do not have "sidecar.istio.io/inject" label yet and exist in a namespace labeled with: "istio-injection: enabled"
Pods are created by K8s resources like: Pods (obvious), Deployments, StatefulSets, etc - everything that can spawn a Pod.

Changes proposed in this pull request:

- Add `sidecar.istio.io/inject: "false"` to the involved resources.

**Related issue(s)**
#2072 
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
