### PR TITLE
Improve naming for event-bus tracing

### DIFF
--- a/resources/core/charts/event-bus/charts/publish/values.yaml
+++ b/resources/core/charts/event-bus/charts/publish/values.yaml
@@ -8,5 +8,5 @@ port: 8080
 service:
   type: ClusterIP
 trace:
-  serviceName: publish-service
-  operationName: send-to-internal-broker
+  serviceName: event-publish-service
+  operationName: publish-the-event

--- a/resources/core/charts/event-bus/charts/push/templates/deployment.yaml
+++ b/resources/core/charts/event-bus/charts/push/templates/deployment.yaml
@@ -46,7 +46,7 @@ spec:
       annotations:
         sidecar.istio.io/inject: "true"
       labels:
-        app: {{ template "push.name" . }}
+        app: "event-http-dispatcher-service" #This is changed because of tracing UI. 
         release: {{ .Release.Name }}
     spec:
       containers:

--- a/resources/core/charts/event-bus/charts/push/values.yaml
+++ b/resources/core/charts/event-bus/charts/push/values.yaml
@@ -8,7 +8,7 @@ port: 8080
 http:
   tlsSkipVerify: true
 trace:
-  serviceName: webhook-service
-  operationName: deliver-to-endpoint
+  serviceName: event-delivery-service
+  operationName: deliver-the-event
 check:
   eventsActivation: true


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Improve naming for event-bus tracing

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
See #371