### PR TITLE
Fix test for multi dex providers

### DIFF
--- a/resources/core/values.yaml
+++ b/resources/core/values.yaml
@@ -16,8 +16,8 @@ global:
     enabled: false
     secretName: etcd-backup-abs-credentials
   acceptance_tests:
-    dir: pr/
-    version: PR-2457
+    dir: develop/
+    version: 501c4fe5
   alpine_net:
     dir: develop/
     version: ed568f0f
@@ -71,8 +71,8 @@ global:
     dir: develop/
     version: 0b8409ea
   ui_api_layer_acceptance_tests:
-    dir: pr/
-    version: PR-2457
+    dir: develop/
+    version: 0b8409ea
 
 test:
   acceptance:

--- a/resources/core/values.yaml
+++ b/resources/core/values.yaml
@@ -16,8 +16,8 @@ global:
     enabled: false
     secretName: etcd-backup-abs-credentials
   acceptance_tests:
-    dir: develop/
-    version: 501c4fe5
+    dir: pr/
+    version: PR-2457
   alpine_net:
     dir: develop/
     version: ed568f0f
@@ -71,8 +71,8 @@ global:
     dir: develop/
     version: 0b8409ea
   ui_api_layer_acceptance_tests:
-    dir: develop/
-    version: 0b8409ea
+    dir: pr/
+    version: PR-2457
 
 test:
   acceptance:

