### PR TITLE
Set sidecar injection to false in charts

### DIFF
--- a/resources/core/charts/console/templates/deployment.yaml
+++ b/resources/core/charts/console/templates/deployment.yaml
@@ -11,6 +11,8 @@ spec:
   replicas: {{ .Values.replicaCount }}
   template:
     metadata:
+      annotations:
+        sidecar.istio.io/inject: "false"
       labels:
         app: {{ template "name" . }}
         release: {{ .Release.Name }}

--- a/resources/core/charts/event-bus/charts/push/templates/deployment.yaml
+++ b/resources/core/charts/event-bus/charts/push/templates/deployment.yaml
@@ -64,7 +64,7 @@ spec:
             - --trace_operation_name={{ .Values.trace.operationName }}
             - --check_events_activation={{ .Values.check.eventsActivation }}
           ports:
-            - name: http 
+            - name: http
               containerPort: {{ .Values.port }}
           livenessProbe:
             httpGet:

--- a/resources/core/charts/event-bus/templates/tests/test-e2e-tester.yaml
+++ b/resources/core/charts/event-bus/templates/tests/test-e2e-tester.yaml
@@ -3,14 +3,14 @@ kind: ServiceAccount
 metadata:
   name:  {{ .Values.e2eTests.nameTester }}
   labels:
-    helm-chart-test: "true"  
+    helm-chart-test: "true"
 ---
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: test-core-event-bus-subs
   labels:
-    helm-chart-test: "true"  
+    helm-chart-test: "true"
 rules:
 - apiGroups: ["eventing.kyma-project.io"]
   resources: ["subscriptions"]
@@ -36,7 +36,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: test-core-event-bus-eas
   labels:
-    helm-chart-test: "true"  
+    helm-chart-test: "true"
 rules:
 - apiGroups: ["applicationconnector.kyma-project.io"]
   resources: ["eventactivations"]
@@ -47,44 +47,44 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: test-core-event-bus-eas
   labels:
-    helm-chart-test: "true"  
+    helm-chart-test: "true"
 subjects:
 - kind: ServiceAccount
   name: {{ .Values.e2eTests.nameTester }}
-  namespace: {{ .Release.Namespace }}   
+  namespace: {{ .Release.Namespace }}
 roleRef:
   kind: ClusterRole
   name: test-core-event-bus-eas
-  apiGroup: rbac.authorization.k8s.io        
+  apiGroup: rbac.authorization.k8s.io
 ---
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: test-core-event-bus-k8s
   labels:
-    helm-chart-test: "true"  
+    helm-chart-test: "true"
 rules:
 - apiGroups: ["apps"]
   resources: ["deployments"]
   verbs: ["*"]
 - apiGroups: [""]
   resources: ["pods", "pods/status", "services"]
-  verbs: ["*"]  
+  verbs: ["*"]
 ---
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: test-core-event-bus-k8s
   labels:
-    helm-chart-test: "true"  
+    helm-chart-test: "true"
 subjects:
 - kind: ServiceAccount
   name: {{ .Values.e2eTests.nameTester }}
-  namespace: {{ .Release.Namespace }}   
+  namespace: {{ .Release.Namespace }}
 roleRef:
   kind: ClusterRole
   name: test-core-event-bus-k8s
-  apiGroup: rbac.authorization.k8s.io        
+  apiGroup: rbac.authorization.k8s.io
 ---
 apiVersion: v1
 kind: Pod
@@ -93,7 +93,7 @@ metadata:
   labels:
     helm-chart-test: "true"
   annotations:
-#    sidecar.istio.io/inject: "true"   # needed if the tester could run with side cars
+    sidecar.istio.io/inject: "false"   # needed if the tester could run with side cars
     helm.sh/hook: test-success
 spec:
   serviceAccount: {{ .Values.e2eTests.nameTester }}

--- a/resources/core/charts/kubeless/charts/lambdas-ui/templates/deployment.yaml
+++ b/resources/core/charts/kubeless/charts/lambdas-ui/templates/deployment.yaml
@@ -11,6 +11,8 @@ spec:
   replicas: {{ .Values.replicaCount }}
   template:
     metadata:
+      annotations:
+        sidecar.istio.io/inject: "false"
       labels:
         app: {{ template "name" . }}
         release: {{ .Release.Name }}

--- a/resources/core/charts/kubeless/templates/kubeless-controller-deployment.yaml
+++ b/resources/core/charts/kubeless/templates/kubeless-controller-deployment.yaml
@@ -17,6 +17,8 @@ spec:
       kubeless: controller
   template:
     metadata:
+      annotations:
+        sidecar.istio.io/inject: "false"
       labels:
         kubeless: controller
         release: {{ .Release.Name }}

--- a/resources/core/charts/kubeless/templates/tests/test-kubeless.yaml
+++ b/resources/core/charts/kubeless/templates/tests/test-kubeless.yaml
@@ -63,6 +63,7 @@ metadata:
   labels:
     helm-chart-test: "true"
   annotations:
