### PR TITLE
Improve testing.sh and bump Octopus version

### DIFF
--- a/installation/resources/installer-cr-cluster.yaml.tpl
+++ b/installation/resources/installer-cr-cluster.yaml.tpl
@@ -12,6 +12,8 @@ spec:
   components:
     - name: "cluster-essentials"
       namespace: "kyma-system"
+    - name: "testing"
+      namespace: "kyma-system"
     - name: "istio-init"
       namespace: "istio-system"
     - name: "istio"
@@ -24,8 +26,6 @@ spec:
       namespace: "knative-eventing"
     - name: "istio-kyma-patch"
       namespace: "istio-system"
-    - name: "testing"
-      namespace: "kyma-system"
     - name: "prometheus-operator"
       namespace: "kyma-system"
     - name: "dex"

--- a/installation/resources/installer-cr.yaml.tpl
+++ b/installation/resources/installer-cr.yaml.tpl
@@ -12,6 +12,8 @@ spec:
   components:
     - name: "cluster-essentials"
       namespace: "kyma-system"
+    - name: "testing"
+      namespace: "kyma-system"
     - name: "istio-init"
       namespace: "istio-system"
     - name: "istio"
@@ -26,8 +28,6 @@ spec:
       namespace: "istio-system"
     # - name: "prometheus-operator"
     # namespace: "kyma-system"
-    - name: "testing"
-      namespace: "kyma-system"
     - name: "dex"
       namespace: "kyma-system"
     - name: "service-catalog"

--- a/installation/scripts/testing.sh
+++ b/installation/scripts/testing.sh
@@ -10,7 +10,7 @@ echo "----------------------------"
 
 kc="kubectl $(context_arg)"
 
-${kc} get clustertestsuites.testing.kyma-project.io
+${kc} get clustertestsuites.testing.kyma-project.io > /dev/null 2>&1
 if [[ $? -eq 1 ]]
 then
    echo "ERROR: script requires ClusterTestSuite CRD"
@@ -67,14 +67,14 @@ do
     sleep 60
 done
 
-echo "ClusterTestSuite details:"
-kubectl get cts ${suiteName} -oyaml
-
 echo "Test summary"
-kubectl get cts  ${suiteName} -o=go-template --template='{{range .status.results}}{{printf "Test status: %s - %s\n" .name .status}}{{end}}'
+kubectl get cts  ${suiteName} -o=go-template --template='{{range .status.results}}{{printf "Test status: %s - %s" .name .status }}{{ if gt (len .executions) 1 }}{{ print " (Retried)" }}{{end}}{{print "\n"}}{{end}}'
 
 waitForTerminationAndPrintLogs ${suiteName}
 cleanupExitCode=$?
+
+echo "ClusterTestSuite details:"
+kubectl get cts ${suiteName} -oyaml
 
 kubectl delete cts ${suiteName}
 

--- a/resources/testing/charts/octopus/templates/manager.yaml
+++ b/resources/testing/charts/octopus/templates/manager.yaml
@@ -39,7 +39,7 @@ spec:
   template:
     metadata:
       annotations:
-        sidecar.istio.io/inject: "true"
+        sidecar.istio.io/inject: "false"
       labels:
         app: {{ template "octopus.name" . }}
         control-plane: controller-manager

--- a/resources/testing/charts/octopus/templates/manager.yaml
+++ b/resources/testing/charts/octopus/templates/manager.yaml
@@ -39,8 +39,7 @@ spec:
   template:
     metadata:
       annotations:
-        # TODO: to discuss
-        status.sidecar.istio.io/port: "0"
+        sidecar.istio.io/inject: "true"
       labels:
         app: {{ template "octopus.name" . }}
         control-plane: controller-manager

--- a/resources/testing/values.yaml
+++ b/resources/testing/values.yaml
@@ -3,4 +3,4 @@ global:
     image:
       registry: eu.gcr.io/kyma-project/incubator
       dir: develop/
-      version: dc5dc284
+      version: c919e4ae


### PR DESCRIPTION
- improve testing.sh script - better output
- install Octopus after cluster-essential component - thanks to that we allow to define tests for Knative Serving (https://github.com/kyma-project/kyma/pull/3661)
- disable sidecar on Octopus - because it is installed before istio
- upgrade Octopus version to the latest version (selective testing will be possible)