### PR TITLE
Add a generic PVC rule for system namespaces

### DIFF
--- a/resources/logging/charts/logging-alerts/templates/logging-component-rules.yaml
+++ b/resources/logging/charts/logging-alerts/templates/logging-component-rules.yaml
@@ -2,16 +2,8 @@
 groups:
 - name: logging-component
   rules:
-  - alert: OKLogDataVolumeUsageIsHigh
-    expr: kubelet_volume_stats_used_bytes{namespace="kube-system",persistentvolumeclaim="data-core-logging-oklog-0"} / kubelet_volume_stats_available_bytes{namespace="kube-system",persistentvolumeclaim="data-core-logging-oklog-0"} * 100 > 80
-    for: 10m
-    labels:
-      severity: critical
-    annotations:
-      description: PVC {{`{{$labels.namespace}}`}}/{{`{{$labels.persistentvolumeclaim}}`}} is using {{`{{$value}}`}} % of the available volume
-      summary: "PVC core-logging usage is high"
   - alert: OKLogPodMemoryUsageIsHigh
-    expr: container_memory_usage_bytes{namespace="kyma-system",pod_name="core-logging-oklog-0", container_name="oklog"} / container_spec_memory_limit_bytes{namespace="kyma-system", pod_name="core-logging-oklog-0", container_name="oklog"} * 100 > 90
+    expr: container_memory_usage_bytes{namespace="kyma-system",pod_name="logging-oklog-0", container_name="oklog"} / container_spec_memory_limit_bytes{namespace="kyma-system", pod_name="logging-oklog-0", container_name="oklog"} * 100 > 90
     for: 10m
     labels:
       severity: critical
@@ -19,7 +11,7 @@ groups:
       description: Pod {{`{{$labels.namespace}}`}}/{{`{{$labels.pod_name}}`}} is using {{`{{$value}}`}} % of the available memory.
       summary: "OK Log pod memory usage is high"
   - alert: LogspoutPodMemoryUsageIsHigh
-    expr: container_memory_usage_bytes{namespace="kyma-system", pod_name=~"core-logging-logspout(.*)",container_name="logspout"} / container_spec_memory_limit_bytes{namespace="kyma-system", pod_name=~"core-logging-logspout(.*)",container_name="logspout"} * 100 > 90
+    expr: container_memory_usage_bytes{namespace="kyma-system", pod_name=~"logging-logspout(.*)",container_name="logspout"} / container_spec_memory_limit_bytes{namespace="kyma-system", pod_name=~"logging-logspout(.*)",container_name="logspout"} * 100 > 90
     for: 10m
     labels:
       severity: critical
@@ -27,7 +19,7 @@ groups:
       description: Pod {{`{{$labels.namespace}}`}}/{{`{{$labels.pod_name}}`}} is using {{`{{$value}}`}} % of the available volume.
       summary: "LogSpout memory usage is high"
   - alert: LogspoutDaemonSetRolloutStuck
-    expr: kube_daemonset_status_number_ready{daemonset="core-logging-logspout",namespace="kyma-system"}/kube_daemonset_status_desired_number_scheduled{daemonset="core-logging-logspout",namespace="kyma-system"} * 100 < 100
+    expr: kube_daemonset_status_number_ready{daemonset="logging-logspout",namespace="kyma-system"}/kube_daemonset_status_desired_number_scheduled{daemonset="logging-logspout",namespace="kyma-system"} * 100 < 100
     for: 30m
     labels:
       severity: critical

--- a/resources/monitoring/charts/alert-rules/README.md
+++ b/resources/monitoring/charts/alert-rules/README.md
@@ -96,6 +96,10 @@ Resource metrics such as **cpu and memory** are also served by kube-state-metric
 - kube_pod_container_resource_requests_nvidia_gpu_devices
 - kube_pod_container_resource_limits_nvidia_gpu_devices
 
+### Monitoring Persistent volume claims
+Under the **data. alert.rules**, there is a configuration of the [pvc-rules.yaml](templates/pvc-rules.yaml) file, which creates a rule for alerting when a PVC(Persistent Volume Claim) in any of the system namespace(`kyma-system`, `kyma-integration`, `heptio-ark`, `istio-system`, `kube-public` or `kube-system`) is more than **90%** filled up. In such a case its recommended to increase the capacity of the PVCs.
+
+
 ### Configure Alertmanager
 
 In Kyma all the configuration related to the Alertmanager is in the chart [alertmanager](../alertmanager/README.md)

