### PR TITLE
Fix acc test, after updating ServiceCatalog to version 0.1.40

### DIFF
--- a/tests/acceptance/pkg/retriever/class.go
+++ b/tests/acceptance/pkg/retriever/class.go
@@ -1,0 +1,35 @@
+package retriever
+
+import (
+	catalog "github.com/kubernetes-incubator/service-catalog/pkg/apis/servicecatalog/v1beta1"
+	"github.com/kubernetes-incubator/service-catalog/pkg/client/clientset_generated/clientset/typed/servicecatalog/v1beta1"
+	"github.com/pkg/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/fields"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+func ServiceClassByExternalID(scClient v1beta1.ServicecatalogV1beta1Interface, namespace, externalID string) (*catalog.ServiceClass, error) {
+	fieldSet := fields.Set{
+		catalog.FilterSpecExternalID: externalID,
+	}
+	fieldSelector := fields.SelectorFromSet(fieldSet).String()
+	listOpts := metav1.ListOptions{FieldSelector: fieldSelector}
+
+	sc, err := scClient.ServiceClasses(namespace).List(listOpts)
+	if err != nil {
+		return nil, errors.Wrap(err, "while getting service class")
+	}
+
+	noItems := len(sc.Items)
+	if noItems == 0 { // using apierrors to simplify assertion in test code
+		return nil, apierrors.NewNotFound(schema.GroupResource{}, externalID)
+	}
+
+	if noItems > 1 {
+		return nil, errors.Errorf("Expect one ServiceClassByExternalID with %s:%s. Found %d", catalog.FilterSpecExternalID, externalID, noItems)
+	}
+
+	return &sc.Items[0], nil
+}


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/master/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- Fix acc test, after updating ServiceCatalog to version 0.1.40

PR with generated image: https://github.com/kyma-project/kyma/pull/2636

### Details 

In Service Catalog they changed the way for setting the ServiceClass name.
Previously the ServiceClass name was the same as the ExternalID.
Currently, the name is the Escaped ExternalID. Their Escape function is not allowing e.g. the `z` letter. 

Previously:
*externalID*: `"acc-test-svc-id-a-jz62z"` so the Service Class name was also `"acc-test-svc-id-a-jz62z"`

Currrently:

*externalID*: `"acc-test-svc-id-a-jz62z"` and the ServiceClass name is `"acc-test-svc-id-a-jz7az62z7az"`

so we cannot find it in our tests.

PR which introduced this changed: https://github.com/kubernetes-incubator/service-catalog/pull/2517

--- 
In this PR I changed the way how we are getting the ServiceClass. I finding the ServiceClass by `spec.externalID` because the *externalID* is always the same as we set in Broker. 

There is an option to just determine the ServiceClass name just be using their `GenerateEscapedName` but  I didnt decide to do that cause it's Service Catalog implementation details and for each upgrade we would be forced to check their implementation.