### PR TITLE
Include the event source-id and the event-type-version in the knative channel name

### DIFF
--- a/components/event-bus/cmd/event-bus-publish-knative/handlers/publish_test.go
+++ b/components/event-bus/cmd/event-bus-publish-knative/handlers/publish_test.go
@@ -4,38 +4,110 @@ import (
 	"testing"
 )
 
-type TestCase struct {
-	name     string
-	expected string
-}
-
 func Test_getChannelName(t *testing.T) {
-	// prepare test-cases
+	// define the test-case struct
+	type TestCase struct {
+		name             string
+		sourceID         string
+		eventType        string
+		eventTypeVersion string
+		expected         string
+	}
+
+	// cache the test-cases output to detect naming collisions
+	channelNames := make(map[string]TestCase)
+
+	// initialize the test-cases
 	testCases := []TestCase{
 		{
-			name:     "ordercreated",
-			expected: "ordercreated",
+			name:             "test-case-1",
+			sourceID:         "ec-default",
+			eventType:        "order.created",
+			eventTypeVersion: "v1",
+			expected:         "ec--default-order-dot-created-v1",
 		},
 		{
-			name:     "order_created",
-			expected: "order_created",
+			name:             "test-case-2",
+			sourceID:         "ec-default",
+			eventType:        "order-created",
+			eventTypeVersion: "v1",
+			expected:         "ec--default-order--created-v1",
 		},
 		{
-			name:     "order.created",
-			expected: "order-created",
+			name:             "test-case-3",
+			sourceID:         "ec.default",
+			eventType:        "order.created",
+			eventTypeVersion: "v1",
+			expected:         "ec-dot-default-order-dot-created-v1",
 		},
 		{
-			name:     "order-created",
-			expected: "order-created",
+			name:             "test-case-4",
+			sourceID:         "ec.default",
+			eventType:        "order-created",
+			eventTypeVersion: "v1",
+			expected:         "ec-dot-default-order--created-v1",
+		},
+		{
+			name:             "test-case-5",
+			sourceID:         "ec..default--test..1",
+			eventType:        "order--created..test--1",
+			eventTypeVersion: "v1",
+			expected:         "ec-dot--dot-default----test-dot--dot-1-order----created-dot--dot-test----1-v1",
+		},
+		{
+			name:             "test-case-6",
+			sourceID:         "ec--default..test--1",
+			eventType:        "order..created--test..1",
+			eventTypeVersion: "v1",
+			expected:         "ec----default-dot--dot-test----1-order-dot--dot-created----test-dot--dot-1-v1",
+		},
+		{
+			name:             "test-case-7",
+			sourceID:         "external-application",
+			eventType:        "order-created",
+			eventTypeVersion: "v1",
+			expected:         "external--application-order--created-v1",
+		},
+		{
+			name:             "test-case-8",
+			sourceID:         "external-application-order",
+			eventType:        "created",
+			eventTypeVersion: "v1",
+			expected:         "external--application--order-created-v1",
+		},
+		{
+			name:             "test-case-9",
+			sourceID:         "external.application",
+			eventType:        "order.created",
+			eventTypeVersion: "v1",
+			expected:         "external-dot-application-order-dot-created-v1",
+		},
+		{
+			name:             "test-case-10",
+			sourceID:         "external.application.order",
+			eventType:        "created",
+			eventTypeVersion: "v1",
+			expected:         "external-dot-application-dot-order-created-v1",
 		},
 	}
 
-	// run test-cases
+	// run the test-cases
 	for _, testCase := range testCases {
 		t.Run(testCase.name, func(t *testing.T) {
-			if got := getChannelName(&testCase.name); got != testCase.expected {
-				t.Errorf("getChannelName('%s') got:%s but expected:%s", testCase.name, got, testCase.expected)
+			result := getChannelName(&testCase.sourceID, &testCase.eventType, &testCase.eventTypeVersion)
+
+			// check the channel naming correctness
+			if result != testCase.expected {
+				t.Errorf("getChannelName returned [%s] but expected [%s]", result, testCase.expected)
 			}
+
+			// check the channel naming collisions
+			if tc, found := channelNames[result]; found {
+				t.Errorf("getChannelName generates the same chanel name [%s] for test case [%s] and [%s]", result, tc.name, testCase.name)
+			}
+
+			// cache the test result
+			channelNames[result] = testCase
 		})
 	}
 }


### PR DESCRIPTION
**Description**

- include the event source-id and the event-type-version in the knative channel name
- update the tests

**Related issue(s)**
#2797 
