### PR TITLE
Define monitoring configuration alerting defaults

### DIFF
--- a/resources/monitoring/charts/alertmanager/values.yaml
+++ b/resources/monitoring/charts/alertmanager/values.yaml
@@ -169,3 +169,14 @@ webhookConfig:
     bearerToken: ''
     bearerTokenFile: ''
     proxyUrl: ""
+
+# disable slack and victorops alerting by default
+global:
+  alertTools:
+    credentials:
+      slack:
+        apiurl: ""
+        channel: ""
+      victorOps:
+        routingkey: ""
+        apikey: ""


### PR DESCRIPTION
**Description**

Monitoring component and its dependency prometheus operator are disabled by default for Kyma local installation.
While working on https://github.com/kyma-project/kyma/issues/2603 I've observed that enabling monitoring component for local Kyma installation is overly complicated, since working defaults for multiple configuration properties are not defined in the installation files. This PR makes it possible to enable monitoring by simply uncommenting it and its prometheus operator dependency in `installer-cr.yaml.tpl` and then running the installation script.

Changes proposed in this pull request:
- Define local monitoring configuration defaults