### PR TITLE
support minikube version in range

### DIFF
--- a/installation/scripts/minikube.sh
+++ b/installation/scripts/minikube.sh
@@ -116,7 +116,7 @@ function checkIfMinikubeIsInitialized() {
 }
 
 function checkMinikubeVersion() {
-    local version=$(minikube version | awk '{print  $3}' | sed s/v// )
+    local version=$(minikube version | awk '{print  $3}' | grep -o '[0-9\.]\+' )
     local version_clean=$(echo $version | awk -F '.' '{print $1"."$2;}')
     local supported_version_min=$(echo ${MINIKUBE_VERSION} | awk -F '.' '{print $1"."--$2;}')
     local supported_version_max=$(echo ${MINIKUBE_VERSION} | awk -F '.' '{printf "%d.%d", $1, ++$2;}')

--- a/installation/scripts/minikube.sh
+++ b/installation/scripts/minikube.sh
@@ -6,7 +6,9 @@ CURRENT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 RESOURCES_DIR="${CURRENT_DIR}/../resources"
 
 MINIKUBE_DOMAIN=""
-MINIKUBE_VERSION=0.33.0
+# Supported Minikube Versions: MINIKUBE_VERSION_MIN (inclusive) up to MINIKUBE_VERSION_MAX (exclusive)
+MINIKUBE_VERSION_MIN=0.33.0
+MINIKUBE_VERSION_MAX=0.34.0
 KUBERNETES_VERSION=1.11.5
 KUBECTL_CLI_VERSION=1.11.0
 VM_DRIVER=hyperkit
@@ -117,8 +119,9 @@ function checkIfMinikubeIsInitialized() {
 function checkMinikubeVersion() {
     local version=$(minikube version | awk '{print  $3}')
 
-    if [[ "${version}" != *"${MINIKUBE_VERSION}"* ]]; then
-        echo "Your minikube is in ${version}. v${MINIKUBE_VERSION} is supported version of minikube. Install supported version!"
+    if [[ "$(echo "${version}\n${MINIKUBE_VERSION_MIN}" | sort -V | head -n1)" = "${MINIKUBE_VERSION_MIN}" ]] && "$(echo "$version\n${MINIKUBE_VERSION_MAX}" | sort -V | head -n1)" = "${version}" ]]; then
+        
+        echo "Your minikube is in ${version}. v${MINIKUBE_VERSION_MIN} - v${MINIKUBE_VERSION_MAX} are supported versions of minikube. Please install a supported version!"
         exit -1
     fi
 }

--- a/installation/scripts/minikube.sh
+++ b/installation/scripts/minikube.sh
@@ -121,8 +121,7 @@ function checkMinikubeVersion() {
 
     if [[ "$(echo "${version}\n${MINIKUBE_VERSION_MIN}" | sort -V | head -n1)" = "${MINIKUBE_VERSION_MIN}" ]] && "$(echo "$version\n${MINIKUBE_VERSION_MAX}" | sort -V | head -n1)" = "${version}" ]]; then
         
-        echo "Your minikube is in ${version}. v${MINIKUBE_VERSION_MIN} - v${MINIKUBE_VERSION_MAX} are supported versions of minikube. Please install a supported version!"
-        exit -1
+        log "Your minikube is in ${version}. v${MINIKUBE_VERSION_MIN} - v${MINIKUBE_VERSION_MAX} are supported versions of minikube. Please install a supported version!" yellow
     fi
 }
 


### PR DESCRIPTION
**Description**

Currently only one specific version of minikube is supported by the script. This PR introduces functionality to specify a range of versions.

Fixes #1923 