### PR TITLE
Use metrics-server instead of retired heapster

### DIFF
--- a/installation/scripts/minikube.ps1
+++ b/installation/scripts/minikube.ps1
@@ -31,8 +31,10 @@ function CheckIfMinikubeIsInitialized() {
 function InitializeMinikubeConfig () {
     $cmd = "minikube config unset ingress"
     Invoke-Expression -Command $cmd
+}
 
-    $cmd = "minikube addons enable heapster"
+function ConfigureMinikubeAddons () {
+    $cmd = "minikube addons enable metrics-server"
     Invoke-Expression -Command $cmd
 }
 
@@ -109,5 +111,6 @@ CheckIfMinikubeIsInitialized
 InitializeMinikubeConfig
 StartMinikube
 WaitForMinikubeToBeUp
+ConfigureMinikubeAddons
 AddDevDomainsToEtcHosts "apiserver", "console", "catalog", "instances", "dex", "docs", "lambdas-ui", "ui-api", "minio", "jaeger", "grafana", "configurations-generator", "gateway", "connector-service"
 IncreaseFsInotifyMaxUserInstances

--- a/installation/scripts/minikube.sh
+++ b/installation/scripts/minikube.sh
@@ -68,8 +68,11 @@ echo "
 function initializeMinikubeConfig() {
     # Disable default nginx ingress controller
     minikube config unset ingress
-    # Enable heapster addon
-    minikube addons enable heapster
+}
+
+function configureMinikubeAddons() {
+    # Enable metrics-server addon for kubectl top
+    minikube addons enable metrics-server
 }
 
 #TODO refactor to use minikube status!
@@ -214,6 +217,8 @@ function start() {
     --bootstrapper=kubeadm
 
     waitForMinikubeToBeUp
+
+    configureMinikubeAddons
 
     # Adding domains to /etc/hosts files
     addDevDomainsToEtcHosts "apiserver.${MINIKUBE_DOMAIN} console.${MINIKUBE_DOMAIN} catalog.${MINIKUBE_DOMAIN} instances.${MINIKUBE_DOMAIN} brokers.${MINIKUBE_DOMAIN} dex.${MINIKUBE_DOMAIN} docs.${MINIKUBE_DOMAIN} lambdas-ui.${MINIKUBE_DOMAIN} ui-api.${MINIKUBE_DOMAIN} minio.${MINIKUBE_DOMAIN} jaeger.${MINIKUBE_DOMAIN} grafana.${MINIKUBE_DOMAIN}  configurations-generator.${MINIKUBE_DOMAIN} gateway.${MINIKUBE_DOMAIN} connector-service.${MINIKUBE_DOMAIN}"


### PR DESCRIPTION
**Description**

While working on #2603 I've noticed that https://github.com/kyma-project/kyma/pull/1739 got broken, `kubectl top` would no longer work because enabling of heapster minikube addon was failing. It seems at some version of minikube, enabling of addons was made possible only after minikube has already been started. Trying to enable addon before minikube has been started - with 0.33.x minikube it would just log `minikube is not currently running so the service cannot be accessed` error, while with 0.34.x minikube configuration initialization would return non-zero exit code and fail installation script. Also, heapster project is [retired](https://github.com/kubernetes-retired/heapster#heapster) and part of its functionality `kubectl top` depends on is replaced with metrics-server.

Changes proposed in this pull request:

- Adjust Kyma minikube installation to enable minikube addons after minikube has been started
- Replace use of retired heapster with metrics-server minikube addon