### PR TITLE
Add roles and configurations to access knative serving and eventing resources

### DIFF
--- a/resources/core/charts/cluster-users/templates/clusterroles-knative-eventing.yaml
+++ b/resources/core/charts/cluster-users/templates/clusterroles-knative-eventing.yaml
@@ -1,0 +1,58 @@
+---
+#View access to knative-eventing resources
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRole
+metadata:
+  name: kyma-knative-eventing-view
+  labels:
+    app: kyma
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    rbac.authorization.kyma-project.io/aggregate-to-kyma-knative-eventing-view: "true"
+  annotations:
+    "helm.sh/hook-weight": "0"
+rules:
+- apiGroups:
+    - "eventing.knative.dev"
+  resources:
+    - "*"
+  verbs:
+{{ toYaml .Values.clusterRoles.verbs.view | indent 4 }}
+
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRole
+metadata:
+  name: kyma-knative-eventing-admin
+  labels:
+    app: kyma
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    rbac.authorization.kyma-project.io/aggregate-to-kyma-knative-eventing-admin: "true"
+  annotations:
+    "helm.sh/hook-weight": "0"
+rules:
+- apiGroups:
+    - "eventing.knative.dev"
+  resources:
+    - "*"
+  verbs:
+    - "*"
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: kyma-knative-eventing-edit
+  labels:
+    app: kyma
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    rbac.authorization.kyma-project.io/aggregate-to-kyma-knative-eventing-edit: "true"
+  annotations:
+    "helm.sh/hook-weight": "0"
+rules:
+- apiGroups:
+    - "eventing.knative.dev"
+  resources:
+    - "*"
+  verbs:
+{{ toYaml .Values.clusterRoles.verbs.edit | indent 4 }}
+

--- a/resources/core/charts/cluster-users/templates/clusterroles-knative-serving.yaml
+++ b/resources/core/charts/cluster-users/templates/clusterroles-knative-serving.yaml
@@ -1,0 +1,66 @@
+---
+#View access to knative-serving resources
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRole
+metadata:
+  name: kyma-knative-serving-view
+  labels:
+    app: kyma
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    rbac.authorization.kyma-project.io/aggregate-to-kyma-knative-serving-view: "true"
+  annotations:
+    "helm.sh/hook-weight": "0"
+rules:
+- apiGroups:
+    - "serving.knative.dev"
+    - "autoscaling.internal.knative.dev"
+    - "networking.internal.knative.dev"
+    - "caching.internal.knative.dev"
+  resources:
+    - "*"
+  verbs:
+{{ toYaml .Values.clusterRoles.verbs.view | indent 4 }}
+
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRole
+metadata:
+  name: kyma-knative-serving-admin
+  labels:
+    app: kyma
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    rbac.authorization.kyma-project.io/aggregate-to-kyma-knative-serving-admin: "true"
+  annotations:
+    "helm.sh/hook-weight": "0"
+rules:
+- apiGroups:
+    - "serving.knative.dev"
+    - "autoscaling.internal.knative.dev"
+    - "networking.internal.knative.dev"
+    - "caching.internal.knative.dev"
+  resources:
+    - "*"
+  verbs:
+    - "*"
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: kyma-knative-serving-edit
+  labels:
+    app: kyma
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    rbac.authorization.kyma-project.io/aggregate-to-kyma-knative-serving-edit: "true"
+  annotations:
+    "helm.sh/hook-weight": "0"
+rules:
+- apiGroups:
+    - "serving.knative.dev"
+    - "autoscaling.internal.knative.dev"
+    - "networking.internal.knative.dev"
+    - "caching.internal.knative.dev"
+  resources:
+    - "*"
+  verbs:
+{{ toYaml .Values.clusterRoles.verbs.edit | indent 4 }}

--- a/resources/core/charts/cluster-users/templates/rbac-roles.yaml
+++ b/resources/core/charts/cluster-users/templates/rbac-roles.yaml
@@ -119,6 +119,10 @@ aggregationRule:
       rbac.authorization.kyma-project.io/aggregate-to-kyma-k8s-view: "true"
   - matchLabels:
       rbac.authorization.kyma-project.io/aggregate-to-kyma-kubeless-view: "true"
+  - matchLabels:
+      rbac.authorization.kyma-project.io/aggregate-to-kyma-knative-serving-view: "true"
+  - matchLabels:
+      rbac.authorization.kyma-project.io/aggregate-to-kyma-knative-eventing-view: "true"
 rules: []
 
 ---
@@ -168,6 +172,10 @@ aggregationRule:
       rbac.authorization.kyma-project.io/aggregate-to-kyma-istio-edit: "true"
   - matchLabels:
       rbac.authorization.kyma-project.io/aggregate-to-kyma-kubeless-edit: "true"
+  - matchLabels:
+      rbac.authorization.kyma-project.io/aggregate-to-kyma-knative-serving-edit: "true"
+  - matchLabels:
+      rbac.authorization.kyma-project.io/aggregate-to-kyma-knative-eventing-edit: "true"
 rules: []
 
 ---
@@ -226,6 +234,10 @@ aggregationRule:
       rbac.authorization.kyma-project.io/aggregate-to-kyma-istio-admin: "true"
   - matchLabels:
       rbac.authorization.kyma-project.io/aggregate-to-kyma-kubeless-admin: "true"
+  - matchLabels:
+      rbac.authorization.kyma-project.io/aggregate-to-kyma-knative-serving-admin: "true"
+  - matchLabels:
+      rbac.authorization.kyma-project.io/aggregate-to-kyma-knative-eventing-admin: "true"
 rules: []
 
 ---


### PR DESCRIPTION
**Description**
- Create two sets of role definitions clusterroles-knative-eventing.yaml and clusterroles-knative-serving.yaml
- Bind the roles to Kyma standard roles in rbac-roles.yaml

**Related issue(s)**
See also #3780 