### PR TITLE
Migration from helm test to Octopus

### DIFF
--- a/components/application-operator/charts/application/templates/tests/application-gateway-tests.yaml
+++ b/components/application-operator/charts/application/templates/tests/application-gateway-tests.yaml
@@ -1,30 +1,27 @@
-{{- if .Capabilities.APIVersions.Has "testing.kyma-project.io/v1alpha1" }}
-apiVersion: "testing.kyma-project.io/v1alpha1"
-kind: TestDefinition
+apiVersion: v1
+kind: Pod
 metadata:
   name: {{.Release.Name }}-application-gateway-tests
+  annotations:
+    helm.sh/hook: test-success
+    sidecar.istio.io/inject: "false"
   labels:
+    helm-chart-test: "true"
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
 spec:
-  template:
-    metadata:
-      annotations:
-        sidecar.istio.io/inject: "false"
-    spec:
-      serviceAccountName: {{.Release.Name }}-application-gateway-tests
-      containers:
-        - name: {{.Release.Name }}-application-gateway-tests
-          image: {{ .Values.global.applicationGatewayTestsImage }}
-          imagePullPolicy: {{ .Values.acceptanceTest.image.pullPolicy }}
-          env:
-            - name: APPLICATION
-              value: {{.Release.Name }}
-            - name: NAMESPACE
-              value: kyma-integration
-            - name: SERVICE_ACCOUNT
-              value: {{.Release.Name }}-application-gateway-tests
-            - name: MOCK_SERVICE_PORT
-              value: "8080"
-      restartPolicy: Never
-{{- end }}
+  serviceAccountName: {{.Release.Name }}-application-gateway-tests
+  containers:
+    - name: {{.Release.Name }}-application-gateway-tests
+      image: {{ .Values.global.applicationGatewayTestsImage }}
+      imagePullPolicy: {{ .Values.acceptanceTest.image.pullPolicy }}
+      env:
+        - name: APPLICATION
+          value: {{.Release.Name }}
+        - name: NAMESPACE
+          value: kyma-integration
+        - name: SERVICE_ACCOUNT
+          value: {{.Release.Name }}-application-gateway-tests
+        - name: MOCK_SERVICE_PORT
+          value: "8080"
+  restartPolicy: Never

--- a/components/application-operator/charts/application/templates/tests/application-gateway-tests.yaml
+++ b/components/application-operator/charts/application/templates/tests/application-gateway-tests.yaml
@@ -1,27 +1,30 @@
-apiVersion: v1
-kind: Pod
+{{- if .Capabilities.APIVersions.Has "testing.kyma-project.io/v1alpha1" }}
+apiVersion: "testing.kyma-project.io/v1alpha1"
+kind: TestDefinition
 metadata:
   name: {{.Release.Name }}-application-gateway-tests
-  annotations:
-    helm.sh/hook: test-success
-    sidecar.istio.io/inject: "false"
   labels:
-    helm-chart-test: "true"
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
 spec:
-  serviceAccountName: {{.Release.Name }}-application-gateway-tests
-  containers:
-    - name: {{.Release.Name }}-application-gateway-tests
-      image: {{ .Values.global.applicationGatewayTestsImage }}
-      imagePullPolicy: {{ .Values.acceptanceTest.image.pullPolicy }}
-      env:
-        - name: APPLICATION
-          value: {{.Release.Name }}
-        - name: NAMESPACE
-          value: kyma-integration
-        - name: SERVICE_ACCOUNT
-          value: {{.Release.Name }}-application-gateway-tests
-        - name: MOCK_SERVICE_PORT
-          value: "8080"
-  restartPolicy: Never
+  template:
+    metadata:
+      annotations:
+        sidecar.istio.io/inject: "false"
+    spec:
+      serviceAccountName: {{.Release.Name }}-application-gateway-tests
+      containers:
+        - name: {{.Release.Name }}-application-gateway-tests
+          image: {{ .Values.global.applicationGatewayTestsImage }}
+          imagePullPolicy: {{ .Values.acceptanceTest.image.pullPolicy }}
+          env:
+            - name: APPLICATION
+              value: {{.Release.Name }}
+            - name: NAMESPACE
+              value: kyma-integration
+            - name: SERVICE_ACCOUNT
+              value: {{.Release.Name }}-application-gateway-tests
+            - name: MOCK_SERVICE_PORT
+              value: "8080"
+      restartPolicy: Never
+{{- end }}

--- a/components/application-operator/charts/application/templates/tests/test-acceptance.yaml
+++ b/components/application-operator/charts/application/templates/tests/test-acceptance.yaml
@@ -1,27 +1,30 @@
-apiVersion: v1
-kind: Pod
+{{- if .Capabilities.APIVersions.Has "testing.kyma-project.io/v1alpha1" }}
+apiVersion: "testing.kyma-project.io/v1alpha1"
+kind: TestDefinition
 metadata:
   name: test-{{.Release.Name }}-event-service-acceptance
-  annotations:
-    helm.sh/hook: test-success
-    sidecar.istio.io/inject: "true"
   labels:
-    helm-chart-test: "true"
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
 spec:
-  shareProcessNamespace: true
-  containers:
-    - name: {{.Release.Name }}-event-service-acceptance
-      image: {{ .Values.global.eventServiceTestsImage }}
-      command: ["/bin/sh"]
-      args: ["-c", "sleep 10; ./entrypoint.sh; exit_code=$?; pkill -INT pilot-agent; sleep 4; exit $exit_code;"]
-      imagePullPolicy: {{ .Values.acceptanceTest.image.pullPolicy }}
-      env:
-        - name: EVENT_SERVICE_URL
-          value: http://{{.Release.Name }}-event-service-external-api.{{ .Release.Namespace }}.svc.cluster.local:8081
-        - name: NAMESPACE
-          value: {{ .Release.Namespace }}
-        - name: APPLICATION
-          value: {{ .Release.Name }}
-  restartPolicy: Never
+  template:
+    metadata:
+      annotations:
+        sidecar.istio.io/inject: "true"
+    spec:
+      shareProcessNamespace: true
+      containers:
+        - name: {{.Release.Name }}-event-service-acceptance
+          image: {{ .Values.global.eventServiceTestsImage }}
+          command: ["/bin/sh"]
+          args: ["-c", "sleep 10; ./entrypoint.sh; exit_code=$?; pkill -INT pilot-agent; sleep 4; exit $exit_code;"]
+          imagePullPolicy: {{ .Values.acceptanceTest.image.pullPolicy }}
+          env:
+            - name: EVENT_SERVICE_URL
+              value: http://{{.Release.Name }}-event-service-external-api.{{ .Release.Namespace }}.svc.cluster.local:8081
+            - name: NAMESPACE
+              value: {{ .Release.Namespace }}
+            - name: APPLICATION
+              value: {{ .Release.Name }}
+      restartPolicy: Never
+{{- end}}

--- a/components/application-operator/charts/application/templates/tests/test-acceptance.yaml
+++ b/components/application-operator/charts/application/templates/tests/test-acceptance.yaml
@@ -1,30 +1,27 @@
-{{- if .Capabilities.APIVersions.Has "testing.kyma-project.io/v1alpha1" }}
-apiVersion: "testing.kyma-project.io/v1alpha1"
-kind: TestDefinition
+apiVersion: v1
+kind: Pod
 metadata:
   name: test-{{.Release.Name }}-event-service-acceptance
+  annotations:
+    helm.sh/hook: test-success
+    sidecar.istio.io/inject: "true"
   labels:
+    helm-chart-test: "true"
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
 spec:
-  template:
-    metadata:
-      annotations:
-        sidecar.istio.io/inject: "true"
-    spec:
-      shareProcessNamespace: true
-      containers:
-        - name: {{.Release.Name }}-event-service-acceptance
-          image: {{ .Values.global.eventServiceTestsImage }}
-          command: ["/bin/sh"]
-          args: ["-c", "sleep 10; ./entrypoint.sh; exit_code=$?; pkill -INT pilot-agent; sleep 4; exit $exit_code;"]
-          imagePullPolicy: {{ .Values.acceptanceTest.image.pullPolicy }}
-          env:
-            - name: EVENT_SERVICE_URL
-              value: http://{{.Release.Name }}-event-service-external-api.{{ .Release.Namespace }}.svc.cluster.local:8081
-            - name: NAMESPACE
-              value: {{ .Release.Namespace }}
-            - name: APPLICATION
-              value: {{ .Release.Name }}
-      restartPolicy: Never
-{{- end}}
+  shareProcessNamespace: true
+  containers:
+    - name: {{.Release.Name }}-event-service-acceptance
+      image: {{ .Values.global.eventServiceTestsImage }}
+      command: ["/bin/sh"]
+      args: ["-c", "sleep 10; ./entrypoint.sh; exit_code=$?; pkill -INT pilot-agent; sleep 4; exit $exit_code;"]
+      imagePullPolicy: {{ .Values.acceptanceTest.image.pullPolicy }}
+      env:
+        - name: EVENT_SERVICE_URL
+          value: http://{{.Release.Name }}-event-service-external-api.{{ .Release.Namespace }}.svc.cluster.local:8081
+        - name: NAMESPACE
+          value: {{ .Release.Namespace }}
+        - name: APPLICATION
+          value: {{ .Release.Name }}
+  restartPolicy: Never

--- a/docs/kyma/docs/03-03-testing.md
+++ b/docs/kyma/docs/03-03-testing.md
@@ -32,7 +32,8 @@ dex
 ```
 
 The test adds a new **test-dex-connection.yaml** under the `templates/tests` directory.
-Detailed TestDefinition description can be found in [Octopus documentation](https://github.com/kyma-incubator/octopus/blob/master/docs/crd-test-definition.md) 
+Detailed TestDefinition description can be found in [Octopus documentation](https://github.com/kyma-incubator/octopus/blob/master/docs/crd-test-definition.md).
+
 In the simplest example, define just `spec.template` which is of type `PodTemplateSpec`.
 In the example below, there is a container that calls the `Dex` endpoint with cURL.
 

--- a/docs/kyma/docs/03-03-testing.md
+++ b/docs/kyma/docs/03-03-testing.md
@@ -10,8 +10,8 @@ Octopus uses two Custom Resource Definitions (CRDs):
 - ClusterTestSuite, which defines a suite of tests to execute and how to execute them.
 
 ## Add a new test
-To add a new test, create a yaml file with `TestDefinition` in your chart. By convention, place it under tests directory.
-See the exemplary test directory prepared for Dex:
+To add a new test, create a yaml file with TestDefinition CR in your chart. By convention, place it under tests directory.
+See the exemplary chart structure for Dex:
 
 ```
 # Chart tree
@@ -64,7 +64,7 @@ spec:
 
 ## Tests execution
 To run all tests, use the `testing.sh` script located in the `/installation/scripts/` directory. 
-Internally, `ClusterTestSuite` resource is defined, that fetches all `TestDefinitions` and executes them.
+Internally, ClusterTestSuite resource is defined, that fetches all TestDefinitions and executes them.
 
 
 ### Run tests manually

--- a/docs/kyma/docs/03-03-testing.md
+++ b/docs/kyma/docs/03-03-testing.md
@@ -3,17 +3,15 @@ title: Testing Kyma
 type: Details
 ---
 