--- a/resources/monitoring/charts/alert-rules/README.md
+++ b/resources/monitoring/charts/alert-rules/README.md
@@ -96,8 +96,8 @@ Resource metrics such as **cpu and memory** are also served by kube-state-metric
 - kube_pod_container_resource_requests_nvidia_gpu_devices
 - kube_pod_container_resource_limits_nvidia_gpu_devices
 
-### Monitoring Persistent volume claims
-Under the **data. alert.rules**, there is a configuration of the [pvc-rules.yaml](templates/pvc-rules.yaml) file, which creates a rule for alerting when a PVC(Persistent Volume Claim) in any of the system namespace(`kyma-system`, `kyma-integration`, `heptio-ark`, `istio-system`, `kube-public` or `kube-system`) is more than **90%** filled up. In such a case its recommended to increase the capacity of the PVCs.
+### Monitoring Persistent Volume Claims
+The [pvc-rules.yaml](templates/pvc-rules.yaml) configuration, located under the **data.alert.rules** parameter, specifes an alerting rule for the `PersistentVolumeClaim` (PVC). The Alertmanager triggers the rule when PVC in any of the system Namespaces such as `kyma-system`, `kyma-integration`, `heptio-ark`, `istio-system`, `kube-public` or `kube-system` exceeds  90%. In such a case, increase the capacity of PVCs.
 
 
 ### Configure Alertmanager

--- a/resources/monitoring/charts/alert-rules/templates/alert-rules-configmap.yaml
+++ b/resources/monitoring/charts/alert-rules/templates/alert-rules-configmap.yaml
@@ -19,4 +19,5 @@ data:
 {{ else }}
   alert.rules: |-
     {{- include "unhealthy-pods-rules.yaml.tpl" . | indent 4}}
+    {{- include "pvc-90-percent-full-rule.yaml.tpl" . | indent 4}}
 {{ end }}

--- a/resources/monitoring/charts/alert-rules/templates/pvc-rules.yaml
+++ b/resources/monitoring/charts/alert-rules/templates/pvc-rules.yaml
@@ -1,0 +1,13 @@
+{{ define "pvc-90-percent-full-rule.yaml.tpl"}}
+groups:
+- name: pvc-90-percent-full-rule
+  rules:
+  - alert: PVC90PercentFull
+    expr: kubelet_volume_stats_used_bytes{namespace="kube-system",exported_namespace=~"kyma-.*|kube-.*|istio-.*|heptio-ark" } / kubelet_volume_stats_available_bytes{namespace="kube-system",exported_namespace=~"kyma-.*|kube-.*|istio-.*|heptio-ark"} * 100 > 90
+    for: 10m
+    labels:
+      severity: critical
+    annotations:
+      description:  "PVC {{`{{$labels.namespace}}`}}/{{`{{$labels.persistentvolumeclaim}}`}} is using {{`{{$value}}`}} % of the available volume"
+      summary: "PVC {{`{{$labels.namespace}}`}}/{{`{{$labels.persistentvolumeclaim}}`}} is using {{`{{$value}}`}} % of the available volume"
+{{ end }}

--- a/resources/monitoring/charts/alert-rules/templates/pvc-rules.yaml
+++ b/resources/monitoring/charts/alert-rules/templates/pvc-rules.yaml
@@ -8,6 +8,6 @@ groups:
     labels:
       severity: critical
     annotations:
-      description:  "PVC {{`{{$labels.namespace}}`}}/{{`{{$labels.persistentvolumeclaim}}`}} is using {{`{{$value}}`}} % of the available volume"
-      summary: "PVC {{`{{$labels.namespace}}`}}/{{`{{$labels.persistentvolumeclaim}}`}} is using {{`{{$value}}`}} % of the available volume"
+      description:  "PVC {{`{{$labels.exported_namespace}}`}}/{{`{{$labels.persistentvolumeclaim}}`}} is using {{`{{$value}}`}} % of the available volume"
+      summary: "PVC {{`{{$labels.exported_namespace}}`}}/{{`{{$labels.persistentvolumeclaim}}`}} is using {{`{{$value}}`}} % of the available volume"
 {{ end }}


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/master/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**
Generic PVC rule for alert manager
Changes proposed in this pull request:
 - We should have generic PVC rule for all the system namespaces and alert when usage is > 90.
 - Also fix the logging alert rules.

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
Fixes: #1818 
