### PR TITLE
Ignore Octopus test pods in Alert Manager

### DIFF
--- a/resources/monitoring/charts/alert-rules/templates/kyma-rules.yaml
+++ b/resources/monitoring/charts/alert-rules/templates/kyma-rules.yaml
@@ -14,7 +14,7 @@ spec:
   - name: pod-not-running-rule
     rules:
     - alert: SystemPodNotRunning
-      expr: sum(kube_pod_container_status_running { namespace=~"kyma-.*|kube-.*|istio-.*|natss", pod!~"(test.*)|((dummy|sample)-.*)|(.*(docs|backup|test)-.*)|(.*-(tests|dummy))" } == 0 )by (pod,namespace) * on(pod, namespace) (kube_pod_status_phase{phase="Succeeded"} != 1)
+      expr: sum(kube_pod_container_status_running { namespace=~"kyma-.*|kube-.*|istio-.*|natss", pod!~"(test.*)|((dummy|sample)-.*)|(.*(docs|backup|test)-.*)|((oct-tp-testsuite-all)-.*)|(.*-(tests|dummy))" } == 0 )by (pod,namespace) * on(pod, namespace) (kube_pod_status_phase{phase="Succeeded"} != 1)
       for: 60s
       labels:
         severity: critical


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/master/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

The Alert Manager is reporting that `oct-tp-testsuite-all-2019-04-19-06-52-application-registry-tests-0` Pod is not running. The new test pod name does not match the regex which should exclude such pods.

Changes proposed in this pull request:

- Regex updated to ignore pods starting with `oct-tp-testsuite-all`

**Related issue(s)**
#3798
