### PR TITLE
Fix e2e-testing script

### DIFF
--- a/installation/scripts/e2e-testing.sh
+++ b/installation/scripts/e2e-testing.sh
@@ -4,6 +4,12 @@ source "${ROOT_PATH}/utils.sh"
 
 #copied from  testing-common.sh: in testing-common.sh we use Octopus, here helm test. TODO later: rewrite e2e-testing to Octopus.
 
+function context_arg() {
+    if [ -n "$KUBE_CONTEXT" ]; then
+        echo "--context $KUBE_CONTEXT"
+    fi
+}
+
 function cleanupHelmTestPods() {
     local namespace=$1
 


### PR DESCRIPTION
When migrating to Octopus testing framework, I removed dependency to `testing-common.sh` script and moved required methods directly to `e2e-testing.sh`

This caused that job `kyma-gke-end-to-end-test-backup-restore` failed:
```
./e2e-testing.sh: line 11: context_arg: command not found
./e2e-testing.sh: line 78: context_arg: command not found
./e2e-testing.sh: line 80: context_arg: command not found
./e2e-testing.sh: line 36: context_arg: command not found
./e2e-testing.sh: line 40: context_arg: command not found
./e2e-testing.sh: line 25: context_arg: command not found
./e2e-testing.sh: line 123: context_arg: command not found
./e2e-testing.sh: line 125: context_arg: command not found
./e2e-testing.sh: line 128: context_arg: command not found
./e2e-testing.sh: line 11: context_arg: command not found
```