### PR TITLE
Use bundles repo 0.3.0

### DIFF
--- a/resources/core/charts/helm-broker/values.yaml
+++ b/resources/core/charts/helm-broker/values.yaml
@@ -10,7 +10,7 @@ service:
 
 repository:
   # semicolon separated repository URLs
-  URLs: "https://github.com/kyma-project/bundles/releases/download/0.2.0/"
+  URLs: "https://github.com/kyma-project/bundles/releases/download/0.3.0/"
 
 config:
   storage:


### PR DESCRIPTION

**Description**

Changes proposed in this pull request:
- use Helm Broker Bundles repo with version 0.3.0