-For testing, the Kyma components use the [Octopus](http://github.com/kyma-incubator/octopus). 
+Kyma components use [Octopus](http://github.com/kyma-incubator/octopus) for testing. 
 Octopus is a testing framework that allows you to run tests defined as Docker images on a running cluster.
-Octopus uses two types of Custom Resource Definitions:
-- TestDefinition defines your test as a Pod specification.
-- ClusterTestSuite defines a suite of tests to execute and how to execute them.
-
-Place your TestDefinition in your chart.
+Octopus uses two Custom Resource Definitions (CRDs):
+- TestDefinition, which defines your test as a Pod specification.
+- ClusterTestSuite, which defines a suite of tests to execute and how to execute them.
 
 ## Add a new test
-
-See the following example of a test prepared for Dex:
+To add a new test, create a yaml file with `TestDefinition` in your chart. By convention, place it under tests directory.
+See the exemplary test directory prepared for Dex:
 
 ```
 # Chart tree
@@ -34,7 +32,9 @@ dex
 ```
 
 The test adds a new **test-dex-connection.yaml** under the `templates/tests` directory.
-This simple test calls the `Dex` endpoint with cURL, defined as follows:
+Detailed TestDefinition description can be found in [Octopus documentation](https://github.com/kyma-incubator/octopus/blob/master/docs/crd-test-definition.md) 
+In the simplest example, define just `spec.template` which is of type `PodTemplateSpec`.
+In the example below, there is a container that calls the `Dex` endpoint with cURL.
 
 ```yaml
 apiVersion: "testing.kyma-project.io/v1alpha1"
@@ -59,17 +59,16 @@ spec:
           "http://dex-service.{{ .Release.Namespace }}.svc.cluster.local:5556/.well-known/openid-configuration"
         ]
       restartPolicy: Never
----
 
 ```
 
-## Test execution
-To execute all tests, use the `testing.sh` script located in the `/installation/scripts/` directory. 
+## Tests execution
+To run all tests, use the `testing.sh` script located in the `/installation/scripts/` directory. 
 Internally, `ClusterTestSuite` resource is defined, that fetches all `TestDefinitions` and executes them.
 
 
-### Run a test manually
-To execute tests manually, create `ClusterTestSuite` on your own. See the following example:
+### Run tests manually
+To run tests manually, create your own ClusterTestSuite resource. See the following example:
 
 ```yaml
 apiVersion: testing.kyma-project.io/v1alpha1
@@ -84,7 +83,7 @@ spec:
   count: 1
 ```
 
-Creation of the suite triggers tests. Current progress of the tests is visible in a `ClusterTestSuite` status.
+Creation of the suite triggers tests execution. See the current progress of the tests in the ClusterTestSuite status. Run:
 ```bash
  kubectl get cts {my-suite} -oyaml
  ```
@@ -126,7 +125,7 @@ status:
   startTime: 2019-04-05T12:22:53Z
 ```
 
-The ID of the execution is the same as the ID of the testing Pod. The testing Pod is created in the same namespace as it's TestDefinition. To get logs for a specific test, execute the following command:
+The ID of the test execution is the same as the ID of the testing Pod. The testing Pod is created in the same Namespace as its TestDefinition. To get logs for a specific test, run the following command:
 ```
-kubeclt logs {execution-id} -n {test-def-namespace}
+kubectl logs {execution-id} -n {test-def-namespace}
 ```

--- a/docs/kyma/docs/03-03-testing.md
+++ b/docs/kyma/docs/03-03-testing.md
@@ -3,11 +3,15 @@ title: Testing Kyma
 type: Details
 ---
 
-For testing, the Kyma components use the Helm test concept. Place your test under the `templates` directory as a Pod definition that specifies a container with a given command to run.
+For testing, the Kyma components use the [Octopus](http://github.com/kyma-incubator/octopus). 
+Octopus is a testing framework that allows you to run tests defined as Docker images on a running cluster.
+Octopus uses two types of Custom Resource Definitions:
+- TestDefinition defines your test as a Pod specification.
+- ClusterTestSuite defines a suite of tests to execute and how to execute them.
+
+Place your TestDefinition in your chart.
 
 ## Add a new test
-
-The system bases tests on the Helm broker concept with one modification: adding a Pod label. Before you create a test, see the official [Chart Tests](https://github.com/kubernetes/helm/blob/release-2.10/docs/chart_tests.md) documentation. Then, add the `"helm-chart-test": "true"` label to your Pod template.
 
 See the following example of a test prepared for Dex:
 
@@ -33,48 +37,96 @@ The test adds a new **test-dex-connection.yaml** under the `templates/tests` dir
 This simple test calls the `Dex` endpoint with cURL, defined as follows:
 
 ```yaml
-apiVersion: v1
-kind: Pod
+apiVersion: "testing.kyma-project.io/v1alpha1"
+kind: TestDefinition
 metadata:
   name: "test-{{ template "fullname" . }}-connection-dex"
-  annotations:
-    "helm.sh/hook": test-success
-  labels:
-      "helm-chart-test": "true" # ! Our customization
 spec:
-  hostNetwork: true
-  containers:
-  - name: "test-{{ template "fullname" . }}-connection-dex"
-    image: tutum/curl:alpine
-    command: ["/usr/bin/curl"]
-    args: [
-      "--fail",
-      "http://dex-service.{{ .Release.Namespace }}.svc.cluster.local:5556/.well-known/openid-configuration"
-    ]
-  restartPolicy: Never
+  template:
+    metadata:
+      annotations:
+        sidecar.istio.io/inject: "false"
+    spec:
+      containers:
+      - name: "test-{{ template "fullname" . }}-connection-dex"
+        image: tutum/curl:alpine
+        command: ["/usr/bin/curl"]
+        args: [
+          "--fail",
+          "--max-time", "10",
+          "--retry", "60",
+          "--retry-delay", "3",
+          "http://dex-service.{{ .Release.Namespace }}.svc.cluster.local:5556/.well-known/openid-configuration"
+        ]
+      restartPolicy: Never
+---
+
 ```
 
 ## Test execution
+To execute all tests, use the `testing.sh` script located in the `/installation/scripts/` directory. 
+Internally, `ClusterTestSuite` resource is defined, that fetches all `TestDefinitions` and executes them.
 
-All tests created for charts under `/resources/core/` run automatically after starting Kyma.
-If any of the tests fails, the system prints the Pod logs in the terminal, then deletes all the Pods.
-
->**NOTE:** If you run Kyma locally, by default, the system does not take into account the test's exit code. As a result, the system does not terminate Kyma Docker container, and you can still access it.
-To force a termination in case of failing tests, use `--exit-on-test-fail` flag when executing `run.sh` script.
-
-CI propagates the exit status of tests. If any test fails, the whole CI job fails as well.
-
-Follow the same guidelines to add a test which is not a part of any `core` component. However, for test execution, see the **Run a test manually** section in this document.
 
 ### Run a test manually
+To execute tests manually, create `ClusterTestSuite` on your own. See the following example:
 
-To run a test manually, use the `testing.sh` script located in the `/installation/scripts/` directory which runs all tests defined for `core` releases.
-If any of the tests fails, the system prints the Pod logs in the terminal, then deletes all the Pods.
-
-Another option is to run a Helm test directly on your release.
-
-```bash
-$ helm test {your_release_name}
+```yaml
+apiVersion: testing.kyma-project.io/v1alpha1
+kind: ClusterTestSuite
+metadata:
+  labels:
+    controller-tools.k8s.io: "1.0"
+  name: {my-suite}
+spec:
+  maxRetries: 0
+  concurrency: 1
+  count: 1
 ```
 
-You can also run your test on custom releases. If you do this, remember to always delete the Pods after a test ends.
+Creation of the suite triggers tests. Current progress of the tests is visible in a `ClusterTestSuite` status.
+```bash
+ kubectl get cts {my-suite} -oyaml
+ ```
+ 
+The sample output looks as follows:
+```
+apiVersion: testing.kyma-project.io/v1alpha1
+kind: ClusterTestSuite
+metadata:
+  name: {my-suite}
+spec:
+  concurrency: 1
+  count: 1
+  maxRetries: 0
+status:
+  conditions:
+  - status: "True"
+    type: Running
+  results:
+  - executions:
+    - completionTime: 2019-04-05T12:23:00Z
+      id: {my-suite}-test-dex-dex-connection-dex-0
+      podPhase: Succeeded
+      startTime: 2019-04-05T12:22:54Z
+    name: test-dex-dex-connection-dex
+    namespace: kyma-system
+    status: Succeeded
+  - executions:
+    - id: {my-suite}-test-core-core-ui-acceptance-0
+      podPhase: Running
+      startTime: 2019-04-05T12:37:53Z
+    name: test-core-core-ui-acceptance
+    namespace: kyma-system
+    status: Running
+  - executions: []
+    name: test-api-controller-acceptance
+    namespace: kyma-system
+    status: NotYetScheduled
+  startTime: 2019-04-05T12:22:53Z
+```
+
+The ID of the execution is the same as the ID of the testing Pod. The testing Pod is created in the same namespace as it's TestDefinition. To get logs for a specific test, execute the following command:
+```
+kubeclt logs {execution-id} -n {test-def-namespace}
+```

--- a/docs/kyma/docs/03-03-testing.md
+++ b/docs/kyma/docs/03-03-testing.md
@@ -5,12 +5,12 @@ type: Details
 
 Kyma components use [Octopus](http://github.com/kyma-incubator/octopus) for testing. 
 Octopus is a testing framework that allows you to run tests defined as Docker images on a running cluster.
-Octopus uses two Custom Resource Definitions (CRDs):
+Octopus uses two CustomResourceDefinitions (CRDs):
 - TestDefinition, which defines your test as a Pod specification.
 - ClusterTestSuite, which defines a suite of tests to execute and how to execute them.
 
 ## Add a new test
-To add a new test, create a yaml file with TestDefinition CR in your chart. By convention, place it under tests directory.
+To add a new test, create a `yaml` file with TestDefinition CR in your chart. To comply with the convention, place it under the `tests` directory.
 See the exemplary chart structure for Dex:
 
 ```
@@ -32,10 +32,9 @@ dex
 ```
 
 The test adds a new **test-dex-connection.yaml** under the `templates/tests` directory.
-Detailed TestDefinition description can be found in [Octopus documentation](https://github.com/kyma-incubator/octopus/blob/master/docs/crd-test-definition.md).
+For more information on TestDefinition, read the [Octopus documentation](https://github.com/kyma-incubator/octopus/blob/master/docs/crd-test-definition.md).
 
-In the simplest example, define just `spec.template` which is of type `PodTemplateSpec`.
-In the example below, there is a container that calls the `Dex` endpoint with cURL.
+The following example presents TestDefinition with a container that calls the Dex endpoint with cURL. You must define at least the **spec.template** parameter which is of the `PodTemplateSpec` type.
 
 ```yaml
 apiVersion: "testing.kyma-project.io/v1alpha1"
@@ -65,7 +64,7 @@ spec:
 
 ## Tests execution
 To run all tests, use the `testing.sh` script located in the `/installation/scripts/` directory. 
-Internally, ClusterTestSuite resource is defined, that fetches all TestDefinitions and executes them.
+Internally, the ClusterTestSuite resource is defined. It fetches all TestDefinitions and executes them.
 
 
 ### Run tests manually
@@ -84,7 +83,7 @@ spec:
   count: 1
 ```
 
-Creation of the suite triggers tests execution. See the current progress of the tests in the ClusterTestSuite status. Run:
+Creation of the suite triggers tests execution. See the current tests progress in the ClusterTestSuite status. Run:
 ```bash
  kubectl get cts {my-suite} -oyaml
  ```

--- a/installation/resources/installer-cr-cluster.yaml.tpl
+++ b/installation/resources/installer-cr-cluster.yaml.tpl
@@ -12,8 +12,6 @@ spec:
   components:
     - name: "cluster-essentials"
       namespace: "kyma-system"
-    - name: "testing"
-      namespace: "kyma-system"
     - name: "istio-init"
       namespace: "istio-system"
     - name: "istio"
@@ -26,6 +24,8 @@ spec:
       namespace: "knative-eventing"
     - name: "istio-kyma-patch"
       namespace: "istio-system"
+    - name: "testing"
+      namespace: "kyma-system"
     - name: "prometheus-operator"
       namespace: "kyma-system"
     - name: "dex"

--- a/installation/resources/installer-cr-cluster.yaml.tpl
+++ b/installation/resources/installer-cr-cluster.yaml.tpl
@@ -12,6 +12,8 @@ spec:
   components:
     - name: "cluster-essentials"
       namespace: "kyma-system"
+    - name: "testing"
+      namespace: "kyma-system"
     - name: "istio-init"
       namespace: "istio-system"
     - name: "istio"

--- a/installation/resources/installer-cr.yaml.tpl
+++ b/installation/resources/installer-cr.yaml.tpl
@@ -12,6 +12,8 @@ spec:
   components:
     - name: "cluster-essentials"
       namespace: "kyma-system"
+    - name: "testing"
+      namespace: "kyma-system"
     - name: "istio-init"
       namespace: "istio-system"
     - name: "istio"

--- a/installation/resources/installer-cr.yaml.tpl
+++ b/installation/resources/installer-cr.yaml.tpl
@@ -12,8 +12,6 @@ spec:
   components:
     - name: "cluster-essentials"
       namespace: "kyma-system"
-    - name: "testing"
-      namespace: "kyma-system"
     - name: "istio-init"
       namespace: "istio-system"
     - name: "istio"
@@ -28,6 +26,8 @@ spec:
       namespace: "istio-system"
     # - name: "prometheus-operator"
     # namespace: "kyma-system"
+    - name: "testing"
+      namespace: "kyma-system"
     - name: "dex"
       namespace: "kyma-system"
     - name: "service-catalog"

--- a/installation/scripts/e2e-testing.sh
+++ b/installation/scripts/e2e-testing.sh
@@ -1,7 +1,170 @@
 #!/usr/bin/env bash
 ROOT_PATH=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
 source "${ROOT_PATH}/utils.sh"
-source "${ROOT_PATH}/testing-common.sh"
+
+#copied from  testing-common.sh: in testing-common.sh we use Octopus, here helm test. TODO later: rewrite e2e-testing to Octopus.
+
+function cleanupHelmTestPods() {
+    local namespace=$1
+
+    log "\nCleaning up helm test pods in namespace ${namespace}" nc bold
+    kubectl $(context_arg)  delete pod -n ${namespace} -l helm-chart-test=true
+    deleteErr=$?
+    if [ ${deleteErr} -ne 0 ]
+    then
+      log "FAILED cleaning test pods.\n" red
+      return 1
+    fi
+    log "Success cleaning test pods.\n" nc bold
+}
+
+function printLogsFromPod() {
+    local namespace=$1 pod=$2
+    local tailLimit=2000 bytesLimit=500000
+    log "Fetching logs from '${pod}' with options tailLimit=${tailLimit} and bytesLimit=${bytesLimit}" nc bold
+    result=$(kubectl $(context_arg)  logs --tail=${tailLimit} --limit-bytes=${bytesLimit} -n ${namespace} ${pod})
+    if [ "${#result}" -eq 0 ]; then
+        log "FAILED" red
+        return 1
+    fi
+    echo "${result}"
+}
+
+function printLogsFromFailedHelmTests() {
+    local namespace=$1
+
+    for POD in $(kubectl $(context_arg)  get pods -n ${namespace} -l helm-chart-test=true --show-all -o jsonpath='{.items[*].metadata.name}')
+    do
+        log "Testing '${POD}'" nc bold
+
+        phase=$(kubectl $(context_arg)  get pod ${POD} -n ${namespace} -o jsonpath="{ .status.phase }")
+
+        case ${phase} in
+        "Failed")
+            log "'${POD}' has Failed status" red
+            printLogsFromPod ${namespace} ${POD}
+        ;;
+        "Running")
+            log "'${POD}' failed due to too long Running status" red
+            printLogsFromPod ${namespace} ${POD}
+        ;;
+        "Pending")
+            log "'${POD}' failed due to too long Pending status" red
+            printf "Fetching events from '${POD}':\n"
+            kubectl $(context_arg)  describe po ${POD} -n ${namespace} | awk 'x==1 {print} /Events:/ {x=1}'
+        ;;
+        "Unknown")
+            log "'${POD}' failed with Unknown status" red
+            printLogsFromPod ${namespace} ${POD}
+        ;;
+        "Succeeded")
+            echo "Test of '${POD}' was successful"
+            echo "Logs are not displayed after success"
+        ;;
+        *)
+            log "Unknown status of '${POD}' - ${phase}" red
+            printLogsFromPod ${namespace} ${POD}
+        ;;
+        esac
+        log "End of testing '${POD}'\n" nc bold
+    done
+}
+
+function checkTestPodTerminated() {
+    local namespace=$1
+
+    runningPods=false
+
+    for POD in $(kubectl $(context_arg)  get pods -n ${namespace} -l helm-chart-test=true --show-all -o jsonpath='{.items[*].metadata.name}')
+    do
+        phase=$(kubectl $(context_arg)  get pod "$POD" -n ${namespace} -o jsonpath="{ .status.phase }")
+        # A Pod's phase  Failed or Succeeded means pod has terminated.
+        # see: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#pod-phase
+        if [ "${phase}" !=  "Succeeded" ] && [ "${phase}" != "Failed" ]
+        then
+          log "Test pod '${POD}' has not terminated, pod phase: ${phase}" red
+          runningPods=true
+        fi
+    done
+
+    if [ ${runningPods} = true ];
+    then
+        return 1
+    fi
+}
+
+function waitForTestPodsTermination() {
+    local retry=0
+    local namespace=$1
+
+    log "All test pods should be terminated. Checking..." nc bold
+    while [ ${retry} -lt 3 ]; do
+        checkTestPodTerminated ${namespace}
+        checkTestPodTerminatedErr=$?
+        if [ ${checkTestPodTerminatedErr} -ne 0 ]; then
+            echo "Waiting for test pods to terminate..."
+            sleep 1
+        else
+            log "OK" green bold
+            return 0
+        fi
+        retry=$[retry + 1]
+    done
+    log "FAILED" red
+    return 1
+}
+
+function checkTestPodLabel() {
+    local namespace=$1
+
+    err=false
+
+    log "Test pods should be marked with label 'helm-chart-test=true'. Checking..." nc bold
+    for POD in $(kubectl $(context_arg)  get pods -n ${namespace} --show-all -o jsonpath='{.items[*].metadata.name}')
+    do
+        annotation=$(kubectl $(context_arg)  get pod "$POD" -n ${namespace} -o jsonpath="{ .metadata.annotations.helm\.sh/hook }")
+        if [ "${annotation}" == "test-success" ] || [ "${annotation}" == "test-failure" ]
+        then
+            helmLabel=$(kubectl $(context_arg)  get pod "${POD}" -n ${namespace} -o jsonpath="{ .metadata.labels.helm-chart-test }" )
+            if [ "${helmLabel}" != "true" ];
+            then
+                err=true
+                log "Pod ${POD} is wrongly labeled" red
+            fi
+        fi
+    done
+
+    if [ ${err} = true ];
+    then
+        log "FAILED" red
+        return 1
+    fi
+    log "OK" green bold
+}
+
+
+function checkAndCleanupTest() {
+    local namespace=$1
+
+    waitForTestPodsTermination ${namespace}
+    checkTestPodTerminatedErr=$?
+
+    printLogsFromFailedHelmTests ${namespace}
+
+    checkTestPodLabel ${namespace}
+    checkTestPodLabelErr=$?
+
+    cleanupHelmTestPods ${namespace}
+    cleanupErr=$?
+
+    if [ ${checkTestPodTerminatedErr} -ne 0 ] || [ ${checkTestPodLabelErr} -ne 0 ] | [ ${cleanupErr} -ne 0 ]
+    then
+        return 1
+    fi
+}
+
+#end of copy
+
 
 if [ -z "${DOMAIN}" ] ; then
   echo "ERROR: DOMAIN is not set"

