### PR TITLE
Update the implementation of CreateSubscription to return "IsAlreadyE…

### DIFF
--- a/components/event-bus/internal/knative/util/eventing.go
+++ b/components/event-bus/internal/knative/util/eventing.go
@@ -131,14 +131,9 @@ func (k *KnativeLib) DeleteChannel(name string, namespace string) error {
 // CreateSubscription creates a Knative/Eventing subscription for the specified channel
 func (k *KnativeLib) CreateSubscription(name string, namespace string, channelName string, uri *string) error {
 	sub := Subscription(name, namespace).ToChannel(channelName).ToUri(uri).EmptyReply().Build()
-	if sub, err := k.evClient.Subscriptions(namespace).Create(sub); err != nil && !k8serrors.IsAlreadyExists(err) {
+	if _, err := k.evClient.Subscriptions(namespace).Create(sub); err != nil {
 		log.Printf("ERROR: CreateSubscription(): creating subscription: %v", err)
 		return err
-	} else if err != nil && k8serrors.IsAlreadyExists(err) {
-		if sub, err = k.evClient.Subscriptions(namespace).Update(sub); err != nil {
-			log.Printf("ERROR: CreateSubscription(): updating subscription: %v", err)
-			return err
-		}
 	}
 	return nil
 }

--- a/components/event-bus/internal/knative/util/eventing_test.go
+++ b/components/event-bus/internal/knative/util/eventing_test.go
@@ -190,3 +190,14 @@ func Test_CreateDeleteSubscription(t *testing.T) {
 	err = k.DeleteSubscription(subscriptionName, testNS)
 	assert.Nil(t, err)
 }
+
+func Test_CreateSubscriptionAgain(t *testing.T) {
+	log.Print("Test_CreateSubscriptionAgain")
+	k := &KnativeLib {}
+	k.InjectClient(evclientsetfake.NewSimpleClientset().EventingV1alpha1())
+	var uri = "dnsName: hello-00001-service.default"
+	err := k.CreateSubscription(subscriptionName, testNS, channelName, &uri)
+	assert.Nil(t, err)
+	err = k.CreateSubscription(subscriptionName, testNS, channelName, &uri)
+	assert.True(t, k8serrors.IsAlreadyExists(err))
+}


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/master/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- If a KN subscription exists, recreating it will return k8serrors.IsAlreadyExists

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
