### PR TITLE
Make migration job a hook so that cleanup works.

### DIFF
--- a/resources/application-connector-ingress/templates/upgrade-job.yaml
+++ b/resources/application-connector-ingress/templates/upgrade-job.yaml
@@ -6,6 +6,9 @@ kind: Job
 metadata:
   name: {{ .Release.Name }}-loadbalancer-migration
   namespace: kyma-system
+  annotations:
+    "helm.sh/hook": pre-install
+    "helm.sh/hook-delete-policy": hook-succeeded
 spec:
   template:
     metadata:


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- application-connector-ingress upgrade job changed to a hook to cleanup Pods on success.
