### PR TITLE
Modify Connector Service certificate revocation to use certificate fingerprint

### DIFF
--- a/components/connector-service/internal/certificates/hash.go
+++ b/components/connector-service/internal/certificates/hash.go
@@ -2,25 +2,20 @@ package certificates
 
 import (
 	"crypto/sha256"
-	"crypto/x509"
 	"encoding/hex"
 	"encoding/pem"
 
 	"github.com/kyma-project/kyma/components/connector-service/internal/apperrors"
 )
 
-func FingerprintSHA256(rawPem []byte) (string, error) {
+// FingerprintSHA256 decodes pem block and returns fingerprint generated using SHA 256 algorithm
+func FingerprintSHA256(rawPem []byte) (string, apperrors.AppError) {
 	block, _ := pem.Decode(rawPem)
 	if block == nil {
-		return "", apperrors.Internal("Faield to decode pem block")
+		return "", apperrors.Internal("Failed to decode pem block.")
 	}
 
-	certificate, err := x509.ParseCertificate(block.Bytes)
-	if err != nil {
-		return "", apperrors.Internal("Failed to parse certificate: %s", err.Error())
-	}
-
-	sha := sha256.Sum256(certificate.Raw)
+	sha := sha256.Sum256(block.Bytes)
 
 	return hex.EncodeToString(sha[:]), nil
 }

--- a/components/connector-service/internal/certificates/hash_test.go
+++ b/components/connector-service/internal/certificates/hash_test.go
@@ -1,94 +1,64 @@
 package certificates
 
 import (
+	"testing"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"testing"
 )
 
 func TestCalculateHash(t *testing.T) {
 
-	t.Run("should calculate correct hash", func(t *testing.T) {
+	t.Run("should calculate correct fingerprint", func(t *testing.T) {
 		// given
-		escapedCert := "-----BEGIN%20CERTIFICATE-----%0A" +
-			"MIIFfjCCA2agAwIBAgIBAjANBgkqhkiG9w0BAQsFADBqMQswCQYDVQQGEwJQTDEK%0A" +
-			"MAgGA1UECAwBTjEQMA4GA1UEBwwHR0xJV0lDRTETMBEGA1UECgwKU0FQIEh5YnJp%0A" +
-			"czENMAsGA1UECwwES3ltYTEZMBcGA1UEAwwQd29ybWhvbGUua3ltYS5jeDAeFw0x%0A" +
-			"OTAxMjQwOTQ1MTJaFw0yMDAxMjQwOTQ1MTJaMHIxCzAJBgNVBAYTAkRFMRAwDgYD%0A" +
-			"VQQIEwdXYWxkb3JmMRAwDgYDVQQHEwdXYWxkb3JmMRUwEwYDVQQKEwxPcmdhbml6%0A" +
-			"YXRpb24xEDAOBgNVBAsTB09yZ1VuaXQxFjAUBgNVBAMTDXVwcy10ZXN0LWFwcDEw%0A" +
-			"ggIiMA0GCSqGSIb3DQEBAQUAA4ICDwAwggIKAoICAQC7eOxYnQy3CcNKYAYb2b48%0A" +
-			"FA92GW1LWjfCBEhu+uP5hLlH572OODpdhyNmtFInpl8gmQ1454x%2FrG5bOjUxOkOi%0A" +
-			"U97xM8e7O1MW4fLIC2LDkY0TapfaMn%2FoYwUHz3QFlx+BKM4yxgpJ+YY5OJVoGDEH%0A" +
-			"TdaSY5LzftnfSBjUMrQIec6wv3+Vy0F8jUmxV3FifODhWxBUBEqZOSm9ruOwOSan%0A" +
-			"J2sY1ovsj4QZZ9HnLJT6mdMt8lAwyDg0o68aOsjPtDEaqOIGWiYls49GIRi%2FcXft%0A" +
-			"1S2L1q5WOiFlK18rkWouFJrx7YppPXEpLzwqY8DjaZ5qbfaBZzTaYHYBgTqClCbp%0A" +
-			"AqwzDBsXuhPKywY+HzGhkGMHJKVxADuycgGObyQsnFDg0284zVJpCU41grVaigjf%0A" +
-			"PsD8NU%2FhO11M+45xVl7WCLecHmVKZpwR3A6g6WpucitFKdHvbdD6jhbt3aUuJN+u%0A" +
-			"U7GdnPk0A+y%2Fs7Y6FzxdoVtfWFIZqnFHIcL1kUT8WeEONnzmmMvOIIh8rz1U9iVO%0A" +
-			"m%2FFZ1u3JloRRdGpaKewTytRsOKBE5Oug24GZSKA5dGG6ex7BDoXRgUgf3WxuUBQ2%0A" +
-			"uidkXunTrcWUFI3IwbAdS9DWnlVhjvYBjOw8OsF3WtUsyIkDKFs11mfQvOKg6Y0m%0A" +
-			"FrF9eKkyolUlmrHrGdG3wwIDAQABoycwJTAOBgNVHQ8BAf8EBAMCB4AwEwYDVR0l%0A" +
-			"BAwwCgYIKwYBBQUHAwIwDQYJKoZIhvcNAQELBQADggIBAGpTE%2FtPB8ZJqR+mqZDB%0A" +
-			"HzTE1fyoYYJvXfGwZQEWrR3GqOPe0Ni3jWQKs9NYoYSGoN9cYFvDJUQy3d5BJ1m8%0A" +
-			"Y0uySIEDewYpKZR1zL7lnUYZ4msjOpNnlcIGNd0xz1EbHDPK3fMljVu+oJ4d+Z7a%0A" +
-			"VdfJ+4fXUPgWxA9ou2E9GoiWtoReGc7ok2sx1NH3%2FZIaSy7zHKfve8ULrwkvVTEs%0A" +
-			"W+jzuGIZvIQXMyY8c2M3sNb4sn14xRTZHA88rDJhI8Yjmhp9ZvaqAv+isaeBcGhY%0A" +
-			"Cpspwgl1qqGqNsgEkoScW6WzN8HP0DvQ6UhsJKKhtTxl2Kd81PKGQIz%2F9vdkhOew%0A" +
-			"irbwUBl1Wx1eoJlcTXFEMSGVVjHUUDDyftfq+hfJ4U90Ny0tjPjr+t9ejHOWfszf%0A" +
-			"3Na0qT+92au76SFBddBVe3J0jaGhcwyFMHmQp8CU9ZKHXnSeumwplo33+25U3M%2Fe%0A" +
-			"ALnDeejOZfFu0zDXTPZsvUFDJBke6PsILtQOAyrGATbDzPCqCZPmIl%2Fp4aMwgPJW%0A" +
-			"zn6TyG%2F0YbJXH7Mysm+8k9qSWTpfT8YRDSrOUIXPFxg9jmMqF8vnksNq8cwto57Z%0A" +
-			"gPzl0TAYNKqS%2FYDkeNOgrwlnJ%2Ff2rLTD0Zki16i%2FJ3s6%2FIy37XXj2No+G8bvGBDZ%0A" +
-			"ffu3gnzaWei6HTmquQp55Kun%0A" +
-			"-----END%20CERTIFICATE-----"
-		expectedHash := "297cc9e776803ffc0aef2e95e1d8544ad6ca92ac567e117990a6ed920520fdf9"
+		rawPemCertificate := []byte(`-----BEGIN CERTIFICATE-----
+MIIFfjCCA2agAwIBAgIBAjANBgkqhkiG9w0BAQsFADBqMQswCQYDVQQGEwJQTDEK
+MAgGA1UECAwBTjEQMA4GA1UEBwwHR0xJV0lDRTETMBEGA1UECgwKU0FQIEh5YnJp
+czENMAsGA1UECwwES3ltYTEZMBcGA1UEAwwQd29ybWhvbGUua3ltYS5jeDAeFw0x
+OTAxMjQwOTQ1MTJaFw0yMDAxMjQwOTQ1MTJaMHIxCzAJBgNVBAYTAkRFMRAwDgYD
+VQQIEwdXYWxkb3JmMRAwDgYDVQQHEwdXYWxkb3JmMRUwEwYDVQQKEwxPcmdhbml6
+YXRpb24xEDAOBgNVBAsTB09yZ1VuaXQxFjAUBgNVBAMTDXVwcy10ZXN0LWFwcDEw
+ggIiMA0GCSqGSIb3DQEBAQUAA4ICDwAwggIKAoICAQC7eOxYnQy3CcNKYAYb2b48
+FA92GW1LWjfCBEhu+uP5hLlH572OODpdhyNmtFInpl8gmQ1454x/rG5bOjUxOkOi
+U97xM8e7O1MW4fLIC2LDkY0TapfaMn/oYwUHz3QFlx+BKM4yxgpJ+YY5OJVoGDEH
+TdaSY5LzftnfSBjUMrQIec6wv3+Vy0F8jUmxV3FifODhWxBUBEqZOSm9ruOwOSan
+J2sY1ovsj4QZZ9HnLJT6mdMt8lAwyDg0o68aOsjPtDEaqOIGWiYls49GIRi/cXft
+1S2L1q5WOiFlK18rkWouFJrx7YppPXEpLzwqY8DjaZ5qbfaBZzTaYHYBgTqClCbp
+AqwzDBsXuhPKywY+HzGhkGMHJKVxADuycgGObyQsnFDg0284zVJpCU41grVaigjf
+PsD8NU/hO11M+45xVl7WCLecHmVKZpwR3A6g6WpucitFKdHvbdD6jhbt3aUuJN+u
+U7GdnPk0A+y/s7Y6FzxdoVtfWFIZqnFHIcL1kUT8WeEONnzmmMvOIIh8rz1U9iVO
+m/FZ1u3JloRRdGpaKewTytRsOKBE5Oug24GZSKA5dGG6ex7BDoXRgUgf3WxuUBQ2
+uidkXunTrcWUFI3IwbAdS9DWnlVhjvYBjOw8OsF3WtUsyIkDKFs11mfQvOKg6Y0m
+FrF9eKkyolUlmrHrGdG3wwIDAQABoycwJTAOBgNVHQ8BAf8EBAMCB4AwEwYDVR0l
+BAwwCgYIKwYBBQUHAwIwDQYJKoZIhvcNAQELBQADggIBAGpTE/tPB8ZJqR+mqZDB
+HzTE1fyoYYJvXfGwZQEWrR3GqOPe0Ni3jWQKs9NYoYSGoN9cYFvDJUQy3d5BJ1m8
+Y0uySIEDewYpKZR1zL7lnUYZ4msjOpNnlcIGNd0xz1EbHDPK3fMljVu+oJ4d+Z7a
+VdfJ+4fXUPgWxA9ou2E9GoiWtoReGc7ok2sx1NH3/ZIaSy7zHKfve8ULrwkvVTEs
+W+jzuGIZvIQXMyY8c2M3sNb4sn14xRTZHA88rDJhI8Yjmhp9ZvaqAv+isaeBcGhY
+Cpspwgl1qqGqNsgEkoScW6WzN8HP0DvQ6UhsJKKhtTxl2Kd81PKGQIz/9vdkhOew
+irbwUBl1Wx1eoJlcTXFEMSGVVjHUUDDyftfq+hfJ4U90Ny0tjPjr+t9ejHOWfszf
+3Na0qT+92au76SFBddBVe3J0jaGhcwyFMHmQp8CU9ZKHXnSeumwplo33+25U3M/e
+ALnDeejOZfFu0zDXTPZsvUFDJBke6PsILtQOAyrGATbDzPCqCZPmIl/p4aMwgPJW
+zn6TyG/0YbJXH7Mysm+8k9qSWTpfT8YRDSrOUIXPFxg9jmMqF8vnksNq8cwto57Z
+gPzl0TAYNKqS/YDkeNOgrwlnJ/f2rLTD0Zki16i/J3s6/Iy37XXj2No+G8bvGBDZ
+ffu3gnzaWei6HTmquQp55Kun
+-----END CERTIFICATE-----`)
+		expectedFingerprint := "daf8a9b0927fc221bdc3319336e4236ab59a7c0e3986d4cf69898601cb8ee604"
 
 		// when
-		calculatedHash, err := CalculateHash(escapedCert)
+		calculatedHash, err := FingerprintSHA256(rawPemCertificate)
 		require.NoError(t, err)
 
 		// then
-		assert.Equal(t, expectedHash, calculatedHash)
+		assert.Equal(t, expectedFingerprint, calculatedHash)
 	})
 
-	t.Run("should return error, when unable to unescape cert", func(t *testing.T) {
+	t.Run("should return error, when unable to decode cert", func(t *testing.T) {
 		// given
-		escapedCertIncorrect := "-----BEGIN%20CERTIFICATE-----%0" +
-			"MIIFfjCCA2agAwIBAgIBAjANBgkqhkiG9w0BAQsFADBqMQswCQYDVQQGEwJQTDEK%0" +
-			"MAgGA1UECAwBTjEQMA4GA1UEBwwHR0xJV0lDRTETMBEGA1UECgwKU0FQIEh5YnJp%0" +
-			"czENMAsGA1UECwwES3ltYTEZMBcGA1UEAwwQd29ybWhvbGUua3ltYS5jeDAeFw0x%0" +
-			"OTAxMjQwOTQ1MTJaFw0yMDAxMjQwOTQ1MTJaMHIxCzAJBgNVBAYTAkRFMRAwDgYD%0" +
-			"VQQIEwdXYWxkb3JmMRAwDgYDVQQHEwdXYWxkb3JmMRUwEwYDVQQKEwxPcmdhbml6%0" +
-			"YXRpb24xEDAOBgNVBAsTB09yZ1VuaXQxFjAUBgNVBAMTDXVwcy10ZXN0LWFwcDEw%0" +
-			"ggIiMA0GCSqGSIb3DQEBAQUAA4ICDwAwggIKAoICAQC7eOxYnQy3CcNKYAYb2b48%0" +
-			"FA92GW1LWjfCBEhu+uP5hLlH572OODpdhyNmtFInpl8gmQ1454x%2FrG5bOjUxOkOi%0" +
-			"U97xM8e7O1MW4fLIC2LDkY0TapfaMn%2FoYwUHz3QFlx+BKM4yxgpJ+YY5OJVoGDEH%0" +
-			"TdaSY5LzftnfSBjUMrQIec6wv3+Vy0F8jUmxV3FifODhWxBUBEqZOSm9ruOwOSan%0" +
-			"J2sY1ovsj4QZZ9HnLJT6mdMt8lAwyDg0o68aOsjPtDEaqOIGWiYls49GIRi%2FcXft%0" +
-			"1S2L1q5WOiFlK18rkWouFJrx7YppPXEpLzwqY8DjaZ5qbfaBZzTaYHYBgTqClCbp%0" +
-			"AqwzDBsXuhPKywY+HzGhkGMHJKVxADuycgGObyQsnFDg0284zVJpCU41grVaigjf%0" +
-			"PsD8NU%2FhO11M+45xVl7WCLecHmVKZpwR3A6g6WpucitFKdHvbdD6jhbt3aUuJN+u%0" +
-			"U7GdnPk0A+y%2Fs7Y6FzxdoVtfWFIZqnFHIcL1kUT8WeEONnzmmMvOIIh8rz1U9iVO%0" +
-			"m%2FFZ1u3JloRRdGpaKewTytRsOKBE5Oug24GZSKA5dGG6ex7BDoXRgUgf3WxuUBQ2%0" +
-			"uidkXunTrcWUFI3IwbAdS9DWnlVhjvYBjOw8OsF3WtUsyIkDKFs11mfQvOKg6Y0m%0" +
-			"FrF9eKkyolUlmrHrGdG3wwIDAQABoycwJTAOBgNVHQ8BAf8EBAMCB4AwEwYDVR0l%0" +
-			"BAwwCgYIKwYBBQUHAwIwDQYJKoZIhvcNAQELBQADggIBAGpTE%2FtPB8ZJqR+mqZDB%0" +
-			"HzTE1fyoYYJvXfGwZQEWrR3GqOPe0Ni3jWQKs9NYoYSGoN9cYFvDJUQy3d5BJ1m8%0" +
-			"Y0uySIEDewYpKZR1zL7lnUYZ4msjOpNnlcIGNd0xz1EbHDPK3fMljVu+oJ4d+Z7a%0" +
-			"VdfJ+4fXUPgWxA9ou2E9GoiWtoReGc7ok2sx1NH3%2FZIaSy7zHKfve8ULrwkvVTEs%0" +
-			"W+jzuGIZvIQXMyY8c2M3sNb4sn14xRTZHA88rDJhI8Yjmhp9ZvaqAv+isaeBcGhY%0" +
-			"Cpspwgl1qqGqNsgEkoScW6WzN8HP0DvQ6UhsJKKhtTxl2Kd81PKGQIz%2F9vdkhOew%0" +
-			"irbwUBl1Wx1eoJlcTXFEMSGVVjHUUDDyftfq+hfJ4U90Ny0tjPjr+t9ejHOWfszf%0" +
-			"3Na0qT+92au76SFBddBVe3J0jaGhcwyFMHmQp8CU9ZKHXnSeumwplo33+25U3M%2Fe%0" +
-			"ALnDeejOZfFu0zDXTPZsvUFDJBke6PsILtQOAyrGATbDzPCqCZPmIl%2Fp4aMwgPJW%0" +
-			"zn6TyG%2F0YbJXH7Mysm+8k9qSWTpfT8YRDSrOUIXPFxg9jmMqF8vnksNq8cwto57Z%0" +
-			"gPzl0TAYNKqS%2FYDkeNOgrwlnJ%2Ff2rLTD0Zki16i%2FJ3s6%2FIy37XXj2No+G8bvGBDZ%0" +
-			"ffu3gnzaWei6HTmquQp55Kun%0" +
-			"-----END%20CERTIFICATE-----"
+		invalidPemCertificate := []byte("invalid-input")
 
 		// when
-		hash, err := CalculateHash(escapedCertIncorrect)
+		hash, err := FingerprintSHA256(invalidPemCertificate)
 
 		// then
 		assert.Equal(t, "", hash)

--- a/components/connector-service/internal/externalapi/revocationhandler.go
+++ b/components/connector-service/internal/externalapi/revocationhandler.go
@@ -1,11 +1,13 @@
 package externalapi
 
 import (
+	"net/http"
+	"net/url"
+
 	"github.com/kyma-project/kyma/components/connector-service/internal/apperrors"
 	"github.com/kyma-project/kyma/components/connector-service/internal/certificates"
 	"github.com/kyma-project/kyma/components/connector-service/internal/httphelpers"
 	"github.com/kyma-project/kyma/components/connector-service/internal/revocation"
-	"net/http"
 )
 
 const (
@@ -46,7 +48,12 @@ func (handler revocationHandler) getCertificateHash(r *http.Request) (string, ap
 		return "", apperrors.Internal("Cannot calculate certificate hash. Certificate not passed to the service.")
 	}
 
-	hash, err := certificates.CalculateHash(cert)
+	pemCert, err := url.PathUnescape(cert)
+	if err != nil {
+		return "", apperrors.Internal("Failed to unescape characters from certificate.")
+	}
+
+	hash, err := certificates.FingerprintSHA256([]byte(pemCert))
 	if err != nil {
 		return "", apperrors.Internal("Failed to calculate certificate hash.")
 	}

--- a/components/connector-service/internal/externalapi/revocationhandler_test.go
+++ b/components/connector-service/internal/externalapi/revocationhandler_test.go
@@ -2,18 +2,19 @@ package externalapi
 
 import (
 	"errors"
-	"github.com/kyma-project/kyma/components/connector-service/internal/revocation/mocks"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/mock"
 	"net/http"
 	"net/http/httptest"
 	"testing"
+
+	"github.com/kyma-project/kyma/components/connector-service/internal/revocation/mocks"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
 )
 
 func TestRevocationHandler(t *testing.T) {
 
 	urlRevocation := "/v1/applications/certificates/revocations"
-	hashedTestCert := "297cc9e776803ffc0aef2e95e1d8544ad6ca92ac567e117990a6ed920520fdf9"
+	hashedTestCert := "daf8a9b0927fc221bdc3319336e4236ab59a7c0e3986d4cf69898601cb8ee604"
 
 	testCert := "-----BEGIN%20CERTIFICATE-----%0A" +
 		"MIIFfjCCA2agAwIBAgIBAjANBgkqhkiG9w0BAQsFADBqMQswCQYDVQQGEwJQTDEK%0A" +

--- a/components/connector-service/internal/revocation/middlewares/revocationcheck_test.go
+++ b/components/connector-service/internal/revocation/middlewares/revocationcheck_test.go
@@ -2,21 +2,54 @@ package middlewares
 
 import (
 	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
 	"github.com/kyma-project/kyma/components/connector-service/internal/externalapi"
 	"github.com/kyma-project/kyma/components/connector-service/internal/revocation/mocks"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"net/http"
-	"net/http/httptest"
-	"testing"
 )
 
 func TestRevocationCheckMiddleware(t *testing.T) {
 
-	t.Run("should return http code 403 when certificate hash on revocation list", func(t *testing.T) {
+	certFingerprint := "daf8a9b0927fc221bdc3319336e4236ab59a7c0e3986d4cf69898601cb8ee604"
+	testCert := "-----BEGIN%20CERTIFICATE-----%0A" +
+		"MIIFfjCCA2agAwIBAgIBAjANBgkqhkiG9w0BAQsFADBqMQswCQYDVQQGEwJQTDEK%0A" +
+		"MAgGA1UECAwBTjEQMA4GA1UEBwwHR0xJV0lDRTETMBEGA1UECgwKU0FQIEh5YnJp%0A" +
+		"czENMAsGA1UECwwES3ltYTEZMBcGA1UEAwwQd29ybWhvbGUua3ltYS5jeDAeFw0x%0A" +
+		"OTAxMjQwOTQ1MTJaFw0yMDAxMjQwOTQ1MTJaMHIxCzAJBgNVBAYTAkRFMRAwDgYD%0A" +
+		"VQQIEwdXYWxkb3JmMRAwDgYDVQQHEwdXYWxkb3JmMRUwEwYDVQQKEwxPcmdhbml6%0A" +
+		"YXRpb24xEDAOBgNVBAsTB09yZ1VuaXQxFjAUBgNVBAMTDXVwcy10ZXN0LWFwcDEw%0A" +
+		"ggIiMA0GCSqGSIb3DQEBAQUAA4ICDwAwggIKAoICAQC7eOxYnQy3CcNKYAYb2b48%0A" +
+		"FA92GW1LWjfCBEhu+uP5hLlH572OODpdhyNmtFInpl8gmQ1454x%2FrG5bOjUxOkOi%0A" +
+		"U97xM8e7O1MW4fLIC2LDkY0TapfaMn%2FoYwUHz3QFlx+BKM4yxgpJ+YY5OJVoGDEH%0A" +
+		"TdaSY5LzftnfSBjUMrQIec6wv3+Vy0F8jUmxV3FifODhWxBUBEqZOSm9ruOwOSan%0A" +
+		"J2sY1ovsj4QZZ9HnLJT6mdMt8lAwyDg0o68aOsjPtDEaqOIGWiYls49GIRi%2FcXft%0A" +
+		"1S2L1q5WOiFlK18rkWouFJrx7YppPXEpLzwqY8DjaZ5qbfaBZzTaYHYBgTqClCbp%0A" +
+		"AqwzDBsXuhPKywY+HzGhkGMHJKVxADuycgGObyQsnFDg0284zVJpCU41grVaigjf%0A" +
+		"PsD8NU%2FhO11M+45xVl7WCLecHmVKZpwR3A6g6WpucitFKdHvbdD6jhbt3aUuJN+u%0A" +
+		"U7GdnPk0A+y%2Fs7Y6FzxdoVtfWFIZqnFHIcL1kUT8WeEONnzmmMvOIIh8rz1U9iVO%0A" +
+		"m%2FFZ1u3JloRRdGpaKewTytRsOKBE5Oug24GZSKA5dGG6ex7BDoXRgUgf3WxuUBQ2%0A" +
+		"uidkXunTrcWUFI3IwbAdS9DWnlVhjvYBjOw8OsF3WtUsyIkDKFs11mfQvOKg6Y0m%0A" +
+		"FrF9eKkyolUlmrHrGdG3wwIDAQABoycwJTAOBgNVHQ8BAf8EBAMCB4AwEwYDVR0l%0A" +
+		"BAwwCgYIKwYBBQUHAwIwDQYJKoZIhvcNAQELBQADggIBAGpTE%2FtPB8ZJqR+mqZDB%0A" +
+		"HzTE1fyoYYJvXfGwZQEWrR3GqOPe0Ni3jWQKs9NYoYSGoN9cYFvDJUQy3d5BJ1m8%0A" +
+		"Y0uySIEDewYpKZR1zL7lnUYZ4msjOpNnlcIGNd0xz1EbHDPK3fMljVu+oJ4d+Z7a%0A" +
+		"VdfJ+4fXUPgWxA9ou2E9GoiWtoReGc7ok2sx1NH3%2FZIaSy7zHKfve8ULrwkvVTEs%0A" +
+		"W+jzuGIZvIQXMyY8c2M3sNb4sn14xRTZHA88rDJhI8Yjmhp9ZvaqAv+isaeBcGhY%0A" +
+		"Cpspwgl1qqGqNsgEkoScW6WzN8HP0DvQ6UhsJKKhtTxl2Kd81PKGQIz%2F9vdkhOew%0A" +
+		"irbwUBl1Wx1eoJlcTXFEMSGVVjHUUDDyftfq+hfJ4U90Ny0tjPjr+t9ejHOWfszf%0A" +
+		"3Na0qT+92au76SFBddBVe3J0jaGhcwyFMHmQp8CU9ZKHXnSeumwplo33+25U3M%2Fe%0A" +
+		"ALnDeejOZfFu0zDXTPZsvUFDJBke6PsILtQOAyrGATbDzPCqCZPmIl%2Fp4aMwgPJW%0A" +
+		"zn6TyG%2F0YbJXH7Mysm+8k9qSWTpfT8YRDSrOUIXPFxg9jmMqF8vnksNq8cwto57Z%0A" +
+		"gPzl0TAYNKqS%2FYDkeNOgrwlnJ%2Ff2rLTD0Zki16i%2FJ3s6%2FIy37XXj2No+G8bvGBDZ%0A" +
+		"ffu3gnzaWei6HTmquQp55Kun%0A" +
+		"-----END%20CERTIFICATE-----"
+
+	t.Run("should return http code 403 when certificate fingerprint present on revocation list", func(t *testing.T) {
 		// given
-		testCert := "testCert"
-		hashedTestCert := "f21139ef2b82d02ee73a56c5c73c053fbafa3480a0b35459cba276b0667c57fc"
 		handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			w.WriteHeader(http.StatusOK)
 		})
@@ -28,7 +61,7 @@ func TestRevocationCheckMiddleware(t *testing.T) {
 		rr := httptest.NewRecorder()
 
 		repository := &mocks.RevocationListRepository{}
-		repository.On("Contains", hashedTestCert).Return(true, nil)
+		repository.On("Contains", certFingerprint).Return(true, nil)
 
 		middleware := NewRevocationCheckMiddleware(repository)
 
@@ -42,8 +75,6 @@ func TestRevocationCheckMiddleware(t *testing.T) {
 
 	t.Run("should allow certificate when hash not on revocation list", func(t *testing.T) {
 		// given
-		testCert := "testCert"
-		hashedTestCert := "f21139ef2b82d02ee73a56c5c73c053fbafa3480a0b35459cba276b0667c57fc"
 		handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			w.WriteHeader(http.StatusOK)
 		})
@@ -55,7 +86,7 @@ func TestRevocationCheckMiddleware(t *testing.T) {
 		rr := httptest.NewRecorder()
 
 		repository := &mocks.RevocationListRepository{}
-		repository.On("Contains", hashedTestCert).Return(false, nil)
+		repository.On("Contains", certFingerprint).Return(false, nil)
 
 		middleware := NewRevocationCheckMiddleware(repository)
 
@@ -69,8 +100,6 @@ func TestRevocationCheckMiddleware(t *testing.T) {
 
 	t.Run("should return http code 500 when error occurred on contains method call", func(t *testing.T) {
 		// given
-		testCert := "testCert"
-		hashedTestCert := "f21139ef2b82d02ee73a56c5c73c053fbafa3480a0b35459cba276b0667c57fc"
 		handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			w.WriteHeader(http.StatusOK)
 		})
@@ -82,7 +111,7 @@ func TestRevocationCheckMiddleware(t *testing.T) {
 		rr := httptest.NewRecorder()
 
 		repository := &mocks.RevocationListRepository{}
-		repository.On("Contains", hashedTestCert).Return(false, errors.New("Some error"))
+		repository.On("Contains", certFingerprint).Return(false, errors.New("Some error"))
 
 		middleware := NewRevocationCheckMiddleware(repository)
 

--- a/docs/application-connector/docs/08-09-revoke-cert.md
+++ b/docs/application-connector/docs/08-09-revoke-cert.md
@@ -3,7 +3,7 @@ title: Revoke the client certificate
 type: Tutorials
 ---
 
-You can revoke a client certificate generated for your Application. Revocation prevents a certificate from being renewed. A revoked certificate, however, continues to be valid until it expires.
+You can revoke a client certificate generated for your Application. Revocation prevents a certificate from being [renewed](#tutorials-renew-the-client-certificate). A revoked certificate, however, continues to be valid until it expires.
 
 To revoke a client certificate, send a request to the `certificates/revocations` endpoint. Pass the certificate you want to revoke and a key that matches this certificate in the call. Run:
     
@@ -11,18 +11,20 @@ To revoke a client certificate, send a request to the `certificates/revocations`
 curl -X POST https://gateway.{CLUSTER_DOMAIN}/v1/applications/certificates/revocations --cert {CERT_TO_REVOKE} --key {CERT_TO_REVOKE_KEY} -k 
 ```
 
-If you have access to the Kyma cluster, you can also revoke a certificate by sending the SHA256 fingerprint of the certificate to the internal `certificates/revocations` endpoint.
+## Revoke a certificate using SHA256 fingerprint
 
-To get SHA256 fingerprint convert certificate in the `pem` format to the `der` format:
-```bash
-openssl x509 -in {CLIENT_CERT_FILE}.crt -outform der -out {CLIENT_CERT_DER_FILE}.der
-```
-To get the SHA256 fingerprint run:
-```bash
-shasum -a 256 {CLIENT_CERT_DER_FORMAT}.der
-```
-Revoke the certificate by running:
+If you have admin access to the Kyma cluster, you can revoke client certificates by sending the SHA256 fingerprint of 
+a certificate to the internal `certificates/revocations` endpoint. Follow these steps: 
 
-```bash
-curl -X POST http://connector-service-internal-api:8080/v1/applications/certificates/revocations -d '{hash: {CERT_TO_REVOKE_SHA256_FINGERPRINT}}'
-```
+1. Convert the certificate from the `pem` format to the `der` format. Run:
+    ```bash
+    openssl x509 -in {CLIENT_CERT_FILE}.crt -outform der -out {CLIENT_CERT_DER_FILE}.der
+    ```
+2. Get the SHA256 fingerprint of the certificate. Run:
+    ```bash
+    shasum -a 256 {CLIENT_CERT_DER_FILE}.der
+    ```
+3. Revoke the certificate using the SHA256 fingerprint:
+    ```bash
+    curl -X POST http://connector-service-internal-api:8080/v1/applications/certificates/revocations -d '{hash: {SHA256_FINGERPRINT_OF_CERT_TO_REVOKE_}}'
+    ```

--- a/docs/application-connector/docs/08-09-revoke-cert.md
+++ b/docs/application-connector/docs/08-09-revoke-cert.md
@@ -11,8 +11,18 @@ To revoke a client certificate, send a request to the `certificates/revocations`
 curl -X POST https://gateway.{CLUSTER_DOMAIN}/v1/applications/certificates/revocations --cert {CERT_TO_REVOKE} --key {CERT_TO_REVOKE_KEY} -k 
 ```
 
-If you have access to the Kyma cluster, you can also revoke a certificate by sending the SHA256 sum of the certificate to the internal `certificates/revocations` endpoint. Run:
+If you have access to the Kyma cluster, you can also revoke a certificate by sending the SHA256 fingerprint of the certificate to the internal `certificates/revocations` endpoint.
+
+To get SHA256 fingerprint convert certificate in the `pem` format to the `der` format:
+```bash
+openssl x509 -in {CLIENT_CERT_FILE}.crt -outform der -out {CLIENT_CERT_DER_FILE}.der
+```
+To get the SHA256 fingerprint run:
+```bash
+shasum -a 256 {CLIENT_CERT_DER_FORMAT}.der
+```
+Revoke the certificate by running:
 
 ```bash
-curl -X POST http://connector-service-internal-api:8080/v1/applications/certificates/revocations -d '{hash: {CERT_TO_REVOKE_SHA256}}'
+curl -X POST http://connector-service-internal-api:8080/v1/applications/certificates/revocations -d '{hash: {CERT_TO_REVOKE_SHA256_FINGERPRINT}}'
 ```

--- a/tests/connector-service-tests/test/testkit/certs.go
+++ b/tests/connector-service-tests/test/testkit/certs.go
@@ -3,9 +3,11 @@ package testkit
 import (
 	"crypto/rand"
 	"crypto/rsa"
+	"crypto/sha256"
 	"crypto/x509"
 	"crypto/x509/pkix"
 	"encoding/base64"
+	"encoding/hex"
 	"encoding/pem"
 	"strings"
 	"testing"
@@ -53,6 +55,13 @@ func CreateCsr(t *testing.T, certInfo CertInfo, keys *rsa.PrivateKey) []byte {
 	return csr
 }
 
+// CertificateSHA256Fingerprint returns certificate fingerprint generated using SHA256 algorithm
+func CertificateSHA256Fingerprint(t *testing.T, certificate *x509.Certificate) string {
+	sha := sha256.Sum256(certificate.Raw)
+
+	return hex.EncodeToString(sha[:])
+}
+
 // EncodedCertChainToPemBytes decodes certificates chain and return pemBlock's bytes for client cert and ca cert
 func EncodedCertChainToPemBytes(t *testing.T, encodedChain string) []byte {
 	crtBytes := decodeBase64Cert(encodedChain, t)
@@ -81,7 +90,7 @@ func EncodedCertToPemBytes(t *testing.T, encodedCert string) []byte {
 
 func EncodeCertToPem(t *testing.T, certificate *x509.Certificate) []byte {
 	pemBlock := &pem.Block{Type: "CERTIFICATE", Bytes: certificate.Raw}
-	
+
 	encodedPem := pem.EncodeToMemory(pemBlock)
 	require.NotNil(t, encodedPem)
 


### PR DESCRIPTION
**Description**

The Connector Service revocation list contained the sha256 hash of certificate in `pem` format. The correct way of determining certificate fingerprint is to calculate it from the `der` format.

Changes proposed in this pull request:

- Modify Connector Service certificate revocation to use certificate fingerprint

**Related issue(s)**
#1608
