### PR TITLE
Add additional flag for reading root CA Certificate

### DIFF
--- a/components/connector-service/cmd/connectorservice/handlers.go
+++ b/components/connector-service/cmd/connectorservice/handlers.go
@@ -2,6 +2,9 @@ package main
 
 import (
 	"fmt"
+	"net/http"
+	"time"
+
 	"github.com/gorilla/mux"
 	"github.com/kyma-project/kyma/components/connector-service/internal/apperrors"
 	"github.com/kyma-project/kyma/components/connector-service/internal/certificates"
@@ -18,8 +21,6 @@ import (
 	log "github.com/sirupsen/logrus"
 	"k8s.io/client-go/kubernetes"
 	restclient "k8s.io/client-go/rest"
-	"net/http"
-	"time"
 )
 
 const (
@@ -70,7 +71,7 @@ func newExternalHandler(tokenManager tokens.Manager, tokenCreatorProvider tokens
 		Province:           env.province,
 	}
 
-	appCertificateService := certificates.NewCertificateService(secretsRepository, certificates.NewCertificateUtility(opts.appCertificateValidityTime), opts.caSecretName, subjectValues)
+	appCertificateService := certificates.NewCertificateService(secretsRepository, certificates.NewCertificateUtility(opts.appCertificateValidityTime), opts.caSecretName, opts.rootCACertificateSecretName, subjectValues)
 
 	appTokenResolverMiddleware := middlewares.NewTokenResolverMiddleware(tokenManager, clientcontext.NewApplicationContextExtender)
 	clusterTokenResolverMiddleware := middlewares.NewTokenResolverMiddleware(tokenManager, clientcontext.NewClusterContextExtender)
@@ -104,7 +105,7 @@ func newExternalHandler(tokenManager tokens.Manager, tokenCreatorProvider tokens
 	handlerBuilder.WithApps(appHandlerConfig)
 
 	if opts.central {
-		runtimeCertificateService := certificates.NewCertificateService(secretsRepository, certificates.NewCertificateUtility(opts.runtimeCertificateValidityTime), opts.caSecretName, subjectValues)
+		runtimeCertificateService := certificates.NewCertificateService(secretsRepository, certificates.NewCertificateUtility(opts.runtimeCertificateValidityTime), opts.caSecretName, opts.rootCACertificateSecretName, subjectValues)
 		runtimeTokenTTLMinutes := time.Duration(opts.runtimeTokenExpirationMinutes) * time.Minute
 
 		runtimeHandlerConfig := externalapi.Config{

--- a/components/connector-service/cmd/connectorservice/options.go
+++ b/components/connector-service/cmd/connectorservice/options.go
@@ -21,6 +21,7 @@ type options struct {
 	appTokenExpirationMinutes      int
 	runtimeTokenExpirationMinutes  int
 	caSecretName                   string
+	rootCACertificateSecretName    string
 	requestLogging                 bool
 	connectorServiceHost           string
 	gatewayHost                    string
@@ -51,7 +52,8 @@ func parseArgs() *options {
 	tokenLength := flag.Int("tokenLength", 64, "Length of a registration tokens.")
 	appTokenExpirationMinutes := flag.Int("appTokenExpirationMinutes", 5, "Time to Live of application tokens expressed in minutes.")
 	runtimeTokenExpirationMinutes := flag.Int("runtimeTokenExpirationMinutes", 10, "Time to Live of runtime tokens expressed in minutes.")
-	caSecretName := flag.String("caSecretName", "nginx-auth-ca", "Name of the secret which contains root CA.")
+	caSecretName := flag.String("caSecretName", "nginx-auth-ca", "Name of the secret which contains certificate and key used for signing client certificates.")
+	rootCACertificateSecretName := flag.String("rootCACertificateSecretName", "", "Name of the secret which contains root CA Certificate in case certificates are singed by intermediate CA.")
 	requestLogging := flag.Bool("requestLogging", false, "Flag for logging incoming requests.")
 	connectorServiceHost := flag.String("connectorServiceHost", "cert-service.wormhole.cluster.kyma.cx", "Host at which this service is accessible.")
 	gatewayHost := flag.String("gatewayHost", "gateway.wormhole.cluster.kyma.cx", "Host at which gateway service is accessible.")
@@ -86,6 +88,7 @@ func parseArgs() *options {
 		appTokenExpirationMinutes:      *appTokenExpirationMinutes,
 		runtimeTokenExpirationMinutes:  *runtimeTokenExpirationMinutes,
 		caSecretName:                   *caSecretName,
+		rootCACertificateSecretName:    *rootCACertificateSecretName,
 		requestLogging:                 *requestLogging,
 		connectorServiceHost:           *connectorServiceHost,
 		gatewayHost:                    *gatewayHost,
@@ -103,12 +106,12 @@ func parseArgs() *options {
 
 func (o *options) String() string {
 	return fmt.Sprintf("--appName=%s --externalAPIPort=%d --internalAPIPort=%d --namespace=%s --tokenLength=%d "+
-		"--appTokenExpirationMinutes=%d --runtimeTokenExpirationMinutes=%d --caSecretName=%s --requestLogging=%t "+
+		"--appTokenExpirationMinutes=%d --runtimeTokenExpirationMinutes=%d --caSecretName=%s --rootCACertificateSecretName=%s --requestLogging=%t "+
 		"--connectorServiceHost=%s --certificateProtectedHost=%s --gatewayHost=%s "+
 		"--appsInfoURL=%s --runtimesInfoURL=%s --central=%t --appCertificateValidityTime=%s --runtimeCertificateValidityTime=%s "+
 		"--revocationConfigMapName=%s --lookupEnabled=%t --lookupConfigMapPath=%s",
 		o.appName, o.externalAPIPort, o.internalAPIPort, o.namespace, o.tokenLength,
-		o.appTokenExpirationMinutes, o.runtimeTokenExpirationMinutes, o.caSecretName, o.requestLogging,
+		o.appTokenExpirationMinutes, o.runtimeTokenExpirationMinutes, o.caSecretName, o.rootCACertificateSecretName, o.requestLogging,
 		o.connectorServiceHost, o.certificateProtectedHost, o.gatewayHost,
 		o.appsInfoURL, o.runtimesInfoURL, o.central, o.appCertificateValidityTime, o.runtimeCertificateValidityTime,
 		o.revocationConfigMapName, o.lookupEnabled, o.lookupConfigMapPath)


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/master/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

In case that client certificates are signed by an intermediate certificate, we want to add the possibility to return the root CA Certificate.

Changes proposed in this pull request:

- Return root CA Certificate if the secret provided

**Related issue(s)**
#3717