### PR TITLE
Remove deprecated kubectl flag --show-all

### DIFF
--- a/installation/scripts/e2e-testing.sh
+++ b/installation/scripts/e2e-testing.sh
@@ -39,7 +39,7 @@ function printLogsFromPod() {
 function printLogsFromFailedHelmTests() {
     local namespace=$1
 
-    for POD in $(kubectl $(context_arg)  get pods -n ${namespace} -l helm-chart-test=true --show-all -o jsonpath='{.items[*].metadata.name}')
+    for POD in $(kubectl $(context_arg)  get pods -n ${namespace} -l helm-chart-test=true -o jsonpath='{.items[*].metadata.name}')
     do
         log "Testing '${POD}'" nc bold
 
@@ -81,7 +81,7 @@ function checkTestPodTerminated() {
 
     runningPods=false
 
-    for POD in $(kubectl $(context_arg)  get pods -n ${namespace} -l helm-chart-test=true --show-all -o jsonpath='{.items[*].metadata.name}')
+    for POD in $(kubectl $(context_arg)  get pods -n ${namespace} -l helm-chart-test=true -o jsonpath='{.items[*].metadata.name}')
     do
         phase=$(kubectl $(context_arg)  get pod "$POD" -n ${namespace} -o jsonpath="{ .status.phase }")
         # A Pod's phase  Failed or Succeeded means pod has terminated.
@@ -126,7 +126,7 @@ function checkTestPodLabel() {
     err=false
 
     log "Test pods should be marked with label 'helm-chart-test=true'. Checking..." nc bold
-    for POD in $(kubectl $(context_arg)  get pods -n ${namespace} --show-all -o jsonpath='{.items[*].metadata.name}')
+    for POD in $(kubectl $(context_arg)  get pods -n ${namespace} -o jsonpath='{.items[*].metadata.name}')
     do
         annotation=$(kubectl $(context_arg)  get pod "$POD" -n ${namespace} -o jsonpath="{ .metadata.annotations.helm\.sh/hook }")
         if [ "${annotation}" == "test-success" ] || [ "${annotation}" == "test-failure" ]

--- a/installation/scripts/testing-common.sh
+++ b/installation/scripts/testing-common.sh
@@ -12,8 +12,7 @@ function cmdGetPodsForSuite() {
     cmd="kubectl $(context_arg) get pods -l testing.kyma-project.io/suite-name=${suiteName} \
             --all-namespaces \
             --no-headers=true \
-            -o=custom-columns=name:metadata.name,ns:metadata.namespace \
-            --show-all=true"
+            -o=custom-columns=name:metadata.name,ns:metadata.namespace"
     echo $cmd
 }
 

--- a/tests/gateway-tests/README.md
+++ b/tests/gateway-tests/README.md
@@ -36,9 +36,9 @@ RUNNING: test-ec-default-acceptance
 PASSED: test-ec-default-acceptance
 ```
 
-3. To see the logs, find the pod, that ran tests using `kubectl get po --show-all`. It'll be in `Completed` state.
+3. To see the logs, find the pod, that ran tests using `kubectl get po`. It'll be in `Completed` state.
 ```sh
-$ kubectl get po --show-all
+$ kubectl get po
 NAME                                  READY     STATUS      RESTARTS   AGE
 ec-default-gateway-5dffff49f-drr7n    2/2       Running     0          1h
 hmc-default-gateway-669965894-5wwv8   2/2       Running     0          3h


### PR DESCRIPTION
**Description**

Starting from kubernetes v1.10 kubectl flag **--show-all** (also **-a**) has been deprecated. Now --show-all is [default behaviour ](https://github.com/kubernetes/kubernetes/issues/67895#issuecomment-416785762) and removing the flag [doesn't affect](https://v1-12.docs.kubernetes.io/docs/reference/generated/kubectl/kubectl-commands) results. 
In v1.14 (latest stable release) it was [removed](https://kubernetes.io/docs/setup/release/notes/#no-really-you-must-read-this-before-you-upgrade) entirely and executing commands with this flag will lead to the error:

> kubectl get po -n kyma-system --show-all
Error: unknown flag: --show-all

<br></br>
**Changes proposed in this pull request**

As kyma [requires](https://kyma-project.io/docs/root/kyma/#installation-install-kyma-on-a-cluster) kubernetes v1.12 this flag can be safely removed from the code.
