### PR TITLE
Prefix Knative channel name with a lowercase alphabet character to fix the istio virtual service name issue

### DIFF
--- a/components/event-bus/internal/knative/publish/opts/opts.go
+++ b/components/event-bus/internal/knative/publish/opts/opts.go
@@ -14,7 +14,7 @@ const (
 	defaultPort                 = 8080
 	defaultMaxRequests          = 100
 	defaultMaxRequestSize       = 65536
-	defaultMaxChannelNameLength = 45
+	defaultMaxChannelNameLength = 33
 
 	// option names
 	port                      = "port"

--- a/components/event-bus/internal/knative/util/util.go
+++ b/components/event-bus/internal/knative/util/util.go
@@ -33,9 +33,11 @@ func encodeChannelName(sourceID, eventType, eventTypeVersion *string) string {
 }
 
 // GetChannelName function returns a unique hash for the knative channel name from the given event components
+// because of a limitation in the current knative version, if the channel name starts with a number, the corresponding
+// istio-virtualservice will not be created, in order to mitigate that, we prefix the channel name with the letter 'k'
 func GetChannelName(sourceID, eventType, eventTypeVersion *string) string {
 	channelName := encodeChannelName(sourceID, eventType, eventTypeVersion)
-	return hash.ComputeHash(&channelName)
+	return fmt.Sprintf("k%s", hash.ComputeHash(&channelName))
 }
 
 // GetKnSubscriptionName joins the kySubscriptionName and kySubscriptionNamespace


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Prefix Knative channel name with a lowercase alphabet character to fix the istio virtual service name issue.
