### PR TITLE
Bring back new line at the end of installer.yaml

### DIFF
--- a/installation/resources/installer.yaml
+++ b/installation/resources/installer.yaml
@@ -276,3 +276,4 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
   name: kyma-installer-reader
+  


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- new line added at the end of `installer.yaml`

Reverts change made 26 days ago https://github.com/kyma-project/kyma/commit/863ea6d542a95d377ab7f8d5c5c05eb3f2b368e0#diff-aa145328b6fcd1e0a597d26f84d11a02R278

It's needed, because during [installation](https://kyma-project.io/docs/master/root/kyma/#using-your-own-image) we append some additional sections to this file and it ends up in the last line of installer.yaml.
```
(cat installation/resources/installer.yaml ; echo "---"  ....
```
I wonder how we missed that :/ 

**Related issue(s)**
* #3893