+    sidecar.istio.io/inject: "false"
     helm.sh/hook: test-success
 spec:
   serviceAccount: "test-{{ template "fullname" . }}"
@@ -161,6 +162,7 @@ metadata:
   labels:
     helm-chart-test: "true"
   annotations:
+    sidecar.istio.io/inject: "false"
     helm.sh/hook: test-success
 spec:
   serviceAccount: "test-{{ template "fullname" . }}-int"

--- a/resources/core/charts/minio/templates/deployment.yaml
+++ b/resources/core/charts/minio/templates/deployment.yaml
@@ -24,6 +24,8 @@ spec:
   template:
     metadata:
       name: {{ template "minio.fullname" . }}
+      annotations:
+        sidecar.istio.io/inject: "false"
       labels:
         app: {{ template "minio.name" . }}
         release: {{ .Release.Name }}
@@ -36,26 +38,26 @@ spec:
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           {{- if .Values.azuregateway.enabled }}
-          command: [ "/bin/sh", 
-          "-ce", 
-          "cp /tmp/config.json {{ .Values.configPath }} && 
+          command: [ "/bin/sh",
+          "-ce",
+          "cp /tmp/config.json {{ .Values.configPath }} &&
           /usr/bin/docker-entrypoint.sh minio -C {{ .Values.configPath }} gateway azure"]
           {{- else }}
           {{- if .Values.gcsgateway.enabled }}
-          command: [ "/bin/sh", 
-          "-ce", 
-          "cp /tmp/config.json {{ .Values.configPath }} && 
+          command: [ "/bin/sh",
+          "-ce",
+          "cp /tmp/config.json {{ .Values.configPath }} &&
           /usr/bin/docker-entrypoint.sh minio -C {{ .Values.configPath }} gateway gcs {{ .Values.gcsgateway.projectId }}"]
           {{- else }}
           {{- if .Values.nasgateway.enabled }}
-          command: [ "/bin/sh", 
-          "-ce", 
-          "cp /tmp/config.json {{ .Values.configPath }} && 
+          command: [ "/bin/sh",
+          "-ce",
+          "cp /tmp/config.json {{ .Values.configPath }} &&
           /usr/bin/docker-entrypoint.sh minio -C {{ .Values.configPath }} gateway nas {{ .Values.mountPath }}"]
           {{- else }}
-          command: [ "/bin/sh", 
-          "-ce", 
-          "cp /tmp/config.json {{ .Values.configPath }} && 
+          command: [ "/bin/sh",
+          "-ce",
+          "cp /tmp/config.json {{ .Values.configPath }} &&
           /usr/bin/docker-entrypoint.sh minio -C {{ .Values.configPath }} server {{ .Values.mountPath }}" ]
           {{- end }}
           {{- end }}

--- a/resources/core/charts/minio/templates/post-install-create-bucket-job.yaml
+++ b/resources/core/charts/minio/templates/post-install-create-bucket-job.yaml
@@ -15,6 +15,8 @@ metadata:
 spec:
   template:
     metadata:
+      annotations:
+        sidecar.istio.io/inject: "false"
       labels:
         app: {{ template "minio.name" . }}
         release: {{ .Release.Name }}

--- a/resources/core/charts/minio/templates/statefulset.yaml
+++ b/resources/core/charts/minio/templates/statefulset.yaml
@@ -19,6 +19,8 @@ spec:
   template:
     metadata:
       name: {{ template "minio.fullname" . }}
+      annotations:
+        sidecar.istio.io/inject: "false"
       labels:
         app: {{ template "minio.name" . }}
         release: {{ .Release.Name }}
@@ -30,8 +32,8 @@ spec:
         - name: {{ .Chart.Name }}
           image: {{ .Values.image.repository }}:{{ .Values.image.tag }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
-          command: [ "/bin/sh", 
-          "-ce", 
+          command: [ "/bin/sh",
+          "-ce",
           "cp /tmp/config.json {{ .Values.configPath }} &&
           /usr/bin/docker-entrypoint.sh minio -C {{ .Values.configPath }} server
           {{- range $i := until $nodeCount }}

--- a/resources/core/charts/service-catalog-addons/charts/catalog-ui/templates/deployment.yaml
+++ b/resources/core/charts/service-catalog-addons/charts/catalog-ui/templates/deployment.yaml
@@ -11,6 +11,8 @@ spec:
   replicas: {{ .Values.replicaCount }}
   template:
     metadata:
+      annotations:
+        sidecar.istio.io/inject: "false"
       labels:
         app: {{ template "name" . }}
         release: {{ .Release.Name }}

--- a/resources/core/charts/service-catalog-addons/charts/instances-ui/templates/deployment.yaml
+++ b/resources/core/charts/service-catalog-addons/charts/instances-ui/templates/deployment.yaml
@@ -11,6 +11,8 @@ spec:
   replicas: {{ .Values.replicaCount }}
   template:
     metadata:
+      annotations:
+        sidecar.istio.io/inject: "false"
       labels:
         app: {{ template "name" . }}
         release: {{ .Release.Name }}

--- a/resources/logging/templates/daemonset.yaml
+++ b/resources/logging/templates/daemonset.yaml
@@ -6,6 +6,8 @@ metadata:
 spec:
   template:
     metadata:
+      annotations:
+        sidecar.istio.io/inject: "false"
       labels:
 {{ include "labels.standard" . | indent 8 }}
         component: logspout

--- a/resources/logging/templates/statefulset.yaml
+++ b/resources/logging/templates/statefulset.yaml
@@ -15,8 +15,10 @@ spec:
   template:
     metadata:
       name:  {{ template "name" . }}
+      annotations:
+        sidecar.istio.io/inject: "false"
       labels:
-{{ include "labels.standard" . | indent 8 }}        
+{{ include "labels.standard" . | indent 8 }}
         component: oklog
     spec:
       {{- if .Values.affinity }}

--- a/resources/logging/templates/tests/logging.yaml
+++ b/resources/logging/templates/tests/logging.yaml
@@ -42,6 +42,7 @@ metadata:
   labels:
     helm-chart-test: "true"
   annotations:
+    sidecar.istio.io/inject: "false"
     helm.sh/hook: test-success
 spec:
   serviceAccount: test-{{ template "fullname" . }}

--- a/resources/monitoring/charts/exporter-kube-state/templates/deployment.yaml
+++ b/resources/monitoring/charts/exporter-kube-state/templates/deployment.yaml
@@ -21,6 +21,8 @@ spec:
       app: {{ template "exporter-kube-state.fullname" . }}
   template:
     metadata:
+      annotations:
+        sidecar.istio.io/inject: "false"
       labels:
         app: {{ template "exporter-kube-state.fullname" . }}
         component: kube-state

--- a/resources/monitoring/charts/exporter-node/templates/daemonset.yaml
+++ b/resources/monitoring/charts/exporter-node/templates/daemonset.yaml
@@ -15,6 +15,8 @@ spec:
     type: RollingUpdate
   template:
     metadata:
+      annotations:
+        sidecar.istio.io/inject: "false"
       labels:
         app: {{ template "exporter-node.fullname" . }}
         component: node-exporter

--- a/resources/monitoring/templates/tests/test-kube-prometheus.yaml
+++ b/resources/monitoring/templates/tests/test-kube-prometheus.yaml
@@ -41,6 +41,7 @@ metadata:
   labels:
     helm-chart-test: "true"
   annotations:
+    sidecar.istio.io/inject: "false"
     helm.sh/hook: test-success
 spec:
   serviceAccount: test-{{ template "fullname" . }}

--- a/resources/prometheus-operator/templates/create-servicemonitor-job.yaml
+++ b/resources/prometheus-operator/templates/create-servicemonitor-job.yaml
@@ -13,6 +13,8 @@ metadata:
 spec:
   template:
     metadata:
+      annotations:
+        sidecar.istio.io/inject: "false"
       labels:
         app: {{ template "prometheus-operator.name" . }}
         release: {{ .Release.Name }}
@@ -24,8 +26,8 @@ spec:
           imagePullPolicy: "{{ .Values.global.hyperkube.pullPolicy }}"
           command:
             - ./kubectl
-            - apply 
-            - -f 
+            - apply
+            - -f
             - /tmp/servicemonitor/servicemonitor-operator.yaml
           volumeMounts:
             - mountPath: "/tmp/servicemonitor"

--- a/resources/prometheus-operator/templates/deployment.yaml
+++ b/resources/prometheus-operator/templates/deployment.yaml
@@ -16,6 +16,8 @@ spec:
       maxUnavailable: 0
   template:
     metadata:
+      annotations:
+        sidecar.istio.io/inject: "false"
       labels:
         app: {{ template "prometheus-operator.name" . }}
         operator: prometheus

--- a/resources/prometheus-operator/templates/get-crd-job.yaml
+++ b/resources/prometheus-operator/templates/get-crd-job.yaml
@@ -13,6 +13,8 @@ metadata:
 spec:
   template:
     metadata:
+      annotations:
+        sidecar.istio.io/inject: "false"
       labels:
         app: {{ template "prometheus-operator.name" . }}
         release: {{ .Release.Name }}


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/master/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

For now, Istio injection is disabled by default.
We plan to switch the default condition to enabled.
To ensure everything is working as before, we have to add an annotation to all K8s Pods that would be in the scope of the change.
These are Pods that do not have "sidecar.istio.io/inject" label yet and exist in a namespace labeled with: "istio-injection: enabled"
Pods are created by K8s resources like: Pods (obvious), Deployments, Jobs, StatefulSets, etc - everything that can spawn a Pod.

Changes proposed in this pull request:

- Add `sidecar.istio.io/inject: "false"` to the involved resources.

**Related issue(s)**
#2072 
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->