### PR TITLE
Add ability to skip Connector Service installation

### DIFF
--- a/resources/application-connector/requirements.yaml
+++ b/resources/application-connector/requirements.yaml
@@ -1,0 +1,9 @@
+dependencies:
+- name: nginx-ingress
+- name: application-broker
+- name: application-operator
+- name: application-registry
+- name: connection-token-handler
+  condition: connector-service.enabled
+- name: connector-service
+  condition: connector-service.enabled


### PR DESCRIPTION

**Description**

Changes proposed in this pull request:

- requirements.yaml added
- connector-service.enabled added (when set to false Application Connector chart won't install Connector Service)

