### PR TITLE
Fix access to Knative Serving workloads through gateway

### DIFF
--- a/resources/knative-serving/README.md
+++ b/resources/knative-serving/README.md
@@ -14,6 +14,6 @@ Kyma-specific changes:
  * The `config-domain` is made configurable by specifying the `.Values.domainName` as the helm template.
  * The `knative-serving` Namespace is no longer created. This happens during the installation process.
  * The image versions are changed to use the release tag.
- * Knative Serving uses the Kyma Istio gateway
+ * Knative Serving uses the Kyma Istio Ingress gateway.
 
 > **NOTE:** The Knative build component is not installed.

--- a/resources/knative-serving/README.md
+++ b/resources/knative-serving/README.md
@@ -14,5 +14,6 @@ Kyma-specific changes:
  * The `config-domain` is made configurable by specifying the `.Values.domainName` as the helm template.
  * The `knative-serving` Namespace is no longer created. This happens during the installation process.
  * The image versions are changed to use the release tag.
+ * Knative Serving uses the Kyma Istio gateway
 
 > **NOTE:** The Knative build component is not installed.

--- a/resources/knative-serving/charts/knative-serving/templates/serving.yaml
+++ b/resources/knative-serving/charts/knative-serving/templates/serving.yaml
@@ -823,6 +823,7 @@ metadata:
 ---
 apiVersion: v1
 data:
+  gateway.{{ .Values.gateway.name }}: {{ .Values.gateway.serviceUrl }}
   _example: |
     ################################
     #                              #

--- a/resources/knative-serving/values.yaml
+++ b/resources/knative-serving/values.yaml
@@ -1,4 +1,7 @@
 knative-serving:
+  gateway:
+    name: kyma-gateway.kyma-system.svc.cluster.local
+    serviceUrl: istio-ingressgateway.istio-system.svc.cluster.local
   domainName: example.com
 
 global:


### PR DESCRIPTION
**Description**

Since the upgrade to Knative Serving v0.4.1 (PR #3051) Knative routes can't be consumed from outside the cluster due to missing gateway configuration.

Changes proposed in this pull request:

- Configure Knative Serving to use Kyma's Istio Ingress gateway
