### PR TITLE
Set sidecar injection to false in service-catalog, cluster-essential, and core charts

### DIFF
--- a/resources/cluster-essentials/charts/pod-preset/templates/controller-manager/stateful-set.yaml
+++ b/resources/cluster-essentials/charts/pod-preset/templates/controller-manager/stateful-set.yaml
@@ -17,6 +17,8 @@ spec:
   serviceName: {{ template "pod-preset.fullname" . }}-controller
   template:
     metadata:
+      annotations:
+        sidecar.istio.io/inject: "false"
       labels:
         app: {{ template "pod-preset.name" . }}-controller
         release: {{ .Release.Name }}

--- a/resources/cluster-essentials/charts/pod-preset/templates/webhook/deploy.yaml
+++ b/resources/cluster-essentials/charts/pod-preset/templates/webhook/deploy.yaml
@@ -17,7 +17,8 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: {{ include (print $.Template.BasePath "/webhook/webhook.yaml") . | sha256sum }}      
+        sidecar.istio.io/inject: "false"
+        checksum/config: {{ include (print $.Template.BasePath "/webhook/webhook.yaml") . | sha256sum }}
       labels:
         app: {{ template "pod-preset.name" . }}-webhook
         release: {{ .Release.Name }}

--- a/resources/core/charts/docs/charts/content-ui/templates/deployment.yaml
+++ b/resources/core/charts/docs/charts/content-ui/templates/deployment.yaml
@@ -11,6 +11,8 @@ spec:
   replicas: {{ .Values.replicaCount }}
   template:
     metadata:
+      annotations:
+        sidecar.istio.io/inject: "false"
       labels:
         app: {{ template "name" . }}
         release: {{ .Release.Name }}

--- a/resources/core/charts/docs/charts/documentation/templates/docs-gcp-service-classes.yaml
+++ b/resources/core/charts/docs/charts/documentation/templates/docs-gcp-service-classes.yaml
@@ -11,6 +11,8 @@ spec:
   template:
     metadata:
       name: {{ template "fullname" . }}-docs
+      annotations:
+        sidecar.istio.io/inject: "false"
       labels:
         inject: docs-upload-config
     spec:

--- a/resources/core/charts/docs/charts/documentation/templates/docs-hb-service-classes.yaml
+++ b/resources/core/charts/docs/charts/documentation/templates/docs-hb-service-classes.yaml
@@ -11,6 +11,8 @@ spec:
   template:
     metadata:
       name: {{ template "fullname" . }}-docs
+      annotations:
+        sidecar.istio.io/inject: "false"
       labels:
         inject: docs-upload-config
     spec:

--- a/resources/core/charts/docs/charts/documentation/templates/docs-job.yaml
+++ b/resources/core/charts/docs/charts/documentation/templates/docs-job.yaml
@@ -11,6 +11,8 @@ spec:
   template:
     metadata:
       name: {{ template "fullname" . }}-docs
+      annotations:
+        sidecar.istio.io/inject: "false"
       labels:
         inject: docs-upload-config
     spec:

--- a/resources/core/charts/etcd-operator/templates/backup-deployment.yaml
+++ b/resources/core/charts/etcd-operator/templates/backup-deployment.yaml
@@ -17,6 +17,8 @@ spec:
   template:
     metadata:
       name: {{ template "name" . }}-backup
+      annotations:
+        sidecar.istio.io/inject: "false"
       labels:
         app: {{ template "name" . }}-backup
         release: {{ .Release.Name }}

--- a/resources/core/charts/helm-broker/charts/etcd-stateful/templates/03-statefulset.yaml
+++ b/resources/core/charts/helm-broker/charts/etcd-stateful/templates/03-statefulset.yaml
@@ -16,6 +16,8 @@ spec:
   template:
     metadata:
       name: {{ template "etcd-hb-fullname" . }}
+      annotations:
+        sidecar.istio.io/inject: "false"
       labels:
         app: {{ template "etcd-hb-fullname" . }}
         chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
@@ -23,7 +25,7 @@ spec:
         heritage: "{{ .Release.Service }}"
     spec:
       terminationGracePeriodSeconds: 60
-      restartPolicy: Always     
+      restartPolicy: Always
       containers:
       - name: "{{ template "etcd-hb-fullname" . }}"
         image: "{{.Values.etcd.image}}:{{.Values.etcd.imageTag}}"
