### PR TITLE
Bump natss provisioner images to fix reconnection issue

### DIFF
--- a/resources/knative-provisioner-natss/charts/knative-provisioner-natss/templates/deployment.yaml
+++ b/resources/knative-provisioner-natss/charts/knative-provisioner-natss/templates/deployment.yaml
@@ -81,6 +81,7 @@ spec:
     matchLabels: &labels
       clusterChannelProvisioner: natss
       role: controller
+      app: natss-controller
   template:
     metadata:
       labels: *labels
@@ -157,6 +158,7 @@ spec:
     matchLabels: &labels
       clusterChannelProvisioner: natss
       role: dispatcher
+      app: natss-dispatcher
   template:
     metadata:
       annotations:

--- a/resources/knative-provisioner-natss/values.yaml
+++ b/resources/knative-provisioner-natss/values.yaml
@@ -9,8 +9,8 @@ knative-provisioner-natss:
   controller:
     image:
       pullPolicy: IfNotPresent
-      location: gcr.io/knative-releases/github.com/knative/eventing/contrib/natss/pkg/controller:v0.4.1
+      location: eu.gcr.io/kyma-project/event-bus/knative/natss/controller:1d23a08
   dispatcher:
     image:
       pullPolicy: IfNotPresent
-      location: gcr.io/knative-releases/github.com/knative/eventing/contrib/natss/pkg/dispatcher:v0.4.1
+      location: eu.gcr.io/kyma-project/event-bus/knative/natss/dispatcher:1d23a08


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Bump natss provisioner images to fix reconnection issue
- Add `app` label for traceability

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
See #3339