--- a/tests/acceptance/Gopkg.lock
+++ b/tests/acceptance/Gopkg.lock
@@ -217,6 +217,8 @@
   name = "golang.org/x/net"
   packages = [
     "context",
+    "html",
+    "html/atom",
     "http2",
     "http2/hpack",
     "idna",
@@ -434,6 +436,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "478e205b2f315b259a8cc1efbeff1223e85c39b5548add812269b6b39822ee44"
+  inputs-digest = "5f8a077a92d1961e0a83bac4c5b864ec0d3749f004fcf723c18404312ea5e73d"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/tests/acceptance/dex/idtokenprovider.go
+++ b/tests/acceptance/dex/idtokenprovider.go
@@ -2,13 +2,14 @@ package dex
 
 import (
 	"fmt"
-	"github.com/pkg/errors"
 	"io"
 	"io/ioutil"
 	"net/http"
 	"net/url"
 	"regexp"
 	"strings"
+
+	"github.com/pkg/errors"
 
 	"log"
 

--- a/tests/acceptance/dex/idtokenprovider.go
+++ b/tests/acceptance/dex/idtokenprovider.go
@@ -4,15 +4,13 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
+	"log"
 	"net/http"
 	"net/url"
 	"regexp"
 	"strings"
 
 	"github.com/pkg/errors"
-
-	"log"
-
 	"golang.org/x/net/html"
 )
 
@@ -50,8 +48,12 @@ func (p *dexIdTokenProvider) implicitFlow() (map[string]string, error) {
 	if err != nil {
 		return nil, err
 	}
-	if authorizeResp.StatusCode < 200 || authorizeResp.StatusCode > 399 {
-		return nil, errors.New(fmt.Sprintf("Authorize - response error: '%s' - %s", authorizeResp.Status, readRespBody(authorizeResp)))
+
+	switch authorizeResp.StatusCode {
+	case http.StatusFound:
+	case http.StatusOK:
+	default:
+		return nil, fmt.Errorf("got unexpected response on authorize: %d - %s", authorizeResp.StatusCode, readRespBody(authorizeResp))
 	}
 
 	// /auth/local?req=qruhpy2cqjvv4hcrbuu44mf4v

--- a/tests/acceptance/dex/idtokenprovider.go
+++ b/tests/acceptance/dex/idtokenprovider.go
@@ -131,7 +131,7 @@ func getLocalAuthEndpoint(body io.Reader) (string, error) {
 	for {
 		nt := z.Next()
 		if nt == html.ErrorToken {
-			return "", fmt.Errorf("got HTML error token")
+			return "", errors.New("got HTML error token")
 		}
 
 		token := z.Token()

--- a/tests/acceptance/dex/idtokenprovider.go
+++ b/tests/acceptance/dex/idtokenprovider.go
@@ -58,7 +58,9 @@ func (p *dexIdTokenProvider) implicitFlow() (map[string]string, error) {
 	var loginEndpoint string
 	if authorizeResp.StatusCode == 200 {
 		loginEndpoint, err = getLocalAuthLink(authorizeResp.Body)
-		return nil, errors.Wrapf(err, "while fetching link to static authentication")
+		if err != nil {
+			return nil, errors.Wrapf(err, "while fetching link to static authentication")
+		}
 	} else {
 		loginEndpoint = authorizeResp.Header.Get("location")
 		if strings.Contains(loginEndpoint, "#.*error") {

--- a/tests/acceptance/dex/idtokenprovider.go
+++ b/tests/acceptance/dex/idtokenprovider.go
@@ -58,7 +58,7 @@ func (p *dexIdTokenProvider) implicitFlow() (map[string]string, error) {
 
 	// /auth/local?req=qruhpy2cqjvv4hcrbuu44mf4v
 	var loginEndpoint string
-	if authorizeResp.StatusCode == 200 {
+	if authorizeResp.StatusCode == http.StatusOK {
 		loginEndpoint, err = getLocalAuthEndpoint(authorizeResp.Body)
 		if err != nil {
 			return nil, errors.Wrapf(err, "while fetching link to static authentication")

--- a/tests/acceptance/dex/idtokenprovider.go
+++ b/tests/acceptance/dex/idtokenprovider.go
@@ -2,12 +2,16 @@ package dex
 
 import (
 	"fmt"
+	"io"
 	"io/ioutil"
 	"net/http"
 	"net/url"
+	"regexp"
 	"strings"
 
 	"log"
+
+	"golang.org/x/net/html"
 )
 
 type idTokenProvider interface {
@@ -44,12 +48,17 @@ func (p *dexIdTokenProvider) implicitFlow() (map[string]string, error) {
 	if err != nil {
 		return nil, err
 	}
-	if authorizeResp.StatusCode < 300 || authorizeResp.StatusCode > 399 {
+	if authorizeResp.StatusCode < 200 || authorizeResp.StatusCode > 399 {
 		return nil, fmt.Errorf("Authorize - response error: '%s' - %s", authorizeResp.Status, readRespBody(authorizeResp))
 	}
 
 	// /auth/local?req=qruhpy2cqjvv4hcrbuu44mf4v
-	loginEndpoint := authorizeResp.Header.Get("location")
+	var loginEndpoint string
+	if authorizeResp.StatusCode == 200 {
+		loginEndpoint = getLocalAuthLink(authorizeResp.Body)
+	} else {
+		loginEndpoint = authorizeResp.Header.Get("location")
+	}
 	if strings.Contains(loginEndpoint, "#.*error") {
 		return nil, fmt.Errorf("Login - Redirected with error: '%s'", loginEndpoint)
 	}
@@ -111,4 +120,28 @@ func readRespBody(resp *http.Response) string {
 		return "<<Error reading response body>>"
 	}
 	return string(b)
+}
+
+func getLocalAuthLink(body io.Reader) string {
+	z := html.NewTokenizer(body)
+	for {
+		nt := z.Next()
+		if nt == html.ErrorToken {
+			return ""
+		}
+
+		token := z.Token()
+		if "a" != token.Data {
+			continue
+		}
+		for _, attr := range token.Attr {
+			if attr.Key != "href" {
+				continue
+			}
+			match, _ := regexp.MatchString("/auth/local.*", attr.Val)
+			if match {
+				return attr.Val
+			}
+		}
+	}
 }

--- a/tests/acceptance/dex/idtokenprovider.go
+++ b/tests/acceptance/dex/idtokenprovider.go
@@ -57,7 +57,7 @@ func (p *dexIdTokenProvider) implicitFlow() (map[string]string, error) {
 	// /auth/local?req=qruhpy2cqjvv4hcrbuu44mf4v
 	var loginEndpoint string
 	if authorizeResp.StatusCode == 200 {
-		loginEndpoint, err = getLocalAuthLink(authorizeResp.Body)
+		loginEndpoint, err = getLocalAuthEndpoint(authorizeResp.Body)
 		if err != nil {
 			return nil, errors.Wrapf(err, "while fetching link to static authentication")
 		}
@@ -126,7 +126,7 @@ func readRespBody(resp *http.Response) string {
 	return string(b)
 }
 
-func getLocalAuthLink(body io.Reader) (string, error) {
+func getLocalAuthEndpoint(body io.Reader) (string, error) {
 	z := html.NewTokenizer(body)
 	for {
 		nt := z.Next()

--- a/tests/ui-api-layer-acceptance-tests/Gopkg.lock
+++ b/tests/ui-api-layer-acceptance-tests/Gopkg.lock
@@ -209,6 +209,8 @@
   branch = "master"
   name = "golang.org/x/net"
   packages = [
+    "html",
+    "html/atom",
     "http/httpguts",
     "http2",
     "http2/hpack",
@@ -395,6 +397,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "0799cab822d238130eac3d077b656882818a56eb2df0d6f7cbecb97fd556544e"
+  inputs-digest = "a0e2594a70d454dffa32b78908546113924a8747d824b26188423b71e6d8ea3d"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/tests/ui-api-layer-acceptance-tests/internal/graphql/idtokenprovider.go
+++ b/tests/ui-api-layer-acceptance-tests/internal/graphql/idtokenprovider.go
@@ -53,8 +53,11 @@ func (p *dexIdTokenProvider) implicitFlow() (map[string]string, error) {
 	if err != nil {
 		return nil, err
 	}
-	if authorizeResp.StatusCode < 200 || authorizeResp.StatusCode > 399 {
-		return nil, errors.New(fmt.Sprintf("Authorize - response error: '%s' - %s", authorizeResp.Status, readRespBody(authorizeResp)))
+	switch authorizeResp.StatusCode {
+	case http.StatusFound:
+	case http.StatusOK:
+	default:
+		return nil, fmt.Errorf("got unexpected response on authorize: %d - %s", authorizeResp.StatusCode, readRespBody(authorizeResp))
 	}
 
 	// /auth/local?req=qruhpy2cqjvv4hcrbuu44mf4v

--- a/tests/ui-api-layer-acceptance-tests/internal/graphql/idtokenprovider.go
+++ b/tests/ui-api-layer-acceptance-tests/internal/graphql/idtokenprovider.go
@@ -61,7 +61,9 @@ func (p *dexIdTokenProvider) implicitFlow() (map[string]string, error) {
 	var loginEndpoint string
 	if authorizeResp.StatusCode == 200 {
 		loginEndpoint, err = getLocalAuthLink(authorizeResp.Body)
-		return nil, errors.Wrapf(err, "while fetching link to static authentication")
+		if err != nil {
+			return nil, errors.Wrapf(err, "while fetching link to static authentication")
+		}
 	} else {
 		loginEndpoint = authorizeResp.Header.Get("location")
 		if strings.Contains(loginEndpoint, "#.*error") {

--- a/tests/ui-api-layer-acceptance-tests/internal/graphql/idtokenprovider.go
+++ b/tests/ui-api-layer-acceptance-tests/internal/graphql/idtokenprovider.go
@@ -134,7 +134,7 @@ func getLocalAuthEndpoint(body io.Reader) (string, error) {
 	for {
 		nt := z.Next()
 		if nt == html.ErrorToken {
-			return "", fmt.Errorf("got HTML error token")
+			return "", errors.New("got HTML error token")
 		}
 
 		token := z.Token()

--- a/tests/ui-api-layer-acceptance-tests/internal/graphql/idtokenprovider.go
+++ b/tests/ui-api-layer-acceptance-tests/internal/graphql/idtokenprovider.go
@@ -62,7 +62,7 @@ func (p *dexIdTokenProvider) implicitFlow() (map[string]string, error) {
 
 	// /auth/local?req=qruhpy2cqjvv4hcrbuu44mf4v
 	var loginEndpoint string
-	if authorizeResp.StatusCode == 200 {
+	if authorizeResp.StatusCode == http.StatusOK {
 		loginEndpoint, err = getLocalAuthEndpoint(authorizeResp.Body)
 		if err != nil {
 			return nil, errors.Wrapf(err, "while fetching link to static authentication")

--- a/tests/ui-api-layer-acceptance-tests/internal/graphql/idtokenprovider.go
+++ b/tests/ui-api-layer-acceptance-tests/internal/graphql/idtokenprovider.go
@@ -60,7 +60,7 @@ func (p *dexIdTokenProvider) implicitFlow() (map[string]string, error) {
 	// /auth/local?req=qruhpy2cqjvv4hcrbuu44mf4v
 	var loginEndpoint string
 	if authorizeResp.StatusCode == 200 {
-		loginEndpoint, err = getLocalAuthLink(authorizeResp.Body)
+		loginEndpoint, err = getLocalAuthEndpoint(authorizeResp.Body)
 		if err != nil {
 			return nil, errors.Wrapf(err, "while fetching link to static authentication")
 		}
@@ -129,7 +129,7 @@ func readRespBody(resp *http.Response) string {
 	return string(b)
 }
 
-func getLocalAuthLink(body io.Reader) (string, error) {
+func getLocalAuthEndpoint(body io.Reader) (string, error) {
 	z := html.NewTokenizer(body)
 	for {
 		nt := z.Next()


### PR DESCRIPTION
**Problem**
On a nightly cluster, where stability checker executes all tests defined in a `testing.sh` file, we are going to enable Github authentication in addition to the static user. Thanks to that, any developer assigned to the proper Github team, can easily login to the Kyma console and download Kubeconfig file.
After enabling second authentication method, some tests start failing, because in tests there was an assumption that dex has only one, static connector and always redirection to the static connector is done.

**Solution**
In this PR, we added a new condition in code fetching token, and if /auth endpoint responds with HTTP 200, instead of making redirection, we fetch a link to static authentication by parsing returned HTML.