### PR TITLE
Print execution statements as test fails on production prow cluster

### DIFF
--- a/installation/scripts/e2e-testing.sh
+++ b/installation/scripts/e2e-testing.sh
@@ -1,4 +1,7 @@
 #!/usr/bin/env bash
+
+set -x
+
 ROOT_PATH=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
 source ${ROOT_PATH}/utils.sh
 source ${ROOT_PATH}/testing-common.sh


### PR DESCRIPTION
e2e-testing.sh is not returning the right exit value if an error happens.
A right exit value is needed to handle the deletion or not deletion of the cluster in gke.