### PR TITLE
readme files for components and tests containing naming convention

### DIFF
--- a/components/README.md
+++ b/components/README.md
@@ -8,9 +8,9 @@ Each subdirectory in the `components` directory defines one component.
 
 ## Details
 
-Every Kyma component resides in a dedicated folder, which contains its sources and a `README.md` file. This file provides instructions on how to build and develop the component.
+Every Kyma component resides in a dedicated folder which contains its sources and a `README.md` file. This file provides instructions on how to build and develop the component.
 
-The component's name consists of a term describing the component, followed by a **component type**. The first part of the name may differ depending on the component's purpose. 
+The component's name consists of a term describing the component, followed by the **component type**. The first part of the name may differ depending on the component's purpose. 
 This table lists the available types:
 
 | type|description|example|

--- a/components/README.md
+++ b/components/README.md
@@ -2,22 +2,22 @@
 
 ## Overview
 
-The components folder contains the sources of all Kyma components.
-A Kyma component is any Pod/container/image deployed with and referenced in a Kyma module/chart to provide the module's functionality.
-Each subfolder in the _components_ directory defines one component.
+The `components` directory contains the sources of all Kyma components.
+A Kyma component is any Pod, container, or image deployed with and referenced in a Kyma module or chart to provide the module's functionality.
+Each subdirectory in the `components` directory defines one component.
 
 ## Details
 
-Every Kyma component has a dedicated folder containing its sources and a README.md containing further instructions on how to build and develop the component.
+Every Kyma component resides in a dedicated folder, which contains its sources and a `README.md` file. This file provides instructions on how to build and develop the component.
 
 The component name and with that the folder name should be suffixed with its component type. The types are defined as following:
 
 | type|description|example|
 |--|--|--|
