### PR TITLE
Move tenant and group from CN to O and OU fields of Subject in certificates

### DIFF
--- a/components/application-operator/charts/application/templates/ingress.yaml
+++ b/components/application-operator/charts/application/templates/ingress.yaml
@@ -19,7 +19,7 @@ metadata:
     nginx.ingress.kubernetes.io/ssl-redirect: "true"
     nginx.ingress.kubernetes.io/proxy-body-size: 5m
     nginx.ingress.kubernetes.io/configuration-snippet: |
-      if ($ssl_client_s_dn !~ '(.*(OU={{ .Values.global.subjectOrganizationUnit }}(,|]|$)).*(O={{ .Values.global.subjectOrganization }}((,|]|$)).*(CN={{ .Values.global.subjectCN }}(,|]|$)).*)') {
+      if ($ssl_client_s_dn !~ {{ .Values.global.ingressValidationRule }}) {
           return 403;
       }
 spec:

--- a/components/application-operator/charts/application/templates/ingress.yaml
+++ b/components/application-operator/charts/application/templates/ingress.yaml
@@ -19,7 +19,7 @@ metadata:
     nginx.ingress.kubernetes.io/ssl-redirect: "true"
     nginx.ingress.kubernetes.io/proxy-body-size: 5m
     nginx.ingress.kubernetes.io/configuration-snippet: |
-      if ($ssl_client_s_dn !~ {{ .Values.global.ingressValidationRule }}) {
+      if ($ssl_client_s_dn !~ '{{ .Values.global.ingressValidationRule }}') {
           return 403;
       }
 spec:

--- a/components/application-operator/charts/application/templates/ingress.yaml
+++ b/components/application-operator/charts/application/templates/ingress.yaml
@@ -19,7 +19,7 @@ metadata:
     nginx.ingress.kubernetes.io/ssl-redirect: "true"
     nginx.ingress.kubernetes.io/proxy-body-size: 5m
     nginx.ingress.kubernetes.io/configuration-snippet: |
-      if ($ssl_client_s_dn !~ '(.*(CN={{ .Values.global.subjectCN }}(,|]|$)).*)') {
+      if ($ssl_client_s_dn !~ '(.*(OU={{ .Values.global.subjectOrganizationUnit }}(,|]|$)).*(O={{ .Values.global.subjectOrganization }}((,|]|$)).*(CN={{ .Values.global.subjectCN }}(,|]|$)).*)') {
           return 403;
       }
 spec:

--- a/components/application-operator/pkg/kymahelm/application/overrides.go
+++ b/components/application-operator/pkg/kymahelm/application/overrides.go
@@ -7,9 +7,7 @@ const (
     applicationGatewayTestsImage: {{ .ApplicationGatewayTestsImage }}
     eventServiceImage: {{ .EventServiceImage }}
     eventServiceTestsImage: {{ .EventServiceTestsImage }}
-    subjectCN: {{ .SubjectCN }}
-    subjectOrganization: {{ .SubjectOrganization }}
-    subjectOrganizationUnit: {{ .SubjectOrganizationUnit }}`
+    ingressValidationRule: {{ .IngressValidationRule }}`
 )
 
 type OverridesData struct {
@@ -18,7 +16,5 @@ type OverridesData struct {
 	ApplicationGatewayTestsImage string
 	EventServiceImage            string
 	EventServiceTestsImage       string
-	SubjectCN                    string
-	SubjectOrganization          string
-	SubjectOrganizationUnit      string
+	IngressValidationRule        string
 }

--- a/components/application-operator/pkg/kymahelm/application/overrides.go
+++ b/components/application-operator/pkg/kymahelm/application/overrides.go
@@ -8,8 +8,8 @@ const (
     eventServiceImage: {{ .EventServiceImage }}
     eventServiceTestsImage: {{ .EventServiceTestsImage }}
     subjectCN: {{ .SubjectCN }}
-	subjectOrganization: {{ .SubjectOrganization }}
-	subjectOrganizationUnit : {{ .SubjectOrganizationUnit }}`
+    subjectOrganization: {{ .SubjectOrganization }}
+    subjectOrganizationUnit : {{ .SubjectOrganizationUnit }}`
 )
 
 type OverridesData struct {

--- a/components/application-operator/pkg/kymahelm/application/overrides.go
+++ b/components/application-operator/pkg/kymahelm/application/overrides.go
@@ -9,7 +9,7 @@ const (
     eventServiceTestsImage: {{ .EventServiceTestsImage }}
     subjectCN: {{ .SubjectCN }}
     subjectOrganization: {{ .SubjectOrganization }}
-    subjectOrganizationUnit : {{ .SubjectOrganizationUnit }}`
+    subjectOrganizationUnit: {{ .SubjectOrganizationUnit }}`
 )
 
 type OverridesData struct {

--- a/components/application-operator/pkg/kymahelm/application/overrides.go
+++ b/components/application-operator/pkg/kymahelm/application/overrides.go
@@ -7,7 +7,9 @@ const (
     applicationGatewayTestsImage: {{ .ApplicationGatewayTestsImage }}
     eventServiceImage: {{ .EventServiceImage }}
     eventServiceTestsImage: {{ .EventServiceTestsImage }}
-    subjectCN: {{ .SubjectCN }}`
+    subjectCN: {{ .SubjectCN }}
+	subjectOrganization: {{ .SubjectOrganization }}
+	subjectOrganizationUnit : {{ .SubjectOrganizationUnit }}`
 )
 
 type OverridesData struct {
@@ -17,4 +19,6 @@ type OverridesData struct {
 	EventServiceImage            string
 	EventServiceTestsImage       string
 	SubjectCN                    string
+	SubjectOrganization          string
+	SubjectOrganizationUnit      string
 }

--- a/components/application-operator/pkg/kymahelm/application/releasemanager.go
+++ b/components/application-operator/pkg/kymahelm/application/releasemanager.go
@@ -1,13 +1,11 @@
 package application
 
 import (
-	"fmt"
-
 	"github.com/kyma-project/kyma/components/application-operator/pkg/apis/applicationconnector/v1alpha1"
 	"github.com/kyma-project/kyma/components/application-operator/pkg/kymahelm"
 	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/util/retry"
 	hapi_4 "k8s.io/helm/pkg/proto/hapi/release"
 )
@@ -104,10 +102,10 @@ func (r *releaseManager) upgradeChart(application *v1alpha1.Application) (hapi_4
 func (r *releaseManager) prepareOverrides(application *v1alpha1.Application) (string, error) {
 	overridesData := r.overridesDefaults
 	if application.Spec.HasTenant() == true && application.Spec.HasGroup() == true {
-		overridesData.SubjectCN = fmt.Sprintf("%s\\\\\\;%s\\\\\\;%s", application.Spec.Tenant, application.Spec.Group, application.Name)
-	} else {
-		overridesData.SubjectCN = application.Name
+		overridesData.SubjectOrganization = application.Spec.Tenant
+		overridesData.SubjectOrganizationUnit = application.Spec.Group
 	}
+	overridesData.SubjectCN = application.Name
 
 	return kymahelm.ParseOverrides(overridesData, overridesTemplate)
 }

--- a/components/application-operator/pkg/kymahelm/application/releasemanager.go
+++ b/components/application-operator/pkg/kymahelm/application/releasemanager.go
@@ -1,6 +1,7 @@
 package application
 
 import (
+	"fmt"
 	"github.com/kyma-project/kyma/components/application-operator/pkg/apis/applicationconnector/v1alpha1"
 	"github.com/kyma-project/kyma/components/application-operator/pkg/kymahelm"
 	"github.com/pkg/errors"
@@ -102,10 +103,10 @@ func (r *releaseManager) upgradeChart(application *v1alpha1.Application) (hapi_4
 func (r *releaseManager) prepareOverrides(application *v1alpha1.Application) (string, error) {
 	overridesData := r.overridesDefaults
 	if application.Spec.HasTenant() == true && application.Spec.HasGroup() == true {
-		overridesData.SubjectOrganization = application.Spec.Tenant
-		overridesData.SubjectOrganizationUnit = application.Spec.Group
+		overridesData.IngressValidationRule = fmt.Sprintf("%s%s%s%s%s%s%s", "'(.*(OU=", application.Spec.Group, "(,|]|$)).*(O=", application.Spec.Tenant, "((,|]|$)).*(CN=", application.Name, "(,|]|$)).*)'")
+	} else {
+		overridesData.IngressValidationRule = fmt.Sprintf("%s%s%s", "'(.*(CN=", application.Name, "(,|]|$)).*)'")
 	}
-	overridesData.SubjectCN = application.Name
 
 	return kymahelm.ParseOverrides(overridesData, overridesTemplate)
 }

--- a/components/application-operator/pkg/kymahelm/application/releasemanager.go
+++ b/components/application-operator/pkg/kymahelm/application/releasemanager.go
@@ -103,9 +103,9 @@ func (r *releaseManager) upgradeChart(application *v1alpha1.Application) (hapi_4
 func (r *releaseManager) prepareOverrides(application *v1alpha1.Application) (string, error) {
 	overridesData := r.overridesDefaults
 	if application.Spec.HasTenant() == true && application.Spec.HasGroup() == true {
-		overridesData.IngressValidationRule = fmt.Sprintf("%s%s%s%s%s%s%s", "'(.*(OU=", application.Spec.Group, "(,|]|$)).*(O=", application.Spec.Tenant, "((,|]|$)).*(CN=", application.Name, "(,|]|$)).*)'")
+		overridesData.IngressValidationRule = fmt.Sprintf("%s%s%s%s%s%s%s", "(.*(OU=", application.Spec.Group, "(,|]|$)).*(O=", application.Spec.Tenant, "((,|]|$)).*(CN=", application.Name, "(,|]|$)).*)")
 	} else {
-		overridesData.IngressValidationRule = fmt.Sprintf("%s%s%s", "'(.*(CN=", application.Name, "(,|]|$)).*)'")
+		overridesData.IngressValidationRule = fmt.Sprintf("%s%s%s", "(.*(CN=", application.Name, "(,|]|$)).*)")
 	}
 
 	return kymahelm.ParseOverrides(overridesData, overridesTemplate)

--- a/components/application-operator/pkg/kymahelm/application/releasemanager_test.go
+++ b/components/application-operator/pkg/kymahelm/application/releasemanager_test.go
@@ -101,7 +101,7 @@ func TestReleaseManager_InstallNewAppChart(t *testing.T) {
 			Spec:       v1alpha1.ApplicationSpec{Tenant: appTenant, Group: appGroup},
 		}
 
-		expectedOverrides := fmt.Sprintf(expectedOverridesFormat, "(.*(OU="+appGroup+"(,|]|$)).*(O="+appTenant+"((,|]|$)).*(CN="+appName+"(,|]|$)).*)")
+		expectedOverrides := fmt.Sprintf(expectedOverridesFormat, "(?=.*(,|^)OU="+appGroup+"(,|]|$))(?=.*(,|^)O="+appTenant+"(,|]|$))(?=.*(,|^)CN="+appName+"(,|]|$)).*")
 
 		helmClient := &helmmocks.HelmClient{}
 		helmClient.On("InstallReleaseFromChart", applicationChartDirectory, namespace, appName, expectedOverrides).Return(installationResponse, nil)

--- a/components/application-operator/pkg/kymahelm/application/releasemanager_test.go
+++ b/components/application-operator/pkg/kymahelm/application/releasemanager_test.go
@@ -21,8 +21,6 @@ import (
 
 const (
 	appName                 = "default-app"
-	appOrganization         = "default-organization"
-	appOrganizationUnit     = "default-organization-unit"
 	namespace               = "integration"
 	expectedOverridesFormat = `global:
     domainName: 
@@ -65,7 +63,7 @@ func TestReleaseManager_InstallNewAppChart(t *testing.T) {
 			},
 		}
 
-		expectedOverrides := fmt.Sprintf(expectedOverridesFormat, appName, appOrganization, appOrganizationUnit)
+		expectedOverrides := fmt.Sprintf(expectedOverridesFormat, appName, "", "")
 
 		helmClient := &helmmocks.HelmClient{}
 		helmClient.On("InstallReleaseFromChart", applicationChartDirectory, namespace, appName, expectedOverrides).Return(installationResponse, nil)
@@ -82,7 +80,7 @@ func TestReleaseManager_InstallNewAppChart(t *testing.T) {
 		helmClient.AssertExpectations(t)
 	})
 
-	t.Run("should install release with CN equal to app name", func(t *testing.T) {
+	t.Run("should install release with CN equal to app name, O equal to tenant and OU equal to group", func(t *testing.T) {
 		// given
 		installationResponse := &rls.InstallReleaseResponse{
 			Release: &hapi_release5.Release{

--- a/components/application-operator/pkg/kymahelm/application/releasemanager_test.go
+++ b/components/application-operator/pkg/kymahelm/application/releasemanager_test.go
@@ -61,7 +61,7 @@ func TestReleaseManager_InstallNewAppChart(t *testing.T) {
 			},
 		}
 
-		expectedOverrides := fmt.Sprintf(expectedOverridesFormat, fmt.Sprintf("%s%s%s", "'(.*(CN=", appName, "(,|]|$)).*)'"))
+		expectedOverrides := fmt.Sprintf(expectedOverridesFormat, "'(.*(CN="+appName+"(,|]|$)).*)'")
 
 		helmClient := &helmmocks.HelmClient{}
 		helmClient.On("InstallReleaseFromChart", applicationChartDirectory, namespace, appName, expectedOverrides).Return(installationResponse, nil)
@@ -91,12 +91,17 @@ func TestReleaseManager_InstallNewAppChart(t *testing.T) {
 			},
 		}
 
+		const (
+			appTenant = "tenant"
+			appGroup  = "group"
+		)
+
 		appWithGroupAndTenant := &v1alpha1.Application{
 			ObjectMeta: v1.ObjectMeta{Name: appName},
-			Spec:       v1alpha1.ApplicationSpec{Tenant: "tenant", Group: "group"},
+			Spec:       v1alpha1.ApplicationSpec{Tenant: appTenant, Group: appGroup},
 		}
 
-		expectedOverrides := fmt.Sprintf(expectedOverridesFormat, fmt.Sprintf("%s%s%s%s%s%s%s", "'(.*(OU=", "group", "(,|]|$)).*(O=", "tenant", "((,|]|$)).*(CN=", appName, "(,|]|$)).*)'"))
+		expectedOverrides := fmt.Sprintf(expectedOverridesFormat, "'(.*(OU="+appGroup+"(,|]|$)).*(O="+appTenant+"((,|]|$)).*(CN="+appName+"(,|]|$)).*)'")
 
 		helmClient := &helmmocks.HelmClient{}
 		helmClient.On("InstallReleaseFromChart", applicationChartDirectory, namespace, appName, expectedOverrides).Return(installationResponse, nil)

--- a/components/application-operator/pkg/kymahelm/application/releasemanager_test.go
+++ b/components/application-operator/pkg/kymahelm/application/releasemanager_test.go
@@ -28,9 +28,7 @@ const (
     applicationGatewayTestsImage: 
     eventServiceImage: 
     eventServiceTestsImage: 
-    subjectCN: %s
-    subjectOrganization: %s
-    subjectOrganizationUnit: %s`
+    ingressValidationRule: %s`
 )
 
 var (
@@ -63,7 +61,7 @@ func TestReleaseManager_InstallNewAppChart(t *testing.T) {
 			},
 		}
 
-		expectedOverrides := fmt.Sprintf(expectedOverridesFormat, appName, "", "")
+		expectedOverrides := fmt.Sprintf(expectedOverridesFormat, fmt.Sprintf("%s%s%s", "'(.*(CN=", appName, "(,|]|$)).*)'"))
 
 		helmClient := &helmmocks.HelmClient{}
 		helmClient.On("InstallReleaseFromChart", applicationChartDirectory, namespace, appName, expectedOverrides).Return(installationResponse, nil)
@@ -98,7 +96,7 @@ func TestReleaseManager_InstallNewAppChart(t *testing.T) {
 			Spec:       v1alpha1.ApplicationSpec{Tenant: "tenant", Group: "group"},
 		}
 
-		expectedOverrides := fmt.Sprintf(expectedOverridesFormat, "default-app", "tenant", "group")
+		expectedOverrides := fmt.Sprintf(expectedOverridesFormat, fmt.Sprintf("%s%s%s%s%s%s%s", "'(.*(OU=", "group", "(,|]|$)).*(O=", "tenant", "((,|]|$)).*(CN=", appName, "(,|]|$)).*)'"))
 
 		helmClient := &helmmocks.HelmClient{}
 		helmClient.On("InstallReleaseFromChart", applicationChartDirectory, namespace, appName, expectedOverrides).Return(installationResponse, nil)

--- a/components/application-operator/pkg/kymahelm/application/releasemanager_test.go
+++ b/components/application-operator/pkg/kymahelm/application/releasemanager_test.go
@@ -61,7 +61,7 @@ func TestReleaseManager_InstallNewAppChart(t *testing.T) {
 			},
 		}
 
-		expectedOverrides := fmt.Sprintf(expectedOverridesFormat, "'(.*(CN="+appName+"(,|]|$)).*)'")
+		expectedOverrides := fmt.Sprintf(expectedOverridesFormat, "(.*(CN="+appName+"(,|]|$)).*)")
 
 		helmClient := &helmmocks.HelmClient{}
 		helmClient.On("InstallReleaseFromChart", applicationChartDirectory, namespace, appName, expectedOverrides).Return(installationResponse, nil)
@@ -101,7 +101,7 @@ func TestReleaseManager_InstallNewAppChart(t *testing.T) {
 			Spec:       v1alpha1.ApplicationSpec{Tenant: appTenant, Group: appGroup},
 		}
 
-		expectedOverrides := fmt.Sprintf(expectedOverridesFormat, "'(.*(OU="+appGroup+"(,|]|$)).*(O="+appTenant+"((,|]|$)).*(CN="+appName+"(,|]|$)).*)'")
+		expectedOverrides := fmt.Sprintf(expectedOverridesFormat, "(.*(OU="+appGroup+"(,|]|$)).*(O="+appTenant+"((,|]|$)).*(CN="+appName+"(,|]|$)).*)")
 
 		helmClient := &helmmocks.HelmClient{}
 		helmClient.On("InstallReleaseFromChart", applicationChartDirectory, namespace, appName, expectedOverrides).Return(installationResponse, nil)

--- a/components/application-operator/pkg/kymahelm/application/releasemanager_test.go
+++ b/components/application-operator/pkg/kymahelm/application/releasemanager_test.go
@@ -21,6 +21,8 @@ import (
 
 const (
 	appName                 = "default-app"
+	appOrganization         = "default-organization"
+	appOrganizationUnit     = "default-organization-unit"
 	namespace               = "integration"
 	expectedOverridesFormat = `global:
     domainName: 
@@ -28,7 +30,9 @@ const (
     applicationGatewayTestsImage: 
     eventServiceImage: 
     eventServiceTestsImage: 
-    subjectCN: %s`
+    subjectCN: %s
+    subjectOrganization: %s
+    subjectOrganizationUnit: %s`
 )
 
 var (
@@ -61,7 +65,7 @@ func TestReleaseManager_InstallNewAppChart(t *testing.T) {
 			},
 		}
 
-		expectedOverrides := fmt.Sprintf(expectedOverridesFormat, appName)
+		expectedOverrides := fmt.Sprintf(expectedOverridesFormat, appName, appOrganization, appOrganizationUnit)
 
 		helmClient := &helmmocks.HelmClient{}
 		helmClient.On("InstallReleaseFromChart", applicationChartDirectory, namespace, appName, expectedOverrides).Return(installationResponse, nil)
@@ -96,7 +100,7 @@ func TestReleaseManager_InstallNewAppChart(t *testing.T) {
 			Spec:       v1alpha1.ApplicationSpec{Tenant: "tenant", Group: "group"},
 		}
 
-		expectedOverrides := fmt.Sprintf(expectedOverridesFormat, "tenant\\\\\\;group\\\\\\;default-app")
+		expectedOverrides := fmt.Sprintf(expectedOverridesFormat, "default-app", "tenant", "group")
 
 		helmClient := &helmmocks.HelmClient{}
 		helmClient.On("InstallReleaseFromChart", applicationChartDirectory, namespace, appName, expectedOverrides).Return(installationResponse, nil)


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Move tenant and group from CN to O and OU fields of Subject in certificates

**Related issue(s)**

See the issue #3707 
See the bump [#3734](https://github.com/kyma-project/kyma/pull/3724)