@@ -154,8 +156,8 @@ spec:
             - /usr/local/bin/etcdctl
             {{ if .Values.etcd.secure }}
             - --endpoints=https://localhost:2379
-            - --cert=/etc/etcdtls/operator/etcd-tls/etcd-client.crt 
-            - --key=/etc/etcdtls/operator/etcd-tls/etcd-client.key 
+            - --cert=/etc/etcdtls/operator/etcd-tls/etcd-client.crt
+            - --key=/etc/etcdtls/operator/etcd-tls/etcd-client.key
             - --cacert=/etc/etcdtls/operator/etcd-tls/etcd-client-ca.crt
             {{ else }}
             - --endpoints=http://localhost:2379
@@ -166,7 +168,7 @@ spec:
           periodSeconds: 15
           timeoutSeconds: 5
           failureThreshold: 3
-        
+
       affinity:
         podAntiAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
@@ -174,7 +176,7 @@ spec:
                 matchExpressions:
                   - key: "app"
                     operator: In
-                    values: 
+                    values:
                     - {{ template "etcd-hb-fullname" . }}
               topologyKey: "kubernetes.io/hostname"
   volumeClaimTemplates:

--- a/resources/core/charts/helm-broker/templates/deploy.yaml
+++ b/resources/core/charts/helm-broker/templates/deploy.yaml
@@ -16,6 +16,8 @@ spec:
     type: Recreate
   template:
     metadata:
+      annotations:
+        sidecar.istio.io/inject: "false"
       labels:
         app: {{ template "fullname" . }}
         chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"

--- a/resources/core/charts/service-catalog-addons/charts/brokers-ui/templates/deployment.yaml
+++ b/resources/core/charts/service-catalog-addons/charts/brokers-ui/templates/deployment.yaml
@@ -11,6 +11,8 @@ spec:
   replicas: {{ .Values.replicaCount }}
   template:
     metadata:
+      annotations:
+        sidecar.istio.io/inject: "false"
       labels:
         app: {{ template "name" . }}
         release: {{ .Release.Name }}

--- a/resources/core/templates/tests/test-core-acceptance.yaml
+++ b/resources/core/templates/tests/test-core-acceptance.yaml
@@ -4,6 +4,7 @@ kind: Pod
 metadata:
   name: test-{{ template "fullname" . }}-acceptance
   annotations:
+    sidecar.istio.io/inject: "false"
     "helm.sh/hook": test-success
   labels:
     "helm-chart-test": "true"

--- a/resources/core/templates/tests/test-ui-acceptance.yaml
+++ b/resources/core/templates/tests/test-ui-acceptance.yaml
@@ -3,6 +3,7 @@ kind: Pod
 metadata:
   name: "test-{{ template "fullname" . }}-ui-acceptance"
   annotations:
+    sidecar.istio.io/inject: "false"
     "helm.sh/hook": test-success
   labels:
     "helm-chart-test": "true"
@@ -37,7 +38,7 @@ spec:
       volumeMounts:
         - name: dex-config
           mountPath: /etc/dex/cfg
-  # Needed for detecting if static user is disabled 
+  # Needed for detecting if static user is disabled
   volumes:
     - name: dex-config
       configMap:
@@ -45,4 +46,4 @@ spec:
         items:
           - key: config.yaml
             path: config.yaml
-  restartPolicy: Never   
+  restartPolicy: Never

--- a/resources/core/templates/tests/test-ui-api-acceptance.yaml
+++ b/resources/core/templates/tests/test-ui-api-acceptance.yaml
@@ -3,6 +3,7 @@ kind: Pod
 metadata:
   name: "test-{{ template "fullname" . }}-ui-api-acceptance"
   annotations:
+    sidecar.istio.io/inject: "false"
     "helm.sh/hook": test-success
   labels:
     "helm-chart-test": "true"
@@ -33,7 +34,7 @@ spec:
       volumeMounts:
         - name: dex-config
           mountPath: /etc/dex/cfg
-  # Needed for detecting if SCI is enabled 
+  # Needed for detecting if SCI is enabled
   volumes:
     - name: dex-config
       configMap:

--- a/resources/service-catalog/charts/catalog/templates/apiserver-deployment.yaml
+++ b/resources/service-catalog/charts/catalog/templates/apiserver-deployment.yaml
@@ -27,8 +27,9 @@ spec:
         release: "{{ .Release.Name }}"
         releaseRevision: "{{ .Release.Revision }}"
         heritage: "{{ .Release.Service }}"
