### PR TITLE
Remove FOSSA from README file

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,6 @@
 [![Go Report Card](https://goreportcard.com/badge/kyma-project/kyma)](https://goreportcard.com/report/github.com/kyma-project/kyma)
 [![Slack](https://img.shields.io/badge/slack-@kyma--community-yellow.svg)](http://slack.kyma-project.io)
 [![Twitter](https://img.shields.io/badge/twitter-@kymaproject-blue.svg)](https://twitter.com/kymaproject)
-[![FOSSA Status](https://app.fossa.io/api/projects/git%2Bgithub.com%2Fkyma-project%2Fkyma.svg?type=shield)](https://app.fossa.io/projects/git%2Bgithub.com%2Fkyma-project%2Fkyma?ref=badge_shield)
 
 
 ## Overview
@@ -77,6 +76,3 @@ The repository has the following structure:
   ├── tests                       # Acceptance tests
   └── tools                       # Source code of utilities used, for example, for the installation and testing
   ```
-
-## License
-[![FOSSA Status](https://app.fossa.io/api/projects/git%2Bgithub.com%2Fkyma-project%2Fkyma.svg?type=large)](https://app.fossa.io/projects/git%2Bgithub.com%2Fkyma-project%2Fkyma?ref=badge_large)


### PR DESCRIPTION
**Description**

The FOSSA License scan continuously reports false positives based on text matches of words that could be linked to a license, and resolving the false positives are not being remembered, so that the license scan will be again shown as failing after some time.

Since we expect more visibility of Kyma, this will be removed from the README file to avoid a negative impression due to false positives.

**Related issue(s)**

