### PR TITLE
Set event publishing quota policy

### DIFF
--- a/resources/event-bus/charts/publish-knative/templates/quota.yaml
+++ b/resources/event-bus/charts/publish-knative/templates/quota.yaml
@@ -1,0 +1,14 @@
+apiVersion: config.istio.io/v1alpha2
+kind: QuotaSpecBinding
+metadata:
+  name: {{ template "publish-knative.fullname" . }}-request-count
+  namespace: {{.Release.Namespace}}
+  labels:
+{{ include "publish-knative.labels.standard" . | indent 4 }}
+spec:
+  quotaSpecs:
+  - name: request-count
+    namespace: istio-system
+  services:
+  - name: {{ template "publish-knative.name" . }}
+    namespace: {{.Release.Namespace}}

--- a/resources/event-bus/charts/publish/templates/quota.yaml
+++ b/resources/event-bus/charts/publish/templates/quota.yaml
@@ -1,0 +1,14 @@
+apiVersion: config.istio.io/v1alpha2
+kind: QuotaSpecBinding
+metadata:
+  name: {{ template "publish.fullname" . }}-request-count
+  namespace: {{.Release.Namespace}}
+  labels:
+{{ include "publish.labels.standard" . | indent 4 }}
+spec:
+  quotaSpecs:
+  - name: request-count
+    namespace: istio-system
+  services:
+  - name: {{ template "publish.name" . }}
+    namespace: {{.Release.Namespace}}

--- a/resources/istio/charts/mixer/templates/quota.yaml
+++ b/resources/istio/charts/mixer/templates/quota.yaml
@@ -1,0 +1,55 @@
+apiVersion: "config.istio.io/v1alpha2"
+kind: memquota
+metadata:
+  name: handler
+  namespace: {{ .Release.Namespace }}
+  labels:
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    release: {{ .Release.Name }}
+spec:
+  quotas:
+  - name: requestcount.quota.{{ .Release.Namespace }}
+    maxAmount: 500
+    validDuration: 1s
+---
+apiVersion: "config.istio.io/v1alpha2"
+kind: quota
+metadata:
+  name: requestcount
+  namespace: {{ .Release.Namespace }}
+  labels:
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    release: {{ .Release.Name }}
+spec:
+  dimensions:
+    source: request.headers["x-forwarded-for"] | "unknown"
+    destination: destination.labels["app"] | destination.service | "unknown"
+    destinationVersion: destination.labels["version"] | "unknown"
+---
+apiVersion: config.istio.io/v1alpha2
+kind: rule
+metadata:
+  name: quota
+  namespace: {{ .Release.Namespace }}
+  labels:
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    release: {{ .Release.Name }}
+spec:
+  actions:
+  - handler: handler.memquota
+    instances:
+    - requestcount.quota
+---
+apiVersion: config.istio.io/v1alpha2
+kind: QuotaSpec
+metadata:
+  name: request-count
+  namespace: {{ .Release.Namespace }}
+  labels:
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    release: {{ .Release.Name }}
+spec:
+  rules:
+  - quotas:
+    - charge: 1
+      quota: requestcount


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Configure Istio in-memory quota adapter with initial default request count quota policy
- Enforce default quota policy on event publishing request count (legacy and knative)