### PR TITLE
Bump ui-api-layer image for openApiSpec and odataSpec fields in SC and CSC

### DIFF
--- a/resources/core/values.yaml
+++ b/resources/core/values.yaml
@@ -64,11 +64,11 @@ global:
     dir: develop/
     version: 429bfbcc
   ui_api_layer:
-    dir: develop/
-    version: "4ad2e460"
+    dir: pr/
+    version: "PR-2962"
   ui_api_layer_acceptance_tests:
-    dir: develop/
-    version: "4ad2e460"
+    dir: pr/
+    version: "PR-2962"
   cluster_users_test:
     dir: develop/
     version: "30b8aafd"

--- a/resources/core/values.yaml
+++ b/resources/core/values.yaml
@@ -64,11 +64,11 @@ global:
     dir: develop/
     version: 429bfbcc
   ui_api_layer:
-    dir: pr/
-    version: "PR-2962"
+    dir: develop/
+    version: b426d54d
   ui_api_layer_acceptance_tests:
-    dir: pr/
-    version: "PR-2962"
+    dir: develop/
+    version: b426d54d
   cluster_users_test:
     dir: develop/
     version: "30b8aafd"

--- a/resources/core/values.yaml
+++ b/resources/core/values.yaml
@@ -106,3 +106,4 @@ test:
       limits:
         memory: 1.5Gi
         cpu: 300m
+


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/master/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:
- Add `openApiSpec` and `odataSpec` field for CSC and SC in ui-api-layer
- Add relevant tests for new fields.
- Add `deprecated` label for `apiSpec` field.
- Add new fields in CSC and SC in acceptance tests of ui-api-layer.

**Related PR(s)**
https://github.com/kyma-project/kyma/pull/2962

**Related issue(s)**
Resolves https://github.com/kyma-project/console/issues/561