### PR TITLE
Fix checking logs from wrong pod and adding limit for memory used by functions

### DIFF
--- a/resources/core/charts/kubeless/templates/tests/svcbind-lambda.yaml
+++ b/resources/core/charts/kubeless/templates/tests/svcbind-lambda.yaml
@@ -28,22 +28,41 @@ spec:
       "name": "svcbind",
       "version": "1.0.0",
       "dependencies": {
-        "redis":  "2.8.0"
+        "async-redis":  "1.1.4"
       }
     }
   function: |
-      const redis = require('redis');
+      const asyncRedis = require("async-redis");
       module.exports = {
-          handler: (event, context) => {
-              const client = redis.createClient({host: process.env.HOST, port: process.env.PORT, password: process.env.REDIS_PASSWORD});
-              client.info(function (err, reply) {
-                  if (err) {
-                      return `Error occurred while connecting to redis: ${err}\n`;
-                  }
-                  console.log(`OK ${event.data}`)
-              });
-              return "OK";
-          },
+        handler: async (event, context) => {
+        try {
+           const client = asyncRedis.createClient({
+             host: process.env.HOST,
+             port: process.env.PORT,
+             password: process.env.REDIS_PASSWORD,
+             retry_strategy: function (options) {
+               if (options.error && options.error.code === 'ECONNREFUSED') {
+                 return new Error('The server refused the connection');
+               }
+               if (options.total_retry_time > 1000*60*60) {
+                 return new Error('Retry time exhausted');
+               }
+               if (options.attempt > 10) {
+                 return undefined;
+               }
+               // reconnect after
+               return Math.min(options.attempt * 100, 3000);
+             }
+           });
+
+           const value = await client.info();
+           console.log(`OK ${event.data}`);
+           return "OK";
+        } catch (err) {
+          console.log(`Got error ${err}`);
+          return "FAIL";
+          }
+        }
       };
 ---
 apiVersion: servicecatalog.kyma-project.io/v1alpha1

--- a/tests/end-to-end/kubeless-integration/test-kubeless.go
+++ b/tests/end-to-end/kubeless-integration/test-kubeless.go
@@ -360,8 +360,7 @@ func ensureOutputIsCorrect(host, expectedOutput, testID, namespace, testName str
 					log.Printf("[%v] Name of the Successful Pod is: %v", testName, string(functionPodName))
 					return
 				}
