### PR TITLE
Admin password windows

### DIFF
--- a/installation/cmd/run.ps1
+++ b/installation/cmd/run.ps1
@@ -27,7 +27,7 @@ if ($SKIP_MINIKUBE_START -eq $false) {
 
 Invoke-Expression -Command "${SCRIPTS_DIR}\build-kyma-installer.ps1 -vm_driver ${VM_DRIVER}"
 
-Invoke-Expression -Command "${SCRIPTS_DIR}\generate-local-config.ps1" -password $PASSWORD
+Invoke-Expression -Command "${SCRIPTS_DIR}\generate-local-config.ps1 -password '${PASSWORD}'"
 
 $CR_PATH = (New-TemporaryFile).FullName
 

--- a/installation/cmd/run.ps1
+++ b/installation/cmd/run.ps1
@@ -2,7 +2,8 @@ param (
     [string]$CR_PATH = "",
     [switch]$SKIP_MINIKUBE_START = $false,
     [switch]$KNATIVE = $false,
-    [string]$VM_DRIVER = "hyperv"
+    [string]$VM_DRIVER = "hyperv",
+    [string]$PASSWORD = ""
 )
 
 $CURRENT_DIR = Split-Path $MyInvocation.MyCommand.Path
@@ -26,7 +27,7 @@ if ($SKIP_MINIKUBE_START -eq $false) {
 
 Invoke-Expression -Command "${SCRIPTS_DIR}\build-kyma-installer.ps1 -vm_driver ${VM_DRIVER}"
 
-Invoke-Expression -Command "${SCRIPTS_DIR}\generate-local-config.ps1"
+Invoke-Expression -Command "${SCRIPTS_DIR}\generate-local-config.ps1" -password $PASSWORD
 
 $CR_PATH = (New-TemporaryFile).FullName
 

--- a/installation/scripts/generate-local-config.ps1
+++ b/installation/scripts/generate-local-config.ps1
@@ -1,5 +1,5 @@
 param (
-    [string]$PASSWORD
+    [string]$PASSWORD = ""
 )
 
 $CURRENT_DIR = Split-Path $MyInvocation.MyCommand.Path
@@ -10,7 +10,7 @@ $CONFIG_OUTPUT_PATH = (New-TemporaryFile).FullName
 $VERSIONS_FILE_PATH = "${CURRENT_DIR}\..\versions-overrides.env"
 
 Copy-Item -Path $CONFIG_TPL_PATH -Destination $CONFIG_OUTPUT_PATH
-(Get-Content $CONFIG_OUTPUT_PATH).replace("global.adminPassword: `"`"", global.adminPassword: "${PASSWORD}") | Set-Content $CONFIG_OUTPUT_PATH
+(Get-Content $CONFIG_OUTPUT_PATH).replace("global.adminPassword: `"`"", "global.adminPassword: `"${PASSWORD}`"") | Set-Content $CONFIG_OUTPUT_PATH
 
 ##########
 

--- a/installation/scripts/generate-local-config.ps1
+++ b/installation/scripts/generate-local-config.ps1
@@ -17,8 +17,6 @@ if(${PASSWORD} -ne "") {
   (Get-Content $CONFIG_OUTPUT_PATH).replace("global.adminPassword: `"`"", "global.adminPassword: `"${ENCODED_PASSWORD}`"") | Set-Content $CONFIG_OUTPUT_PATH
 }
 
-(Get-Content $CONFIG_OUTPUT_PATH).replace("global.adminPassword: `"`"", "global.adminPassword: `"${PASSWORD}`"") | Set-Content $CONFIG_OUTPUT_PATH
-
 ##########
 
 Write-Output "Applying configuration"

--- a/installation/scripts/generate-local-config.ps1
+++ b/installation/scripts/generate-local-config.ps1
@@ -1,3 +1,7 @@
+param (
+    [string]$PASSWORD
+)
+
 $CURRENT_DIR = Split-Path $MyInvocation.MyCommand.Path
 
 $CONFIG_TPL_PATH = "${CURRENT_DIR}\..\resources\installer-config-local.yaml.tpl"
@@ -6,6 +10,7 @@ $CONFIG_OUTPUT_PATH = (New-TemporaryFile).FullName
 $VERSIONS_FILE_PATH = "${CURRENT_DIR}\..\versions-overrides.env"
 
 Copy-Item -Path $CONFIG_TPL_PATH -Destination $CONFIG_OUTPUT_PATH
+(Get-Content $CONFIG_OUTPUT_PATH).replace("global.adminPassword: `"`"", global.adminPassword: "${PASSWORD}") | Set-Content $CONFIG_OUTPUT_PATH
 
 ##########
 

--- a/installation/scripts/generate-local-config.ps1
+++ b/installation/scripts/generate-local-config.ps1
@@ -10,6 +10,13 @@ $CONFIG_OUTPUT_PATH = (New-TemporaryFile).FullName
 $VERSIONS_FILE_PATH = "${CURRENT_DIR}\..\versions-overrides.env"
 
 Copy-Item -Path $CONFIG_TPL_PATH -Destination $CONFIG_OUTPUT_PATH
+
+if(${PASSWORD} -ne "") {
+  $PASSWORD_BYTES = [System.Text.Encoding]::UTF8.GetBytes(${PASSWORD})
+  $ENCODED_PASSWORD = [System.Convert]::ToBase64String(${PASSWORD_BYTES})
+  (Get-Content $CONFIG_OUTPUT_PATH).replace("global.adminPassword: `"`"", "global.adminPassword: `"${ENCODED_PASSWORD}`"") | Set-Content $CONFIG_OUTPUT_PATH
+}
+
 (Get-Content $CONFIG_OUTPUT_PATH).replace("global.adminPassword: `"`"", "global.adminPassword: `"${PASSWORD}`"") | Set-Content $CONFIG_OUTPUT_PATH
 
 ##########


### PR DESCRIPTION
**Description**
For local installation run.ps1 script can be started with `-password <your_password>` parameter.

Example invocation: `powershell -File run.ps1 -password dummyPassword`

Changes proposed in this pull request:

- Added `-password` flag to the run.ps1 script

Related issue(s)
See also #1488 
