### PR TITLE
Add test fail report to service catalog accepatnce test

### DIFF
--- a/tests/acceptance/servicecatalog/helpers_test.go
+++ b/tests/acceptance/servicecatalog/helpers_test.go
@@ -127,7 +127,7 @@ func fixNamespace(name string) *corev1.Namespace {
 	}
 }
 
-func serviceClassesReport(t *testing.T, services []osb.Service, ns string) {
+func testDetailsReport(t *testing.T, services []osb.Service, ns string) {
 	t.Log("##### Start test report #####")
 
 	cs, err := clientset.NewForConfig(kubeConfig(t))

--- a/tests/acceptance/servicecatalog/helpers_test.go
+++ b/tests/acceptance/servicecatalog/helpers_test.go
@@ -124,3 +124,33 @@ func fixNamespace(name string) *corev1.Namespace {
 		},
 	}
 }
+
+func serviceClassesReport(t *testing.T, services []osb.Service, ns string) {
+	t.Log("##### Start test report #####")
+
+	cs, err := clientset.NewForConfig(kubeConfig(t))
+	if err != nil {
+		t.Errorf("Cannot get clientset during creating a report: %s", err)
+	}
+
+	scs, err := cs.ServicecatalogV1beta1().ServiceClasses(ns).List(v1.ListOptions{})
+	if err != nil {
+		t.Errorf("Cannot fetch ClusterServiceClasses list during creating a report: %s", err)
+	}
+
+	t.Logf("Available Classes from Service broker (amount: %d)", len(services))
+	for _, service := range services {
+		t.Logf(" - ServiceId: %q - Service name: %q \n", service.ID, service.Name)
+	}
+
+	t.Logf("Status of ClusterServiceClasses (amount: %d)", len(scs.Items))
+	for _, sc := range scs.Items {
+		t.Logf(" - Name: %q (ExternalName: %s, ExternalId: %q) \n",
+			sc.Name,
+			sc.GetExternalName(),
+			sc.Spec.ExternalID)
+		t.Logf("   Is removed from catalog: %t", sc.Status.CommonServiceClassStatus.RemovedFromBrokerCatalog)
+	}
+
+	t.Log("#####  End test report  #####")
+}

--- a/tests/acceptance/servicecatalog/servicecatalog_test.go
+++ b/tests/acceptance/servicecatalog/servicecatalog_test.go
@@ -81,6 +81,9 @@ func TestServiceCatalogContainsABServiceClasses(t *testing.T) {
 	require.NoError(t, err)
 
 	defer func() {
+		if t.Failed() {
+			serviceClassesReport(t, brokerServices, broker.namespace)
+		}
 		err = k8sClient.Namespaces().Delete(broker.namespace, &metav1.DeleteOptions{})
 		assert.NoError(t, err)
 		err = aClient.ApplicationconnectorV1alpha1().Applications().Delete(app.Name, &metav1.DeleteOptions{

--- a/tests/acceptance/servicecatalog/servicecatalog_test.go
+++ b/tests/acceptance/servicecatalog/servicecatalog_test.go
@@ -82,7 +82,7 @@ func TestServiceCatalogContainsABServiceClasses(t *testing.T) {
 
 	defer func() {
 		if t.Failed() {
-			serviceClassesReport(t, brokerServices, broker.namespace)
+			testDetailsReport(t, brokerServices, broker.namespace)
 		}
 		err = k8sClient.Namespaces().Delete(broker.namespace, &metav1.DeleteOptions{})
 		assert.NoError(t, err)


### PR DESCRIPTION
**Description**
One of the ProwJobs reported a test error on `acceptance-test`:
```
--- FAIL: TestServiceCatalogContainsABServiceClasses (121.03s)
    servicecatalog_test.go:75: Creating Application
    servicecatalog_test.go:79: Creating Namespace test-acc-ns-broker-zwq4
    servicecatalog_test.go:93: Creating ApplicationMapping
    helpers_test.go:63: Waiting for function failed in given timeout 2m0s. Function was executed 120 times. Last error: service catalog must contains ServiceClasses for every broker service. Missing: provider-4951:id-00000-1234-test
FAIL
```
Attempts to reproduce the error on local cluster failed (For ten attempts one of them has above error). PR adds new reports logs in case of test failed which could shows the status of `ClusterServiceClasses`