### PR TITLE
Truncate source-id and event-type after encoding if any of them exceeds the length limit

### DIFF
--- a/components/event-bus/api/publish/validators.go
+++ b/components/event-bus/api/publish/validators.go
@@ -8,8 +8,8 @@ import (
 const (
 	// event components max lengths
 	// todo make them all configurable
-	sourceIdMaxLength         = 15
-	eventTypeMaxLength        = 15
+	SourceIdMaxLength         = 28
+	EventTypeMaxLength        = 28
 	eventTypeVersionMaxLength = 2
 )
 
@@ -43,11 +43,11 @@ func ValidatePublish(r *PublishRequest) *Error {
 	}
 
 	//validate the event components lengths
-	if len(r.SourceID) > sourceIdMaxLength {
-		return errorInvalidSourceIDLength(sourceIdMaxLength)
+	if len(r.SourceID) > SourceIdMaxLength {
+		return errorInvalidSourceIDLength(SourceIdMaxLength)
 	}
-	if len(r.EventType) > eventTypeMaxLength {
-		return errorInvalidEventTypeLength(eventTypeMaxLength)
+	if len(r.EventType) > EventTypeMaxLength {
+		return errorInvalidEventTypeLength(EventTypeMaxLength)
 	}
 	if len(r.EventTypeVersion) > eventTypeVersionMaxLength {
 		return errorInvalidEventTypeVersionLength(eventTypeVersionMaxLength)

--- a/components/event-bus/api/publish/validators_test.go
+++ b/components/event-bus/api/publish/validators_test.go
@@ -128,7 +128,7 @@ func Test_ValidatePublish_Success(t *testing.T) {
 
 func Test_ValidatePublish_InvalidSourceIdLength(t *testing.T) {
 	publishRequest := buildTestPublishRequest()
-	publishRequest.SourceID = "this-is-a-long-source-id"
+	publishRequest.SourceID = "this-is-a-very-long-source-id"
 	err := ValidatePublish(&publishRequest)
 	assert.NotEqual(t, len(err.Details), 0)
 	assert.Equal(t, http.StatusBadRequest, err.Status)
@@ -138,7 +138,7 @@ func Test_ValidatePublish_InvalidSourceIdLength(t *testing.T) {
 
 func Test_ValidatePublish_InvalidEventTypeLength(t *testing.T) {
 	publishRequest := buildTestPublishRequest()
-	publishRequest.EventType = "this-is-a-long-event-type"
+	publishRequest.EventType = "this-is-a-very-long-event-type"
 	err := ValidatePublish(&publishRequest)
 	assert.NotEqual(t, len(err.Details), 0)
 	assert.Equal(t, http.StatusBadRequest, err.Status)

--- a/components/event-bus/internal/knative/util/util.go
+++ b/components/event-bus/internal/knative/util/util.go
@@ -3,6 +3,8 @@ package util
 import (
 	"fmt"
 	"strings"
+
+	"github.com/kyma-project/kyma/components/event-bus/api/publish"
 )
 
 const (
@@ -18,21 +20,30 @@ var (
 //  * In case there was a '-' or more in any of the argument values, each occurrence of the '-' will be escaped by '-d'.
 //  * In case there was a '.' or more in any of the argument values, each occurrence of the '.' will be replaced by the '-p' character sequence,
 //    because of a limitation in the current knative version, if the channel name has a '.', the corresponding istio-virtualservice will not be created.
-func escapeHyphensAndPeriods(str *string) string {
-	return replacer.Replace(*str)
+func escapeHyphensAndPeriods(str *string) *string {
+	out := replacer.Replace(*str)
+	return &out
+}
+
+func truncate(str *string, length int) *string {
+	if len(*str) > length {
+		out := (*str)[:length]
+		return &out
+	}
+	return str
 }
 
 // GetChannelName function joins the sourceID, eventType and eventTypeVersion respectively with a '--' as a delimiter.
 func GetChannelName(sourceID, eventType, eventTypeVersion *string) string {
 	return fmt.Sprintf("%s%s%s%s%s",
-		escapeHyphensAndPeriods(sourceID), delimiter,
-		escapeHyphensAndPeriods(eventType), delimiter,
-		escapeHyphensAndPeriods(eventTypeVersion))
+		*truncate(escapeHyphensAndPeriods(sourceID), publish.SourceIdMaxLength), delimiter,
+		*truncate(escapeHyphensAndPeriods(eventType), publish.EventTypeMaxLength), delimiter,
+		*escapeHyphensAndPeriods(eventTypeVersion))
 }
 
 // GetKnSubscriptionName joins the kySubscriptionName and kySubscriptionNamespace
 func GetKnSubscriptionName(kySubscriptionName, kySubscriptionNamespace *string) string {
-	return fmt.Sprintf("%s%s%s", *kySubscriptionName, delimiter, escapeHyphensAndPeriods(kySubscriptionNamespace))
+	return fmt.Sprintf("%s%s%s", *kySubscriptionName, delimiter, *escapeHyphensAndPeriods(kySubscriptionNamespace))
 }
 
 // GetDefaultChannelNamespace() returns the default namespace of Knative/Eventing channels and subscriptions

--- a/components/event-bus/internal/knative/util/util_test.go
+++ b/components/event-bus/internal/knative/util/util_test.go
@@ -52,14 +52,14 @@ func Test_getChannelName(t *testing.T) {
 			sourceID:         "ec..default--test..1",
 			eventType:        "order--created..test--1",
 			eventTypeVersion: "v1",
-			expected:         "ec-p-pdefault-d-dtest-p-p1--order-d-dcreated-p-ptest-d-d1--v1",
+			expected:         "ec-p-pdefault-d-dtest-p-p1--order-d-dcreated-p-ptest-d-d--v1", // truncation applied on the event-type
 		},
 		{
 			name:             "test-case-6",
 			sourceID:         "ec--default..test--1",
 			eventType:        "order..created--test..1",
 			eventTypeVersion: "v1",
-			expected:         "ec-d-ddefault-p-ptest-d-d1--order-p-pcreated-d-dtest-p-p1--v1",
+			expected:         "ec-d-ddefault-p-ptest-d-d1--order-p-pcreated-d-dtest-p-p--v1", // truncation applied on the event-type
 		},
 		{
 			name:             "test-case-7",


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Truncate source-id and event-type after encoding if any of them exceeds the length limit.

**Related issue(s)**
#3157 