--- a/installation/scripts/e2e-testing.sh
+++ b/installation/scripts/e2e-testing.sh
@@ -58,8 +58,7 @@ function printLogsFromFailedHelmTests() {
             printLogsFromPod ${namespace} ${POD}
         ;;
         "Succeeded")
-            echo "Test of '${POD}' was successful"
-            echo "Logs are not displayed after success"
+           # do nothing
         ;;
         *)
             log "Unknown status of '${POD}' - ${phase}" red

--- a/installation/scripts/e2e-testing.sh
+++ b/installation/scripts/e2e-testing.sh
@@ -58,7 +58,8 @@ function printLogsFromFailedHelmTests() {
             printLogsFromPod ${namespace} ${POD}
         ;;
         "Succeeded")
-           # do nothing
+            echo "Test of '${POD}' was successful"
+            echo "Logs are not displayed after success"
         ;;
         *)
             log "Unknown status of '${POD}' - ${phase}" red

--- a/installation/scripts/testing-common.sh
+++ b/installation/scripts/testing-common.sh
@@ -7,43 +7,68 @@ function context_arg() {
     fi
 }
 
-function printLogsFromFailedHelmTests() {
-    local namespace=$1
+function cmdGetPodsForSuite() {
+    local suiteName=$1
+    cmd="kubectl $(context_arg) get pods -l testing.kyma-project.io/suite-name=${suiteName} \
+            --all-namespaces \
+            --no-headers=true \
+            -o=custom-columns=name:metadata.name,ns:metadata.namespace \
+            --show-all=true"
+    echo $cmd
+}
 
-    for POD in $(kubectl $(context_arg)  get pods -n ${namespace} -l helm-chart-test=true --show-all -o jsonpath='{.items[*].metadata.name}')
+function printLogsFromFailedTests() {
+    local suiteName=$1
+    cmd=$(cmdGetPodsForSuite $suiteName)
+
+    pod=""
+    namespace=""
+    idx=0
+
+    for podOrNs in $($cmd)
     do
-        log "Testing '${POD}'" nc bold
+        n=$((idx%2))
+         if [[ "$n" == 0 ]];then
+            pod=${podOrNs}
+            idx=$((${idx}+1))
+            continue
+        fi
+        namespace=${podOrNs}
+        idx=$((${idx}+1))
 
-        phase=$(kubectl $(context_arg)  get pod ${POD} -n ${namespace} -o jsonpath="{ .status.phase }")
+        log "Testing '${pod}' from namespace '${namespace}'" nc bold
+
+        phase=$(kubectl $(context_arg)  get pod ${pod} -n ${namespace} -o jsonpath="{ .status.phase }")
 
         case ${phase} in
         "Failed")
-            log "'${POD}' has Failed status" red
-            printLogsFromPod ${namespace} ${POD}
+            log "'${pod}' has Failed status" red
+            printLogsFromPod ${namespace} ${pod}
         ;;
         "Running")
-            log "'${POD}' failed due to too long Running status" red
-            printLogsFromPod ${namespace} ${POD}
+            log "'${pod}' failed due to too long Running status" red
+            printLogsFromPod ${namespace} ${pod}
         ;;
         "Pending")
-            log "'${POD}' failed due to too long Pending status" red
-            printf "Fetching events from '${POD}':\n"
-            kubectl $(context_arg)  describe po ${POD} -n ${namespace} | awk 'x==1 {print} /Events:/ {x=1}'
+            log "'${pod}' failed due to too long Pending status" red
+            printf "Fetching events from '${pod}':\n"
+            kubectl $(context_arg)  describe po ${pod} -n ${namespace} | awk 'x==1 {print} /Events:/ {x=1}'
         ;;
         "Unknown")
-            log "'${POD}' failed with Unknown status" red
-            printLogsFromPod ${namespace} ${POD}
+            log "'${pod}' failed with Unknown status" red
+            printLogsFromPod ${namespace} ${pod}
         ;;
         "Succeeded")
-            echo "Test of '${POD}' was successful"
+            echo "Test of '${pod}' was successful"
             echo "Logs are not displayed after success"
         ;;
         *)
-            log "Unknown status of '${POD}' - ${phase}" red
-            printLogsFromPod ${namespace} ${POD}
+            log "Unknown status of '${pod}' - ${phase}" red
+            printLogsFromPod ${namespace} ${pod}
         ;;
         esac
-        log "End of testing '${POD}'\n" nc bold
+        log "End of testing '${pod}'\n" nc bold
+
     done
 }
 
