### PR TITLE
Bump version of HelmBroker bundles to 0.4.0

### DIFF
--- a/resources/helm-broker/templates/cfg-repos-url.yaml
+++ b/resources/helm-broker/templates/cfg-repos-url.yaml
@@ -8,4 +8,4 @@ metadata:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     helm-broker-repo: "true"
 data:
-  URLs: "https://github.com/kyma-project/bundles/releases/download/0.3.1/"
+  URLs: "https://github.com/kyma-project/bundles/releases/download/0.4.0/"


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Bundles bumped to [0.4.0](https://github.com/kyma-project/bundles/releases/tag/0.4.0)

**Related issue(s)**
* #2877
