### PR TITLE
Remove default namespace-scoped roles from namespace-controller

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -85,7 +85,7 @@
 /resources/core/charts/istio-rbac/ @piotrmsc @kubadz @sjanota @strekm @jakkab @Tomasz-Smelcerz-SAP @kfurgol @Demonsthere
 
 # The `namespace-controller` subchart
-/resources/core/charts/namespace-controller/ @Tomasz-Smelcerz-SAP @strekm @jakkab @crabtree @piotrmsc @kubadz @sjanota @kfurgol @Demonsthere
+/resources/core/charts/namespace-controller/ @Tomasz-Smelcerz-SAP @strekm @jakkab @piotrmsc @kubadz @sjanota @kfurgol @Demonsthere
 
 # The `etcd-operator` subchart
 /resources/core/charts/etcd-operator/ @aszecowka @PK85 @mszostok @piotrmiskiewicz @polskikiel @mwieczorek @jasiu001 @adamwalach
@@ -212,7 +212,7 @@
 /components/configurations-generator/ @piotrmsc @kubadz @sjanota @strekm @jakkab @Tomasz-Smelcerz-SAP @kfurgol @Demonsthere
 
 # Namespace controller Component
-/components/namespace-controller/ @Tomasz-Smelcerz-SAP @strekm @jakkab @crabtree @piotrmsc @kubadz @sjanota @kfurgol @Demonsthere
+/components/namespace-controller/ @Tomasz-Smelcerz-SAP @strekm @jakkab @piotrmsc @kubadz @sjanota @kfurgol @Demonsthere
 
 # Istio Extensions Component
 /components/istio-kyma-patch/ @piotrmsc @sjanota @kubadz @strekm @jakkab @Tomasz-Smelcerz-SAP @kfurgol @Demonsthere
@@ -268,7 +268,7 @@
 /tests/acceptance/dex @sjanota @piotrmsc @kubadz @strekm @jakkab @Tomasz-Smelcerz-SAP @kfurgol @Demonsthere
 
 # test-namespace-controller
-/tests/test-namespace-controller/ @Tomasz-Smelcerz-SAP @strekm @jakkab @crabtree @piotrmsc @kubadz @sjanota @kfurgol @Demonsthere
+/tests/test-namespace-controller/ @Tomasz-Smelcerz-SAP @strekm @jakkab @piotrmsc @kubadz @sjanota @kfurgol @Demonsthere
 
 # monitoring tests
 /tests/monitoring/ @rakesh-garimella @joek @sayanh @venturasr @lilitgh @k15r

--- a/components/namespace-controller/README.md
+++ b/components/namespace-controller/README.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-This controller injects limit ranges and resource quotas into each Namespace that you create. In addtion it enables Istio injection for the Namespace by labelling it with `istio-injection` label.
+This controller injects limit ranges and resource quotas into each Namespace that you create. In addition, it enables Istio injection for the Namespace by labeling it with `istio-injection` label.
 
 Developers create default roles from a roles template that they first define in a Namespace inside the Kubernetes cluster.
 At the time of cluster provisioning, developers might define the roles in the `3-bootstrap-roles.yaml` file. The controller looks for roles labeled as `env=true` at the creation of the new Namespace. Next, the controller copies the roles to the new Namespace.

--- a/components/namespace-controller/README.md
+++ b/components/namespace-controller/README.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-This controller injects limit ranges, resource quotas, and default roles into each Namespace that you create.
+This controller injects limit ranges and resource quotas into each Namespace that you create. In addtion it enables Istio injection for the Namespace by labelling it with `istio-injection` label.
 
 Developers create default roles from a roles template that they first define in a Namespace inside the Kubernetes cluster.
 At the time of cluster provisioning, developers might define the roles in the `3-bootstrap-roles.yaml` file. The controller looks for roles labeled as `env=true` at the creation of the new Namespace. Next, the controller copies the roles to the new Namespace.

