### PR TITLE
Fix tutorial links in App Conn. docs

### DIFF
--- a/docs/application-connector/docs/08-05-trigger-lambda-with-event.md
+++ b/docs/application-connector/docs/08-05-trigger-lambda-with-event.md
@@ -16,7 +16,7 @@ This guide shows how to create a simple lambda function and trigger it with an e
 
 1. Register a service with the following specification to the desired App.
 
->**NOTE:** See [this](#getting-started-get-the-client-certificate) Getting Started Guide to learn how to register a service.
+>**NOTE:** See [this](#tutorials-get-the-client-certificate) tutorial to learn how to register a service.
 ```json
 {
   "name": "my-service",

--- a/docs/application-connector/docs/08-06-call-registered-service-from-kyma.md
+++ b/docs/application-connector/docs/08-06-call-registered-service-from-kyma.md
@@ -16,7 +16,7 @@ This guide shows how to call a registered external service from Kyma using a sim
 ## Steps
 
 1. Register a service with the following specification to the desired Application.
->**NOTE:** See [this](#getting-started-register-a-service) Getting Started Guide to learn how to register a service.
+>**NOTE:** See [this](#tutorials-register-a-service) tutorial to learn how to register a service.
 ```json
 {
   "name": "my-service",


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Fixed dead tutorial links in App Connector documentation. 


**Related issue(s)**
#3128 
