### PR TITLE
Update the event-bus version and the max Knative channel name length

### DIFF
--- a/resources/event-bus/values.yaml
+++ b/resources/event-bus/values.yaml
@@ -7,7 +7,7 @@ global:
     path: eu.gcr.io/kyma-project
   event_bus:
     dir: develop/
-    version: 6e822c98
+    version: 016e87ef
   event_bus_tests:
     dir: develop/
     version: f4c58b01
@@ -23,7 +23,7 @@ global:
   publishKnative:
     maxRequests: 16
     maxRequestSize: 65536
-    maxChannelNameLength: 32
+    maxChannelNameLength: 33
     maxSourceIDLength: 253
     maxEventTypeLength: 253
     maxEventTypeVersionLength: 4


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Update the event-bus version.
- Update the max Knative channel name length configuration.
