### PR TITLE
Add to helm broker removing instance during deprovisioning bundle

### DIFF
--- a/components/helm-broker/internal/broker/automock/extended.go
+++ b/components/helm-broker/internal/broker/automock/extended.go
@@ -27,6 +27,10 @@ func (_m *InstanceStorage) ExpectOnGet(iID internal.InstanceID, expInstance inte
 	return _m.On("Get", iID).Return(&expInstance, nil)
 }
 
+func (_m *InstanceStorage) ExpectOnRemove(iID internal.InstanceID) *mock.Call {
+	return _m.On("Remove", iID).Return(nil)
+}
+
 func (_m *InstanceStorage) ExpectErrorOnGet(iID internal.InstanceID, err error) *mock.Call {
 	return _m.On("Get", iID).Return(nil, err)
 }

--- a/components/helm-broker/internal/broker/automock/extended.go
+++ b/components/helm-broker/internal/broker/automock/extended.go
@@ -31,6 +31,10 @@ func (_m *InstanceStorage) ExpectOnRemove(iID internal.InstanceID) *mock.Call {
 	return _m.On("Remove", iID).Return(nil)
 }
 
+func (_m *InstanceStorage) ExpectErrorRemove(iID internal.InstanceID, err error) *mock.Call {
+	return _m.On("Remove", iID).Return(err)
+}
+
 func (_m *InstanceStorage) ExpectErrorOnGet(iID internal.InstanceID, err error) *mock.Call {
 	return _m.On("Get", iID).Return(nil, err)
 }

