### PR TITLE
Update the cluster user tests to check for patterns

### DIFF
--- a/tests/cluster-users-test/sar-test.sh
+++ b/tests/cluster-users-test/sar-test.sh
@@ -17,8 +17,11 @@ function testPermissions() {
 	TEST=$(kubectl auth can-i "${OPERATION}" "${RESOURCE}" --as "${USER}" -n "${TEST_NS}")
 	set -e
 	if [[ "${TEST}" == "${EXPECTED}" ]]; then
-		echo "----> PASSED"
-		return 0
+	    echo "----> PASSED"
+	    return 0
+	elif [[ ${TEST} == ${EXPECTED}* ]]; then
+	    echo "----> PASSED"
+	    return 0
 	fi
 	echo "----> |FAIL| Expected: ${EXPECTED} got: ${TEST}"
 	return 1


### PR DESCRIPTION
**Description**
While doing a recent K8S upgrade required for Knative upgrade, it is observed that the
cluster-users-test is failing for a pattern match
`|FAIL| Expected: no got: no - no RBAC policy matched`
The reason being with K8S 1.12 the output of can-i
changed from no to no - reason.
This PR accommodates this possibility to have an extra `elif` check
**Related issue(s)**
See also #2153 