### PR TITLE
Bump helm-broker image, add develope mode env variable

### DIFF
--- a/docs/helm-broker/docs/05-04-configure-hb.md
+++ b/docs/helm-broker/docs/05-04-configure-hb.md
@@ -45,3 +45,9 @@ By default, the Helm Broker fetches bundles listed in the `index.yaml` file from
   >**CAUTION:** If you use your bundle in two different repositories simultaneously, the Helm Broker detects a conflict and does not display this bundle at all. You can see the details of the conflict in the Helm Broker application logs. If you need a given bundle in two or more repositories, do not use them at the same time.
 
 4. The Helm Broker triggers the Service Catalog synchronization automatically. New Service Classes appear after a few seconds.
+
+## Configuration rules
+
+These are the rules you must follow when you configure the Helm Broker. Otherwise, the Helm Broker will not display your bundles.
+* If you use your bundle in two different repositories simultaneously, the Helm Broker detects a conflict and does not display this bundle at all. You can see the details of the conflict in the Helm Broker application logs. If you need a given bundle in two or more repositories, do not use them at the same time.
+* On your non-local clusters, you can use only servers with TLS enabled. All incorrect or unsecured URLs will be omitted. Find the information about the rejected URLs in the Helm Broker logs. You can use unsecured URLs only on your local cluster. To use URLs without TLS enabled, set the **config.isDevelopMode** environment variable in the [values.yaml](https://github.com/kyma-project/kyma/blob/master/resources/helm-broker/values.yaml) file to `true`.

--- a/installation/resources/installer-config-local.yaml.tpl
+++ b/installation/resources/installer-config-local.yaml.tpl
@@ -77,6 +77,18 @@ data:
 apiVersion: v1
 kind: ConfigMap
 metadata:
+  name: helm-broker-overrides
+  namespace: kyma-installer
+  labels:
+    installer: overrides
+    component: helm-broker
+    kyma-project.io/installation: ""
+data:
+  config.isDevelopMode: "true"
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
   name: knative-serving-overrides
   namespace: kyma-installer
   labels:

--- a/resources/helm-broker/templates/deploy.yaml
+++ b/resources/helm-broker/templates/deploy.yaml
@@ -51,6 +51,8 @@ spec:
             value: {{ template "fullname" . }}
           - name: APP_HELM_BROKER_URL
             value: http://{{ template "fullname" . }}
+          - name: APP_DEVELOP_MODE
+            value: "{{ .Values.config.isDevelopMode }}"
 
         volumeMounts:
         - mountPath: /tmp

--- a/resources/helm-broker/values.yaml
+++ b/resources/helm-broker/values.yaml
@@ -9,6 +9,7 @@ service:
   internalPort: 8080
 
 config:
+  isDevelopMode: "false"
   storage:
     - driver: etcd
       provide:
@@ -29,7 +30,7 @@ global:
     path: eu.gcr.io/kyma-project
   helm_broker:
     dir: develop/
-    version: d375742b
+    version: 5e3fedb6
   alpine_net:
     dir: develop/
     version: ed568f0f


### PR DESCRIPTION
Related with this [issue](https://github.com/kyma-project/kyma/pull/3445) 
- Bump image version
- Add new env variable to deployment chart
- Add documentation