### PR TITLE
Remove type matadata from two docs

### DIFF
--- a/docs/asset-store/docs/01-01-asset-store.md
+++ b/docs/asset-store/docs/01-01-asset-store.md
@@ -1,6 +1,5 @@
 ---
-title: Asset Store
-type: Overview
+title: Overview
 ---
 
 The Asset Store is a Kubernetes-native solution for storing assets, such as documents, files, images, API specifications, and client-side applications.

--- a/docs/asset-store/docs/02-01-asset-store.md
+++ b/docs/asset-store/docs/02-01-asset-store.md
@@ -1,6 +1,5 @@
 ---
-title: Asset Store
-type: Architecture
+title: Architecture
 ---
 
 ## Resources


### PR DESCRIPTION

**Description**

Changes proposed in this pull request:

- Remove the `type` matadata from two docs on the Asset Store as it didn't render correctly on the website

