### PR TITLE
Replace hostNetwork setting with hostAliases for ui-acceptance test minikube executions

### DIFF
--- a/installation/resources/installer-config-local.yaml.tpl
+++ b/installation/resources/installer-config-local.yaml.tpl
@@ -111,3 +111,15 @@ metadata:
 data:
   minio.resources.requests.memory: 64Mi
   minio.resources.limits.cpu: 100m
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: core-test-ui-acceptance-overrides
+  namespace: kyma-installer
+  labels:
+    installer: overrides
+    component: core
+    kyma-project.io/installation: ""
+data:
+  test.acceptance.ui.minikubeIP: ""

--- a/installation/scripts/installer.sh
+++ b/installation/scripts/installer.sh
@@ -102,8 +102,6 @@ if [ $KNATIVE ]; then
     kubectl -n kyma-installer patch configmap installation-config-overrides -p '{"data": {"global.knative": "true", "global.kymaEventBus": "false", "global.natsStreaming.clusterID": "knative-nats-streaming"}}'
 fi
 
-
-
 echo -e "\nConfiguring sub-components"
 bash ${CURRENT_DIR}/configure-components.sh
 

--- a/installation/scripts/installer.sh
+++ b/installation/scripts/installer.sh
@@ -97,6 +97,24 @@ if [ $KNATIVE ]; then
     kubectl -n kyma-installer patch configmap installation-config-overrides -p '{"data": {"global.knative": "true", "global.kymaEventBus": "false", "global.natsStreaming.clusterID": "knative-nats-streaming"}}'
 fi
 
+if [ $LOCAL ]; then
+
+MINIKUBE_IP=$(minikube ip)
+cat <<EOF | kubectl -n kyma-installer apply -f -
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: core-test-ui-acceptance-overrides
+  namespace: kyma-installer
+  labels:
+    installer: overrides
+    component: core
+    kyma-project.io/installation: ""
+data:
+  test.acceptance.ui.minikubeIP: "$MINIKUBE_IP"
+EOF
+fi
+
 echo -e "\nConfiguring sub-components"
 bash ${CURRENT_DIR}/configure-components.sh
 

--- a/resources/core/templates/tests/test-ui-acceptance.yaml
+++ b/resources/core/templates/tests/test-ui-acceptance.yaml
@@ -9,7 +9,18 @@ metadata:
     "helm-chart-test": "true"
 spec:
   {{ if .Values.global.isLocalEnv }}
-  hostNetwork: true
+  hostAliases:
+   - ip: "127.0.0.1"
+     hostnames:
+      - "apiserver.{{ .Values.global.domainName }}"
+      - "console.{{ .Values.global.domainName }}"
+      - "catalog.{{ .Values.global.domainName }}"
+      - "instances.{{ .Values.global.domainName }}"
+      - "brokers.{{ .Values.global.domainName }}"
+      - "dex.{{ .Values.global.domainName }}"
+      - "docs.{{ .Values.global.domainName }}"
+      - "lambdas-ui.{{ .Values.global.domainName }}"
+      - "ui-api.{{ .Values.global.domainName }}"
   {{ end }}
   serviceAccountName:  "test-{{ template "fullname" . }}-ui-acceptance"
   containers:

--- a/resources/core/templates/tests/test-ui-acceptance.yaml
+++ b/resources/core/templates/tests/test-ui-acceptance.yaml
@@ -10,7 +10,7 @@ metadata:
 spec:
   {{ if .Values.global.isLocalEnv }}
   hostAliases:
-   - ip: "127.0.0.1"
+   - ip: "$(minikube ip)"
      hostnames:
       - "apiserver.{{ .Values.global.domainName }}"
       - "console.{{ .Values.global.domainName }}"

--- a/resources/core/templates/tests/test-ui-acceptance.yaml
+++ b/resources/core/templates/tests/test-ui-acceptance.yaml
@@ -8,7 +8,9 @@ metadata:
   labels:
     "helm-chart-test": "true"
 spec:
+  {{ if .Values.global.isLocalEnv }}
   hostNetwork: true
+  {{ end }}
   serviceAccountName:  "test-{{ template "fullname" . }}-ui-acceptance"
   containers:
     - name: "test-{{ template "fullname" . }}-ui-acceptance"

--- a/resources/core/templates/tests/test-ui-acceptance.yaml
+++ b/resources/core/templates/tests/test-ui-acceptance.yaml
@@ -21,6 +21,7 @@ spec:
       - "docs.{{ .Values.global.domainName }}"
       - "lambdas-ui.{{ .Values.global.domainName }}"
       - "ui-api.{{ .Values.global.domainName }}"
+      - "minio.{{ .Values.global.domainName }}"
   {{ end }}
   serviceAccountName:  "test-{{ template "fullname" . }}-ui-acceptance"
   containers:

--- a/resources/core/templates/tests/test-ui-acceptance.yaml
+++ b/resources/core/templates/tests/test-ui-acceptance.yaml
@@ -10,7 +10,7 @@ metadata:
 spec:
   {{ if .Values.global.isLocalEnv }}
   hostAliases:
-   - ip: "$(minikube ip)"
+   - ip: {{ .Values.test.acceptance.ui.minikubeIP }}
      hostnames:
       - "apiserver.{{ .Values.global.domainName }}"
       - "console.{{ .Values.global.domainName }}"

--- a/resources/core/values.yaml
+++ b/resources/core/values.yaml
@@ -109,3 +109,4 @@ test:
       limits:
         memory: 1.5Gi
         cpu: 300m
+      minikubeIP:

--- a/resources/core/values.yaml
+++ b/resources/core/values.yaml
@@ -109,4 +109,3 @@ test:
       limits:
         memory: 1.5Gi
         cpu: 300m
-      minikubeIP:


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

-  Applied `hostAliases` instead of  `hostNetwork` configuration for ui test pod when executed on  minikube

**Related issue(s)**
https://github.com/kyma-project/kyma/issues/2705