@@ -73,18 +98,31 @@ function printLogsFromPod() {
 }
 
 function checkTestPodTerminated() {
-    local namespace=$1
-
+    local suiteName=$1
     runningPods=false
 
-    for POD in $(kubectl $(context_arg)  get pods -n ${namespace} -l helm-chart-test=true --show-all -o jsonpath='{.items[*].metadata.name}')
+    pod=""
+    namespace=""
+    idx=0
+
+    cmd=$(cmdGetPodsForSuite $suiteName)
+    for podOrNs in $($cmd)
     do
-        phase=$(kubectl $(context_arg)  get pod "$POD" -n ${namespace} -o jsonpath="{ .status.phase }")
+       n=$((idx%2))
+       if [[ "$n" == 0 ]];then
+         pod=${podOrNs}
+         idx=$((${idx}+1))
+         continue
+       fi
+        namespace=${podOrNs}
+        idx=$((${idx}+1))
+
+        phase=$(kubectl $(context_arg)  get pod "$pod" -n ${namespace} -o jsonpath="{ .status.phase }")
         # A Pod's phase  Failed or Succeeded means pod has terminated.
         # see: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#pod-phase
         if [ "${phase}" !=  "Succeeded" ] && [ "${phase}" != "Failed" ]
         then
-          log "Test pod '${POD}' has not terminated, pod phase: ${phase}" red
+          log "Test pod '${pod}' has not terminated, pod phase: ${phase}" red
           runningPods=true
         fi
     done
@@ -95,55 +133,13 @@ function checkTestPodTerminated() {
     fi
 }
 
-function checkTestPodLabel() {
-    local namespace=$1
-
-    err=false
-
-    log "Test pods should be marked with label 'helm-chart-test=true'. Checking..." nc bold
-    for POD in $(kubectl $(context_arg)  get pods -n ${namespace} --show-all -o jsonpath='{.items[*].metadata.name}')
-    do
-        annotation=$(kubectl $(context_arg)  get pod "$POD" -n ${namespace} -o jsonpath="{ .metadata.annotations.helm\.sh/hook }")
-        if [ "${annotation}" == "test-success" ] || [ "${annotation}" == "test-failure" ]
-        then
-            helmLabel=$(kubectl $(context_arg)  get pod "${POD}" -n ${namespace} -o jsonpath="{ .metadata.labels.helm-chart-test }" )
-            if [ "${helmLabel}" != "true" ];
-            then
-                err=true
-                log "Pod ${POD} is wrongly labeled" red
-            fi
-        fi
-    done
-
-    if [ ${err} = true ];
-    then
-        log "FAILED" red
-        return 1
-    fi
-    log "OK" green bold
-}
-
-function cleanupHelmTestPods() {
-    local namespace=$1
-
-    log "\nCleaning up helm test pods in namespace ${namespace}" nc bold
-    kubectl $(context_arg)  delete pod -n ${namespace} -l helm-chart-test=true
-    deleteErr=$?
-    if [ ${deleteErr} -ne 0 ]
-    then
-      log "FAILED cleaning test pods.\n" red
-      return 1
-    fi
-    log "Success cleaning test pods.\n" nc bold
-}
-
 function waitForTestPodsTermination() {
     local retry=0
-    local namespace=$1
+    local suiteName=$1
 
     log "All test pods should be terminated. Checking..." nc bold
     while [ ${retry} -lt 3 ]; do
-        checkTestPodTerminated ${namespace}
+        checkTestPodTerminated ${suiteName}
         checkTestPodTerminatedErr=$?
         if [ ${checkTestPodTerminatedErr} -ne 0 ]; then
             echo "Waiting for test pods to terminate..."
@@ -158,21 +154,14 @@ function waitForTestPodsTermination() {
     return 1
 }
 
-function checkAndCleanupTest() {
-    local namespace=$1
+function waitForTerminationAndPrintLogs() {
+    local suiteName=$1
 
-    waitForTestPodsTermination ${namespace}
+    waitForTestPodsTermination ${suiteName}
     checkTestPodTerminatedErr=$?
 
-    printLogsFromFailedHelmTests ${namespace}
-
-    checkTestPodLabel ${namespace}
-    checkTestPodLabelErr=$?
-
-    cleanupHelmTestPods ${namespace}
-    cleanupErr=$?
-
-    if [ ${checkTestPodTerminatedErr} -ne 0 ] || [ ${checkTestPodLabelErr} -ne 0 ] | [ ${cleanupErr} -ne 0 ]
+    printLogsFromFailedTests ${suiteName}
+    if [ ${checkTestPodTerminatedErr} -ne 0 ]
     then
         return 1
     fi

--- a/installation/scripts/testing-common.sh
+++ b/installation/scripts/testing-common.sh
@@ -59,8 +59,7 @@ function printLogsFromFailedTests() {
             printLogsFromPod ${namespace} ${pod}
         ;;
         "Succeeded")
-            echo "Test of '${pod}' was successful"
-            echo "Logs are not displayed after success"
+            # do nothing
         ;;
         *)
             log "Unknown status of '${pod}' - ${phase}" red

--- a/installation/scripts/testing.sh
+++ b/installation/scripts/testing.sh
@@ -3,103 +3,82 @@ ROOT_PATH=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
 
 source ${ROOT_PATH}/testing-common.sh
 
-echo "-------------------------------"
-echo "- Ensure test Pods are deleted "
-echo "-------------------------------"
-
-if [ -n "$KUBE_CONTEXT" ]; then
-    echo "Using context: $KUBE_CONTEXT"
-    KUBE_CONTEXT_ARG="--kube-context $KUBE_CONTEXT"
-fi
-
-cleanupHelmTestPods kyma-system
-cleanupCoreErr=$?
-
-cleanupHelmTestPods istio-system
-cleanupIstioErr=$?
-
-cleanupHelmTestPods knative-serving
-cleanupKnativeServingErr=$?
-
-cleanupHelmTestPods kyma-integration
-cleanupGatewayErr=$?
-
-if [ ${cleanupGatewayErr} -ne 0 ] || [ ${cleanupIstioErr} -ne 0 ] || [ ${cleanupCoreErr} -ne 0 ] || [ ${cleanupKnativeServingErr} -ne 0 ]
-then
-    exit 1
-fi
-
-monitoringTestErr=0
-loggingTestErr=0
-eventBusTestErr=0
-
+suiteName="testsuite-all-$(date '+%Y-%m-%d-%H-%M')"
 echo "----------------------------"
 echo "- Testing Kyma..."
 echo "----------------------------"
 
-echo "- Testing Core components..."
-# timeout set to 10 minutes
-helm ${KUBE_CONTEXT_ARG} test core --timeout 600 --tls
-coreTestErr=$?
+kc="kubectl $(context_arg)"
 
-# execute assetstore tests if 'assetstore' is installed
-if helm ${KUBE_CONTEXT_ARG} list --tls | grep -q "assetstore"; then
-echo "- Testing Asset Store"
-helm ${KUBE_CONTEXT_ARG} test assetstore --timeout 600 --tls
-assetstoreTestErr=$?
+${kc} get clustertestsuites.testing.kyma-project.io
+if [[ $? -eq 1 ]]
+then
+   echo "ERROR: script requires ClusterTestSuite CRD"
+   exit 1
 fi
 
-# execute monitoring tests if 'monitoring' is installed
-if helm ${KUBE_CONTEXT_ARG} list --tls | grep -q "monitoring"; then
-echo "- Montitoring module is installed. Running tests for same"
-helm ${KUBE_CONTEXT_ARG} test monitoring --timeout 600 --tls
-monitoringTestErr=$?
-fi
+cat <<EOF | ${kc} apply -f -
+apiVersion: testing.kyma-project.io/v1alpha1
+kind: ClusterTestSuite
+metadata:
+  labels:
+    controller-tools.k8s.io: "1.0"
+  name: ${suiteName}
+spec:
+  maxRetries: 1
+  concurrency: 1
+EOF
 
-# execute logging tests if 'logging' is installed
-if helm ${KUBE_CONTEXT_ARG} list --tls | grep -q "logging"; then
-echo "- Logging module is installed. Running tests for same"
-helm ${KUBE_CONTEXT_ARG} test logging --timeout 600 --tls
-loggingTestErr=$?
-fi
+startTime=$(date +%s)
 
-# run event-bus tests if Knative is installed
-if kubectl -n knative-eventing get deployments.apps | grep -q "webhook"; then
-    echo "- Testing Event-Bus..."
-    helm ${KUBE_CONTEXT_ARG} test event-bus --timeout 600 --tls
-    eventBusTestErr=$?
-fi
+testExitCode=0
 
-checkAndCleanupTest kyma-system
-testCheckCore=$?
+while true
+do
+    currTime=$(date +%s)
+    statusSucceeded=$(${kc} get cts ${suiteName}  -ojsonpath="{.status.conditions[?(@.type=='Succeeded')]}")
+    statusFailed=$(${kc} get cts ${suiteName}  -ojsonpath="{.status.conditions[?(@.type=='Failed')]}")
+    statusError=$(${kc} get cts  ${suiteName} -ojsonpath="{.status.conditions[?(@.type=='Error')]}" )
 
-echo "- Testing Istio components..."
-helm ${KUBE_CONTEXT_ARG} test istio --tls
-istioTestErr=$?
+    if [[ "${statusSucceeded}" == *"True"* ]]; then
+       echo "Test suite '${suiteName}' succeeded."
+       break
+    fi
 
-checkAndCleanupTest istio-system
-testCheckIstio=$?
+    if [[ "${statusFailed}" == *"True"* ]]; then
+        echo "Test suite '${suiteName}' failed."
+        testExitCode=1
+        break
+    fi
 
-echo "- Testing Knative serving components..."
-helm ${KUBE_CONTEXT_ARG} test knative-serving --tls
-knativeServingTestErr=$?
+    if [[ "${statusError}" == *"True"* ]]; then
+        echo "Test suite '${suiteName}' errored."
+        testExitCode=1
+        break
+    fi
+    sec=$((currTime-startTime))
+    min=$((sec/60))
+    if (( min > 60 )); then
+        echo "Timeout for test suite '${suiteName}' occurred."
+        testExitCode=1
+        break
+    fi
+    echo "ClusterTestSuite not finished. Waiting..."
+    sleep 60
+done
 
-checkAndCleanupTest knative-serving
-knativeServingTestErr=$?
+echo "ClusterTestSuite details:"
+kubectl get cts ${suiteName} -oyaml
 
-echo "- Testing Application Connector"
-helm ${KUBE_CONTEXT_ARG} test application-connector --timeout 600 --tls
-acTestErr=$?
+echo "Test summary"
+kubectl get cts  ${suiteName} -o=go-template --template='{{range .status.results}}{{printf "Test status: %s - %s\n" .name .status}}{{end}}'
 
-checkAndCleanupTest kyma-integration
-testCheckGateway=$?
+waitForTerminationAndPrintLogs ${suiteName}
+cleanupExitCode=$?
+
+kubectl delete cts ${suiteName}
 
 printImagesWithLatestTag
-latestTagsErr=$?
+latestTagExitCode=$?
 
-if [ ${latestTagsErr} -ne 0 ] || [ ${coreTestErr} -ne 0 ] || [ ${assetstoreTestErr} -ne 0 ]  || [ ${istioTestErr} -ne 0 ] || [ ${acTestErr} -ne 0 ] || [ ${loggingTestErr} -ne 0 ] || [ ${monitoringTestErr} -ne 0 ] || [ ${knativeServingTestErr} -ne 0 ] || [ ${eventBusTestErr} -ne 0 ]
-then
-    exit 1
-else
-    exit 0
-fi
+exit $(($testExitCode + $cleanupExitCode + $latestTagExitCode))

--- a/resources/application-connector/charts/application-operator/templates/tests/test-acceptance.yaml
+++ b/resources/application-connector/charts/application-operator/templates/tests/test-acceptance.yaml
@@ -1,41 +1,44 @@
 {{ if .Values.tests.enabled }}
-apiVersion: v1
-kind: Pod
+{{- if .Capabilities.APIVersions.Has "testing.kyma-project.io/v1alpha1" }}
+apiVersion: "testing.kyma-project.io/v1alpha1"
+kind: TestDefinition
 metadata:
   name: {{ .Chart.Name }}-tests
   namespace: {{ .Values.global.namespace }}
-  annotations:
-    sidecar.istio.io/inject: "false"
-    "helm.sh/hook": test-success
   labels:
-    helm-chart-test: "true"
     app: {{ .Chart.Name }}-tests
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
 spec:
-  serviceAccountName: {{ .Chart.Name }}-tests
-  containers:
-    - name: {{ .Chart.Name }}-tests
-      image: {{ .Values.global.containerRegistry.path }}/{{ .Values.global.application_operator_tests.dir }}application-operator-tests:{{ .Values.global.application_operator_tests.version }}
-      imagePullPolicy: {{ .Values.tests.pullPolicy }}
-      env:
-      - name: NAMESPACE
-        value: {{ .Values.global.namespace }}
-      - name: TILLER_HOST
-        value: {{ .Values.controller.args.tillerUrl }}
-      - name: HELM_TLS_KEY_FILE
-        value: {{ .Values.controller.args.helmTLSKeyFile }}
-      - name: HELM_TLS_CERTIFICATE_FILE
-        value: {{ .Values.controller.args.helmTLSCertificateFile }}
-      - name: TILLER_TLS_SKIP_VERIFY
-        value: "{{ .Values.controller.args.tillerTLSInsecure }}"
-      volumeMounts:
-        - mountPath: /etc/certs
-          name: helm-certs
-          readOnly: true
-  volumes:
-    - name: helm-certs
-      secret:
-        secretName: helm-secret
-  restartPolicy: Never
+  template:
+    metadata:
+      annotations:
+        sidecar.istio.io/inject: "false"
+    spec:
+      serviceAccountName: {{ .Chart.Name }}-tests
+      containers:
+        - name: {{ .Chart.Name }}-tests
+          image: {{ .Values.global.containerRegistry.path }}/{{ .Values.global.application_operator_tests.dir }}application-operator-tests:{{ .Values.global.application_operator_tests.version }}
+          imagePullPolicy: {{ .Values.tests.pullPolicy }}
+          env:
+          - name: NAMESPACE
+            value: {{ .Values.global.namespace }}
+          - name: TILLER_HOST
+            value: {{ .Values.controller.args.tillerUrl }}
+          - name: HELM_TLS_KEY_FILE
+            value: {{ .Values.controller.args.helmTLSKeyFile }}
+          - name: HELM_TLS_CERTIFICATE_FILE
+            value: {{ .Values.controller.args.helmTLSCertificateFile }}
+          - name: TILLER_TLS_SKIP_VERIFY
+            value: "{{ .Values.controller.args.tillerTLSInsecure }}"
+          volumeMounts:
+              - mountPath: /etc/certs
+                name: helm-certs
+                readOnly: true
+      volumes:
+          - name: helm-certs
+            secret:
+                secretName: helm-secret
+      restartPolicy: Never
+{{- end }}
 {{ end }}

--- a/resources/application-connector/charts/application-registry/templates/tests/test-acceptance.yaml
+++ b/resources/application-connector/charts/application-registry/templates/tests/test-acceptance.yaml
@@ -1,23 +1,25 @@
 {{ if not .Values.global.isLocalEnv }}
-apiVersion: v1
-kind: Pod
+{{- if .Capabilities.APIVersions.Has "testing.kyma-project.io/v1alpha1" }}
+apiVersion: "testing.kyma-project.io/v1alpha1"
+kind: TestDefinition
 metadata:
   name: {{ .Chart.Name }}-tests
   namespace: {{ .Values.global.namespace }}
-  annotations:
-    sidecar.istio.io/inject: "false"
-    "helm.sh/hook": test-success
-  labels:
-    "helm-chart-test": "true"
 spec:
-  containers:
-    - name: {{ .Chart.Name }}-tests
-      image: {{ .Values.global.containerRegistry.path }}/{{ .Values.global.application_registry_tests.dir }}application-registry-tests:{{ .Values.global.application_registry_tests.version }}
-      imagePullPolicy: IfNotPresent
-      env:
-      - name: METADATA_URL
-        value: http://{{ .Chart.Name }}-external-api.{{ .Values.global.namespace }}.svc.cluster.local:8081
-      - name: NAMESPACE
-        value: {{ .Values.global.namespace }}
-  restartPolicy: Never
+  template:
+    metadata:
+      annotations:
+        sidecar.istio.io/inject: "false"
+    spec:
+      containers:
+        - name: {{ .Chart.Name }}-tests
+          image: {{ .Values.global.containerRegistry.path }}/{{ .Values.global.application_registry_tests.dir }}application-registry-tests:{{ .Values.global.application_registry_tests.version }}
+          imagePullPolicy: IfNotPresent
+          env:
+          - name: METADATA_URL
+            value: http://{{ .Chart.Name }}-external-api.{{ .Values.global.namespace }}.svc.cluster.local:8081
+          - name: NAMESPACE
+            value: {{ .Values.global.namespace }}
+      restartPolicy: Never
+{{- end }}
 {{ end }}

--- a/resources/application-connector/charts/connection-token-handler/templates/tests/test-acceptance.yaml
+++ b/resources/application-connector/charts/connection-token-handler/templates/tests/test-acceptance.yaml
@@ -1,21 +1,24 @@
-apiVersion: v1
-kind: Pod
+{{- if .Capabilities.APIVersions.Has "testing.kyma-project.io/v1alpha1" }}
+apiVersion: "testing.kyma-project.io/v1alpha1"
+kind: TestDefinition
 metadata:
   name: {{ .Chart.Name }}-tests
-  annotations:
-    helm.sh/hook: test-success
-    sidecar.istio.io/inject: "false"
   labels:
-    helm-chart-test: "true"
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
 spec:
-  serviceAccountName: {{ .Chart.Name }}-tests
-  containers:
-  - name: {{ .Release.Name }}-connection-token-handler-tests
-    image: {{ .Values.global.containerRegistry.path }}/{{ .Values.global.connection_token_handler_tests.dir }}connection-token-handler-tests:{{ .Values.global.connection_token_handler_tests.version }}
-    imagePullPolicy: {{ .Values.tests.image.pullPolicy }}
-    env:
-    - name: CENTRAL
-      value: "{{ .Values.tests.central }}"
-  restartPolicy: Never
+  template:
+    metadata:
+      annotations:
+        sidecar.istio.io/inject: "false"
+    spec:
+      serviceAccountName: {{ .Chart.Name }}-tests
+      containers:
+      - name: {{ .Release.Name }}-connection-token-handler-tests
+        image: {{ .Values.global.containerRegistry.path }}/{{ .Values.global.connection_token_handler_tests.dir }}connection-token-handler-tests:{{ .Values.global.connection_token_handler_tests.version }}
+        imagePullPolicy: {{ .Values.tests.image.pullPolicy }}
+        env:
+        - name: CENTRAL
+          value: "{{ .Values.tests.central }}"
+      restartPolicy: Never
+{{- end}}

--- a/resources/application-connector/charts/connector-service/templates/tests/test-acceptance.yaml
+++ b/resources/application-connector/charts/connector-service/templates/tests/test-acceptance.yaml
@@ -1,30 +1,31 @@
 {{ if and ( .Values.tests.enabled ) ( not .Values.global.isLocalEnv ) }}
-apiVersion: v1
-kind: Pod
+{{- if .Capabilities.APIVersions.Has "testing.kyma-project.io/v1alpha1" }}
+apiVersion: "testing.kyma-project.io/v1alpha1"
+kind: TestDefinition
 metadata:
   name: {{ .Chart.Name }}-tests
   namespace: {{ .Values.global.namespace }}
-  annotations:
-    sidecar.istio.io/inject: "false"
-    "helm.sh/hook": test-success
-  labels:
-    "helm-chart-test": "true"
 spec:
-  containers:
-  - name: {{ .Chart.Name }}-tests
-    image: {{ .Values.global.containerRegistry.path }}/{{ .Values.global.connector_service_tests.dir }}connector-service-tests:{{ .Values.global.connector_service_tests.version }}
-    imagePullPolicy: {{ .Values.tests.image.pullPolicy }}
-    env:
-    - name: INTERNAL_API_URL
-      value: http://{{ .Chart.Name }}-internal-api.{{ .Values.global.namespace }}.svc.cluster.local:{{ .Values.service.internalapi.port }}
-    - name: EXTERNAL_API_URL
-      value: http://{{ .Chart.Name }}-external-api.{{ .Values.global.namespace }}.svc.cluster.local:{{ .Values.service.externalapi.port }}
-    - name: GATEWAY_URL
-      value: https://gateway.{{ .Values.global.applicationConnector.domainName }}
-    - name: SKIP_SSL_VERIFY
-      value: "{{ .Values.tests.skipSslVerify }}"
-    - name: CENTRAL
-      value: "{{ .Values.tests.central }}"
-
-  restartPolicy: Never
+  template:
+    metadata:
+      annotations:
+        sidecar.istio.io/inject: "false"
+    spec:
+      containers:
+      - name: {{ .Chart.Name }}-tests
+        image: {{ .Values.global.containerRegistry.path }}/{{ .Values.global.connector_service_tests.dir }}connector-service-tests:{{ .Values.global.connector_service_tests.version }}
+        imagePullPolicy: {{ .Values.tests.image.pullPolicy }}
+        env:
+        - name: INTERNAL_API_URL
+          value: http://{{ .Chart.Name }}-internal-api.{{ .Values.global.namespace }}.svc.cluster.local:{{ .Values.service.internalapi.port }}
+        - name: EXTERNAL_API_URL
+          value: http://{{ .Chart.Name }}-external-api.{{ .Values.global.namespace }}.svc.cluster.local:{{ .Values.service.externalapi.port }}
+        - name: GATEWAY_URL
+          value: https://gateway.{{ .Values.global.applicationConnector.domainName }}
+        - name: SKIP_SSL_VERIFY
+          value: "{{ .Values.tests.skipSslVerify }}"
+        - name: CENTRAL
+          value: "{{ .Values.tests.central }}"
+      restartPolicy: Never
+{{ end }}
 {{ end }}

--- a/resources/assetstore/templates/tests/test-integration.yaml
+++ b/resources/assetstore/templates/tests/test-integration.yaml
@@ -1,54 +1,56 @@
-apiVersion: v1
-kind: Pod
+{{- if .Capabilities.APIVersions.Has "testing.kyma-project.io/v1alpha1" }}
+apiVersion: "testing.kyma-project.io/v1alpha1"
+kind: TestDefinition
 metadata:
   name: "test-{{ template "fullname" . }}-integration"
-  annotations:
-    sidecar.istio.io/inject: "true"
-    "helm.sh/hook": test-success
-  labels:
-    "helm-chart-test": "true"
 spec:
-  {{ if .Values.global.isLocalEnv }}
-  hostAliases:
-   - ip: {{ .Values.test.integration.minikubeIP }}
-     hostnames:
-      - "minio.{{ .Values.global.ingress.domainName }}"
-  {{ end }}
-  shareProcessNamespace: true
-  serviceAccountName:  "test-{{ template "fullname" . }}-integration"
-  restartPolicy: Never
-  containers:
-    - name: "test-{{ template "fullname" . }}-integration"
-      image: {{ .Values.global.containerRegistry.path }}/{{ .Values.global.asset_store_test.dir }}asset-store-test:{{ .Values.global.asset_store_test.version }}
-      command: ["/bin/sh"]
-      args: ["-c", "sleep 10; /app/main.test; exit_code=$?; pkill -INT pilot-agent; sleep 4; exit $exit_code;"]
-      env:
-        - name: APP_TEST_UPLOAD_SERVICE_URL
-          value: "http://assetstore-asset-upload-service.kyma-system.svc.cluster.local:3000/v1/upload"
-        - name: APP_TEST_WAIT_TIMEOUT
-          value: "3m"
-        - name: APP_TEST_NAMESPACE
-          value: "test-asset-store"
-        - name: APP_TEST_MINIO_ENDPOINT
-          valueFrom:
-              configMapKeyRef:
-                name: assetstore-minio-docs-upload
-                key: APP_UPLOAD_ENDPOINT_WITH_PORT
-        - name: APP_TEST_MINIO_USE_SSL
-          valueFrom:
-            configMapKeyRef:
-              name: assetstore-minio-docs-upload
-              key: APP_UPLOAD_SECURE
-        - name: APP_TEST_MINIO_ACCESS_KEY
-          valueFrom:
-            secretKeyRef:
-              name: assetstore-minio
-              key: accesskey
-        - name: APP_TEST_MINIO_SECRET_KEY
-          valueFrom:
-            secretKeyRef:
-              name: assetstore-minio
-              key: secretkey
-      resources:
-        limits:
-          memory: 128Mi
+  template:
+    metadata:
+      annotations:
+        sidecar.istio.io/inject: "true"
+    spec:
+      {{ if .Values.global.isLocalEnv }}
+      hostAliases:
+       - ip: {{ .Values.test.integration.minikubeIP }}
+         hostnames:
+          - "minio.{{ .Values.global.ingress.domainName }}"
+      {{ end }}
+      shareProcessNamespace: true
+      serviceAccountName:  "test-{{ template "fullname" . }}-integration"
+      restartPolicy: Never
+      containers:
+        - name: "test-{{ template "fullname" . }}-integration"
+          image: {{ .Values.global.containerRegistry.path }}/{{ .Values.global.asset_store_test.dir }}asset-store-test:{{ .Values.global.asset_store_test.version }}
+          command: ["/bin/sh"]
+          args: ["-c", "sleep 10; /app/main.test; exit_code=$?; pkill -INT pilot-agent; sleep 4; exit $exit_code;"]
+          env:
+            - name: APP_TEST_UPLOAD_SERVICE_URL
+              value: "http://assetstore-asset-upload-service.kyma-system.svc.cluster.local:3000/v1/upload"
+            - name: APP_TEST_WAIT_TIMEOUT
+              value: "3m"
+            - name: APP_TEST_NAMESPACE
+              value: "test-asset-store"
+            - name: APP_TEST_MINIO_ENDPOINT
+              valueFrom:
+                  configMapKeyRef:
+                    name: assetstore-minio-docs-upload
+                    key: APP_UPLOAD_ENDPOINT_WITH_PORT
+            - name: APP_TEST_MINIO_USE_SSL
+              valueFrom:
+                configMapKeyRef:
+                  name: assetstore-minio-docs-upload
+                  key: APP_UPLOAD_SECURE
+            - name: APP_TEST_MINIO_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: assetstore-minio
+                  key: accesskey
+            - name: APP_TEST_MINIO_SECRET_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: assetstore-minio
+                  key: secretkey
+          resources:
+            limits:
+              memory: 128Mi
+{{- end }}

--- a/resources/core/charts/api-controller/templates/tests/test-api-controller.yaml
+++ b/resources/core/charts/api-controller/templates/tests/test-api-controller.yaml
@@ -1,25 +1,27 @@
-apiVersion: v1
-kind: Pod
+{{- if .Capabilities.APIVersions.Has "testing.kyma-project.io/v1alpha1" }}
+apiVersion: "testing.kyma-project.io/v1alpha1"
+kind: TestDefinition
 metadata:
   name: test-api-controller-acceptance
-  annotations:
-    sidecar.istio.io/inject: "false"
-    "helm.sh/hook": test-success
-  labels:
-    "helm-chart-test": "true"
 spec:
-  shareProcessNamespace: true
-  serviceAccount: api-controller-test-account
-  containers:
-  - name: test-api-controller-acceptance
-    image: {{ .Values.global.containerRegistry.path }}/{{ .Values.global.api_controller_acceptance_tests.dir }}api-controller-acceptance-tests:{{ .Values.global.api_controller_acceptance_tests.version }}
-    command: ["/bin/sh"]
-    args: ["-c", "sleep 10; /apicontroller.test -test.v; exit_code=$?; pkill -INT pilot-agent; sleep 4; exit $exit_code;"]
-    env:
-    - name: DOMAIN_NAME
-      value: {{ .Values.global.ingress.domainName }}
-    - name: INGRESSGATEWAY_ADDRESS
-      value: istio-ingressgateway.istio-system.svc.cluster.local
-    - name: NAMESPACE
-      value: {{ .Values.global.api_controller_acceptance_tests.testNamespace }}
-  restartPolicy: Never
+  template:
+    metadata:
+      annotations:
+        sidecar.istio.io/inject: "false"
+    spec:
+      shareProcessNamespace: true
+      serviceAccount: api-controller-test-account
+      containers:
+      - name: test-api-controller-acceptance
+        image: {{ .Values.global.containerRegistry.path }}/{{ .Values.global.api_controller_acceptance_tests.dir }}api-controller-acceptance-tests:{{ .Values.global.api_controller_acceptance_tests.version }}
+        command: ["/bin/sh"]
+        args: ["-c", "sleep 10; /apicontroller.test -test.v; exit_code=$?; pkill -INT pilot-agent; sleep 4; exit $exit_code;"]
+        env:
+        - name: DOMAIN_NAME
+          value: {{ .Values.global.ingress.domainName }}
+        - name: INGRESSGATEWAY_ADDRESS
+          value: istio-ingressgateway.istio-system.svc.cluster.local
+        - name: NAMESPACE
+          value: {{ .Values.global.api_controller_acceptance_tests.testNamespace }}
+      restartPolicy: Never
+{{- end }}

--- a/resources/core/charts/apiserver-proxy/templates/tests/test-apiserver-proxy.yaml
+++ b/resources/core/charts/apiserver-proxy/templates/tests/test-apiserver-proxy.yaml
@@ -29,7 +29,9 @@ spec:
         args: ["-c", "sleep 10; ./test.sh; exit_code=$?; pkill -INT pilot-agent; exit $exit_code;"]
         env:
             - name: POD_NAME
-              value: test-{{ .Release.Name }}-apiserver-proxy
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
             - name: DOMAIN
               value: {{ .Values.global.ingress.domainName }}
             - name: USER_EMAIL

--- a/resources/core/charts/apiserver-proxy/templates/tests/test-apiserver-proxy.yaml
+++ b/resources/core/charts/apiserver-proxy/templates/tests/test-apiserver-proxy.yaml
@@ -1,43 +1,46 @@
 ---
-apiVersion: v1
-kind: Pod
+{{- if .Capabilities.APIVersions.Has "testing.kyma-project.io/v1alpha1" }}
+
+apiVersion: "testing.kyma-project.io/v1alpha1"
+kind: TestDefinition
 metadata:
   name: test-{{ .Release.Name }}-apiserver-proxy
   namespace: kyma-system
-  annotations:
-    sidecar.istio.io/inject: "true"
-    "helm.sh/hook": test-success
-  labels:
-    "helm-chart-test": "true"
 spec:
-  {{ if .Values.global.isLocalEnv }}
-  hostAliases:
-    - ip: {{ .Values.minikubeIP }}
-      hostnames:
-        - "configurations-generator.{{ .Values.global.ingress.domainName }}"
-        - "dex.{{ .Values.global.ingress.domainName }}"
-        - "apiserver.{{ .Values.global.ingress.domainName }}"
-  {{ end }}
-  shareProcessNamespace: true
-  containers:
-    - name: test-{{ .Release.Name }}-apiserver-proxy
-      image: {{ .Values.global.containerRegistry.path }}/{{ .Values.global.test_apiserver_proxy.dir }}apiserver-proxy-test:{{ .Values.global.test_apiserver_proxy.version }}
-      imagePullPolicy: Always
-      command: ["/bin/bash"]
-      args: ["-c", "sleep 10; ./test.sh; exit_code=$?; pkill -INT pilot-agent; exit $exit_code;"]
-      env:
-      - name: POD_NAME
-        value: test-{{ .Release.Name }}-apiserver-proxy
-      - name: DOMAIN
-        value: {{ .Values.global.ingress.domainName }}
-      - name: USER_EMAIL
-        valueFrom:
-          secretKeyRef:
-            name: admin-user
-            key: email
-      - name: USER_PASSWORD
-        valueFrom:
-          secretKeyRef:
-            name: admin-user
-            key: password
-  restartPolicy: Never
+  template:
+    metadata:
+      annotations:
+        sidecar.istio.io/inject: "true"
+    spec:
+      {{ if .Values.global.isLocalEnv }}
+      hostAliases:
+      - ip: {{ .Values.minikubeIP }}
+        hostnames:
+            - "configurations-generator.{{ .Values.global.ingress.domainName }}"
+            - "dex.{{ .Values.global.ingress.domainName }}"
+            - "apiserver.{{ .Values.global.ingress.domainName }}"
+      {{ end }}
+      shareProcessNamespace: true
+      containers:
+      - name: test-{{ .Release.Name }}-apiserver-proxy
+        image: {{ .Values.global.containerRegistry.path }}/{{ .Values.global.test_apiserver_proxy.dir }}apiserver-proxy-test:{{ .Values.global.test_apiserver_proxy.version }}
+        imagePullPolicy: Always
+        command: ["/bin/bash"]
+        args: ["-c", "sleep 10; ./test.sh; exit_code=$?; pkill -INT pilot-agent; exit $exit_code;"]
+        env:
+            - name: POD_NAME
+              value: test-{{ .Release.Name }}-apiserver-proxy
+            - name: DOMAIN
+              value: {{ .Values.global.ingress.domainName }}
+            - name: USER_EMAIL
+              valueFrom:
+                  secretKeyRef:
+                      name: admin-user
+                      key: email
+            - name: USER_PASSWORD
+              valueFrom:
+                  secretKeyRef:
+                      name: admin-user
+                      key: password
+      restartPolicy: Never
+{{- end}}

--- a/resources/core/charts/cluster-users/templates/tests/test-cluster-users.yaml
+++ b/resources/core/charts/cluster-users/templates/tests/test-cluster-users.yaml
@@ -1,56 +1,57 @@
 {{ if .Values.global.isLocalEnv }}
 ---
-apiVersion: v1
-kind: Pod
+{{- if .Capabilities.APIVersions.Has "testing.kyma-project.io/v1alpha1" }}
+apiVersion: "testing.kyma-project.io/v1alpha1"
+kind: TestDefinition
 metadata:
   name: cluster-users-test
   namespace: {{ .Release.Namespace }}
-  annotations:
-    sidecar.istio.io/inject: "false"
-    "helm.sh/hook": test-success
-  labels:
-    "helm-chart-test": "true"
 spec:
-  hostNetwork: true
-  dnsPolicy: ClusterFirstWithHostNet
-  serviceAccount: cluster-users-test
-  containers:
-    - name: test-cluster-users
-      image: {{ .Values.global.containerRegistry.path }}/{{ .Values.global.cluster_users_test.dir }}cluster-users-test:{{ .Values.global.cluster_users_test.version }}
-      env:
-      - name: ADMIN_EMAIL
-        valueFrom:
-          secretKeyRef:
-            name: admin-user
-            key: email
-      - name: ADMIN_PASSWORD
-        valueFrom:
-          secretKeyRef:
-            name: admin-user
-            key: password
-      - name: DEVELOPER_EMAIL
-        valueFrom:
-          secretKeyRef:
-            name: test-developer-user
-            key: email
-      - name: DEVELOPER_PASSWORD
-        valueFrom:
-          secretKeyRef:
-            name: test-developer-user
-            key: password
-      - name: VIEW_EMAIL
-        valueFrom:
-          secretKeyRef:
-            name: test-read-only-user
-            key: email
-      - name: VIEW_PASSWORD
-        valueFrom:
-          secretKeyRef:
-            name: test-read-only-user
-            key: password
-      - name: NAMESPACE
-        value: {{ .Values.namespace }}
-  restartPolicy: Never
+  template:
+    metadata:
+      annotations:
+        sidecar.istio.io/inject: "false"
+    spec:
+      hostNetwork: true
+      dnsPolicy: ClusterFirstWithHostNet
+      serviceAccount: cluster-users-test
+      containers:
+        - name: test-cluster-users
+          image: {{ .Values.global.containerRegistry.path }}/{{ .Values.global.cluster_users_test.dir }}cluster-users-test:{{ .Values.global.cluster_users_test.version }}
+          env:
+          - name: ADMIN_EMAIL
+            valueFrom:
+              secretKeyRef:
+                name: admin-user
+                key: email
+          - name: ADMIN_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: admin-user
+                key: password
+          - name: DEVELOPER_EMAIL
+            valueFrom:
+              secretKeyRef:
+                name: test-developer-user
+                key: email
+          - name: DEVELOPER_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: test-developer-user
+                key: password
+          - name: VIEW_EMAIL
+            valueFrom:
+              secretKeyRef:
+                name: test-read-only-user
+                key: email
+          - name: VIEW_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: test-read-only-user
+                key: password
+          - name: NAMESPACE
+            value: {{ .Values.namespace }}
+      restartPolicy: Never
 ---
 apiVersion: v1
 kind: ServiceAccount
@@ -71,4 +72,5 @@ subjects:
 - kind: ServiceAccount
   name: cluster-users-test
   namespace: {{ .Release.Namespace }}
+{{- end }}
 {{ end }}

--- a/resources/core/charts/kubeless/templates/tests/test-kubeless.yaml
+++ b/resources/core/charts/kubeless/templates/tests/test-kubeless.yaml
@@ -170,6 +170,7 @@ spec:
       annotations:
         sidecar.istio.io/inject: "true"
     spec:
+      shareProcessNamespace: true
       serviceAccount: "test-{{ template "fullname" . }}-int"
       containers:
       - name: test-{{ template "fullname" . }}

--- a/resources/core/charts/kubeless/templates/tests/test-kubeless.yaml
+++ b/resources/core/charts/kubeless/templates/tests/test-kubeless.yaml
@@ -55,31 +55,33 @@ subjects:
   name: test-{{ template "fullname" . }}
   namespace: {{ .Release.Namespace }}
 ---
-apiVersion: v1
-kind: Pod
+{{- if .Capabilities.APIVersions.Has "testing.kyma-project.io/v1alpha1" }}
+apiVersion: "testing.kyma-project.io/v1alpha1"
+kind: TestDefinition
 metadata:
   name: test-{{ template "fullname" . }}
-  labels:
-    helm-chart-test: "true"
-  annotations:
-    sidecar.istio.io/inject: "true"
-    helm.sh/hook: test-success
 spec:
-  shareProcessNamespace: true
-  serviceAccount: "test-{{ template "fullname" . }}"
-  containers:
-  - name: test-{{ template "fullname" . }}
-    image: {{ .Values.global.containerRegistry.path }}/{{ .Values.global.kubeless_tests.dir }}kubeless-tests:{{ .Values.global.kubeless_tests.version }}
-    env:
-    - name: KUBELESS_NAMESPACE
-      value: kyma-system
-    - name: KUBELESS_CONFIG
-      value: {{ template "fullname" . }}-config
-    - name: DOMAIN_NAME
-      value: {{ .Values.global.ingress.domainName }}
-    command: ["/bin/sh"]
-    args: ["-c", "sleep 10; /kubeless-tests; exit_code=$?; pkill -INT pilot-agent; sleep 4; exit $exit_code;"]
-  restartPolicy: Never
+  template:
+    metadata:
+      annotations:
+        sidecar.istio.io/inject: "true"
+    spec:
+      shareProcessNamespace: true
+      serviceAccount: "test-{{ template "fullname" . }}"
+      containers:
+      - name: test-{{ template "fullname" . }}
+        image: {{ .Values.global.containerRegistry.path }}/{{ .Values.global.kubeless_tests.dir }}kubeless-tests:{{ .Values.global.kubeless_tests.version }}
+        command: ["/bin/sh"]
+        args: ["-c", "sleep 10; /kubeless-tests; exit_code=$?; pkill -INT pilot-agent; sleep 4; exit $exit_code;"]
+        env:
+        - name: KUBELESS_NAMESPACE
+          value: kyma-system
+        - name: KUBELESS_CONFIG
+          value: {{ template "fullname" . }}-config
+        - name: DOMAIN_NAME
+          value: {{ .Values.global.ingress.domainName }}
+      restartPolicy: Never
+{{- end }}
 ---
 {{- if not .Values.global.isLocalEnv }}
 ### Executes integration kubeless tests along with other Kyma resources
@@ -157,43 +159,44 @@ subjects:
   name: test-{{ template "fullname" . }}-int
   namespace: {{ .Release.Namespace }}
 ---
-apiVersion: v1
-kind: Pod
+{{- if .Capabilities.APIVersions.Has "testing.kyma-project.io/v1alpha1" }}
+apiVersion: "testing.kyma-project.io/v1alpha1"
+kind: TestDefinition
 metadata:
   name: test-{{ template "fullname" . }}-int
-  labels:
-    helm-chart-test: "true"
-  annotations:
-    sidecar.istio.io/inject: "true"
-    helm.sh/hook: test-success
 spec:
-  shareProcessNamespace: true
-  serviceAccount: "test-{{ template "fullname" . }}-int"
-  containers:
-  - name: test-{{ template "fullname" . }}
-    image: {{ .Values.global.containerRegistry.path }}/{{ .Values.global.kubeless_integration_tests.dir }}kubeless-integration:{{ .Values.global.kubeless_integration_tests.version }}
-    command: ["/bin/sh"]
-    args: ["-c", "sleep 10; /test-kubeless; exit_code=$?; pkill -INT pilot-agent; sleep 4; exit $exit_code;"]
-    volumeMounts:
-    - name: k8syaml
-      mountPath: /k8syaml
-    env:
-    - name: INGRESSGATEWAY_ADDRESS
-      value: istio-ingressgateway.istio-system.svc.cluster.local
-    - name: KUBELESS_NAMESPACE
-      value: kyma-system
-    - name: KUBELESS_CONFIG
-      value: {{ template "fullname" . }}-config
-    - name: DOMAIN_NAME
-      value: {{ .Values.global.ingress.domainName }}
-  volumes:
-    - name: k8syaml
-      configMap:
-        name: "test-{{ template "fullname" . }}-config-int"
-        items:
-          - key: k8sYaml
-            path: k8s.yaml
-          - key: svcBindLambdaYaml
-            path: svcbind-lambda.yaml
-  restartPolicy: Never
+  template:
+    metadata:
+      annotations:
+        sidecar.istio.io/inject: "true"
+    spec:
+      serviceAccount: "test-{{ template "fullname" . }}-int"
+      containers:
+      - name: test-{{ template "fullname" . }}
+        image: {{ .Values.global.containerRegistry.path }}/{{ .Values.global.kubeless_integration_tests.dir }}kubeless-integration:{{ .Values.global.kubeless_integration_tests.version }}
+        command: ["/bin/sh"]
+        args: ["-c", "sleep 10; /test-kubeless; exit_code=$?; pkill -INT pilot-agent; sleep 4; exit $exit_code;"]
+        volumeMounts:
+        - name: k8syaml
+          mountPath: /k8syaml
+        env:
+        - name: INGRESSGATEWAY_ADDRESS
+          value: istio-ingressgateway.istio-system.svc.cluster.local
+        - name: KUBELESS_NAMESPACE
+          value: kyma-system
+        - name: KUBELESS_CONFIG
+          value: {{ template "fullname" . }}-config
+        - name: DOMAIN_NAME
+          value: {{ .Values.global.ingress.domainName }}
+      volumes:
+        - name: k8syaml
+          configMap:
+            name: "test-{{ template "fullname" . }}-config-int"
+            items:
+              - key: k8sYaml
+                path: k8s.yaml
+              - key: svcBindLambdaYaml
+                path: svcbind-lambda.yaml
+      restartPolicy: Never
+{{- end }}
 {{- end }}

--- a/resources/core/charts/namespace-controller/templates/tests/test-namespace-controller.yaml
+++ b/resources/core/charts/namespace-controller/templates/tests/test-namespace-controller.yaml
@@ -34,30 +34,32 @@ subjects:
   name: test-{{ template "fullname" . }}
   namespace: {{ .Release.Namespace }}
 ---
-apiVersion: v1
-kind: Pod
+{{- if .Capabilities.APIVersions.Has "testing.kyma-project.io/v1alpha1" }}
+apiVersion: "testing.kyma-project.io/v1alpha1"
+kind: TestDefinition
 metadata:
   name: test-{{ template "fullname" . }}
-  annotations:
-    sidecar.istio.io/inject: "false"
-    "helm.sh/hook": test-success
-  labels:
-      "helm-chart-test": "true"
 spec:
-  serviceAccountName: test-{{ template "fullname" . }}
-  containers:
-  - name: test-{{ template "fullname" . }}
-    image: {{ .Values.global.containerRegistry.path }}/{{ .Values.global.test_namespace_controller.dir }}test-namespace-controller:{{ .Values.global.test_namespace_controller.version }}
-    env:
-      - name: EXPECTED_LIMIT_RANGE_MEMORY_DEFAULT_REQUEST
-        value: "{{ .Values.limitRanges.defaultRequest }}"
-      - name: EXPECTED_LIMIT_RANGE_MEMORY_DEFAULT
-        value: "{{ .Values.limitRanges.default }}"
-      - name: EXPECTED_LIMIT_RANGE_MEMORY_MAX
-        value: "{{ .Values.limitRanges.max }}"
-      - name: EXPECTED_RESOURCE_QUOTA_LIMITS_MEMORY
-        value: "{{ .Values.resourceQuota.limitsMemory}}"
-      - name: EXPECTED_RESOURCE_QUOTA_REQUESTS_MEMORY
-        value: "{{ .Values.resourceQuota.requestsMemory}}"
-  restartPolicy: Never
+  template:
+    metadata:
+      annotations:
+        sidecar.istio.io/inject: "false"
+    spec:
+      serviceAccountName: test-{{ template "fullname" . }}
+      containers:
+      - name: test-{{ template "fullname" . }}
+        image: {{ .Values.global.containerRegistry.path }}/{{ .Values.global.test_namespace_controller.dir }}test-namespace-controller:{{ .Values.global.test_namespace_controller.version }}
+        env:
+          - name: EXPECTED_LIMIT_RANGE_MEMORY_DEFAULT_REQUEST
+            value: "{{ .Values.limitRanges.defaultRequest }}"
+          - name: EXPECTED_LIMIT_RANGE_MEMORY_DEFAULT
+            value: "{{ .Values.limitRanges.default }}"
+          - name: EXPECTED_LIMIT_RANGE_MEMORY_MAX
+            value: "{{ .Values.limitRanges.max }}"
+          - name: EXPECTED_RESOURCE_QUOTA_LIMITS_MEMORY
+            value: "{{ .Values.resourceQuota.limitsMemory}}"
+          - name: EXPECTED_RESOURCE_QUOTA_REQUESTS_MEMORY
+            value: "{{ .Values.resourceQuota.requestsMemory}}"
+      restartPolicy: Never
 ---
+{{- end }}

--- a/resources/core/templates/tests/test-core-acceptance.yaml
+++ b/resources/core/templates/tests/test-core-acceptance.yaml
@@ -1,54 +1,56 @@
-apiVersion: v1
-kind: Pod
+{{- if .Capabilities.APIVersions.Has "testing.kyma-project.io/v1alpha1" }}
+apiVersion: "testing.kyma-project.io/v1alpha1"
+kind: TestDefinition
 metadata:
   name: test-{{ template "fullname" . }}-acceptance
-  annotations:
-    sidecar.istio.io/inject: "true"
-    "helm.sh/hook": test-success
-  labels:
-    "helm-chart-test": "true"
 spec:
-  shareProcessNamespace: true
-  serviceAccountName:  test-{{ template "fullname" . }}-acceptance
-  containers:
-    - name: test-{{ template "fullname" . }}-acceptance
-      image: {{ .Values.global.containerRegistry.path }}/{{ .Values.global.acceptance_tests.dir }}acceptance-tests:{{ .Values.global.acceptance_tests.version }}
-      env:
-      - name: HELM_BROKER_URL
-        value: http://helm-broker.kyma-system.svc.cluster.local
-      - name: RELEASE_NAMESPACE
-        value: {{ .Values.test.acceptance.core.application.brokerNamespace }}
-      - name: KYMA_DOMAIN
-        value: {{ .Values.global.ingress.domainName }}
-      - name: IS_LOCAL_ENV
-        value: {{ .Values.global.isLocalEnv | toString | quote }}
-      - name: DEX_USER_EMAIL
-        valueFrom:
-          secretKeyRef:
-            name: admin-user
-            key: email
-      - name: DEX_USER_PASSWORD
-        valueFrom:
-          secretKeyRef:
-            name: admin-user
-            key: password
-      - name: INGRESSGATEWAY_FQDN
-        value: istio-ingressgateway.istio-system.svc.cluster.local
-      - name: STUBS_DOCKER_IMAGE
-        value: {{ .Values.global.containerRegistry.path }}/{{ .Values.global.acceptance_tests.dir }}acceptance-tests:{{ .Values.global.acceptance_tests.version }}
-      - name: APPLICATION_UNLINKING_TIMEOUT
-        value: {{ .Values.test.acceptance.core.application.unlinkingTimeout | quote }}
-      - name: APPLICATION_LINKING_TIMEOUT
-        value: {{ .Values.test.acceptance.core.application.linkingTimeout | quote }}
-      - name: APPLICATION_KEEP_RESOURCES
-        value: "false"
-      - name: APPLICATION_DISABLED
-        value: {{ .Values.test.acceptance.core.application.disabled | quote }}
-      - name: TEAR_DOWN_TIMEOUT_PER_STEP
-        value: {{ .Values.test.acceptance.core.application.tearDownTimeoutPerStep | quote }}
-      command:
-      - "/bin/sh"
-      args:
-      - "-c"
-      - "echo 'TESTING start'; sleep 10; ./entrypoint.sh; exit_code=$?; echo code is $exit_code; echo 'killing pilot-agent...'; pkill -INT pilot-agent; sleep 4; exit $exit_code;"
-  restartPolicy: Never
+  template:
+    metadata:
+      annotations:
+        sidecar.istio.io/inject: "true"
+    spec:
+      shareProcessNamespace: true
+      serviceAccountName:  test-{{ template "fullname" . }}-acceptance
+      containers:
+      - name: test-{{ template "fullname" . }}-acceptance
+        image: {{ .Values.global.containerRegistry.path }}/{{ .Values.global.acceptance_tests.dir }}acceptance-tests:{{ .Values.global.acceptance_tests.version }}
+        env:
+            - name: HELM_BROKER_URL
+              value: http://helm-broker.kyma-system.svc.cluster.local
+            - name: RELEASE_NAMESPACE
+              value: {{ .Values.test.acceptance.core.application.brokerNamespace }}
+            - name: KYMA_DOMAIN
+              value: {{ .Values.global.ingress.domainName }}
+            - name: IS_LOCAL_ENV
+              value: {{ .Values.global.isLocalEnv | toString | quote }}
+            - name: DEX_USER_EMAIL
+              valueFrom:
+                  secretKeyRef:
+                      name: admin-user
+                      key: email
+            - name: DEX_USER_PASSWORD
+              valueFrom:
+                  secretKeyRef:
+                      name: admin-user
+                      key: password
+            - name: INGRESSGATEWAY_FQDN
+              value: istio-ingressgateway.istio-system.svc.cluster.local
+            - name: STUBS_DOCKER_IMAGE
+              value: {{ .Values.global.containerRegistry.path }}/{{ .Values.global.acceptance_tests.dir }}acceptance-tests:{{ .Values.global.acceptance_tests.version }}
+            - name: APPLICATION_UNLINKING_TIMEOUT
+              value: {{ .Values.test.acceptance.core.application.unlinkingTimeout | quote }}
+            - name: APPLICATION_LINKING_TIMEOUT
+              value: {{ .Values.test.acceptance.core.application.linkingTimeout | quote }}
+            - name: APPLICATION_KEEP_RESOURCES
+              value: "false"
+            - name: APPLICATION_DISABLED
+              value: {{ .Values.test.acceptance.core.application.disabled | quote }}
+            - name: TEAR_DOWN_TIMEOUT_PER_STEP
+              value: {{ .Values.test.acceptance.core.application.tearDownTimeoutPerStep | quote }}
+        command:
+            - "/bin/sh"
+        args:
+            - "-c"
+            - "echo 'TESTING start'; sleep 10; ./entrypoint.sh; exit_code=$?; echo code is $exit_code; echo 'killing pilot-agent...'; pkill -INT pilot-agent; sleep 4; exit $exit_code;"
+      restartPolicy: Never
+{{- end }}

--- a/resources/core/templates/tests/test-ui-acceptance.yaml
+++ b/resources/core/templates/tests/test-ui-acceptance.yaml
@@ -1,86 +1,86 @@
-{{- $uiDeploymentEnabled :=  .Values.test.acceptance.ui.logging.enabled | default "false" -}}
-apiVersion: v1
-kind: Pod
+{{- if .Capabilities.APIVersions.Has "testing.kyma-project.io/v1alpha1" }}
+apiVersion: "testing.kyma-project.io/v1alpha1"
+kind: TestDefinition
 metadata:
   name: "test-{{ template "fullname" . }}-ui-acceptance"
-  annotations:
-    sidecar.istio.io/inject: "true"
-    "helm.sh/hook": test-success
-  labels:
-    "helm-chart-test": "true"
 spec:
-  shareProcessNamespace: true
-  {{ if .Values.global.isLocalEnv }}
-  hostAliases:
-   - ip: {{ .Values.test.acceptance.ui.minikubeIP }}
-     hostnames:
-      - "apiserver.{{ .Values.global.ingress.domainName }}"
-      - "console.{{ .Values.global.ingress.domainName }}"
-      - "catalog.{{ .Values.global.ingress.domainName }}"
-      - "instances.{{ .Values.global.ingress.domainName }}"
-      - "brokers.{{ .Values.global.ingress.domainName }}"
-      - "dex.{{ .Values.global.ingress.domainName }}"
-      - "docs.{{ .Values.global.ingress.domainName }}"
-      - "lambdas-ui.{{ .Values.global.ingress.domainName }}"
-      - "console-backend.{{ .Values.global.ingress.domainName }}"
-      - "minio.{{ .Values.global.ingress.domainName }}"
-  {{ end }}
-  serviceAccountName:  "test-{{ template "fullname" . }}-ui-acceptance"
-  containers:
-    - name: "test-{{ template "fullname" . }}-ui-acceptance"
-      image: {{ .Values.global.containerRegistry.path }}/ui-tests:1fb907f7
-      imagePullPolicy: IfNotPresent
-      resources:
-         requests:
-           memory: {{ .Values.test.acceptance.ui.requests.memory }}
-           cpu: {{ .Values.test.acceptance.ui.requests.cpu }}
-         limits:
-           memory: {{ .Values.test.acceptance.ui.limits.memory }}
-           cpu: {{ .Values.test.acceptance.ui.limits.cpu }}
-      env:
-        - name: LOGGING_ENABLED
-          value: {{ $uiDeploymentEnabled | quote}}
-        - name: DOMAIN
-          value: {{ .Values.global.ingress.domainName }}
-        - name: LOGIN
-          valueFrom:
-            secretKeyRef:
-              name: admin-user
-              key: email
-        - name: PASSWORD
-          valueFrom:
-            secretKeyRef:
-              name: admin-user
-              key: password
-        - name: DEX_CONFIG
-          value: /etc/dex/cfg/config.yaml
-      volumeMounts:
-        - name: dex-config
-          mountPath: /etc/dex/cfg
-    - image: eu.gcr.io/kyma-project/test-infra/alpine-kubectl:v20190325-ff66a3a
-      name: manager
-      command:
-        - bin/sh
-        - -c
-        - |
-          SERVICE="npm"
-          sleep 10
-          while true; do
-          if pgrep -x "${SERVICE}"; then
-            echo "---> ${SERVICE} is running."
-              sleep 10
-            else
-              echo "---> ${SERVICE} has stopped, stopping istio"
-              pkill -TERM pilot-agent
-              break
-            fi
-          done
-  # Needed for detecting if static user is disabled
-  volumes:
-    - name: dex-config
-      configMap:
-        name: dex-config
-        items:
-          - key: config.yaml
-            path: config.yaml
-  restartPolicy: Never
+    template:
+        metadata:
+          annotations:
+            sidecar.istio.io/inject: "false"
+        spec:
+          {{ if .Values.global.isLocalEnv }}
+          hostAliases:
+           - ip: {{ .Values.test.acceptance.ui.minikubeIP }}
+             hostnames:
+              - "apiserver.{{ .Values.global.ingress.domainName }}"
+              - "console.{{ .Values.global.ingress.domainName }}"
+              - "catalog.{{ .Values.global.ingress.domainName }}"
+              - "instances.{{ .Values.global.ingress.domainName }}"
+              - "brokers.{{ .Values.global.ingress.domainName }}"
+              - "dex.{{ .Values.global.ingress.domainName }}"
+              - "docs.{{ .Values.global.ingress.domainName }}"
+              - "lambdas-ui.{{ .Values.global.ingress.domainName }}"
+              - "console-backend.{{ .Values.global.ingress.domainName }}"
+              - "minio.{{ .Values.global.ingress.domainName }}"
+          {{ end }}
+          serviceAccountName:  "test-{{ template "fullname" . }}-ui-acceptance"
+          containers:
+            - name: "test-{{ template "fullname" . }}-ui-acceptance"
+              image: {{ .Values.global.containerRegistry.path }}/ui-tests:5859bb17
+              imagePullPolicy: IfNotPresent
+              resources:
+                 requests:
+                   memory: {{ .Values.test.acceptance.ui.requests.memory }}
+                   cpu: {{ .Values.test.acceptance.ui.requests.cpu }}
+                 limits:
+                   memory: {{ .Values.test.acceptance.ui.limits.memory }}
+                   cpu: {{ .Values.test.acceptance.ui.limits.cpu }}
+              env:
+               - name: LOGGING_ENABLED
+                 value: {{ $uiDeploymentEnabled | quote}}
+                - name: DOMAIN
+                  value: {{ .Values.global.ingress.domainName }}
+                - name: LOGIN
+                  valueFrom:
+                    secretKeyRef:
+                      name: admin-user
+                      key: email
+                - name: PASSWORD
+                  valueFrom:
+                    secretKeyRef:
+                      name: admin-user
+                      key: password
+                - name: DEX_CONFIG
+                  value: /etc/dex/cfg/config.yaml
+              volumeMounts:
+                - name: dex-config
+                  mountPath: /etc/dex/cfg
+            - image: eu.gcr.io/kyma-project/test-infra/alpine-kubectl:v20190325-ff66a3a
+              name: manager
+              command:
+                - bin/sh
+                - -c
+                - |
+                  SERVICE="npm"
+                  sleep 10
+                  while true; do
+                    if pgrep -x "${SERVICE}"; then
+                      echo "---> ${SERVICE} is running."
+                      sleep 10
+                    else
+                      echo "---> ${SERVICE} has stopped, stopping istio"
+                      pkill -TERM pilot-agent
+                      break
+                    fi
+                  done
+          # Needed for detecting if static user is disabled
+          volumes:
+            - name: dex-config
+              configMap:
+                name: dex-config
+                items:
+                  - key: config.yaml
+                    path: config.yaml
+          restartPolicy: Never
+{{- end}}

--- a/resources/core/templates/tests/test-ui-acceptance.yaml
+++ b/resources/core/templates/tests/test-ui-acceptance.yaml
@@ -1,4 +1,5 @@
 {{- if .Capabilities.APIVersions.Has "testing.kyma-project.io/v1alpha1" }}
+{{- $uiDeploymentEnabled :=  .Values.test.acceptance.ui.logging.enabled | default "false" -}}
 apiVersion: "testing.kyma-project.io/v1alpha1"
 kind: TestDefinition
 metadata:
@@ -7,8 +8,9 @@ spec:
     template:
         metadata:
           annotations:
-            sidecar.istio.io/inject: "false"
+            sidecar.istio.io/inject: "true"
         spec:
+          shareProcessNamespace: true
           {{ if .Values.global.isLocalEnv }}
           hostAliases:
            - ip: {{ .Values.test.acceptance.ui.minikubeIP }}
@@ -24,10 +26,10 @@ spec:
               - "console-backend.{{ .Values.global.ingress.domainName }}"
               - "minio.{{ .Values.global.ingress.domainName }}"
           {{ end }}
-          serviceAccountName:  "test-{{ template "fullname" . }}-ui-acceptance"
+          serviceAccountName: "test-{{ template "fullname" . }}-ui-acceptance"
           containers:
             - name: "test-{{ template "fullname" . }}-ui-acceptance"
-              image: {{ .Values.global.containerRegistry.path }}/ui-tests:5859bb17
+              image: {{ .Values.global.containerRegistry.path }}/ui-tests:1fb907f7
               imagePullPolicy: IfNotPresent
               resources:
                  requests:
@@ -37,8 +39,8 @@ spec:
                    memory: {{ .Values.test.acceptance.ui.limits.memory }}
                    cpu: {{ .Values.test.acceptance.ui.limits.cpu }}
               env:
-               - name: LOGGING_ENABLED
-                 value: {{ $uiDeploymentEnabled | quote}}
+                - name: LOGGING_ENABLED
+                  value: {{ $uiDeploymentEnabled | quote }}
                 - name: DOMAIN
                   value: {{ .Values.global.ingress.domainName }}
                 - name: LOGIN

--- a/resources/dex/templates/tests/test-dex-connection.yaml
+++ b/resources/dex/templates/tests/test-dex-connection.yaml
@@ -1,23 +1,25 @@
-apiVersion: v1
-kind: Pod
+{{- if .Capabilities.APIVersions.Has "testing.kyma-project.io/v1alpha1" }}
+apiVersion: "testing.kyma-project.io/v1alpha1"
+kind: TestDefinition
 metadata:
   name: "test-{{ template "fullname" . }}-connection-dex"
-  annotations:
-    sidecar.istio.io/inject: "false"
-    "helm.sh/hook": test-success
-  labels:
-      "helm-chart-test": "true"
 spec:
-  containers:
-  - name: "test-{{ template "fullname" . }}-connection-dex"
-    image: tutum/curl:alpine
-    command: ["/usr/bin/curl"]
-    args: [
-      "--fail",
-      "--max-time", "10",
-      "--retry", "60",
-      "--retry-delay", "3",
-      "http://dex-service.{{ .Release.Namespace }}.svc.cluster.local:5556/.well-known/openid-configuration"
-    ]
-  restartPolicy: Never
+  template:
+    metadata:
+      annotations:
+        sidecar.istio.io/inject: "false"
+    spec:
+      containers:
+      - name: "test-{{ template "fullname" . }}-connection-dex"
+        image: tutum/curl:alpine
+        command: ["/usr/bin/curl"]
+        args: [
+          "--fail",
+          "--max-time", "10",
+          "--retry", "60",
+          "--retry-delay", "3",
+          "http://dex-service.{{ .Release.Namespace }}.svc.cluster.local:5556/.well-known/openid-configuration"
+        ]
+      restartPolicy: Never
 ---
+{{- end }}

--- a/resources/event-bus/templates/tests/test-e2e-tester.yaml
+++ b/resources/event-bus/templates/tests/test-e2e-tester.yaml
@@ -86,41 +86,43 @@ roleRef:
   name: test-event-bus-k8s
   apiGroup: rbac.authorization.k8s.io
 ---
-apiVersion: v1
-kind: Pod
+{{- if .Capabilities.APIVersions.Has "testing.kyma-project.io/v1alpha1" }}
+apiVersion: "testing.kyma-project.io/v1alpha1"
+kind: TestDefinition
 metadata:
   name: {{ .Values.e2eTests.nameTester }}
-  labels:
-    helm-chart-test: "true"
-  annotations:
-    sidecar.istio.io/inject: "true"   # needed if the tester could run with side cars
-    helm.sh/hook: test-success
 spec:
-  shareProcessNamespace: true
-  serviceAccount: {{ .Values.e2eTests.nameTester }}
-  containers:
-  - image: "{{ .Values.global.containerRegistry.path }}/{{ .Values.global.event_bus_tests.dir }}event-bus-e2e-tester:{{ .Values.global.event_bus_tests.version }}"
-    imagePullPolicy: IfNotPresent
-    name: {{ .Values.e2eTests.nameTester }}
-    args:
-      - --publish-event-uri=http://event-bus-publish:8080/v1/events
-      - --publish-status-uri=http://event-bus-publish:8080/v1/status/ready
-      - --subscriber-image={{ .Values.global.containerRegistry.path }}/{{ .Values.global.event_bus_tests.dir }}event-bus-e2e-subscriber:{{ .Values.global.event_bus_tests.version }}
-  - image: eu.gcr.io/kyma-project/test-infra/alpine-kubectl:v20190325-ff66a3a
-    name: manager
-    command:
-      - bin/sh
-      - -c 
-      - |
-        SERVICE="/root/e2e-tester"
-        while true; do
-          if pgrep -x "${SERVICE}"; then
-            echo "---> ${SERVICE} is running."
-            sleep 10
-          else
-            echo "---> ${SERVICE} has stopped, stopping istio"
-            pkill -TERM pilot-agent
-            break
-          fi
-        done
-  restartPolicy: Never
+  template:
+    metadata:
+      annotations:
+        sidecar.istio.io/inject: "true"
+    spec:
+      shareProcessNamespace: true
+      serviceAccount: {{ .Values.e2eTests.nameTester }}
+      containers:
+      - image: "{{ .Values.global.containerRegistry.path }}/{{ .Values.global.event_bus_tests.dir }}event-bus-e2e-tester:{{ .Values.global.event_bus_tests.version }}"
+        imagePullPolicy: IfNotPresent
+        name: {{ .Values.e2eTests.nameTester }}
+        args:
+            - --publish-event-uri=http://event-bus-publish:8080/v1/events
+            - --publish-status-uri=http://event-bus-publish:8080/v1/status/ready
+            - --subscriber-image={{ .Values.global.containerRegistry.path }}/{{ .Values.global.event_bus_tests.dir }}event-bus-e2e-subscriber:{{ .Values.global.event_bus_tests.version }}
+      - image: eu.gcr.io/kyma-project/test-infra/alpine-kubectl:v20190325-ff66a3a
+        name: manager
+        command:
+            - bin/sh
+            - -c
+            - |
+                SERVICE="/root/e2e-tester"
+                while true; do
+                  if pgrep -x "${SERVICE}"; then
+                    echo "---> ${SERVICE} is running."
+                    sleep 10
+                  else
+                    echo "---> ${SERVICE} has stopped, stopping istio"
+                    pkill -TERM pilot-agent
+                    break
+                  fi
+                done
+      restartPolicy: Never
+{{- end}}

--- a/resources/logging/templates/tests/logging.yaml
+++ b/resources/logging/templates/tests/logging.yaml
@@ -35,31 +35,33 @@ subjects:
   name: test-{{ template "fullname" . }}
   namespace: kyma-system
 ---
-apiVersion: v1
-kind: Pod
+{{- if .Capabilities.APIVersions.Has "testing.kyma-project.io/v1alpha1" }}
+apiVersion: "testing.kyma-project.io/v1alpha1"
+kind: TestDefinition
 metadata:
   name: test-{{ template "fullname" . }}
-  labels:
-    helm-chart-test: "true"
-  annotations:
-    sidecar.istio.io/inject: "false"
-    helm.sh/hook: test-success
 spec:
-  serviceAccountName: test-{{ template "fullname" . }}
-  restartPolicy: Never
-  containers:
-  - name: test-{{ template "fullname" . }}
-    image: {{ .Values.global.containerRegistry.path }}/{{ .Values.global.test_logging.dir }}{{ .Values.test.image.name }}:{{ .Values.global.test_logging.version }}
-    imagePullPolicy: Always
-    command:
-      - "/bin/sh"
-    args:
-    - "-c"
-    - "./test-logging"
-  volumes:
-    - name: dex-config
-      configMap:
-        name: dex-config
-        items:
-          - key: config.yaml
-            path: config.yaml
+  template:
+    metadata:
+      annotations:
+        sidecar.istio.io/inject: "false"
+    spec:
+      serviceAccountName: test-{{ template "fullname" . }}
+      restartPolicy: Never
+      containers:
+      - name: test-{{ template "fullname" . }}
+        image: {{ .Values.global.containerRegistry.path }}/{{ .Values.global.test_logging.dir }}/{{ .Values.test.image.name }}:{{ .Values.global.test_logging.version }}
+        imagePullPolicy: Always
+        command:
+          - "/bin/sh"
+        args:
+        - "-c"
+        - "./test-logging"
+      volumes:
+      - name: dex-config
+        configMap:
+            name: dex-config
+            items:
+                - key: config.yaml
+                  path: config.yaml
+{{- end}}

--- a/resources/logging/templates/tests/logging.yaml
+++ b/resources/logging/templates/tests/logging.yaml
@@ -50,7 +50,7 @@ spec:
       restartPolicy: Never
       containers:
       - name: test-{{ template "fullname" . }}
-        image: {{ .Values.global.containerRegistry.path }}/{{ .Values.global.test_logging.dir }}/{{ .Values.test.image.name }}:{{ .Values.global.test_logging.version }}
+        image: {{ .Values.global.containerRegistry.path }}/{{ .Values.global.test_logging.dir }}{{ .Values.test.image.name }}:{{ .Values.global.test_logging.version }}
         imagePullPolicy: Always
         command:
           - "/bin/sh"

--- a/resources/monitoring/templates/tests/test-kube-prometheus.yaml
+++ b/resources/monitoring/templates/tests/test-kube-prometheus.yaml
@@ -34,27 +34,29 @@ subjects:
   name: test-{{ template "fullname" . }}
   namespace: {{ .Release.Namespace }}
 ---
-apiVersion: v1
-kind: Pod
+{{- if .Capabilities.APIVersions.Has "testing.kyma-project.io/v1alpha1" }}
+apiVersion: "testing.kyma-project.io/v1alpha1"
+kind: TestDefinition
 metadata:
   name: test-{{ template "fullname" . }}
-  labels:
-    helm-chart-test: "true"
-  annotations:
-    sidecar.istio.io/inject: "true"
-    helm.sh/hook: test-success
 spec:
-  shareProcessNamespace: true
-  serviceAccount: test-{{ template "fullname" . }}
-  containers:
-  - name: test-{{ template "fullname" . }}
-    image: {{ .Values.global.containerRegistry.path }}/{{ .Values.test.image.dir }}{{ .Values.test.image.name }}:{{ .Values.test.image.version }}
-    imagePullPolicy: IfNotPresent
-    command: ["/bin/sh"]
-    args: ["-c", "sleep 10; /test-monitoring; exit_code=$?; pkill -INT pilot-agent; sleep 4; exit $exit_code;"]
-    resources:
-      limits:
-        memory: 200Mi
-      requests:
-        memory: 96Mi
-  restartPolicy: Never
+  template:
+    metadata:
+      annotations:
+        sidecar.istio.io/inject: "true"
+    spec:
+        shareProcessNamespace: true
+      serviceAccount: test-{{ template "fullname" . }}
+      containers:
+      - name: test-{{ template "fullname" . }}
+        image: {{ .Values.global.containerRegistry.path }}/{{ .Values.test.image.dir }}{{ .Values.test.image.name }}:{{ .Values.test.image.version }}
+        imagePullPolicy: IfNotPresent
+        command: ["/bin/sh"]
+        args: ["-c", "sleep 10; /test-monitoring; exit_code=$?; pkill -INT pilot-agent; sleep 4; exit $exit_code;"]
+        resources:
+          limits:
+            memory: 200Mi
+          requests:
+            memory: 96Mi
+      restartPolicy: Never
+{{- end }}

--- a/resources/monitoring/templates/tests/test-kube-prometheus.yaml
+++ b/resources/monitoring/templates/tests/test-kube-prometheus.yaml
@@ -45,7 +45,7 @@ spec:
       annotations:
         sidecar.istio.io/inject: "true"
     spec:
-        shareProcessNamespace: true
+      shareProcessNamespace: true
       serviceAccount: test-{{ template "fullname" . }}
       containers:
       - name: test-{{ template "fullname" . }}

--- a/resources/testing/.helmignore
+++ b/resources/testing/.helmignore
@@ -1,0 +1,21 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj

--- a/resources/testing/Chart.yaml
+++ b/resources/testing/Chart.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+name: testing
+description: Testing
+version: 0.0.1
+keywords:
+- testing
+- kyma

--- a/resources/testing/README.md
+++ b/resources/testing/README.md
@@ -2,5 +2,5 @@
 
 ## Overview
 
-The Testing chart consists of the following sub-charts:
-* `octopus` - it is a testing framework that allows you to run tests defined as Docker images on a running cluster.
+This chart consists of the following sub-charts:
+* `octopus`, which is a testing framework that allows you to run tests defined as Docker images on a running cluster.

--- a/resources/testing/README.md
+++ b/resources/testing/README.md
@@ -1,0 +1,6 @@
+# Testing
+
+## Overview
+
+The Testing chart consists of the following sub-charts:
+* `octopus` - it is a testing framework that allows you to run tests defined as Docker images on a running cluster.

--- a/resources/testing/charts/octopus/.helmignore
+++ b/resources/testing/charts/octopus/.helmignore
@@ -1,0 +1,21 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj

--- a/resources/testing/charts/octopus/Chart.yaml
+++ b/resources/testing/charts/octopus/Chart.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+description: A Helm chart for Octopus framework
+name: octopus
+version: 0.1.0

--- a/resources/testing/charts/octopus/templates/_helpers.tpl
+++ b/resources/testing/charts/octopus/templates/_helpers.tpl
@@ -1,0 +1,32 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "octopus.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "octopus.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "octopus.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}

--- a/resources/testing/charts/octopus/templates/clustertestsuite.crd.yaml
+++ b/resources/testing/charts/octopus/templates/clustertestsuite.crd.yaml
@@ -1,0 +1,138 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  creationTimestamp: null
+  labels:
+    controller-tools.k8s.io: "1.0"
+  name: clustertestsuites.testing.kyma-project.io
+spec:
+  group: testing.kyma-project.io
+  names:
+    kind: ClusterTestSuite
+    plural: clustertestsuites
+    shortNames:
+    - cts
+  scope: Cluster
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          properties:
+            concurrency:
+              description: How many tests we want to execute at the same time. Depends
+                on cluster size and it's load. Default value is 1
+              format: int64
+              type: integer
+            count:
+              description: How many times should I run every test? Default value is
+                1.
+              format: int64
+              type: integer
+            maxRetries:
+              description: In case of a failed test, how many times it will be retried.
+                If test failed and on retry it succeeded, Test Suite should be marked
+                as a succeeded. Default value is 0 - no retries. MaxRetries and Count
+                cannot be used mutually.
+              format: int64
+              type: integer
+            selectors:
+              description: Decide which tests to execute. If not provided execute
+                all tests
+              properties:
+                matchLabels:
+                  description: Find test definitions by it's labels. TestDefinition
+                    should have AT LEAST one label listed here to be executed.
+                  items:
+                    type: string
+                  type: array
+                matchNames:
+                  description: Find test definitions by it's name
+                  items:
+                    properties:
+                      name:
+                        type: string
+                      namespace:
+                        type: string
+                    required:
+                    - name
+                    - namespace
+                    type: object
+                  type: array
+              type: object
+          type: object
+        status:
+          properties:
+            conditions:
+              items:
+                properties:
+                  message:
+                    type: string
+                  reason:
+                    type: string
+                  status:
+                    type: string
+                  type:
+                    type: string
+                required:
+                - type
+                - status
+                type: object
+              type: array
+            results:
+              items:
+                properties:
+                  disabledConcurrency:
+                    type: boolean
+                  executions:
+                    items:
+                      properties:
+                        id:
+                          description: ID is equivalent to a testing Pod name
+                          type: string
+                        message:
+                          type: string
+                        podPhase:
+                          type: string
+                        reason:
+                          type: string
+                      required:
+                      - id
+                      - podPhase
+                      type: object
+                    type: array
+                  name:
+                    description: Test name
+                    type: string
+                  namespace:
+                    type: string
+                  status:
+                    type: string
+                required:
+                - name
+                - namespace
+                - status
+                - executions
+                type: object
+              type: array
+          type: object
+  version: v1alpha1
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/resources/testing/charts/octopus/templates/manager.yaml
+++ b/resources/testing/charts/octopus/templates/manager.yaml
@@ -1,0 +1,86 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "octopus.fullname" . }}
+  labels:
+    app: {{ template "octopus.name" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+    control-plane: controller-manager
+    controller-tools.k8s.io: "1.0"
+spec:
+  selector:
+    app: {{ template "octopus.name" . }}
+    control-plane: controller-manager
+    controller-tools.k8s.io: "1.0"
+  ports:
+  - port: 443
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: {{ template "octopus.fullname" . }}
+  labels:
+    app: {{ template "octopus.name" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+    control-plane: controller-manager
+    controller-tools.k8s.io: "1.0"
+spec:
+  selector:
+    matchLabels:
+      app: {{ template "octopus.name" . }}
+      control-plane: controller-manager
+      controller-tools.k8s.io: "1.0"
+  serviceName: {{ template "octopus.fullname" . }}
+  template:
+
+    metadata:
+      labels:
+        app: {{ template "octopus.name" . }}
+        control-plane: controller-manager
+        controller-tools.k8s.io: "1.0"
+    spec:
+      serviceAccountName: {{ template "octopus.fullname" . }}
+      containers:
+      - command:
+        - /manager
+        image: {{.Values.global.octopus.image.registry}}/{{.Values.global.octopus.image.dir}}octopus:{{.Values.global.octopus.image.version}}
+        imagePullPolicy: Always
+        name: manager
+        env:
+          - name: POD_NAMESPACE
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
+          - name: SECRET_NAME
+            value: webhook-server-secret
+        resources:
+          limits:
+            cpu: 100m
+            memory: 30Mi
+          requests:
+            cpu: 100m
+            memory: 20Mi
+        ports:
+        - containerPort: 9876
+          name: webhook-server
+          protocol: TCP
+        volumeMounts:
+        - mountPath: /tmp/cert
+          name: cert
+          readOnly: true
+      terminationGracePeriodSeconds: 10
+      volumes:
+      - name: cert
+        secret:
+          defaultMode: 420
+          secretName: webhook-server-secret
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: webhook-server-secret

--- a/resources/testing/charts/octopus/templates/manager.yaml
+++ b/resources/testing/charts/octopus/templates/manager.yaml
@@ -40,7 +40,7 @@ spec:
     metadata:
       annotations:
         # TODO: to discuss
-        status.sidecar.istio.io/port: 0
+        status.sidecar.istio.io/port: "0"
       labels:
         app: {{ template "octopus.name" . }}
         control-plane: controller-manager

--- a/resources/testing/charts/octopus/templates/manager.yaml
+++ b/resources/testing/charts/octopus/templates/manager.yaml
@@ -37,8 +37,10 @@ spec:
       controller-tools.k8s.io: "1.0"
   serviceName: {{ template "octopus.fullname" . }}
   template:
-
     metadata:
+      annotations:
+        # TODO: to discuss
+        status.sidecar.istio.io/port: 0
       labels:
         app: {{ template "octopus.name" . }}
         control-plane: controller-manager
@@ -67,7 +69,7 @@ spec:
             memory: 20Mi
         ports:
         - containerPort: 9876
-          name: webhook-server
+          name: tcp-webhook-srv
           protocol: TCP
         volumeMounts:
         - mountPath: /tmp/cert

--- a/resources/testing/charts/octopus/templates/rbac_role.yaml
+++ b/resources/testing/charts/octopus/templates/rbac_role.yaml
@@ -1,0 +1,33 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  creationTimestamp: null
+  name:  {{ template "octopus.fullname" . }}
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - delete
+- apiGroups:
+  - testing.kyma-project.io
+  resources:
+  - clustertestsuites
+  - testdefinitions
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - testing.kyma-project.io
+  resources:
+  - clustertestsuites/status
+  verbs:
+  - get
+  - update
+  - patch

--- a/resources/testing/charts/octopus/templates/rbac_role_binding.yaml
+++ b/resources/testing/charts/octopus/templates/rbac_role_binding.yaml
@@ -1,0 +1,13 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  creationTimestamp: null
+  name:  {{ template "octopus.fullname" . }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ template "octopus.fullname" . }}
+subjects:
+- kind: ServiceAccount
+  name: {{ template "octopus.fullname" . }}
+  namespace: {{ .Release.Namespace }}

--- a/resources/testing/charts/octopus/templates/service-account.yaml
+++ b/resources/testing/charts/octopus/templates/service-account.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ template "octopus.fullname" . }}
+  labels:
+    app: {{ template "octopus.name" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"

--- a/resources/testing/charts/octopus/templates/testdefinition.crd.yaml
+++ b/resources/testing/charts/octopus/templates/testdefinition.crd.yaml
@@ -1,0 +1,53 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  creationTimestamp: null
+  labels:
+    controller-tools.k8s.io: "1.0"
+  name: testdefinitions.testing.kyma-project.io
+spec:
+  group: testing.kyma-project.io
+  names:
+    kind: TestDefinition
+    plural: testdefinitions
+    shortNames:
+    - td
+  scope: Namespaced
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          properties:
+            disableConcurrency:
+              description: If test is working on data that can be modified by another
+                test, I would like to run it in separation. Default value is false
+              type: boolean
+            skip:
+              description: If there are some problems with given test, we add possibility
+                to don't execute them. On Testsuite level such test should be marked
+                as a skipped. Default value is false
+              type: boolean
+            template:
+              type: object
+          required:
+          - template
+          type: object
+  version: v1alpha1
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/resources/testing/charts/octopus/values.yaml
+++ b/resources/testing/charts/octopus/values.yaml
@@ -1,0 +1,3 @@
+# Default values for octopus.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.

--- a/resources/testing/values.yaml
+++ b/resources/testing/values.yaml
@@ -1,0 +1,6 @@
+global:
+  octopus:
+    image:
+      registry: eu.gcr.io/kyma-project/incubator
+      dir: develop/
+      version: dc5dc284

--- a/tests/acceptance/servicecatalog/binding_usage_test.go
+++ b/tests/acceptance/servicecatalog/binding_usage_test.go
@@ -69,7 +69,7 @@ func TestServiceBindingUsagePrefixing(t *testing.T) {
 	}()
 
 	ts.enableApplicationInTestNamespace()
-	ts.waitForAppServiceClasses(time.Second * 90)
+	ts.waitForAppServiceClasses(timeoutPerAssert)
 
 	ts.createAndWaitForServiceInstanceA(timeoutPerStep)
 	ts.createAndWaitForServiceInstanceB(timeoutPerStep)

--- a/tests/acceptance/servicecatalog/binding_usage_test.go
+++ b/tests/acceptance/servicecatalog/binding_usage_test.go
@@ -69,7 +69,7 @@ func TestServiceBindingUsagePrefixing(t *testing.T) {
 	}()
 
 	ts.enableApplicationInTestNamespace()
-	ts.waitForAppServiceClasses(timeoutPerAssert)
+	ts.waitForAppServiceClasses(time.Second * 90)
 
 	ts.createAndWaitForServiceInstanceA(timeoutPerStep)
 	ts.createAndWaitForServiceInstanceB(timeoutPerStep)


### PR DESCRIPTION
In this PR we migrate our integration tests from helm test to Octopus.
To learn more about Octopus visit https://github.com/kyma-incubator/octopus/
How Octopus is used in Kyma, is decsribed in `docs/kyma/docs/03-03-testing.md`.

In this PR we do not modify e2e tests (`e2e-testing.sh`).
In the current approach, TestSuite defines `MaxRetries` to 1, so if some test fail it will be retried - but only once. 