-      {{ if .Values.apiserver.annotations }}
       annotations:
+        sidecar.istio.io/inject: "false"
+      {{ if .Values.apiserver.annotations }}
 {{ toYaml .Values.apiserver.annotations | indent 8 }}
       {{- end }}
     spec:

--- a/resources/service-catalog/charts/catalog/templates/controller-manager-deployment.yaml
+++ b/resources/service-catalog/charts/catalog/templates/controller-manager-deployment.yaml
@@ -22,6 +22,7 @@ spec:
   template:
     metadata:
       annotations:
+        sidecar.istio.io/inject: "false"
         prometheus.io/scrape: "{{ .Values.controllerManager.enablePrometheusScrape }}"
       {{ if .Values.controllerManager.annotations }}
 {{ toYaml .Values.controllerManager.annotations | indent 8 }}

--- a/resources/service-catalog/charts/etcd-stateful/templates/00-etcd-tls-setup-job.yaml
+++ b/resources/service-catalog/charts/etcd-stateful/templates/00-etcd-tls-setup-job.yaml
@@ -14,6 +14,8 @@ spec:
   template:
     metadata:
       name: "{{ template "etcd-fullname" . }}-job"
+      annotations:
+        sidecar.istio.io/inject: "false"
       labels:
         heritage: {{.Release.Service | quote }}
         release: {{.Release.Name | quote }}

--- a/resources/service-catalog/charts/etcd-stateful/templates/03-statefulset.yaml
+++ b/resources/service-catalog/charts/etcd-stateful/templates/03-statefulset.yaml
@@ -16,6 +16,8 @@ spec:
   template:
     metadata:
       name: {{ template "etcd-fullname" . }}
+      annotations:
+        sidecar.istio.io/inject: "false"
       labels:
         app: {{ template "etcd-fullname" . }}
         chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
@@ -23,7 +25,7 @@ spec:
         heritage: "{{ .Release.Service }}"
     spec:
       terminationGracePeriodSeconds: 60
-      restartPolicy: Always     
+      restartPolicy: Always
       containers:
       - name: "{{ template "etcd-fullname" . }}"
         image: "{{.Values.etcd.image}}:{{.Values.etcd.imageTag}}"
@@ -164,8 +166,8 @@ spec:
             - /usr/local/bin/etcdctl
             {{ if .Values.etcd.secure }}
             - --endpoints=https://localhost:2379
-            - --cert=/etc/etcdtls/operator/etcd-tls/etcd-client.crt 
-            - --key=/etc/etcdtls/operator/etcd-tls/etcd-client.key 
+            - --cert=/etc/etcdtls/operator/etcd-tls/etcd-client.crt
+            - --key=/etc/etcdtls/operator/etcd-tls/etcd-client.key
             - --cacert=/etc/etcdtls/operator/etcd-tls/etcd-client-ca.crt
             {{ else }}
             - --endpoints=http://localhost:2379
@@ -176,7 +178,7 @@ spec:
           periodSeconds: 15
           timeoutSeconds: 5
           failureThreshold: 3
-        
+
       affinity:
         podAntiAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
@@ -184,10 +186,10 @@ spec:
                 matchExpressions:
                   - key: "app"
                     operator: In
-                    values: 
+                    values:
                     - {{ template "etcd-fullname" . }}
               topologyKey: "kubernetes.io/hostname"
-  
+
       volumes:
       - name: member-peer-tls
         secret:

--- a/resources/service-catalog/charts/etcd-stateful/templates/05-backup-job.yaml
+++ b/resources/service-catalog/charts/etcd-stateful/templates/05-backup-job.yaml
@@ -16,6 +16,9 @@ spec:
   jobTemplate:
     spec:
       template:
+        metadata:
+          annotations:
+            sidecar.istio.io/inject: "false"
         spec:
           serviceAccountName: {{ template "etcd-fullname" . }}-backup
           containers:


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/master/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

For now, Istio injection is disabled by default.
We plan to switch the default condition to enabled.
To ensure everything is working as before, we have to add an annotation to all K8s Pods that would be in the scope of the change.
These are Pods that do not have "sidecar.istio.io/inject" label yet and exist in a namespace labeled with: "istio-injection: enabled"
Pods are created by K8s resources like: Pods (obvious), Deployments, StatefulSets, etc - everything that can spawn a Pod.

Changes proposed in this pull request:

- Add `sidecar.istio.io/inject: "false"` to the involved resources.

**Related issue(s)**
#2072 
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
