### PR TITLE
Revert Bump service catalog version to 0.1.41 (#2882)

### DIFF
--- a/docs/service-catalog/docs/07-01-cli-reference.md
+++ b/docs/service-catalog/docs/07-01-cli-reference.md
@@ -38,7 +38,7 @@ Follow the `kubectl` syntax, `kubectl {command} {type} {name} {flags}`, where:
 ### Examples
 The following examples show how to create a ServiceInstance, how to get a list of ClusterServiceClasses and a list of ClusterServiceClasses with human-readable names, a list of ClusterServicePlans, and a list of all ServiceInstances.
 
-* Create a ServiceInstance using the example of the Redis ServiceInstance for the 0.1.41 version of the Service Catalog:
+* Create a ServiceInstance using the example of the Redis ServiceInstance for the 0.1.38 version of the Service Catalog:
 
 ```
 cat <<EOF | kubectl create -f -

--- a/docs/service-catalog/docs/07-01-cli-reference.md
+++ b/docs/service-catalog/docs/07-01-cli-reference.md
@@ -38,7 +38,7 @@ Follow the `kubectl` syntax, `kubectl {command} {type} {name} {flags}`, where:
 ### Examples
 The following examples show how to create a ServiceInstance, how to get a list of ClusterServiceClasses and a list of ClusterServiceClasses with human-readable names, a list of ClusterServicePlans, and a list of all ServiceInstances.
 
-* Create a ServiceInstance using the example of the Redis ServiceInstance for the 0.1.38 version of the Service Catalog:
+* Create a ServiceInstance using the example of the Redis ServiceInstance for the 0.1.40 version of the Service Catalog:
 
 ```
 cat <<EOF | kubectl create -f -

--- a/resources/service-catalog/charts/catalog/Chart.yaml
+++ b/resources/service-catalog/charts/catalog/Chart.yaml
@@ -1,3 +1,3 @@
 name: catalog
 description: service-catalog API server and controller-manager helm chart
-version: 0.1.41
+version: 0.1.38

--- a/resources/service-catalog/charts/catalog/Chart.yaml
+++ b/resources/service-catalog/charts/catalog/Chart.yaml
@@ -1,3 +1,3 @@
 name: catalog
 description: service-catalog API server and controller-manager helm chart
-version: 0.1.38
+version: 0.1.40

--- a/resources/service-catalog/charts/catalog/values.yaml
+++ b/resources/service-catalog/charts/catalog/values.yaml
@@ -1,6 +1,6 @@
 # Default values for Service Catalog
 # service-catalog image to use
-image: quay.io/kubernetes-service-catalog/service-catalog:v0.1.41
+image: quay.io/kubernetes-service-catalog/service-catalog:v0.1.40
 # imagePullPolicy for the service-catalog; valid values are "IfNotPresent",
 # "Never", and "Always"
 imagePullPolicy: Always


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Revert Bump service catalog version to 0.1.41 (#2882). We found that Service Catalog in version 0.1.41 has bug which is a blocker for next release