### PR TITLE
Add bash trap to delete GC credentials file

### DIFF
--- a/tools/gcp-broker-provider/bin/gcp-broker.sh
+++ b/tools/gcp-broker-provider/bin/gcp-broker.sh
@@ -13,6 +13,16 @@ set -o errexit # exit immediately if a command exits with a non-zero status.
 readonly CURRENT_DIR="$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)"
 readonly GCP_SECRET_NAME="gcp-broker-data"
 
+trap cleanup EXIT SIGINT SIGTERM
+
+function cleanup() {
+    printf  "\n- Cleaning up...\n"
+    echo "Ensure gcloud credentials are removed"
+    rm -f "${GOOGLE_APPLICATION_CREDENTIALS}"
+    echo "OK"
+}
+
+
 function discoveredUnsetVar() {
     local discoveredUnsetVar=false
     for e in WORKING_NAMESPACE; do
@@ -56,12 +66,6 @@ function configureGCloud() {
 
     return 0
 }
-
-function deleteGoogleApplicationCredentials () {
-    rm -f "${GOOGLE_APPLICATION_CREDENTIALS}"
-}
-
-trap deleteGoogleApplicationCredentials EXIT SIGINT SIGTERM
 
 function printToolsVersions() {
     printf "kubectl version\n"

--- a/tools/gcp-broker-provider/bin/gcp-broker.sh
+++ b/tools/gcp-broker-provider/bin/gcp-broker.sh
@@ -57,6 +57,12 @@ function configureGCloud() {
     return 0
 }
 
+function deleteGoogleApplicationCredentials () {
+    rm -f "${GOOGLE_APPLICATION_CREDENTIALS}"
+}
+
+trap deleteGoogleApplicationCredentials EXIT SIGINT SIGTERM
+
 function printToolsVersions() {
     printf "kubectl version\n"
     kubectl version --short

--- a/tools/gcp-broker-provider/bin/gcp-broker.sh
+++ b/tools/gcp-broker-provider/bin/gcp-broker.sh
@@ -18,7 +18,10 @@ trap cleanup EXIT SIGINT SIGTERM
 function cleanup() {
     printf  "\n- Cleaning up...\n"
     echo "Ensure gcloud credentials are removed"
-    rm -f "${GOOGLE_APPLICATION_CREDENTIALS}"
+    if [ ! -z "${GOOGLE_APPLICATION_CREDENTIALS}" ]
+    then
+        rm -f "${GOOGLE_APPLICATION_CREDENTIALS}"
+    fi
     echo "OK"
 }
 


### PR DESCRIPTION
**Description**

Add bash trap to delete Google Cloud credentials file made in `tools/gcp-broker-provider/bin` by `gcp-broker.sh`

Changes proposed in this pull request:

- add bash trap to remove secure data (GC credentials)

**Related issue(s)**
Resolves #2469
