### PR TITLE
Make dex static users login available with stop and restart Kyma without reinstalling scenario

### DIFF
--- a/tools/static-users-generator/scripts/config_replace.sh
+++ b/tools/static-users-generator/scripts/config_replace.sh
@@ -12,6 +12,19 @@ PLACEHOLDER="#__STATIC_PASSWORDS__"
 
 NEWLINE="%"
 
+# check if kubectl works as expected. Minikube stop and then minikube start cases temporary unavailability of the api-server)
+while :
+do
+  if [[ $(kubectl get secrets -l dex-user-config=true --all-namespaces -o json) ]]
+    then
+      echo "api-server available via kubectl"
+      break
+    else
+      echo "api-server not available via kubectl - waiting 5s..."
+      sleep 5
+    fi
+done
+
 NUM=0
 for secret in $(kubectl get secrets -l dex-user-config=true --all-namespaces -o json | jq -r -c '.items | .[] | .data')
 do
@@ -49,7 +62,7 @@ do
 
   # generate userID
   USER_ID=$(cat /dev/urandom | LC_ALL=C tr -dc 'a-z0-9' | fold -w 32 | head -n 1)
-  
+
   # prepare config map to enable static users
   if [ $NUM -eq 1 ]
   then

--- a/tools/static-users-generator/scripts/config_replace.sh
+++ b/tools/static-users-generator/scripts/config_replace.sh
@@ -11,19 +11,35 @@ DEST_FILE_PATH="/config/dst/config.yaml"
 PLACEHOLDER="#__STATIC_PASSWORDS__"
 
 NEWLINE="%"
+MAX_RETRIES=60
 
 # check if kubectl works as expected. Minikube stop and then minikube start cases temporary unavailability of the api-server)
-while :
-do
-  if [[ $(kubectl get secrets -l dex-user-config=true --all-namespaces -o json) ]]
-    then
-      echo "api-server available via kubectl"
-      break
-    else
-      echo "api-server not available via kubectl - waiting 5s..."
-      sleep 5
-    fi
-done
+function checkIfApiServerAvailable() {
+    local cnt=0
+    set +o errexit
+
+    while :
+    do
+      if [[ $(kubectl get secrets -l dex-user-config=true --all-namespaces -o json) ]]
+        then
+          echo "Api-server available via kubectl."
+          break
+        else
+          ((cnt++))
+          if (( cnt > $MAX_RETRIES )); then
+            echo "Max retries has been reached (retries $MAX_RETRIES). Exit."
+            exit 1
+          fi
+
+          echo "Api-server not available via kubectl - waiting 5s..."
+          sleep 5
+        fi
+    done
+
+    set -o errexit
+}
+
+checkIfApiServerAvailable
 
 NUM=0
 for secret in $(kubectl get secrets -l dex-user-config=true --all-namespaces -o json | jq -r -c '.items | .[] | .data')


### PR DESCRIPTION


**Description**

Changes proposed in this pull request:

- After minikube stop/start dex works as expected
- ``` 
   kubectl -n kyma-system logs $(kubectl get pod -l app=dex -n kyma-system -o jsonpath= . 
   {.items..metadata.name}) dex-users-configurator
   ```
  will say:
   ```
   error:
   The connection to the server 10.96.0.1:443 was refused - did you specify the right host or port?
   api-server not available via kubectl - waiting 5s...
   api-server available via kubectl
   successfully created user: admin
   successfully created user: developer-user
   successfully created user: no-rights-user
   successfully created user: read-only-user
   ```
   or
   ```
   error: the server doesn't have a resource type "secrets"  api-server not available via kubectl - waiting 
   5s...
   api-server available via kubectl
   successfully created user: admin
   successfully created user: developer-user
   successfully created user: no-rights-user
   successfully created user: read-only-user
   ```