-|controller|is a [Kubernetes Controller](https://kubernetes.io/docs/concepts/workloads/controllers/) reacting on standard Kubernetes resource or managing resources of a [Custom Resource Definition](https://kubernetes.io/docs/tasks/access-kubernetes-api/custom-resources/custom-resource-definitions/). The name of the component reflects name of the primary resource which it controls.|namespace-controller|
+|controller|A [Kubernetes Controller](https://kubernetes.io/docs/concepts/workloads/controllers/) which reacts on a standard Kubernetes resource or manages [Custom Resource Definition](https://kubernetes.io/docs/tasks/access-kubernetes-api/custom-resources/custom-resource-definitions/) resources. The component's name reflects the name of the primary resource it controls.|namespace-controller|
 |operator|is a [Kubernetes Operator](https://coreos.com/operators/) covering  application specific logic for operatiion of the application, like steps to upscale a stateful applicatin. It usually reacts on changes to resources of a [Custom Resource Definition](https://kubernetes.io/docs/tasks/access-kubernetes-api/custom-resources/custom-resource-definitions/). It uses the name of the application it operates. |application-operator|
-|job|is a [Kubernetes Job](https://kubernetes.io/docs/tasks/job/), performing a task once or periodically. It uses the name of the task it performs. |istio-patch-job (not renamed yet)|
-|proxy| proxies an existing component, usually introducing a security model for the proxied component. It uses the component name. | apiserver-proxy|
-|service| serves an HTTP/S-based API, usually exposed securely to the public. It uses the domain name and the API it serves.|connector-service|
-|broker| is implementing the [OpenServiceBroker](https://www.openservicebrokerapi.org/) specification to enrich the Kyma Service Catalog with services of a provider. It uses the name of the provider it integrates with.|azure-broker|
-|configurer|a one time task usually executed as an [init container](https://kubernetes.io/docs/concepts/workloads/pods/init-containers/) in order to configure an application|ark-plugins-configurer (not migrated yet)|
+|job| A [Kubernetes Job](https://kubernetes.io/docs/tasks/job/) which performs a task once or periodically. It uses the name of the task it performs. |istio-patch-job (not renamed yet)|
+|proxy| Acts as a proxy for an existing component, usually introducing a security model for this component. It uses the component's name. | apiserver-proxy|
+|service| Serves an HTTP/S-based API, usually securely exposed to the public. It uses the domain name and the API it serves.|connector-service|
+|broker| Implements the [OpenServiceBroker](https://www.openservicebrokerapi.org/) specification to enrich the Kyma Service Catalog with the services of a provider. It uses the name of the provider it integrates with.|azure-broker|
+|configurer| A one-time task usually executed as an [init container](https://kubernetes.io/docs/concepts/workloads/pods/init-containers/) in order to configure an application.|ark-plugins-configurer (not migrated yet)|

--- a/components/README.md
+++ b/components/README.md
@@ -1,0 +1,23 @@
+# Components
+
+## Overview
+
+The components folder contains the sources of all Kyma components.
+A Kyma component is any Pod/container/image deployed with and referenced in a Kyma module/chart to provide the module's functionality.
+Each subfolder in the _components_ directory defines one component.
+
+## Details
+
+Every Kyma component has a dedicated folder containing its sources and a README.md containing further instructions on how to build and develop the component.
+
+The component name and with that the folder name should be suffixed with its component type. The types are defined as following:
+
+| type|description|example|
+|--|--|--|
+|controller|is a [Kubernetes Controller](https://kubernetes.io/docs/concepts/workloads/controllers/) reacting on standard Kubernetes resource or managing resources of a [Custom Resource Definition](https://kubernetes.io/docs/tasks/access-kubernetes-api/custom-resources/custom-resource-definitions/). The name of the component reflects name of the primary resource which it controls.|namespace-controller|
+|operator|is a [Kubernetes Operator](https://coreos.com/operators/) covering  application specific logic for operatiion of the application, like steps to upscale a stateful applicatin. It usually reacts on changes to resources of a [Custom Resource Definition](https://kubernetes.io/docs/tasks/access-kubernetes-api/custom-resources/custom-resource-definitions/). It uses the name of the application it operates. |application-operator|
+|job|is a [Kubernetes Job](https://kubernetes.io/docs/tasks/job/), performing a task once or periodically. It uses the name of the task it performs. |istio-patch-job (not renamed yet)|
+|proxy| proxies an existing component, usually introducing a security model for the proxied component. It uses the component name. | apiserver-proxy|
+|service| serves an HTTP/S-based API, usually exposed securely to the public. It uses the domain name and the API it serves.|connector-service|
+|broker| is implementing the [OpenServiceBroker](https://www.openservicebrokerapi.org/) specification to enrich the Kyma Service Catalog with services of a provider. It uses the name of the provider it integrates with.|azure-broker|
+|configurer|a one time task usually executed as an [init container](https://kubernetes.io/docs/concepts/workloads/pods/init-containers/) in order to configure an application|ark-plugins-configurer (not migrated yet)|

--- a/components/README.md
+++ b/components/README.md
@@ -10,7 +10,8 @@ Each subdirectory in the `components` directory defines one component.
 
 Every Kyma component resides in a dedicated folder, which contains its sources and a `README.md` file. This file provides instructions on how to build and develop the component.
 
-The component name and with that the folder name should be suffixed with its component type. The types are defined as following:
+The component's name consists of a term describing the component, followed by a **component type**. The first part of the name may differ depending on the component's purpose. 
+This table lists the available types:
 
 | type|description|example|
 |--|--|--|
@@ -20,4 +21,4 @@ The component name and with that the folder name should be suffixed with its com
 |proxy| Acts as a proxy for an existing component, usually introducing a security model for this component. It uses the component's name. | apiserver-proxy|
 |service| Serves an HTTP/S-based API, usually securely exposed to the public. It uses the domain name and the API it serves.|connector-service|
 |broker| Implements the [OpenServiceBroker](https://www.openservicebrokerapi.org/) specification to enrich the Kyma Service Catalog with the services of a provider. It uses the name of the provider it integrates with.|azure-broker|
-|configurer| A one-time task usually executed as an [init container](https://kubernetes.io/docs/concepts/workloads/pods/init-containers/) in order to configure an application.|ark-plugins-configurer (not migrated yet)|
+|configurer| A one-time task which usually runs as an [Init Container](https://kubernetes.io/docs/concepts/workloads/pods/init-containers/) in order to configure the application.|ark-plugins-configurer (not migrated yet)|

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,19 @@
+# Tests
+
+## Overview
+
+The tests folder contains the sources for all Kyma tests.
+A Kyma test is Pod/container/image referenced in a Kyma module/chart test section to provide the module's test functionality. 
+A Kyma test gets executed against a running Kyma cluster to assure integrity and functional correctness of the cluster with all modules installed. These are acceptance tests.
+Each subfolder in the tests directory defines sources for one test suite, usually focusing on one component. The resulting docker images are then referenced by the related Kyma modules/charts.
+
+## Details
+
+Every Kyma test has a dedicated folder containing its sources and a README.md containing further instructions on how to build and develop the test suite.
+
+The test name and with that the folder name should reflect the component under test. It should not have a prefix and no suffix, just the component name under test, for example _monitoring_.
+
+The docker image resulting from the sources of a test suite should reside in the tests subfolder.
+Example: The Event-Bus component has its acceptance tests in the tests/event-bus folder and produces the XX/tests/event-bus:0.5.1 docker image.
+
+Bundle the real e2e scenarios (like kubeless-integration) into one end-to-end subfolder. Here we should have one test project which executes all end-to-end tests divided by scenarios into different packages, see the [README.md](end-to-end/README.md) for more details.

--- a/tests/README.md
+++ b/tests/README.md
@@ -2,18 +2,18 @@
 
 ## Overview
 
-The `tests` folder contains the sources for all Kyma tests.
+The `tests` directory contains the sources for all Kyma tests.
 A Kyma test is Pod, container, or image referenced in a Kyma module or chart test section. It provides the module's test functionality. 
 A Kyma test runs against a running Kyma cluster. It ensures the integrity and functional correctness of the cluster with all installed modules. 
-Each subdirectory in the tests directory defines sources for one test suite, usually focusing on one component. The resulting docker images are then referenced by the related Kyma modules or charts.
+Each subdirectory in the tests directory defines sources for one test suite, usually focusing on one component. The resulting Docker images are then referenced by the related Kyma modules or charts.
 
 ## Details
 
-Every Kyma test resides in a dedicated folder containing its sources and a `README.md ` file. This file provides instructions on how to build and develop the test suite.
+Every Kyma test resides in a dedicated folder which contains its sources and a `README.md ` file. This file provides instructions on how to build and develop the test suite.
 
-The test name, which is also the folder name, reflects the tested component without any prefix or suffix. For example,  `monitoring`.
+The test name, which is also the folder name,  is the component's name without any prefix or suffix. For example,  `monitoring`.
 
-The docker image resulting from the sources of a test suite resides in the tests subfolder.
-Example: The Event Bus component has its acceptance tests in the `tests/event-bus` folder and produces the `XX/tests/event-bus:0.5.1` docker image.
+The Docker image resulting from the sources of a test suite resides in the dedicated `tests` subfolder.
+Example: The Event Bus component has its acceptance tests in the `tests/event-bus` folder and produces the `XX/tests/event-bus:0.5.1` Docker image.
 
 Bundle the real e2e scenarios, such as **kubeless-integration** into one end-to-end subfolder. This folder contains one test project which executes all end-to-end tests divided into different packages by scenarios. For details, see the [`README.md`](end-to-end/README.md) file.

--- a/tests/README.md
+++ b/tests/README.md
@@ -16,4 +16,4 @@ The test name, which is also the folder name,  is the component's name without a
 The Docker image resulting from the sources of a test suite resides in the dedicated `tests` subfolder.
 Example: The Event Bus component has its acceptance tests in the `tests/event-bus` folder and produces the `XX/tests/event-bus:0.5.1` Docker image.
 
-Bundle the real e2e scenarios, such as **kubeless-integration** into one end-to-end subfolder. This folder contains one test project which executes all end-to-end tests divided into different packages by scenarios. For details, see the [`README.md`](end-to-end/README.md) file.
+Bundle the real e2e scenarios, such as **kubeless-integration** into one end-to-end subfolder. This folder contains one test project which executes all end-to-end tests divided into different packages by scenarios.

--- a/tests/README.md
+++ b/tests/README.md
@@ -2,18 +2,18 @@
 
 ## Overview
 
-The tests folder contains the sources for all Kyma tests.
+The `tests` folder contains the sources for all Kyma tests.
 A Kyma test is Pod/container/image referenced in a Kyma module/chart test section to provide the module's test functionality. 
 A Kyma test gets executed against a running Kyma cluster to assure integrity and functional correctness of the cluster with all modules installed. These are acceptance tests.
-Each subfolder in the tests directory defines sources for one test suite, usually focusing on one component. The resulting docker images are then referenced by the related Kyma modules/charts.
+Each subdirectory in the tests directory defines sources for one test suite, usually focusing on one component. The resulting docker images are then referenced by the related Kyma modules or charts.
 
 ## Details
 
-Every Kyma test has a dedicated folder containing its sources and a README.md containing further instructions on how to build and develop the test suite.
+Every Kyma test resides in a dedicated folder containing its sources and a `README.md ` file. This file provides instructions on how to build and develop the test suite.
 
-The test name and with that the folder name should reflect the component under test. It should not have a prefix and no suffix, just the component name under test, for example _monitoring_.
+The test name, which is also the folder name, reflects the tested component without any prefix or suffix. For example,  `monitoring`.
 
-The docker image resulting from the sources of a test suite should reside in the tests subfolder.
-Example: The Event-Bus component has its acceptance tests in the tests/event-bus folder and produces the XX/tests/event-bus:0.5.1 docker image.
+The docker image resulting from the sources of a test suite resides in the tests subfolder.
+Example: The Event Bus component has its acceptance tests in the `tests/event-bus` folder and produces the `XX/tests/event-bus:0.5.1` docker image.
 
-Bundle the real e2e scenarios (like kubeless-integration) into one end-to-end subfolder. Here we should have one test project which executes all end-to-end tests divided by scenarios into different packages, see the [README.md](end-to-end/README.md) for more details.
+Bundle the real e2e scenarios, such as **kubeless-integration** into one end-to-end subfolder. This folder contains one test project which executes all end-to-end tests divided into different packages by scenarios. For details, see the [`README.md`](end-to-end/README.md) file.

--- a/tests/README.md
+++ b/tests/README.md
@@ -3,8 +3,8 @@
 ## Overview
 
 The `tests` folder contains the sources for all Kyma tests.
-A Kyma test is Pod/container/image referenced in a Kyma module/chart test section to provide the module's test functionality. 
-A Kyma test gets executed against a running Kyma cluster to assure integrity and functional correctness of the cluster with all modules installed. These are acceptance tests.
+A Kyma test is Pod, container, or image referenced in a Kyma module or chart test section. It provides the module's test functionality. 
+A Kyma test runs against a running Kyma cluster. It ensures the integrity and functional correctness of the cluster with all installed modules. 
 Each subdirectory in the tests directory defines sources for one test suite, usually focusing on one component. The resulting docker images are then referenced by the related Kyma modules or charts.
 
 ## Details


### PR DESCRIPTION
As an outcome of [component-folder-consolidation.md](https://github.com/kyma-project/community/blob/master/sig-and-wg/sig-core/proposals/component-folder-consolidation.md) and [test-folder-consolidation.md](https://github.com/kyma-project/community/blob/master/sig-and-wg/sig-core/proposals/test-folder-consolidation.md).
I provided readme files covering the agreed naming convention.
Any new project should follow it, existing projects can slowly migrate.

Related to https://github.com/kyma-project/kyma/issues/2501 and https://github.com/kyma-project/kyma/issues/2503