### PR TITLE
Update scripts to test AC locally

### DIFF
--- a/tests/application-operator-tests/scripts/run-local-tests.sh
+++ b/tests/application-operator-tests/scripts/run-local-tests.sh
@@ -29,6 +29,8 @@ apiVersion: v1
 kind: Pod
 metadata:
   name: application-operator-tests
+  annotations:
+   sidecar.istio.io/inject: “false”
 spec:
   containers:
   - name: application-operator-tests

--- a/tests/application-registry-tests/scripts/run-local-tests.sh
+++ b/tests/application-registry-tests/scripts/run-local-tests.sh
@@ -29,6 +29,8 @@ apiVersion: v1
 kind: Pod
 metadata:
   name: application-registry-tests
+  annotations:
+    sidecar.istio.io/inject: “false”
 spec:
   containers:
   - name: application-registry-tests

--- a/tests/connector-service-tests/scripts/run-local-tests.sh
+++ b/tests/connector-service-tests/scripts/run-local-tests.sh
@@ -33,6 +33,8 @@ apiVersion: v1
 kind: Pod
 metadata:
   name: connector-service-tests
+  annotations:
+    sidecar.istio.io/inject: “false”
 spec:
   hostAliases:
   - ip: "$MINIKUBE_IP"


### PR DESCRIPTION
**Description**

As Istio sidecar injection is done by default, testing scripts need an update.

Changes proposed in this pull request:

- Update scripts to test AC locally
