### PR TITLE
Support for token fetching in central connector service

### DIFF
--- a/components/connection-token-handler/pkg/apis/applicationconnector/v1alpha1/tokenrequest_types.go
+++ b/components/connection-token-handler/pkg/apis/applicationconnector/v1alpha1/tokenrequest_types.go
@@ -23,6 +23,11 @@ type TokenRequestStatus struct {
 	State       TokenRequestState `json:"state"`
 }
 
+type ClusterContext struct {
+	Tenant string `json:"tenant,omitempty"`
+	Group  string `json:"group,omitempty"`
+}
+
 // +genclient
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
@@ -31,6 +36,8 @@ type TokenRequestStatus struct {
 type TokenRequest struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
+
+	Context ClusterContext `json:"context,omitempty"`
 
 	Status TokenRequestStatus `json:"status,omitempty"`
 }

--- a/components/connection-token-handler/pkg/controller/tokenrequest/tokenrequest_client.go
+++ b/components/connection-token-handler/pkg/controller/tokenrequest/tokenrequest_client.go
@@ -13,6 +13,8 @@ const (
 	applicationHeader = "Application"
 	tenantHeader      = "Tenant"
 	groupHeader       = "Group"
+	emptyTenant       = ""
+	emptyGroup        = ""
 )
 
 // TokenDto represents data structure returned from connector-service
