### PR TITLE
Refactor serverless documentation

### DIFF
--- a/docs/serverless/docs/01-01-serverless.md
+++ b/docs/serverless/docs/01-01-serverless.md
@@ -10,10 +10,11 @@ Lambdas or lambda functions are small functions that run in Kyma in a cost-effic
 This is an example lambda function:
 
 ```
-def myfunction (event, context):
-  print event
-  return event['data']
-
+module.exports = {
+  foo: function (event, context) {
+    return 'hello world!';
+  }
+}
 ```
 
 The use of lambdas in Kyma addresses several scenarios:  

--- a/docs/serverless/docs/01-01-serverless.md
+++ b/docs/serverless/docs/01-01-serverless.md
@@ -11,7 +11,7 @@ This is an example lambda function:
 
 ```
 module.exports = {
-  foo: function (event, context) {
+  main: function (event, context) {
     return 'hello world!';
   }
 }

--- a/docs/serverless/docs/07-01-cli-reference.md
+++ b/docs/serverless/docs/07-01-cli-reference.md
@@ -44,7 +44,7 @@ kubeless function list hello
 You can deploy a function using the Kubernetes and Kubeless CLI. See the following example:
 
 ```bash
-kubeless function deploy hello --runtime nodejs8 --handler hello.main --from-file https://raw.githubusercontent.com/kyma-project/examples/master/event-subscription/lambda/js/hello-with-data.js --trigger-http
+kubeless function deploy hello --runtime nodejs8 --handler hello.main --from-file https://raw.githubusercontent.com/kyma-project/examples/master/event-subscription/lambda/js/hello-with-data.js
 ```
 
 ### Call a function using the CLI

--- a/docs/serverless/docs/07-01-cli-reference.md
+++ b/docs/serverless/docs/07-01-cli-reference.md
@@ -19,9 +19,9 @@ The commands throughout this guide use URLs that require you to provide the doma
 
 For example, if your cluster's domain is `demo.cluster.kyma.cx`, run the following command:
 
-   ```bash
-   export yourClusterDomain='demo.cluster.kyma.cx'
-   ```
+```bash
+export yourClusterDomain='demo.cluster.kyma.cx'
+```
 
 ## Details
 
@@ -68,7 +68,7 @@ kubectl apply -f https://raw.githubusercontent.com/kyma-project/examples/master/
 If your function is deployed to a cluster, run:
 
 ```bash
- curl -k https://github.com/kyma-project/examples/blob/master/gateway/lambda/api-with-auth.yaml | sed "s/.kyma.local/.$yourClusterDomain/" | kubectl apply -f -
+curl -k https://raw.githubusercontent.com/kyma-project/examples/master/gateway/lambda/api-with-auth.yaml | sed "s/.kyma.local/.$yourClusterDomain/" | kubectl apply -f -
 ```
 
 
@@ -81,7 +81,7 @@ echo "$(minikube ip) hello.kyma.local" | sudo tee -a /etc/hosts
 Create the API for your function:
 
 ```bash
-kubectl apply -f https://github.com/kyma-project/examples/blob/master/gateway/lambda/api-with-auth.yaml
+kubectl apply -f https://raw.githubusercontent.com/kyma-project/examples/master/gateway/lambda/api-with-auth.yaml
 ```
 
 ### Bind a function to events

--- a/docs/serverless/docs/07-01-cli-reference.md
+++ b/docs/serverless/docs/07-01-cli-reference.md
@@ -27,7 +27,9 @@ export yourClusterDomain='demo.cluster.kyma.cx'
 
 Use the command line to create, call, deploy, expose, and bind a function.
 
-### Deploy a function using a yaml file and kubectl
+### Deploy a function
+
+#### Using a yaml file and kubectl
 
 You can use the Kubeless CLI to deploy functions in Kyma.
 
@@ -35,11 +37,7 @@ You can use the Kubeless CLI to deploy functions in Kyma.
 kubectl apply -f https://raw.githubusercontent.com/kyma-project/examples/master/gateway/lambda/deployment.yaml
 ```
 
-Check if the function is available:
-```bash
-kubeless function list hello
-```
-### Deploy a function using a JS file and the Kubeless CLI
+#### Using a JS file and the Kubeless CLI
 
 You can deploy a function using the Kubernetes and Kubeless CLI. See the following example:
 
@@ -47,15 +45,17 @@ You can deploy a function using the Kubernetes and Kubeless CLI. See the followi
 kubeless function deploy hello --runtime nodejs8 --handler hello.main --from-file https://raw.githubusercontent.com/kyma-project/examples/master/event-subscription/lambda/js/hello-with-data.js
 ```
 
-### Call a function using the CLI
+### List functions
 
-Use the CLI to call a function:
+Check if the function is available:
 
 ```bash
-kubeless function call hello
+kubeless function list hello
 ```
 
-### Expose a function without authentication
+### Expose a function
+
+#### Without authentication
 
 Use the CLI to create an API for your function:
 
@@ -63,14 +63,15 @@ Use the CLI to create an API for your function:
 kubectl apply -f https://raw.githubusercontent.com/kyma-project/examples/master/gateway/lambda/api-without-auth.yaml
 ```
 
-### Expose a function with authentication enabled
+#### With authentication enabled
 
 If your function is deployed to a cluster, run:
 
 ```bash
-curl -k https://raw.githubusercontent.com/kyma-project/examples/master/gateway/lambda/api-with-auth.yaml | sed "s/.kyma.local/.$yourClusterDomain/" | kubectl apply -f -
+curl https://raw.githubusercontent.com/kyma-project/examples/master/gateway/lambda/api-with-auth.yaml | sed "s/.kyma.local/.$yourClusterDomain/" | kubectl apply -f -
 ```
 
+### Call the function using curl
 
 If Kyma is running locally, add `hello.kyma.local` mapped to `minikube ip` to `/etc/hosts`.
 
@@ -78,10 +79,16 @@ If Kyma is running locally, add `hello.kyma.local` mapped to `minikube ip` to `/
 echo "$(minikube ip) hello.kyma.local" | sudo tee -a /etc/hosts
 ```
 
-Create the API for your function:
+Use curl to call the function:
 
 ```bash
-kubectl apply -f https://raw.githubusercontent.com/kyma-project/examples/master/gateway/lambda/api-with-auth.yaml
+curl -L -k hello.kyma.local
+```
+
+You should receive the following response:
+
+```
+hello world
 ```
 
 ### Bind a function to events


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/master/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:
- Use javascript function as example serverless function instead of unsupported python function
- Fix all kubectl calls to use `raw.githubusercontent.com` (some URLs returned HTML instead of Yaml)
- Use curl to call function instead of `kubeless function call` which is not working any more
-  Remove `--trigger-http`CLI argument which has been removed from kubeless within this [merge request](https://github.com/kubeless/kubeless/pull/654)
- Change order of calls: before function can be called the function has to be exposed properly

**Details**
Calling the function with kubeless results in the following error:
```bash
$ kubeless function call hello
ERRO[0000]
FATA[0000] the server is currently unable to handle the request (get services hello:http-function-port)
```

```
$ kyma version
Kyma CLI version: v0.6.1
Kyma cluster version: 1.0.0
```

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->