### PR TITLE
Update event-bus e2e tests version

### DIFF
--- a/resources/event-bus/templates/tests/test-e2e-tester.yaml
+++ b/resources/event-bus/templates/tests/test-e2e-tester.yaml
@@ -102,5 +102,7 @@ spec:
     imagePullPolicy: IfNotPresent
     name: {{ .Values.e2eTests.nameTester }}
     args:
+      - publish-event-uri=http://event-bus-publish:8080/v1/events 
+      - publish-status-uri=http://event-bus-publish:8080/v1/status/ready
       - -subscriber-image={{ .Values.global.containerRegistry.path }}/{{ .Values.global.event_bus_tests.dir }}event-bus-e2e-subscriber:{{ .Values.global.event_bus_tests.version }}
   restartPolicy: Never

--- a/resources/event-bus/values.yaml
+++ b/resources/event-bus/values.yaml
@@ -9,7 +9,7 @@ global:
     version: ab9c73dd
   event_bus_tests:
     dir: develop/
-    version: f01c8848
+    version: 0c471dd3
   natsStreaming:
     url: "http://nats-streaming.natss:4222"
     clusterID: "kyma-nats-streaming"


### PR DESCRIPTION
Update event-bus e2e tests version.
Bump the publish service URL as a test parameter.

See also #2279