@@ -46,7 +48,7 @@ func (c *connectorServiceClient) FetchToken(appName, tenant, group string) (*Tok
 
 	req.Header.Set(applicationHeader, appName)
 
-	if tenant != "" && group != "" {
+	if tenant != emptyTenant && group != emptyGroup {
 		req.Header.Set(tenantHeader, tenant)
 		req.Header.Set(groupHeader, group)
 	}

--- a/components/connection-token-handler/pkg/controller/tokenrequest/tokenrequest_client.go
+++ b/components/connection-token-handler/pkg/controller/tokenrequest/tokenrequest_client.go
@@ -11,6 +11,8 @@ import (
 
 const (
 	applicationHeader = "Application"
+	tenantHeader      = "Tenant"
+	groupHeader       = "Group"
 )
 
 // TokenDto represents data structure returned from connector-service
@@ -21,7 +23,7 @@ type TokenDto struct {
 
 // ConnectorServiceClient interface describes client contract to communicate with connector-service
 type ConnectorServiceClient interface {
-	FetchToken(appName string) (*TokenDto, error)
+	FetchToken(appName, tenant, group string) (*TokenDto, error)
 }
 
 type connectorServiceClient struct {
@@ -30,7 +32,7 @@ type connectorServiceClient struct {
 }
 
 // FetchToken method connects to connector-service and fetches new token for remote-environment
-func (c *connectorServiceClient) FetchToken(appName string) (*TokenDto, error) {
+func (c *connectorServiceClient) FetchToken(appName, tenant, group string) (*TokenDto, error) {
 	if strings.TrimSpace(appName) == "" {
 		return nil, errors.New("appName cannot be empty")
 	}
@@ -43,6 +45,12 @@ func (c *connectorServiceClient) FetchToken(appName string) (*TokenDto, error) {
 	}
 
 	req.Header.Set(applicationHeader, appName)
+
+	if tenant != "" && group != "" {
+		req.Header.Set(tenantHeader, tenant)
+		req.Header.Set(groupHeader, group)
+	}
+
 	req.Header.Set("Content-Type", "application/json")
 
 	res, err := c.Do(req)

--- a/components/connection-token-handler/pkg/controller/tokenrequest/tokenrequest_client_test.go
+++ b/components/connection-token-handler/pkg/controller/tokenrequest/tokenrequest_client_test.go
@@ -9,11 +9,11 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func getServerMock(t *testing.T, appName, token string) *httptest.Server {
+func getServerMock(t *testing.T, appName, tenant, group, token string) *httptest.Server {
 	return httptest.NewServer(
 		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			if r.URL.Path == "/v1/applications/tokens" {
-				assert.Equal(t, appName, r.Header.Get(applicationHeader))
+				checkHeaders(t, appName, r, tenant, group)
 
 				w.Header().Add("Content-Type", "application/json")
 				w.Write([]byte(fmt.Sprintf(
@@ -22,29 +22,55 @@ func getServerMock(t *testing.T, appName, token string) *httptest.Server {
 		}),
 	)
 }
+
+func checkHeaders(t *testing.T, appName string, r *http.Request, tenant string, group string) {
+	assert.Equal(t, appName, r.Header.Get(applicationHeader))
+	if tenant != "" && group != "" {
+		assert.Equal(t, tenant, r.Header.Get(tenantHeader))
+		assert.Equal(t, group, r.Header.Get(groupHeader))
+	}
+}
+
 func TestTokenRequestClient_FetchToken(t *testing.T) {
 	appName := "some-app"
 	token := "some-long-token-value"
 
 	t.Run("should return TokenDto with valid token", func(t *testing.T) {
-		srvMock := getServerMock(t, appName, token)
+		//given
+		srvMock := getServerMock(t, appName, "", "", token)
 		defer srvMock.Close()
-
+		//when
 		svcClient := NewConnectorServiceClient(srvMock.URL)
-		tokenDto, err := svcClient.FetchToken(appName)
+		tokenDto, err := svcClient.FetchToken(appName, "", "")
+		//then
+		assert.NoError(t, err)
+		assert.NotNil(t, tokenDto)
+		assert.Equal(t, token, tokenDto.Token)
+	})
 
+	t.Run("should return TokenDto with valid token when tenant and group provided", func(t *testing.T) {
+		//given
+		tenant := "some-tenant"
+		group := "some-group"
+		srvMock := getServerMock(t, appName, tenant, group, token)
+		defer srvMock.Close()
+		//when
+		svcClient := NewConnectorServiceClient(srvMock.URL)
+		tokenDto, err := svcClient.FetchToken(appName, tenant, group)
+		//then
 		assert.NoError(t, err)
 		assert.NotNil(t, tokenDto)
 		assert.Equal(t, token, tokenDto.Token)
 	})
 
 	t.Run("should return error when calling invalid URL", func(t *testing.T) {
-		srvMock := getServerMock(t, appName, token)
+		//given
+		srvMock := getServerMock(t, appName, "", "", token)
 		defer srvMock.Close()
-
+		//when
 		svcClient := NewConnectorServiceClient(srvMock.URL + "/some-text")
-		_, err := svcClient.FetchToken(appName)
-
+		_, err := svcClient.FetchToken(appName, "", "")
+		//then
 		assert.Error(t, err)
 	})
 }

--- a/components/connection-token-handler/pkg/controller/tokenrequest/tokenrequest_client_test.go
+++ b/components/connection-token-handler/pkg/controller/tokenrequest/tokenrequest_client_test.go
@@ -25,7 +25,7 @@ func getServerMock(t *testing.T, appName, tenant, group, token string) *httptest
 
 func checkHeaders(t *testing.T, appName string, r *http.Request, tenant string, group string) {
 	assert.Equal(t, appName, r.Header.Get(applicationHeader))
-	if tenant != "" && group != "" {
+	if tenant != emptyTenant && group != emptyGroup {
 		assert.Equal(t, tenant, r.Header.Get(tenantHeader))
 		assert.Equal(t, group, r.Header.Get(groupHeader))
 	}
@@ -37,11 +37,11 @@ func TestTokenRequestClient_FetchToken(t *testing.T) {
 
 	t.Run("should return TokenDto with valid token", func(t *testing.T) {
 		//given
-		srvMock := getServerMock(t, appName, "", "", token)
+		srvMock := getServerMock(t, appName, emptyTenant, emptyGroup, token)
 		defer srvMock.Close()
 		//when
 		svcClient := NewConnectorServiceClient(srvMock.URL)
-		tokenDto, err := svcClient.FetchToken(appName, "", "")
+		tokenDto, err := svcClient.FetchToken(appName, emptyTenant, emptyGroup)
 		//then
 		assert.NoError(t, err)
 		assert.NotNil(t, tokenDto)
@@ -65,11 +65,11 @@ func TestTokenRequestClient_FetchToken(t *testing.T) {
 
 	t.Run("should return error when calling invalid URL", func(t *testing.T) {
 		//given
-		srvMock := getServerMock(t, appName, "", "", token)
+		srvMock := getServerMock(t, appName, emptyTenant, emptyGroup, token)
 		defer srvMock.Close()
 		//when
 		svcClient := NewConnectorServiceClient(srvMock.URL + "/some-text")
-		_, err := svcClient.FetchToken(appName, "", "")
+		_, err := svcClient.FetchToken(appName, emptyTenant, emptyGroup)
 		//then
 		assert.Error(t, err)
 	})

--- a/components/connection-token-handler/pkg/controller/tokenrequest/tokenrequest_controller.go
+++ b/components/connection-token-handler/pkg/controller/tokenrequest/tokenrequest_controller.go
@@ -85,7 +85,7 @@ func (r *ReconcileTokenRequest) Reconcile(request reconcile.Request) (reconcile.
 	} else if instance.ShouldFetch() {
 		log.Printf("Fetching token for TokenRequest %s", request.NamespacedName)
 
-		tokenDto, err := r.connectorServiceClient.FetchToken(instance.ObjectMeta.Name)
+		tokenDto, err := r.connectorServiceClient.FetchToken(instance.ObjectMeta.Name, instance.Context.Tenant, instance.Context.Group)
 		if err != nil {
 			log.Printf("Fetching token for TokenRequest %s failed", request.NamespacedName)
 


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/master/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- connection-token-handler accepts additional fields: Tenant and Group and passes them as headers to Application Connector. 

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->

#2910