### PR TITLE
Handle a lack of static users in testing.sh script

### DIFF
--- a/installation/resources/test-selector.yaml.tpl
+++ b/installation/resources/test-selector.yaml.tpl
@@ -1,0 +1,6 @@
+  selectors:
+    matchNames:
+{{- range .items}}
+      - name: {{.metadata.name}}
+        namespace: {{.metadata.namespace}}
+{{- end}}

--- a/installation/scripts/testing.sh
+++ b/installation/scripts/testing.sh
@@ -23,8 +23,9 @@ ${kc} get cm dex-config -n kyma-system -ojsonpath="{.data}" | grep --silent "#__
 if [[ $? -eq 1 ]]
 then
   # if static users are not available, do not execute tests which requires them
-  matchTests=$(${kc} get testdefinitions --all-namespaces -l 'require-static-users!=true' -o=go-template --template='{{println "  selectors:"}}{{println "    matchNames:"}}{{range .items}}{{printf "      - name: %s\n" .metadata.name}}{{printf "        namespace: %s\n" .metadata.namespace}}{{end}}')
-  echo "WARNING: some tests will be skipped due to the lack of static users"
+  matchTests=$(${kc} get testdefinitions --all-namespaces -l 'require-static-users!=true' -o=go-template-file --template='./../resources/test-selector.yaml.tpl')
+  echo "WARNING: following tests will be skipped due to the lack of static users:"
+  echo "$(${kc} get testdefinitions --all-namespaces -l 'require-static-users=true' -o=go-template --template='{{- range .items}}{{printf " - %s\n" .metadata.name}}{{- end}}')"
 fi
 
 cat <<EOF | ${kc} apply -f -

--- a/installation/scripts/testing.sh
+++ b/installation/scripts/testing.sh
@@ -17,6 +17,16 @@ then
    exit 1
 fi
 
+matchTests="" # match all tests
+
+${kc} get cm dex-config -n kyma-system -ojsonpath="{.data}" | grep --silent "#__STATIC_PASSWORDS__"
+if [[ $? -eq 1 ]]
+then
+  # if static users are not available, do not execute tests which requires them
+  matchTests=$(${kc} get testdefinitions --all-namespaces -l 'require-static-users!=true' -o=go-template --template='{{println "  selectors:"}}{{println "    matchNames:"}}{{range .items}}{{printf "      - name: %s\n" .metadata.name}}{{printf "        namespace: %s\n" .metadata.namespace}}{{end}}')
+  echo "WARNING: some tests will be skipped due to the lack of static users"
+fi
+
 cat <<EOF | ${kc} apply -f -
 apiVersion: testing.kyma-project.io/v1alpha1
 kind: ClusterTestSuite
@@ -27,6 +37,7 @@ metadata:
 spec:
   maxRetries: 1
   concurrency: 1
+${matchTests}
 EOF
 
 startTime=$(date +%s)

--- a/resources/core/charts/apiserver-proxy/templates/tests/test-apiserver-proxy.yaml
+++ b/resources/core/charts/apiserver-proxy/templates/tests/test-apiserver-proxy.yaml
@@ -6,6 +6,8 @@ kind: TestDefinition
 metadata:
   name: test-{{ .Release.Name }}-apiserver-proxy
   namespace: kyma-system
+  labels:
+    require-static-users: "true" # the test will fail if run on the cluster without static users
 spec:
   template:
     metadata:


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/master/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->
 
**Description**

Changes proposed in this pull request:

- change testing.sh behaviour to not run tests requiring static users if these are disabled
- add `require-static-users` label to the TestDefinition for apiserver-proxy tests

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
See also #3350 
