### PR TITLE
Fix installation of Knative Serving when no domain is specified

### DIFF
--- a/resources/knative-serving/charts/knative-serving/templates/serving.yaml
+++ b/resources/knative-serving/charts/knative-serving/templates/serving.yaml
@@ -774,7 +774,9 @@ metadata:
 ---
 apiVersion: v1
 data:
+  {{ if (ne "" .Values.domainName) }}
   {{ .Values.domainName }}: ""
+  {{ end }}
 kind: ConfigMap
 metadata:
   labels:


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Fix Knative Serving installation failing if the domainName is an empty string, like in an xip.io-installation
