### PR TITLE
Add graceful shutdown for the knative-publish HTTP server

### DIFF
--- a/components/event-bus/cmd/event-bus-publish-knative/httpserver/httpserver.go
+++ b/components/event-bus/cmd/event-bus-publish-knative/httpserver/httpserver.go
@@ -1,12 +1,21 @@
 package httpserver
 
 import (
+	"context"
 	"fmt"
 	"log"
 	"net/http"
+	"os"
+	"os/signal"
+	"syscall"
+	"time"
 )
 
-func NewHttpServer(port *int, handler *http.Handler) *http.Server {
+type HttpServer struct {
+	server *http.Server
+}
+
+func NewHttpServer(port *int, handler *http.Handler) *HttpServer {
 	if port == nil {
 		log.Println("cannot create HTTP server the port is missing")
 		return nil
@@ -15,19 +24,47 @@ func NewHttpServer(port *int, handler *http.Handler) *http.Server {
 		log.Println("cannot create HTTP server the HTTP handler function is missing")
 		return nil
 	}
+
 	server := &http.Server{
 		Addr:    fmt.Sprintf(":%d", *port),
 		Handler: *handler,
 	}
-	return server
+
+	httpServer := HttpServer{server: server}
+	return &httpServer
 }
 
-func Close(server *http.Server) {
-	if server == nil {
-		log.Println("cannot close a nil HTTP server")
+func (h *HttpServer) Start() {
+	if h.server == nil {
+		log.Println("cannot start a nil HTTP server")
 		return
 	}
-	if err := server.Close(); err != nil {
-		log.Printf("failed to stop the http server: %v", err)
+
+	if err := h.server.ListenAndServe(); err != nil {
+		log.Printf("HTTP server ListenAndServe error: %v", err)
+	}
+}
+
+func (h *HttpServer) Shutdown(timeout time.Duration) {
+	if h.server == nil {
+		log.Println("cannot shutdown a nil HTTP server")
+		return
+	}
+
+	shutdownSignal := make(chan os.Signal, 1)
+	defer close(shutdownSignal)
+
+	signal.Notify(shutdownSignal, os.Interrupt, syscall.SIGTERM, syscall.SIGINT)
+	<-shutdownSignal
+
+	log.Printf("HTTP server shutdown with timeout: %s\n", timeout)
+
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+
+	if err := h.server.Shutdown(ctx); err != nil {
+		log.Printf("HTTP server shutdown error: %v\n", err)
+	} else {
+		log.Println("HTTP server shutdown successful")
 	}
 }


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- add graceful shutdown for the knative-publish HTTP server.

**Related issue(s)**
#2438 