### PR TITLE
Add resources persistentvolumeclaims and persistentvolumes to the Clu…

### DIFF
--- a/tests/end-to-end/backup-restore-test/deploy/chart/backup-test/templates/test/test-backup.yaml
+++ b/tests/end-to-end/backup-restore-test/deploy/chart/backup-test/templates/test/test-backup.yaml
@@ -37,7 +37,7 @@ rules:
   resources: ["horizontalpodautoscalers"]
   verbs: ["get", "list"]
 - apiGroups: [""]
-  resources: ["secrets", "statefulsets", "pods"]
+  resources: ["secrets", "statefulsets", "pods", "persistentvolumeclaims", "persistentvolumes"]
   verbs: ["create", "get", "update", "delete"]
 ---
 apiVersion: v1


### PR DESCRIPTION
Fix issue found during the execution of the backup end to end test.
`'persistentvolumeclaims is forbidden: User "system:serviceaccount:end-to-end:backup-test" cannot list resource "persistentvolumeclaims" in API group "" in the namespace "kyma-system"'`
