### PR TITLE
Improve local development with custom password for admin account

### DIFF
--- a/installation/cmd/run.sh
+++ b/installation/cmd/run.sh
@@ -40,6 +40,12 @@ do
             KNATIVE="--knative"
             shift
         ;;
+        --p)
+            checkInputParameterValue "$2"
+            ADMIN_PASSWORD="${2}"
+            shift # past argument
+            shift # past value
+        ;;
         --*)
             echo "Unknown flag ${1}"
             exit 1
@@ -74,5 +80,5 @@ if [ -z "$CR_PATH" ]; then
 
 fi
 
-bash ${SCRIPTS_DIR}/installer.sh --local --cr "${CR_PATH}" "${KNATIVE}"
+bash ${SCRIPTS_DIR}/installer.sh --local --cr "${CR_PATH}" "${KNATIVE}" --p "${ADMIN_PASSWORD}"
 rm -rf $TMPDIR

--- a/installation/cmd/run.sh
+++ b/installation/cmd/run.sh
@@ -40,7 +40,7 @@ do
             KNATIVE="--knative"
             shift
         ;;
-        --p)
+        --password)
             checkInputParameterValue "$2"
             ADMIN_PASSWORD="${2}"
             shift # past argument
@@ -80,5 +80,5 @@ if [ -z "$CR_PATH" ]; then
 
 fi
 
-bash ${SCRIPTS_DIR}/installer.sh --local --cr "${CR_PATH}" "${KNATIVE}" --p "${ADMIN_PASSWORD}"
+bash ${SCRIPTS_DIR}/installer.sh --local --cr "${CR_PATH}" "${KNATIVE}" --password "${ADMIN_PASSWORD}"
 rm -rf $TMPDIR

--- a/installation/resources/installer-config-local.yaml.tpl
+++ b/installation/resources/installer-config-local.yaml.tpl
@@ -34,6 +34,7 @@ data:
   global.domainName: "kyma.local"
   global.etcdBackup.containerName: ""
   global.etcdBackup.enabled: "false"
+  global.adminPassword: ""
   nginx-ingress.controller.service.loadBalancerIP: ""
   cluster-users.users.adminGroup: ""
 ---

--- a/installation/scripts/installer.sh
+++ b/installation/scripts/installer.sh
@@ -31,6 +31,12 @@ do
             KNATIVE=true
             shift
             ;;
+        --p)
+            checkInputParameterValue "$2"
+            ADMIN_PASSWORD="$2"
+            shift
+            shift
+            ;;
         --*)
             echo "Unknown flag ${1}"
             exit 1
@@ -91,6 +97,11 @@ echo -e "\nApplying installation combo yaml"
 COMBO_YAML=$(bash ${CURRENT_DIR}/concat-yamls.sh ${INSTALLER} ${INSTALLER_CONFIG} ${AZURE_BROKER_CONFIG} ${CR_PATH})
 
 rm -rf ${AZURE_BROKER_CONFIG}
+
+if [ ${ADMIN_PASSWORD} ]; then
+    ADMIN_PASSWORD=$(echo ${ADMIN_PASSWORD} | base64)
+    COMBO_YAML=$(sed 's/global\.adminPassword: .*/global.adminPassword: '"${ADMIN_PASSWORD}"'/g' <<<"$COMBO_YAML")
+fi
 
 if [ $KNATIVE ]; then
     COMBO_YAML=$(sed 's/global\.knative: .*/global.knative: "true"/g' <<<"$COMBO_YAML")

--- a/installation/scripts/installer.sh
+++ b/installation/scripts/installer.sh
@@ -32,7 +32,6 @@ do
             shift
             ;;
         --p)
-            checkInputParameterValue "$2"
             ADMIN_PASSWORD="$2"
             shift
             shift

--- a/installation/scripts/installer.sh
+++ b/installation/scripts/installer.sh
@@ -31,7 +31,7 @@ do
             KNATIVE=true
             shift
             ;;
-        --p)
+        --password)
             ADMIN_PASSWORD="$2"
             shift
             shift

--- a/resources/dex/templates/dex-users-secret.yaml
+++ b/resources/dex/templates/dex-users-secret.yaml
@@ -10,6 +10,6 @@ metadata:
 data:
   email: YWRtaW5Aa3ltYS5jeA==
   username: YWRtaW4=
-  password: {{ randAlphaNum 12 | b64enc }}
+  password: {{ .Values.global.adminPassword | default ( randAlphaNum 12 | b64enc ) }}
   
 type: Opaque


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/master/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**
For local installation `run.sh` script can be started with `--p your_password` flag

Changes proposed in this pull request:

- Added --p flag to run.sh script
- Added global.adminPassword override
- Provided changes in dex chart to use a custom password

**Related issue(s)**
#1488
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
