### PR TITLE
Bump the application operator image to the latest version after enabling the event-service monitoring

### DIFF
--- a/resources/application-connector/values.yaml
+++ b/resources/application-connector/values.yaml
@@ -18,7 +18,7 @@ global:
     path: eu.gcr.io/kyma-project
   application_operator:
     dir: develop/
-    version: 6cb16c1c
+    version: b1ef90ef
   application_operator_tests:
     dir: develop/
     version: 6cb16c1c


### PR DESCRIPTION
See also #3089 
