### PR TITLE
Disable autoscaler in ingressagteway for minikube

### DIFF
--- a/installation/resources/installer-config-local.yaml.tpl
+++ b/installation/resources/installer-config-local.yaml.tpl
@@ -52,6 +52,7 @@ metadata:
 data:
   gateways.istio-ingressgateway.loadBalancerIP: ""
   gateways.istio-ingressgateway.type: "NodePort"
+  gateways.istio-ingressgateway.autoscaleEnabled: "false"
 
   pilot.resources.limits.memory: 1024Mi
   pilot.resources.limits.cpu: 200m


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/master/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

On minikube ingressagateway has hostPort allocated. This makes autoscaling senseless as additional pods are not able to start. 

Changes proposed in this pull request:

- disable autoscaling for ingressgateway on minikube

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
