### PR TITLE
Enable grafana for Loki

### DIFF
--- a/resources/logging/templates/loki/istio-rbac.yaml
+++ b/resources/logging/templates/loki/istio-rbac.yaml
@@ -29,6 +29,7 @@ metadata:
 spec:
   subjects:
   - user: "cluster.local/ns/kyma-system/sa/logging"
+  - user: "cluster.local/ns/kyma-system/sa/monitoring-grafana-loki"
   - properties:
       request.auth.audiences: "kyma-client"
   roleRef:

--- a/resources/monitoring/charts/grafana/templates/datasource-configmap.yaml
+++ b/resources/monitoring/charts/grafana/templates/datasource-configmap.yaml
@@ -38,6 +38,6 @@ data:
 
     - name: Loki
       type: loki
-      access: direct
+      access: proxy
       url: http://logging:3100
       editable: true

--- a/resources/monitoring/charts/grafana/templates/grafana-deployment.yaml
+++ b/resources/monitoring/charts/grafana/templates/grafana-deployment.yaml
@@ -100,6 +100,7 @@ spec:
       tolerations:
 {{ toYaml .Values.tolerations | indent 8 }}
     {{- end }}
+      serviceAccountName: {{ .Release.Name }}-grafana-loki
       securityContext:
         fsGroup: 472
       volumes:

--- a/resources/monitoring/charts/grafana/templates/serviceaccount.yaml
+++ b/resources/monitoring/charts/grafana/templates/serviceaccount.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    app: {{ template "prometheus.name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+  name: {{ .Release.Name }}-grafana-loki


### PR DESCRIPTION
 - Create serviveaccounts for grafana
 - Allow the serviceaccount from grana to access loki.

<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/master/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Enable grafana for loki.

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
Fixes: #2650 