-				log.Printf("[%v] Name of the Failed Pod is: %v", testName, string(functionPodName))
-				log.Fatalf("[%v] Response is not equal to expected output: %v != %v", testName, string(bodyBytes), expectedOutput)
+				log.Printf("[%v] Response is not equal to expected output: %v != %v, pod name: %s. Retry...", testName, string(bodyBytes), expectedOutput, string(functionPodName))
 			} else {
 				log.Printf("[%v] Tick: Response code is: %v", testName, resp.StatusCode)
 				bodyBytes, err := ioutil.ReadAll(resp.Body)

--- a/tests/end-to-end/kubeless-integration/test-kubeless.go
+++ b/tests/end-to-end/kubeless-integration/test-kubeless.go
@@ -79,7 +79,7 @@ func deleteNamespace(namespace string) {
 }
 
 func deployFun(namespace, name, runtime, codeFile, handler string) {
-	cmd := exec.Command("kubeless", "-n", namespace, "function", "deploy", name, "-r", runtime, "-f", codeFile, "--handler", handler)
+	cmd := exec.Command("kubeless", "-n", namespace, "function", "deploy", name, "-r", runtime, "-f", codeFile, "--handler", handler, "--memory", "128Mi")
 	stdoutStderr, err := cmd.CombinedOutput()
 	if err != nil {
 		log.Fatal("Unable to deploy function ", name, ":\n", string(stdoutStderr))

--- a/tests/end-to-end/kubeless-integration/test-kubeless.go
+++ b/tests/end-to-end/kubeless-integration/test-kubeless.go
@@ -235,14 +235,14 @@ func printDebugLogsSvcBindingUsageFailed(namespace, name string) {
 	log.Printf("Function pods status:\n%s\n", string(functionPodsStdOutStdErr))
 
 	controllerNamespace := os.Getenv("KUBELESS_NAMESPACE")
-	svcBindingUsageControllerPodNameCmd := exec.Command("kubectl", "-n", controllerNamespace, "get", "po", "-l", "app=binding-usage-controller", "-o", "jsonpath={.items[0].metadata.name}")
+	svcBindingUsageControllerPodNameCmd := exec.Command("kubectl", "-n", controllerNamespace, "get", "po", "-l", "app=service-binding-usage-controller", "-o", "jsonpath={.items[0].metadata.name}")
 
 	svcBindingUsageControllerPodName, err := svcBindingUsageControllerPodNameCmd.CombinedOutput()
 	if err != nil {
 		log.Fatalf("Error while fetching servicebindingusagercontroller pod: \n%s\n", string(svcBindingUsageControllerPodName))
 	}
 
-	svcBindingUsageControllerLogsCmd := exec.Command("kubectl", "-n", controllerNamespace, "log", string(svcBindingUsageControllerPodName), "-c", "binding-usage-controller")
+	svcBindingUsageControllerLogsCmd := exec.Command("kubectl", "-n", controllerNamespace, "log", string(svcBindingUsageControllerPodName), "-c", "service-binding-usage-controller")
 
 	svcBindingUsageControllerLogsCmdOutErr, err := svcBindingUsageControllerLogsCmd.CombinedOutput()
 	if err != nil {


### PR DESCRIPTION
This PR solves 3 issues we encountered in `test-core-kubeless-int`

# Fix: Checking logs from wrong Pod
This PR is going to solve #3318 
As you can find in the issue description:
> we check logs from Pod1, but the request was sent to Pod2. Pod2 does not have injected variables to connect to the Redis and it is failing.

> It looks like there is a problem with handling errors in function. Even that error was thrown, function respond with status HTTP 200:

To solve this:
- I refactored kubeless function, to return "FAIL" if it cannot connect to the Redis. It will happen for a Pod where we don't have injected credentials to connect to Redis.
- test is not failing immediatelly in case of "FAIL" response, it will be retreid

# Fix: Getting logs from Service Binding Usage Controller
Binding Usage Controller was renamed some time ago to Service Binding Usage Controller, but in this test it was not changed. Because of that, we got error on getting logs from the controller. 

# Limit memory used by functions
After introducing sidecar for Redis provisioned by the helm-broker(#3139, not yet merged), `test-core-kubeless-int` always fails. Problem is the following:
`test-kubeless` namespace, has ResourceQuota that specifies memory limit to 3Gi. 
In `test-kubeless.go` we create 3 functions in the namespace and provision Redis instance, with following memory settings:
- redis: memory limit: 512Mi, istio-proxy: 128Mi
- kubeless function 3x: 512Mi, istio-proxy: 128Mi 
In summary, we use: 2048Mi + 512Mi (istio) = 2560 Mi. 
In the test, ServiceBindingUsage is created. As a result, we add some label to the function's deployment and expect that new Pods will be created. Deployment has a strategy `RollingUpdate`, it means that new Pods will be created after old Pods will be removed. Unfortunately, new Pods are unable to create because it will exceed limits defined in Resource Quota (2560 + 512 +128 > 3 Gi).
In this PR I reduce memory requested by 2 kubeless function, which does not define any dependency ( (test-hello and test-event).  Setting 128Mi should be enough, because actual usage of memory  is following:
```
kubectl top pods -n kubeless-test
NAME                                                              CPU(cores)   MEMORY(bytes)
hb-redis-micro-26e62338-4c9b-11e9-85ac-0a580a0c0012-redis-vcwhf   6m           39Mi
test-event-7c6d489dbb-7tggv                                       9m           53Mi
test-hello-cb4d885d8-t2c24                                        7m           52Mi
test-svcbind-7cfb8f4856-bklt4                                     8m           59Mi
```