### PR TITLE
Select stability-checker container while getting logs

### DIFF
--- a/tools/stability-checker/deploy/chart/stability-checker/templates/deploy.yaml
+++ b/tools/stability-checker/deploy/chart/stability-checker/templates/deploy.yaml
@@ -32,7 +32,8 @@ spec:
             claimName: {{ .Values.storage.claimName }}
 
       containers:
-      - name: {{ .Chart.Name }}
+      # The container name is hardcoded in the stability checker, do not change it
+      - name: stability-checker
         image: "{{ .Values.containerRegistry.path }}/develop/stability-checker:{{ .Values.image.tag }}"
         imagePullPolicy: "{{ .Values.image.pullPolicy }}"
 

--- a/tools/stability-checker/internal/log/logfetcher.go
+++ b/tools/stability-checker/internal/log/logfetcher.go
@@ -10,6 +10,8 @@ import (
 	restclient "k8s.io/client-go/rest"
 )
 
+const stabilityCheckerContainerName = "stability-checker"
+
 // PodLogFetcher is responsible for fetching logs from a specific pod
 type PodLogFetcher struct {
 	workingNamespace string
@@ -38,7 +40,7 @@ func NewPodLogFetcher(workingNamespace, podName string) (*PodLogFetcher, error) 
 
 // GetLogsFromPod returns logs from pod
 func (p *PodLogFetcher) GetLogsFromPod() (io.ReadCloser, error) {
-	req := p.coreV1Client.Pods(p.workingNamespace).GetLogs(p.podName, &v1.PodLogOptions{})
+	req := p.coreV1Client.Pods(p.workingNamespace).GetLogs(p.podName, &v1.PodLogOptions{Container: stabilityCheckerContainerName})
 	readCloser, err := req.Stream()
 	if err != nil {
 		return nil, errors.Wrapf(err, "while streaming logs from pod %q", p.podName)


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/master/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:
- stability-checker fetches logs from pod and specified container. This feature prevents from errors like: 
```
{"level":"error","log":{"message":"Cannot get test summary for execution IDs [[1ed1e46d-2180-4f87-87ad-eae909da711b 7045cdec-287d-4c51-bb38-bd62512ad852 212b5783-da44-446e-a2ef-2e4b447ecb8d 9f334bd7-b0eb-41d8-ba71-c208bcf1ed4c e30a1aba-763a-4548-89b7-25df2c6fe768 2e3b5512-c547-4dfd-b24b-be974a53a575 b10d7f4c-4c45-4f07-9a84-54e93a7a21d9 da597f71-14ad-47c5-a6ec-8359224323fd]], got error: while streaming logs from pod \"stability-checker-5cf9456876-v625w\": a container name must be specified for pod stability-checker-5cf9456876-v625w, choose one of: [stability-checker istio-proxy] or one of the init containers: [istio-init]","time":"2019-01-31T02:46:09.193Z"}}
```