--- a/components/helm-broker/internal/broker/broker.go
+++ b/components/helm-broker/internal/broker/broker.go
@@ -180,6 +180,7 @@ func newWithIDProvider(bs bundleStorage, cs chartStorage, os operationStorage, i
 		},
 		deprovisioner: &deprovisionService{
 			instanceGetter:    is,
+			instanceRemover:   is,
 			operationInserter: os,
 			instanceStateGetter: &instanceStateService{
 				operationCollectionGetter: os,

--- a/components/helm-broker/internal/broker/deprovision.go
+++ b/components/helm-broker/internal/broker/deprovision.go
@@ -14,6 +14,7 @@ import (
 
 type deprovisionService struct {
 	instanceGetter          instanceGetter
+	instanceRemover         instanceRemover
 	instanceStateGetter     instanceStateDeprovisionGetter
 	operationInserter       operationInserter
 	operationUpdater        operationUpdater
@@ -90,7 +91,7 @@ func (svc *deprovisionService) Deprovision(ctx context.Context, osbCtx OsbContex
 		return nil, errors.Wrap(err, "while inserting instance operation to storage")
 	}
 
-	svc.doAsync(ctx, iID, opID, i.Namespace, i.ReleaseName)
+	svc.doAsync(ctx, iID, opID, i.ReleaseName)
 
 	opKey := osb.OperationKey(op.OperationID)
 	resp := &osb.DeprovisionResponse{
@@ -101,15 +102,15 @@ func (svc *deprovisionService) Deprovision(ctx context.Context, osbCtx OsbContex
 	return resp, nil
 }
 
-func (svc *deprovisionService) doAsync(ctx context.Context, iID internal.InstanceID, opID internal.OperationID, namespace internal.Namespace, releaseName internal.ReleaseName) {
+func (svc *deprovisionService) doAsync(ctx context.Context, iID internal.InstanceID, opID internal.OperationID, releaseName internal.ReleaseName) {
 	if svc.testHookAsyncCalled != nil {
 		svc.testHookAsyncCalled(opID)
 	}
-	go svc.do(ctx, iID, opID, namespace, releaseName)
+	go svc.do(ctx, iID, opID, releaseName)
 }
 
 // do is called asynchronously
-func (svc *deprovisionService) do(ctx context.Context, iID internal.InstanceID, opID internal.OperationID, namespace internal.Namespace, releaseName internal.ReleaseName) {
+func (svc *deprovisionService) do(ctx context.Context, iID internal.InstanceID, opID internal.OperationID, releaseName internal.ReleaseName) {
 
 	fDo := func() error {
 		if err := svc.helmDeleter.Delete(releaseName); err != nil {
@@ -126,6 +127,14 @@ func (svc *deprovisionService) do(ctx context.Context, iID internal.InstanceID, 
 		case err == nil, IsNotFoundError(err):
 		default:
 			return fmt.Errorf("cannot remove instance bind data from storage: %s", err.Error())
+		}
+
+		// remove instance entity from storage
+		err = svc.instanceRemover.Remove(iID)
+		switch {
+		case err == nil, IsNotFoundError(err):
+		default:
+			return fmt.Errorf("cannot remove instance entity from storage: %s", err.Error())
 		}
 
 		return nil

--- a/components/helm-broker/internal/broker/deprovision.go
+++ b/components/helm-broker/internal/broker/deprovision.go
@@ -126,7 +126,7 @@ func (svc *deprovisionService) do(ctx context.Context, iID internal.InstanceID, 
 		// 3. Then deprovisioning is wrongly marked as failed
 		case err == nil, IsNotFoundError(err):
 		default:
-			return fmt.Errorf("cannot remove instance bind data from storage: %s", err.Error())
+			return errors.Wrap(err, "while removing instance bind data from storage")
 		}
 
 		// remove instance entity from storage
@@ -134,7 +134,7 @@ func (svc *deprovisionService) do(ctx context.Context, iID internal.InstanceID, 
 		switch {
 		case err == nil, IsNotFoundError(err):
 		default:
-			return fmt.Errorf("cannot remove instance entity from storage: %s", err.Error())
+			return errors.Wrap(err, "while removing instance entity from storage")
 		}
 
 		return nil

--- a/components/helm-broker/internal/broker/deprovision_export_test.go
+++ b/components/helm-broker/internal/broker/deprovision_export_test.go
@@ -2,9 +2,10 @@ package broker
 
 import "github.com/kyma-project/kyma/components/helm-broker/internal"
 
-func NewDeprovisionService(ig instanceGetter, oi operationInserter, ou operationUpdater, ibdr instanceBindDataRemover, hd helmDeleter, oIDProv func() (internal.OperationID, error), isg instanceStateGetter) *deprovisionService {
+func NewDeprovisionService(is instanceStorage, oi operationInserter, ou operationUpdater, ibdr instanceBindDataRemover, hd helmDeleter, oIDProv func() (internal.OperationID, error), isg instanceStateGetter) *deprovisionService {
 	return &deprovisionService{
-		instanceGetter:          ig,
+		instanceGetter:          is,
+		instanceRemover:		 is,
 		instanceStateGetter:     isg,
 		operationInserter:       oi,
 		operationUpdater:        ou,

--- a/components/helm-broker/internal/broker/deprovision_test.go
+++ b/components/helm-broker/internal/broker/deprovision_test.go
@@ -90,7 +90,7 @@ func TestDeprovisionServiceDeprovisionFailureAsync(t *testing.T) {
 			ts.InstStorageMock.ExpectOnGet(ts.Exp.InstanceID, ts.FixInstance()).Once()
 
 			ts.OpStorageMock.ExpectOnInsert(ts.FixInstanceOperation()).Once()
-			expDesc := fmt.Sprintf("deprovisioning failed on error: cannot remove instance bind data from storage: %s", fixErr)
+			expDesc := fmt.Sprintf("deprovisioning failed on error: while removing instance bind data from storage: %s", fixErr)
 			ts.OpStorageMock.ExpectOnUpdateStateDesc(ts.Exp.InstanceID, ts.Exp.OperationID, internal.OperationStateFailed, expDesc).
 				Run(func(args mock.Arguments) {
 					close(ts.UpdateStateDescMethodCalled)
@@ -99,6 +99,24 @@ func TestDeprovisionServiceDeprovisionFailureAsync(t *testing.T) {
 			ts.HelmClientMock.ExpectOnDelete(ts.Exp.ReleaseName).Once()
 
 			ts.InstBindDataMock.ExpectErrorRemove(ts.Exp.InstanceID, fixErr).Once()
+		},
+		"on instance Remove": func(ts *deprovisionServiceTestSuite) {
+			ts.InstStateGetterMock.ExpectOnIsDeprovisioned(ts.Exp.InstanceID, false).Once()
+			ts.InstStateGetterMock.ExpectOnIsDeprovisioningInProgress(ts.Exp.InstanceID, internal.OperationID(""), false).Once()
+
+			ts.InstStorageMock.ExpectOnGet(ts.Exp.InstanceID, ts.FixInstance()).Once()
+
+			ts.OpStorageMock.ExpectOnInsert(ts.FixInstanceOperation()).Once()
+			expDesc := fmt.Sprintf("deprovisioning failed on error: while removing instance entity from storage: %s", fixErr)
+			ts.OpStorageMock.ExpectOnUpdateStateDesc(ts.Exp.InstanceID, ts.Exp.OperationID, internal.OperationStateFailed, expDesc).
+				Run(func(args mock.Arguments) {
+					close(ts.UpdateStateDescMethodCalled)
+				}).Once()
+
+			ts.HelmClientMock.ExpectOnDelete(ts.Exp.ReleaseName).Once()
+			ts.InstBindDataMock.ExpectOnRemove(ts.Exp.InstanceID).Once()
+
+			ts.InstStorageMock.ExpectErrorRemove(ts.Exp.InstanceID, fixErr).Once()
 		},
 	} {
 		t.Run(tn, func(t *testing.T) {

--- a/components/helm-broker/internal/broker/deprovision_test.go
+++ b/components/helm-broker/internal/broker/deprovision_test.go
@@ -38,6 +38,7 @@ func TestDeprovisionServiceDeprovisionSuccess(t *testing.T) {
 	ts.HelmClientMock.ExpectOnDelete(ts.Exp.ReleaseName).Once()
 
 	ts.InstBindDataMock.ExpectOnRemove(ts.Exp.InstanceID).Once()
+	ts.InstStorageMock.ExpectOnRemove(ts.Exp.InstanceID).Once()
 
 	ts.OpIDProviderFake = func() (internal.OperationID, error) {
 		return ts.Exp.OperationID, nil


### PR DESCRIPTION
**Description**

PR removes instance entity from helm broker storage during deprovisioning releases. Removing operation is launched after delete `release` from helm and remove `bind data` from storage (only if this two operations are succeeded).

Instance entity is not needed, the only reason why instance should be keep in storage is situation when deprovisioning operation failed and SC tries remove it again, then instance keeps information about `release` name which can be use to delete `release` by helm but if removing instance operation is launching after successful delete `release`, keeps entity is not necessary anymore.

**Related issues**

PR fixes two issues: 
#1716 allows provision bundle with `provisionOnlyOnce` flag after deprovisioning it from concrete namespace. 
#2197 error message about the right error (error from ConfigMap) is not covered by information connected with attempt provisioning instance which already exist in storage.

**Extra**

PR also removes not used function argument `namespace` from async deprovisioning operation.