### PR TITLE
Add missing double-quote at the end for windows minikube installation

### DIFF
--- a/installation/cmd/run.ps1
+++ b/installation/cmd/run.ps1
@@ -11,7 +11,7 @@ $DOMAIN = "kyma.local"
 $CREATE_CR_EXTRA_ARGS = ""
 
 if ($SKIP_MINIKUBE_START -eq $false) {
-    Invoke-Expression -Command "${SCRIPTS_DIR}\minikube.ps1 -vm_driver ${VM_DRIVER} -domain ${DOMAIN}
+    Invoke-Expression -Command "${SCRIPTS_DIR}\minikube.ps1 -vm_driver ${VM_DRIVER} -domain ${DOMAIN}"
 
     if($LastExitCode -gt 0){
         exit


### PR DESCRIPTION
See also #3017 