--- a/components/namespace-controller/README.md
+++ b/components/namespace-controller/README.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-This controller injects limit ranges and resource quotas into each Namespace that you create. In addition, it enables Istio injection for the Namespace by labeling it with `istio-injection` label.
+This controller injects limit ranges and resource quotas into each Namespace that you create. In addition, it enables Istio injection for the Namespace by labeling it with the `istio-injection` label.
 
 Developers create default roles from a roles template that they first define in a Namespace inside the Kubernetes cluster.
 At the time of cluster provisioning, developers might define the roles in the `3-bootstrap-roles.yaml` file. The controller looks for roles labeled as `env=true` at the creation of the new Namespace. Next, the controller copies the roles to the new Namespace.

--- a/components/namespace-controller/internal/controller/controller_test.go
+++ b/components/namespace-controller/internal/controller/controller_test.go
@@ -96,7 +96,6 @@ func GetTestSetup() (envs *controller, nc *testNamespacesClient, rc *testRolesCl
 		Clientset:           nil,
 		Config:              testNamespacesConfig,
 		NamespacesClient:    nc,
-		RolesClient:         rc,
 		LimitRangeClient:    lr,
 		ResourceQuotaClient: rq,
 		ErrorHandlers:       &internal.ErrorHandlers{},
@@ -188,73 +187,6 @@ func (lr *testResourceQuotaClient) DeleteResourceQuota(namespace string) error {
 }
 
 func TestNamespaces(t *testing.T) {
-	Convey("Adding roles for namespace shouldn't return error", t, func() {
-
-		envs, nc, rc, lr, _ := GetTestSetup()
-
-		err := envs.AddRolesForNamespace(testNamespace)
-
-		So(err, ShouldBeNil)
-		So(nc.GetNamespaceCalled, ShouldBeTrue)
-		So(nc.UpdateNamespaceCalled, ShouldBeTrue)
-
-		allLimitRangeClientMethodsShouldNotBeCalled(lr)
-
-		So(rc.CreateRoleCalled, ShouldBeTrue)
-		So(rc.GetListCalled, ShouldBeTrue)
-		So(rc.DeleteRoleCalled, ShouldBeFalse)
-		So(rc.GetRoleCalled, ShouldBeFalse)
-	})
-
-	Convey("Should not add roles for namespace with existing roles", t, func() {
-
-		origNamespace := testNamespace.DeepCopy()
-		envs, nc, rc, lr, _ := GetTestSetup()
-
-		annotations := make(map[string]string)
-		annotations[rolesAnnotName] = "true"
-		testNamespace.SetAnnotations(annotations)
-
-		err := envs.AddRolesForNamespace(testNamespace)
-
-		So(err, ShouldBeNil)
-		So(nc.GetNamespaceCalled, ShouldBeTrue)
-		So(nc.UpdateNamespaceCalled, ShouldBeFalse)
-
-		allRolesClientMethodsShouldNotBeCalled(rc)
-		allLimitRangeClientMethodsShouldNotBeCalled(lr)
-
-		Reset(func() {
-			testNamespace = origNamespace
-		})
-	})
-
-	Convey("Removing roles from namespace shouldn't return error", t, func() {
-
-		origNamespace := testNamespace.DeepCopy()
-		envs, nc, rc, lr, _ := GetTestSetup()
-
-		annotations := make(map[string]string)
-		annotations[rolesAnnotName] = "true"
-		testNamespace.SetAnnotations(annotations)
-
-		err := envs.RemoveRolesFromNamespace(testNamespace)
-
-		So(err, ShouldBeNil)
-		So(nc.GetNamespaceCalled, ShouldBeTrue)
-		So(nc.UpdateNamespaceCalled, ShouldBeTrue)
-
-		allLimitRangeClientMethodsShouldNotBeCalled(lr)
-
-		So(rc.GetListCalled, ShouldBeTrue)
-		So(rc.DeleteRoleCalled, ShouldBeTrue)
-		So(rc.CreateRoleCalled, ShouldBeFalse)
-		So(rc.GetRoleCalled, ShouldBeFalse)
-
-		Reset(func() {
-			testNamespace = origNamespace
-		})
-	})
 
 	Convey("istio-inject label", t, func() {
 


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Remove handling of namespace-scoped k8s rules from the namespace-controller

**Related issue(s)**
See also #2896 
