### PR TITLE
Add monitoring setup for minio and fix other custom monitoring

### DIFF
--- a/docs/monitoring/docs/08-01-monitoring-custom-metrics.md
+++ b/docs/monitoring/docs/08-01-monitoring-custom-metrics.md
@@ -98,7 +98,7 @@ Use either the `cpu_temperature_celsius` or `hd_errors_total` in the [**expressi
 
 Prometheus can reach the service using ServiceMonitor. ServiceMonitor is a specific CRD used by the Prometheus operator to monitor services.
 
-In Kyma, the Prometheus server discovers all ServiceMonitors through the **serviceMonitorSelector** matching the `prometheus: core` label.
+In Kyma, the Prometheus server discovers all ServiceMonitors through the **serviceMonitorSelector** matching the `prometheus: monitoring` label.
 
 ```yaml
   serviceMonitorSelector:

--- a/docs/monitoring/docs/08-01-monitoring-custom-metrics.md
+++ b/docs/monitoring/docs/08-01-monitoring-custom-metrics.md
@@ -63,10 +63,7 @@ This is a basic example where `Gauge` and `Counter` metrics are exported using t
     ```bash
     kubectl get pods
     NAME                             READY     STATUS    RESTARTS   AGE
-    sample-metrics-c9f998959-jd2fz   2/2       Running   0          2m
-    sample-metrics-c9f998959-kfbp8   2/2       Running   0          2m
-    sample-metrics-c9f998959-nnp2n   2/2       Running   0          2m
-    sample-metrics-c9f998959-vdnkn   2/2       Running   0          2m
+    sample-metrics-67c6885d8c-smt62   2/2       Running   0          2m
     ```
 
 2. Run the `port-forward` command on the `sample-metrics-8081` service for the`8081` port to check the metrics.

--- a/resources/application-connector/charts/application-registry/templates/service.yaml
+++ b/resources/application-connector/charts/application-registry/templates/service.yaml
@@ -25,7 +25,7 @@ metadata:
   name: {{ .Chart.Name}}-metrics
   namespace: {{ .Values.global.namespace }}
   labels:
-    k8s-app: metrics
+    k8s-app: {{ .Chart.Name}}-metrics
 spec:
   selector:
     app: {{ .Chart.Name }}

--- a/resources/application-connector/charts/application-registry/templates/servicemonitor.yaml
+++ b/resources/application-connector/charts/application-registry/templates/servicemonitor.yaml
@@ -2,7 +2,7 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   name: application-registry-metrics
-  namespace: {{ .Values.global.namespace }}
+  namespace: kyma-system
   labels:
     prometheus: monitoring
     app: {{ .Chart.Name }}

--- a/resources/application-connector/charts/application-registry/templates/servicemonitor.yaml
+++ b/resources/application-connector/charts/application-registry/templates/servicemonitor.yaml
@@ -2,14 +2,15 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   name: application-registry-metrics
-  namespace: kyma-system
+  namespace: {{ .Values.global.namespace }}
   labels:
-    prometheus: core
-    example: monitoring-custom-metrics
+    prometheus: monitoring
+    app: {{ .Chart.Name }}
+    release: {{ .Chart.Name }}
 spec:
   selector:
     matchLabels:
-      k8s-app: metrics
+      k8s-app: {{ .Chart.Name}}-metrics
   targetLabels:
     - k8s-app
   endpoints:

--- a/resources/application-connector/charts/connector-service/templates/service.yaml
+++ b/resources/application-connector/charts/connector-service/templates/service.yaml
@@ -42,7 +42,7 @@ metadata:
   name: {{ .Chart.Name}}-metrics
   namespace: {{ .Values.global.namespace }}
   labels:
-    k8s-app: metrics
+    k8s-app: {{ .Chart.Name}}-metrics
 spec:
   selector:
     app: {{ .Chart.Name }}

--- a/resources/application-connector/charts/connector-service/templates/servicemonitor.yaml
+++ b/resources/application-connector/charts/connector-service/templates/servicemonitor.yaml
@@ -3,7 +3,7 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   name: connector-service-metrics
-  namespace: {{ .Values.global.namespace }}
+  namespace: kyma-system
   labels:
     prometheus: monitoring
     app: {{ .Chart.Name }}

--- a/resources/application-connector/charts/connector-service/templates/servicemonitor.yaml
+++ b/resources/application-connector/charts/connector-service/templates/servicemonitor.yaml
@@ -3,14 +3,15 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   name: connector-service-metrics
-  namespace: kyma-system
+  namespace: {{ .Values.global.namespace }}
   labels:
-    prometheus: core
-    example: monitoring-custom-metrics
+    prometheus: monitoring
+    app: {{ .Chart.Name }}
+    release: {{ .Chart.Name }}
 spec:
   selector:
     matchLabels:
-      k8s-app: metrics
+      k8s-app: {{ .Chart.Name}}-metrics
   targetLabels:
     - k8s-app
   endpoints:

--- a/resources/ark/templates/service-monitor.yaml
+++ b/resources/ark/templates/service-monitor.yaml
@@ -2,7 +2,7 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   labels:
-    prometheus: core
+    prometheus: monitoring
     app: {{ template "ark.name" . }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"

--- a/resources/assetstore/charts/minio/templates/servicemonitor.yaml
+++ b/resources/assetstore/charts/minio/templates/servicemonitor.yaml
@@ -1,0 +1,18 @@
+#This resource is not part of oryginal Minio chart. It was created for Kyma use case
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ template "minio.fullname" . }}
+  namespace: {{ .Values.global.namespace }}
+  labels:
+    app: {{ template "minio.name" . }}
+    release: {{ .Chart.Name }}
+    prometheus: monitoring
+spec:
+  selector:
+    matchLabels:
+      app: {{ template "minio.name" . }}
+  endpoints:
+  - port: service
+    path: /minio/prometheus/metrics
+    interval: 10s

--- a/resources/helm-broker/charts/etcd-stateful/templates/04-servicemonitor.yaml
+++ b/resources/helm-broker/charts/etcd-stateful/templates/04-servicemonitor.yaml
@@ -2,7 +2,7 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   labels:
-    prometheus: core
+    prometheus: monitoring
     app: {{ template "etcd-hb-fullname" . }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"

--- a/resources/monitoring/Chart.yaml
+++ b/resources/monitoring/Chart.yaml
@@ -1,4 +1,7 @@
 apiVersion: v1
+#This value is used as serviceMonitorSelector matching label.
+#Whenever you change this value please make sure to update Service Monitor kind of all components
+#The label called prometheus must have the same name
 name: monitoring
 description: Monitoring chart based on kube-prometheus
 engine: gotpl

--- a/resources/monitoring/charts/grafana/dashboards/minio-dashboard.json
+++ b/resources/monitoring/charts/grafana/dashboards/minio-dashboard.json
@@ -1,21 +1,4 @@
 {
-    "__inputs": [
-      {
-        "name": "DS_PROMETHEUS",
-        "label": "Prometheus",
-        "description": "",
-        "type": "datasource",
-        "pluginId": "prometheus",
-        "pluginName": "Prometheus"
-      },
-      {
-        "name": "VAR_SERVICE",
-        "type": "constant",
-        "label": "service",
-        "value": "assetstore-minio",
-        "description": ""
-      }
-    ],
     "__requires": [
       {
         "type": "grafana",
@@ -94,7 +77,7 @@
           "rgba(237, 129, 40, 0.89)",
           "rgba(50, 172, 45, 0.97)"
         ],
-        "datasource": "${DS_PROMETHEUS}",
+        "datasource": "Prometheus",
         "description": "Start time of the Minio server",
         "format": "dtdurations",
         "gauge": {
@@ -174,7 +157,7 @@
         "bars": false,
         "dashLength": 10,
         "dashes": false,
-        "datasource": "${DS_PROMETHEUS}",
+        "datasource": "Prometheus",
         "decimals": null,
         "description": "Data sent by current Minio server instance",
         "fill": 1,
@@ -263,7 +246,7 @@
         "bars": false,
         "dashLength": 10,
         "dashes": false,
-        "datasource": "${DS_PROMETHEUS}",
+        "datasource": "Prometheus",
         "decimals": null,
         "description": "Data received by current Minio server instance",
         "fill": 1,
@@ -351,7 +334,7 @@
         "bars": false,
         "dashLength": 10,
         "dashes": false,
-        "datasource": "${DS_PROMETHEUS}",
+        "datasource": "Prometheus",
         "description": "Data received x transmited by current Minio server instance",
         "fill": 1,
         "gridPos": {
@@ -447,7 +430,7 @@
         "bars": false,
         "dashLength": 10,
         "dashes": false,
-        "datasource": "${DS_PROMETHEUS}",
+        "datasource": "Prometheus",
         "description": "The current aggregate time spent servicing all HTTP requests  in seconds",
         "fill": 1,
         "gridPos": {
@@ -570,7 +553,7 @@
         "bars": false,
         "dashLength": 10,
         "dashes": false,
-        "datasource": "${DS_PROMETHEUS}",
+        "datasource": "Prometheus",
         "fill": 1,
         "gridPos": {
           "h": 9,
@@ -653,7 +636,7 @@
         "bars": false,
         "dashLength": 10,
         "dashes": false,
-        "datasource": "${DS_PROMETHEUS}",
+        "datasource": "Prometheus",
         "fill": 1,
         "gridPos": {
           "h": 9,
@@ -740,19 +723,19 @@
       "list": [
         {
           "current": {
-            "value": "${VAR_SERVICE}",
-            "text": "${VAR_SERVICE}"
+            "value": "assetstore-minio",
+            "text": "assetstore-minio"
           },
           "hide": 2,
           "label": null,
           "name": "service",
           "options": [
             {
-              "value": "${VAR_SERVICE}",
-              "text": "${VAR_SERVICE}"
+              "value": "assetstore-minio",
+              "text": "assetstore-minio"
             }
           ],
-          "query": "${VAR_SERVICE}",
+          "query": "assetstore-minio",
           "type": "constant"
         }
       ]

--- a/resources/monitoring/charts/grafana/dashboards/minio-dashboard.json
+++ b/resources/monitoring/charts/grafana/dashboards/minio-dashboard.json
@@ -1,0 +1,793 @@
+{
+    "__inputs": [
+      {
+        "name": "DS_PROMETHEUS",
+        "label": "Prometheus",
+        "description": "",
+        "type": "datasource",
+        "pluginId": "prometheus",
+        "pluginName": "Prometheus"
+      },
+      {
+        "name": "VAR_SERVICE",
+        "type": "constant",
+        "label": "service",
+        "value": "assetstore-minio",
+        "description": ""
+      }
+    ],
+    "__requires": [
+      {
+        "type": "grafana",
+        "id": "grafana",
+        "name": "Grafana",
+        "version": "5.2.4"
+      },
+      {
+        "type": "panel",
+        "id": "graph",
+        "name": "Graph",
+        "version": "5.0.0"
+      },
+      {
+        "type": "datasource",
+        "id": "prometheus",
+        "name": "Prometheus",
+        "version": "5.0.0"
+      },
+      {
+        "type": "panel",
+        "id": "singlestat",
+        "name": "Singlestat",
+        "version": "5.0.0"
+      },
+      {
+        "type": "panel",
+        "id": "text",
+        "name": "Text",
+        "version": "5.0.0"
+      }
+    ],
+    "annotations": {
+      "list": [
+        {
+          "builtIn": 1,
+          "datasource": "-- Grafana --",
+          "enable": true,
+          "hide": true,
+          "iconColor": "rgba(0, 211, 255, 1)",
+          "name": "Annotations & Alerts",
+          "type": "dashboard"
+        }
+      ]
+    },
+    "description": "minio dashboard",
+    "editable": true,
+    "gnetId": 6248,
+    "graphTooltip": 0,
+    "id": null,
+    "iteration": 1551733899479,
+    "links": [],
+    "panels": [
+      {
+        "content": "<img src=\"https://www.dropbox.com/s/s5z6rn7offp7ov3/Minio_Logo_White.png?raw=1\" style=\"height: 55px;\"></img>\n<img src=\"https://www.dropbox.com/s/59wm2aemin3cvsc/Minio_wm_light_32px.png?raw=1\" style=\"height: 40px;\"></img>\n<p style=\"margin-top: 10px;\"><small>\nMinio is a high performance distributed object storage server. In Kyma it is used as a dependency for the Asset Store component. For more information, check out the <a href=\"https://kyma-project.io/docs/components/asset-store\">docs</a>.\n</small></p>",
+        "description": "Minio is a high performance distributed object storage server. In Kyma it is used as a dependency for the Asset Store component. For more information, check out the docs.",
+        "gridPos": {
+          "h": 5,
+          "w": 8,
+          "x": 0,
+          "y": 0
+        },
+        "id": 8,
+        "links": [],
+        "mode": "html",
+        "title": "",
+        "transparent": true,
+        "type": "text"
+      },
+      {
+        "cacheTimeout": null,
+        "colorBackground": false,
+        "colorValue": false,
+        "colors": [
+          "rgba(245, 54, 54, 0.9)",
+          "rgba(237, 129, 40, 0.89)",
+          "rgba(50, 172, 45, 0.97)"
+        ],
+        "datasource": "${DS_PROMETHEUS}",
+        "description": "Start time of the Minio server",
+        "format": "dtdurations",
+        "gauge": {
+          "maxValue": 100,
+          "minValue": 0,
+          "show": false,
+          "thresholdLabels": false,
+          "thresholdMarkers": false
+        },
+        "gridPos": {
+          "h": 5,
+          "w": 16,
+          "x": 8,
+          "y": 0
+        },
+        "id": 1,
+        "interval": null,
+        "links": [],
+        "mappingType": 1,
+        "mappingTypes": [
+          {
+            "name": "value to text",
+            "value": 1
+          },
+          {
+            "name": "range to text",
+            "value": 2
+          }
+        ],
+        "maxDataPoints": 100,
+        "nullPointMode": "connected",
+        "nullText": null,
+        "postfix": "",
+        "postfixFontSize": "50%",
+        "prefix": "",
+        "prefixFontSize": "50%",
+        "rangeMaps": [
+          {
+            "from": "null",
+            "text": "N/A",
+            "to": "null"
+          }
+        ],
+        "sparkline": {
+          "fillColor": "rgba(31, 118, 189, 0.18)",
+          "full": false,
+          "lineColor": "rgb(31, 120, 193)",
+          "show": true
+        },
+        "tableColumn": "Value",
+        "targets": [
+          {
+            "expr": "time() - max(process_start_time_seconds)",
+            "format": "time_series",
+            "intervalFactor": 1,
+            "legendFormat": "Start time of the Minio server",
+            "metric": "process_start_time_seconds",
+            "refId": "A",
+            "step": 60
+          }
+        ],
+        "thresholds": "",
+        "title": "Uptime",
+        "type": "singlestat",
+        "valueFontSize": "80%",
+        "valueMaps": [
+          {
+            "op": "=",
+            "text": "N/A",
+            "value": "null"
+          }
+        ],
+        "valueName": "avg"
+      },
+      {
+        "aliasColors": {},
+        "bars": false,
+        "dashLength": 10,
+        "dashes": false,
+        "datasource": "${DS_PROMETHEUS}",
+        "decimals": null,
+        "description": "Data sent by current Minio server instance",
+        "fill": 1,
+        "gridPos": {
+          "h": 7,
+          "w": 8,
+          "x": 0,
+          "y": 5
+        },
+        "id": 4,
+        "legend": {
+          "avg": false,
+          "current": true,
+          "max": false,
+          "min": false,
+          "show": true,
+          "total": true,
+          "values": true
+        },
+        "lines": true,
+        "linewidth": 1,
+        "links": [],
+        "nullPointMode": "null",
+        "percentage": false,
+        "pointradius": 5,
+        "points": false,
+        "renderer": "flot",
+        "seriesOverrides": [],
+        "spaceLength": 10,
+        "stack": false,
+        "steppedLine": false,
+        "targets": [
+          {
+            "expr": "rate(minio_network_sent_bytes_total{service=\"$service\"}[1m])",
+            "format": "time_series",
+            "hide": false,
+            "intervalFactor": 2,
+            "legendFormat": "Transmited:",
+            "metric": "minio_network_sent_bytes_total",
+            "refId": "A",
+            "step": 10
+          }
+        ],
+        "thresholds": [],
+        "timeFrom": null,
+        "timeShift": null,
+        "title": "Data Transmited",
+        "tooltip": {
+          "shared": true,
+          "sort": 0,
+          "value_type": "individual"
+        },
+        "type": "graph",
+        "xaxis": {
+          "buckets": null,
+          "mode": "time",
+          "name": null,
+          "show": true,
+          "values": []
+        },
+        "yaxes": [
+          {
+            "format": "decbytes",
+            "label": null,
+            "logBase": 1,
+            "max": null,
+            "min": null,
+            "show": true
+          },
+          {
+            "format": "decbytes",
+            "label": null,
+            "logBase": 1,
+            "max": null,
+            "min": null,
+            "show": true
+          }
+        ],
+        "yaxis": {
+          "align": false,
+          "alignLevel": null
+        }
+      },
+      {
+        "aliasColors": {},
+        "bars": false,
+        "dashLength": 10,
+        "dashes": false,
+        "datasource": "${DS_PROMETHEUS}",
+        "decimals": null,
+        "description": "Data received by current Minio server instance",
+        "fill": 1,
+        "gridPos": {
+          "h": 7,
+          "w": 8,
+          "x": 8,
+          "y": 5
+        },
+        "id": 5,
+        "legend": {
+          "avg": false,
+          "current": true,
+          "max": false,
+          "min": false,
+          "show": true,
+          "total": true,
+          "values": true
+        },
+        "lines": true,
+        "linewidth": 1,
+        "links": [],
+        "nullPointMode": "null",
+        "percentage": false,
+        "pointradius": 5,
+        "points": false,
+        "renderer": "flot",
+        "seriesOverrides": [],
+        "spaceLength": 10,
+        "stack": false,
+        "steppedLine": false,
+        "targets": [
+          {
+            "expr": "rate(minio_network_received_bytes_total{service=\"$service\"}[1m])",
+            "format": "time_series",
+            "intervalFactor": 2,
+            "legendFormat": "Received:",
+            "metric": "minio_network_received_bytes_total",
+            "refId": "A",
+            "step": 10
+          }
+        ],
+        "thresholds": [],
+        "timeFrom": null,
+        "timeShift": null,
+        "title": "Data Received",
+        "tooltip": {
+          "shared": true,
+          "sort": 0,
+          "value_type": "individual"
+        },
+        "type": "graph",
+        "xaxis": {
+          "buckets": null,
+          "mode": "time",
+          "name": null,
+          "show": true,
+          "values": []
+        },
+        "yaxes": [
+          {
+            "format": "decbytes",
+            "label": null,
+            "logBase": 1,
+            "max": null,
+            "min": null,
+            "show": true
+          },
+          {
+            "format": "decbytes",
+            "label": null,
+            "logBase": 1,
+            "max": null,
+            "min": null,
+            "show": true
+          }
+        ],
+        "yaxis": {
+          "align": false,
+          "alignLevel": null
+        }
+      },
+      {
+        "aliasColors": {},
+        "bars": false,
+        "dashLength": 10,
+        "dashes": false,
+        "datasource": "${DS_PROMETHEUS}",
+        "description": "Data received x transmited by current Minio server instance",
+        "fill": 1,
+        "gridPos": {
+          "h": 7,
+          "w": 8,
+          "x": 16,
+          "y": 5
+        },
+        "height": "",
+        "id": 6,
+        "legend": {
+          "avg": false,
+          "current": true,
+          "max": false,
+          "min": false,
+          "show": true,
+          "total": false,
+          "values": true
+        },
+        "lines": true,
+        "linewidth": 1,
+        "links": [],
+        "nullPointMode": "null",
+        "percentage": false,
+        "pointradius": 5,
+        "points": false,
+        "renderer": "flot",
+        "seriesOverrides": [],
+        "spaceLength": 10,
+        "stack": false,
+        "steppedLine": false,
+        "targets": [
+          {
+            "expr": "rate(minio_network_received_bytes_total{service=\"$service\"}[1m])",
+            "format": "time_series",
+            "intervalFactor": 2,
+            "legendFormat": "Received: ",
+            "metric": "minio_network_received_bytes_total",
+            "refId": "A",
+            "step": 10
+          },
+          {
+            "expr": "rate(minio_network_sent_bytes_total{service=\"$service\"}[1m])",
+            "format": "time_series",
+            "intervalFactor": 2,
+            "legendFormat": "Transmited:",
+            "refId": "B",
+            "step": 10
+          }
+        ],
+        "thresholds": [],
+        "timeFrom": null,
+        "timeShift": null,
+        "title": "Total In/Out Throughput",
+        "tooltip": {
+          "shared": true,
+          "sort": 0,
+          "value_type": "individual"
+        },
+        "type": "graph",
+        "xaxis": {
+          "buckets": null,
+          "mode": "time",
+          "name": null,
+          "show": true,
+          "values": []
+        },
+        "yaxes": [
+          {
+            "format": "decbytes",
+            "label": null,
+            "logBase": 1,
+            "max": null,
+            "min": null,
+            "show": true
+          },
+          {
+            "format": "decbytes",
+            "label": null,
+            "logBase": 1,
+            "max": null,
+            "min": null,
+            "show": true
+          }
+        ],
+        "yaxis": {
+          "align": false,
+          "alignLevel": null
+        }
+      },
+      {
+        "aliasColors": {},
+        "bars": false,
+        "dashLength": 10,
+        "dashes": false,
+        "datasource": "${DS_PROMETHEUS}",
+        "description": "The current aggregate time spent servicing all HTTP requests  in seconds",
+        "fill": 1,
+        "gridPos": {
+          "h": 7,
+          "w": 24,
+          "x": 0,
+          "y": 12
+        },
+        "id": 7,
+        "legend": {
+          "avg": false,
+          "current": true,
+          "max": false,
+          "min": false,
+          "show": true,
+          "total": false,
+          "values": true
+        },
+        "lines": true,
+        "linewidth": 1,
+        "links": [],
+        "nullPointMode": "null",
+        "percentage": false,
+        "pointradius": 5,
+        "points": false,
+        "renderer": "flot",
+        "seriesOverrides": [],
+        "spaceLength": 10,
+        "stack": false,
+        "steppedLine": false,
+        "targets": [
+          {
+            "expr": "rate(minio_http_requests_duration_seconds_sum{request_type=\"GET\",service=\"$service\"}[1m])",
+            "format": "time_series",
+            "intervalFactor": 2,
+            "legendFormat": "GET",
+            "metric": "minio_http_requests_duration_seconds_count",
+            "refId": "A",
+            "step": 4
+          },
+          {
+            "expr": "rate(minio_http_requests_duration_seconds_sum{request_type=\"POST\",service=\"$service\"}[1m])",
+            "format": "time_series",
+            "intervalFactor": 2,
+            "legendFormat": "POST",
+            "metric": "minio_http_requests_duration_seconds_count",
+            "refId": "B",
+            "step": 4
+          },
+          {
+            "expr": "rate(minio_http_requests_duration_seconds_sum{request_type=\"PUT\",service=\"$service\"}[1m])",
+            "format": "time_series",
+            "intervalFactor": 2,
+            "legendFormat": "PUT",
+            "metric": "minio_http_requests_duration_seconds_count",
+            "refId": "C",
+            "step": 4
+          },
+          {
+            "expr": "rate(minio_http_requests_duration_seconds_sum{request_type=\"HEAD\",service=\"$service\"}[1m])",
+            "format": "time_series",
+            "intervalFactor": 2,
+            "legendFormat": "HEAD",
+            "metric": "minio_http_requests_duration_seconds_count",
+            "refId": "D",
+            "step": 4
+          },
+          {
+            "expr": "rate(minio_http_requests_duration_seconds_sum{request_type=\"DELETE\",service=\"$service\"}[1m])",
+            "format": "time_series",
+            "intervalFactor": 2,
+            "legendFormat": "DELETE",
+            "metric": "minio_http_requests_duration_seconds_count",
+            "refId": "E",
+            "step": 4
+          }
+        ],
+        "thresholds": [],
+        "timeFrom": null,
+        "timeShift": null,
+        "title": "HTTP Requests duration/s",
+        "tooltip": {
+          "shared": true,
+          "sort": 0,
+          "value_type": "individual"
+        },
+        "type": "graph",
+        "xaxis": {
+          "buckets": null,
+          "mode": "time",
+          "name": null,
+          "show": true,
+          "values": []
+        },
+        "yaxes": [
+          {
+            "format": "short",
+            "label": null,
+            "logBase": 1,
+            "max": null,
+            "min": null,
+            "show": true
+          },
+          {
+            "format": "short",
+            "label": null,
+            "logBase": 1,
+            "max": null,
+            "min": null,
+            "show": true
+          }
+        ],
+        "yaxis": {
+          "align": false,
+          "alignLevel": null
+        }
+      },
+      {
+        "aliasColors": {},
+        "bars": false,
+        "dashLength": 10,
+        "dashes": false,
+        "datasource": "${DS_PROMETHEUS}",
+        "fill": 1,
+        "gridPos": {
+          "h": 9,
+          "w": 12,
+          "x": 0,
+          "y": 19
+        },
+        "id": 10,
+        "legend": {
+          "avg": false,
+          "current": false,
+          "max": false,
+          "min": false,
+          "show": true,
+          "total": false,
+          "values": false
+        },
+        "lines": true,
+        "linewidth": 1,
+        "links": [],
+        "nullPointMode": "null",
+        "percentage": false,
+        "pointradius": 5,
+        "points": false,
+        "renderer": "flot",
+        "seriesOverrides": [],
+        "spaceLength": 10,
+        "stack": false,
+        "steppedLine": false,
+        "targets": [
+          {
+            "expr": "rate(go_goroutines{service=\"$service\"}[1m])",
+            "format": "time_series",
+            "intervalFactor": 2,
+            "refId": "A"
+          }
+        ],
+        "thresholds": [],
+        "timeFrom": null,
+        "timeShift": null,
+        "title": "Goroutines Rate",
+        "tooltip": {
+          "shared": true,
+          "sort": 0,
+          "value_type": "individual"
+        },
+        "type": "graph",
+        "xaxis": {
+          "buckets": null,
+          "mode": "time",
+          "name": null,
+          "show": true,
+          "values": []
+        },
+        "yaxes": [
+          {
+            "format": "short",
+            "label": null,
+            "logBase": 1,
+            "max": null,
+            "min": null,
+            "show": true
+          },
+          {
+            "format": "short",
+            "label": null,
+            "logBase": 1,
+            "max": null,
+            "min": null,
+            "show": true
+          }
+        ],
+        "yaxis": {
+          "align": false,
+          "alignLevel": null
+        }
+      },
+      {
+        "aliasColors": {},
+        "bars": false,
+        "dashLength": 10,
+        "dashes": false,
+        "datasource": "${DS_PROMETHEUS}",
+        "fill": 1,
+        "gridPos": {
+          "h": 9,
+          "w": 12,
+          "x": 12,
+          "y": 19
+        },
+        "id": 12,
+        "legend": {
+          "avg": false,
+          "current": false,
+          "max": false,
+          "min": false,
+          "show": true,
+          "total": false,
+          "values": false
+        },
+        "lines": true,
+        "linewidth": 1,
+        "links": [],
+        "nullPointMode": "null",
+        "percentage": false,
+        "pointradius": 5,
+        "points": false,
+        "renderer": "flot",
+        "seriesOverrides": [],
+        "spaceLength": 10,
+        "stack": false,
+        "steppedLine": false,
+        "targets": [
+          {
+            "expr": "go_goroutines{service=\"$service\"}",
+            "format": "time_series",
+            "intervalFactor": 1,
+            "refId": "A"
+          }
+        ],
+        "thresholds": [],
+        "timeFrom": null,
+        "timeShift": null,
+        "title": "Goroutines Number",
+        "tooltip": {
+          "shared": true,
+          "sort": 0,
+          "value_type": "individual"
+        },
+        "type": "graph",
+        "xaxis": {
+          "buckets": null,
+          "mode": "time",
+          "name": null,
+          "show": true,
+          "values": []
+        },
+        "yaxes": [
+          {
+            "format": "short",
+            "label": null,
+            "logBase": 1,
+            "max": null,
+            "min": null,
+            "show": true
+          },
+          {
+            "format": "short",
+            "label": null,
+            "logBase": 1,
+            "max": null,
+            "min": null,
+            "show": true
+          }
+        ],
+        "yaxis": {
+          "align": false,
+          "alignLevel": null
+        }
+      }
+    ],
+    "refresh": "5s",
+    "schemaVersion": 16,
+    "style": "dark",
+    "tags": [],
+    "templating": {
+      "list": [
+        {
+          "current": {
+            "value": "${VAR_SERVICE}",
+            "text": "${VAR_SERVICE}"
+          },
+          "hide": 2,
+          "label": null,
+          "name": "service",
+          "options": [
+            {
+              "value": "${VAR_SERVICE}",
+              "text": "${VAR_SERVICE}"
+            }
+          ],
+          "query": "${VAR_SERVICE}",
+          "type": "constant"
+        }
+      ]
+    },
+    "time": {
+      "from": "now-1h",
+      "to": "now"
+    },
+    "timepicker": {
+      "refresh_intervals": [
+        "5s",
+        "10s",
+        "30s",
+        "1m",
+        "5m",
+        "15m",
+        "30m",
+        "1h",
+        "2h",
+        "1d"
+      ],
+      "time_options": [
+        "5m",
+        "15m",
+        "1h",
+        "6h",
+        "12h",
+        "24h",
+        "2d",
+        "7d",
+        "30d"
+      ]
+    },
+    "timezone": "",
+    "title": "Minio",
+    "uid": "EHNtE69ik",
+    "version": 5
+  }

--- a/resources/service-catalog/charts/catalog/templates/servicemonitor.yaml
+++ b/resources/service-catalog/charts/catalog/templates/servicemonitor.yaml
@@ -2,7 +2,7 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   labels:
-    prometheus: core
+    prometheus: monitoring
     app: {{ template "fullname" . }}-apiserver
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"
@@ -27,7 +27,7 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   labels:
-    prometheus: core
+    prometheus: monitoring
     app: {{ template "fullname" . }}-controller-manager
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"

--- a/resources/service-catalog/charts/etcd-stateful/templates/04-servicemonitor.yaml
+++ b/resources/service-catalog/charts/etcd-stateful/templates/04-servicemonitor.yaml
@@ -2,7 +2,7 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   labels:
-    prometheus: core
+    prometheus: monitoring
     app: {{ template "etcd-fullname" . }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Enable monitoring for minio
  <img width="1602" alt="screen shot 2019-03-04 at 21 15 11" src="https://user-images.githubusercontent.com/6995927/53764425-83163800-3ecd-11e9-8814-0070cdf6c190.png">
- Custom Grafana dashboard for Minio
- Fix for Service Monitors from different components
