### PR TITLE
Test Application Operator upgrade managing lifecycle of Event Service and Application Proxy

### DIFF
--- a/tests/end-to-end/upgrade/chart/upgrade/templates/rbac.yaml
+++ b/tests/end-to-end/upgrade/chart/upgrade/templates/rbac.yaml
@@ -24,7 +24,7 @@ rules:
   verbs: ["create", "delete", "get", "list", "patch", "update"]
 - apiGroups: [""]
   resources: ["configmaps"]
-  verbs: ["list", "get"]
+  verbs: ["list", "get", "create", "delete"]
 - apiGroups: ["apps"]
   resources: ["deployments"]
   verbs: ["create", "get", "delete", "list"]

--- a/tests/end-to-end/upgrade/main.go
+++ b/tests/end-to-end/upgrade/main.go
@@ -147,7 +147,7 @@ func main() {
 		"AssetStoreUpgradeTest":           assetStore.NewAssetStoreUpgradeTest(dynamicCli),
 		"HeadlessCMSUpgradeTest":          cms.NewHeadlessCmsUpgradeTest(dynamicCli),
 		"ApiControllerUpgradeTest":        apiController.New(gatewayCli, k8sCli, kubelessCli, domainName, dexConfig.IdProviderConfig()),
-		"ApplicationOperatorUpgradeTest":  applicationOperator.NewApplicationOperatorUpgradeTest(appConnectorCli, k8sCli.AppsV1()),
+		"ApplicationOperatorUpgradeTest":  applicationOperator.NewApplicationOperatorUpgradeTest(appConnectorCli, *k8sCli),
 	}
 
 	// Execute requested action

--- a/tests/end-to-end/upgrade/main.go
+++ b/tests/end-to-end/upgrade/main.go
@@ -147,7 +147,7 @@ func main() {
 		"AssetStoreUpgradeTest":           assetStore.NewAssetStoreUpgradeTest(dynamicCli),
 		"HeadlessCMSUpgradeTest":          cms.NewHeadlessCmsUpgradeTest(dynamicCli),
 		"ApiControllerUpgradeTest":        apiController.New(gatewayCli, k8sCli, kubelessCli, domainName, dexConfig.IdProviderConfig()),
-		"ApplicationOperatorUpgradeTest":  applicationOperator.NewApplicationOperatorUpgradeTest(appConnectorCli),
+		"ApplicationOperatorUpgradeTest":  applicationOperator.NewApplicationOperatorUpgradeTest(appConnectorCli, scCli),
 	}
 
 	// Execute requested action

--- a/tests/end-to-end/upgrade/main.go
+++ b/tests/end-to-end/upgrade/main.go
@@ -147,7 +147,7 @@ func main() {
 		"AssetStoreUpgradeTest":           assetStore.NewAssetStoreUpgradeTest(dynamicCli),
 		"HeadlessCMSUpgradeTest":          cms.NewHeadlessCmsUpgradeTest(dynamicCli),
 		"ApiControllerUpgradeTest":        apiController.New(gatewayCli, k8sCli, kubelessCli, domainName, dexConfig.IdProviderConfig()),
-		"ApplicationOperatorUpgradeTest":  applicationOperator.NewApplicationOperatorUpgradeTest(appConnectorCli, scCli),
+		"ApplicationOperatorUpgradeTest":  applicationOperator.NewApplicationOperatorUpgradeTest(appConnectorCli, k8sCli.AppsV1()),
 	}
 
 	// Execute requested action

--- a/tests/end-to-end/upgrade/main.go
+++ b/tests/end-to-end/upgrade/main.go
@@ -34,6 +34,7 @@ import (
 	"github.com/kyma-project/kyma/tests/end-to-end/upgrade/internal/platform/logger"
 	"github.com/kyma-project/kyma/tests/end-to-end/upgrade/internal/platform/signal"
 	"github.com/kyma-project/kyma/tests/end-to-end/upgrade/internal/runner"
+	applicationOperator "github.com/kyma-project/kyma/tests/end-to-end/upgrade/pkg/tests/application-operator"
 	assetStore "github.com/kyma-project/kyma/tests/end-to-end/upgrade/pkg/tests/asset-store"
 	"github.com/kyma-project/kyma/tests/end-to-end/upgrade/pkg/tests/cms"
 	eventBus "github.com/kyma-project/kyma/tests/end-to-end/upgrade/pkg/tests/event-bus"
@@ -146,6 +147,7 @@ func main() {
 		"AssetStoreUpgradeTest":           assetStore.NewAssetStoreUpgradeTest(dynamicCli),
 		"HeadlessCMSUpgradeTest":          cms.NewHeadlessCmsUpgradeTest(dynamicCli),
 		"ApiControllerUpgradeTest":        apiController.New(gatewayCli, k8sCli, kubelessCli, domainName, dexConfig.IdProviderConfig()),
+		"ApplicationOperatorUpgradeTest":  applicationOperator.NewApplicationOperatorUpgradeTest(),
 	}
 
 	// Execute requested action

--- a/tests/end-to-end/upgrade/main.go
+++ b/tests/end-to-end/upgrade/main.go
@@ -147,7 +147,7 @@ func main() {
 		"AssetStoreUpgradeTest":           assetStore.NewAssetStoreUpgradeTest(dynamicCli),
 		"HeadlessCMSUpgradeTest":          cms.NewHeadlessCmsUpgradeTest(dynamicCli),
 		"ApiControllerUpgradeTest":        apiController.New(gatewayCli, k8sCli, kubelessCli, domainName, dexConfig.IdProviderConfig()),
-		"ApplicationOperatorUpgradeTest":  applicationOperator.NewApplicationOperatorUpgradeTest(),
+		"ApplicationOperatorUpgradeTest":  applicationOperator.NewApplicationOperatorUpgradeTest(appConnectorCli),
 	}
 
 	// Execute requested action

--- a/tests/end-to-end/upgrade/pkg/tests/application-operator/application_operator.go
+++ b/tests/end-to-end/upgrade/pkg/tests/application-operator/application_operator.go
@@ -1,0 +1,30 @@
+package applicationoperator
+
+import "github.com/sirupsen/logrus"
+
+// UpgradeTest checks if Application Operator upgrades image versions of Application Proxy and Event Service of the created Application.
+type UpgradeTest struct {
+}
+
+// NewApplicationOperatorUpgradeTest returns new instance of the UpgradeTest.
+func NewApplicationOperatorUpgradeTest() *UpgradeTest {
+	return &UpgradeTest{}
+}
+
+// CreateResources creates resources needed for e2e upgrade test
+func (ut *UpgradeTest) CreateResources(stop <-chan struct{}, log logrus.FieldLogger, namespace string) error {
+	log.Println("ApplicationOperator UpgradeTest creating resources...")
+	//TODO:
+
+	log.Println("ApplicationOperator UpgradeTest resources created!")
+	return nil
+}
+
+// TestResources tests resources after backup phase
+func (ut *UpgradeTest) TestResources(stop <-chan struct{}, log logrus.FieldLogger, namespace string) error {
+	log.Println("ApplicationOperator UpgradeTest testing resources...")
+	//TODO:
+
+	log.Println("ApplicationOperator UpgradeTest test passed!")
+	return nil
+}

--- a/tests/end-to-end/upgrade/pkg/tests/application-operator/application_operator.go
+++ b/tests/end-to-end/upgrade/pkg/tests/application-operator/application_operator.go
@@ -1,7 +1,11 @@
 package applicationoperator
 
 import (
-	"fmt"
+	"time"
+
+	"github.com/kubernetes-incubator/service-catalog/pkg/apis/servicecatalog/v1beta1"
+	"github.com/kubernetes-incubator/service-catalog/pkg/client/clientset_generated/clientset"
+	"k8s.io/apimachinery/pkg/util/wait"
 
 	"github.com/kyma-project/kyma/components/application-operator/pkg/apis/applicationconnector/v1alpha1"
 	appConnector "github.com/kyma-project/kyma/components/application-operator/pkg/client/clientset/versioned"
@@ -19,13 +23,15 @@ const (
 
 // UpgradeTest checks if Application Operator upgrades image versions of Application Proxy and Event Service of the created Application.
 type UpgradeTest struct {
-	appConnectorInterface appConnector.Interface
+	appConnectorInterface   appConnector.Interface
+	serviceCatalogInterface clientset.Interface
 }
 
 // NewApplicationOperatorUpgradeTest returns new instance of the UpgradeTest.
-func NewApplicationOperatorUpgradeTest(acCli appConnector.Interface) *UpgradeTest {
+func NewApplicationOperatorUpgradeTest(acCli appConnector.Interface, scCli clientset.Interface) *UpgradeTest {
 	return &UpgradeTest{
-		appConnectorInterface: acCli,
+		appConnectorInterface:   acCli,
+		serviceCatalogInterface: scCli,
 	}
 }
 
@@ -33,17 +39,12 @@ func NewApplicationOperatorUpgradeTest(acCli appConnector.Interface) *UpgradeTes
 func (ut *UpgradeTest) CreateResources(stop <-chan struct{}, log logrus.FieldLogger, namespace string) error {
 	log.Info("ApplicationOperator UpgradeTest creating resources...")
 
-	err := ut.createApplication(log)
-	if err != nil {
+	if err := ut.createApplication(log); err != nil {
 		return errors.Wrap(err, "could not create Application")
 	}
 
-	found, err := ut.findResources()
-	if err != nil {
+	if err := ut.waitForResources(stop, log, namespace); err != nil {
 		return errors.Wrap(err, "could not find resources")
-	}
-	if !found {
-		return fmt.Errorf("could not find Application Proxy or Event Service")
 	}
 
 	log.Info("ApplicationOperator UpgradeTest resources created!")
@@ -64,7 +65,7 @@ func (ut *UpgradeTest) createApplication(log logrus.FieldLogger) error {
 		Spec: v1alpha1.ApplicationSpec{
 			AccessLabel:      "app-access-label",
 			Description:      "Application used by application acceptance test",
-			SkipInstallation: true,
+			SkipInstallation: true, //TODO: Make sure that "true" value is correct here
 			Services: []v1alpha1.Service{
 				{
 					ID:   apiServiceID,
@@ -106,9 +107,41 @@ func (ut *UpgradeTest) createApplication(log logrus.FieldLogger) error {
 	return err
 }
 
-func (ut *UpgradeTest) findResources() (bool, error) {
-	//TODO: Make sure that Application Proxy and Event Service are created
-	return true, nil
+func (ut *UpgradeTest) waitForResources(stop <-chan struct{}, log logrus.FieldLogger, namespace string) error {
+	//TODO: Make sure that Application Proxy is created by Application Operator
+
+	if err := ut.waitForInstance(eventsServiceID, namespace, stop); err != nil {
+		return errors.Wrap(err, "could not find Event Service instance")
+	}
+
+	return nil
+}
+
+func (ut *UpgradeTest) waitForInstance(name, namespace string, stop <-chan struct{}) error {
+	return ut.wait(2*time.Minute, func() (done bool, err error) {
+		si, err := ut.serviceCatalogInterface.ServicecatalogV1beta1().ServiceInstances(namespace).Get(name, metav1.GetOptions{})
+		if err != nil {
+			return false, err
+		}
+		if si.Status.ProvisionStatus == v1beta1.ServiceInstanceProvisionStatusProvisioned {
+			return true, nil
+		}
+		return false, nil
+	}, stop)
+}
+
+func (ut *UpgradeTest) wait(timeout time.Duration, conditionFunc wait.ConditionFunc, stop <-chan struct{}) error {
+	timeoutCh := time.After(timeout)
+	stopCh := make(chan struct{})
+	go func() {
+		select {
+		case <-timeoutCh:
+			close(stopCh)
+		case <-stop:
+			close(stopCh)
+		}
+	}()
+	return wait.PollUntil(500*time.Millisecond, conditionFunc, stopCh)
 }
 
 // TestResources tests resources after backup phase
@@ -116,6 +149,32 @@ func (ut *UpgradeTest) TestResources(stop <-chan struct{}, log logrus.FieldLogge
 	log.Info("ApplicationOperator UpgradeTest testing resources...")
 	//TODO: Make sure that image versions of the Application Proxy and Event Service are upgraded
 
+	if err := ut.deleteResources(log, namespace); err != nil {
+		return errors.Wrap(err, "could not delete resources")
+	}
+
 	log.Info("ApplicationOperator UpgradeTest test passed!")
 	return nil
+}
+
+func (ut *UpgradeTest) deleteResources(log logrus.FieldLogger, namespace string) error {
+	if err := ut.deleteApplication(log); err != nil {
+		return err
+	}
+
+	if err := ut.deleteServiceInstance(eventsServiceID, namespace); err != nil {
+		return err
+	}
+
+	//TODO: Delete Application Proxy and other created resources
+
+	return nil
+}
+
+func (ut *UpgradeTest) deleteApplication(log logrus.FieldLogger) error {
+	return ut.appConnectorInterface.ApplicationconnectorV1alpha1().Applications().Delete(applicationName, &metav1.DeleteOptions{})
+}
+
+func (ut *UpgradeTest) deleteServiceInstance(name, namespace string) error {
+	return ut.serviceCatalogInterface.ServicecatalogV1beta1().ServiceInstances(namespace).Delete(name, &metav1.DeleteOptions{})
 }

--- a/tests/end-to-end/upgrade/pkg/tests/application-operator/application_operator.go
+++ b/tests/end-to-end/upgrade/pkg/tests/application-operator/application_operator.go
@@ -1,30 +1,121 @@
 package applicationoperator
 
-import "github.com/sirupsen/logrus"
+import (
+	"fmt"
+
+	"github.com/kyma-project/kyma/components/application-operator/pkg/apis/applicationconnector/v1alpha1"
+	appConnector "github.com/kyma-project/kyma/components/application-operator/pkg/client/clientset/versioned"
+	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+const (
+	applicationName = "application-for-testing"
+	apiServiceID    = "api-service-id"
+	eventsServiceID = "events-service-id"
+	gatewayURL      = "https://gateway.local"
+)
 
 // UpgradeTest checks if Application Operator upgrades image versions of Application Proxy and Event Service of the created Application.
 type UpgradeTest struct {
+	appConnectorInterface appConnector.Interface
 }
 
 // NewApplicationOperatorUpgradeTest returns new instance of the UpgradeTest.
-func NewApplicationOperatorUpgradeTest() *UpgradeTest {
-	return &UpgradeTest{}
+func NewApplicationOperatorUpgradeTest(acCli appConnector.Interface) *UpgradeTest {
+	return &UpgradeTest{
+		appConnectorInterface: acCli,
+	}
 }
 
 // CreateResources creates resources needed for e2e upgrade test
 func (ut *UpgradeTest) CreateResources(stop <-chan struct{}, log logrus.FieldLogger, namespace string) error {
-	log.Println("ApplicationOperator UpgradeTest creating resources...")
-	//TODO:
+	log.Info("ApplicationOperator UpgradeTest creating resources...")
 
-	log.Println("ApplicationOperator UpgradeTest resources created!")
+	err := ut.createApplication(log)
+	if err != nil {
+		return errors.Wrap(err, "could not create Application")
+	}
+
+	found, err := ut.findResources()
+	if err != nil {
+		return errors.Wrap(err, "could not find resources")
+	}
+	if !found {
+		return fmt.Errorf("could not find Application Proxy or Event Service")
+	}
+
+	log.Info("ApplicationOperator UpgradeTest resources created!")
 	return nil
+}
+
+func (ut *UpgradeTest) createApplication(log logrus.FieldLogger) error {
+	log.Info("Creating Application...")
+
+	_, err := ut.appConnectorInterface.ApplicationconnectorV1alpha1().Applications().Create(&v1alpha1.Application{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "Application",
+			APIVersion: "applicationconnector.kyma-project.io/v1alpha1",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: applicationName,
+		},
+		Spec: v1alpha1.ApplicationSpec{
+			AccessLabel:      "app-access-label",
+			Description:      "Application used by application acceptance test",
+			SkipInstallation: true,
+			Services: []v1alpha1.Service{
+				{
+					ID:   apiServiceID,
+					Name: apiServiceID,
+					Labels: map[string]string{
+						"connected-app": "app-name",
+					},
+					ProviderDisplayName: "provider",
+					DisplayName:         "Some API",
+					Description:         "Application Service Class with API",
+					Tags:                []string{},
+					Entries: []v1alpha1.Entry{
+						{
+							Type:        "API",
+							AccessLabel: "accessLabel",
+							GatewayUrl:  gatewayURL,
+						},
+					},
+				},
+				{
+					ID:   eventsServiceID,
+					Name: eventsServiceID,
+					Labels: map[string]string{
+						"connected-app": "app-name",
+					},
+					ProviderDisplayName: "provider",
+					DisplayName:         "Some Events",
+					Description:         "Application Service Class with Events",
+					Tags:                []string{},
+					Entries: []v1alpha1.Entry{
+						{
+							Type: "Events",
+						},
+					},
+				},
+			},
+		},
+	})
+	return err
+}
+
+func (ut *UpgradeTest) findResources() (bool, error) {
+	//TODO: Make sure that Application Proxy and Event Service are created
+	return true, nil
 }
 
 // TestResources tests resources after backup phase
 func (ut *UpgradeTest) TestResources(stop <-chan struct{}, log logrus.FieldLogger, namespace string) error {
-	log.Println("ApplicationOperator UpgradeTest testing resources...")
-	//TODO:
+	log.Info("ApplicationOperator UpgradeTest testing resources...")
+	//TODO: Make sure that image versions of the Application Proxy and Event Service are upgraded
 
-	log.Println("ApplicationOperator UpgradeTest test passed!")
+	log.Info("ApplicationOperator UpgradeTest test passed!")
 	return nil
 }

--- a/tests/end-to-end/upgrade/pkg/tests/application-operator/application_operator.go
+++ b/tests/end-to-end/upgrade/pkg/tests/application-operator/application_operator.go
@@ -24,6 +24,7 @@ const (
 	applicationProxyDeployment = "test-app-haufmzt-application-gateway"
 	eventsConfigMapName        = "test-app-haufmzt-configmap-events"
 	proxyConfigMapName         = "test-app-haufmzt-configmap-proxy"
+	integrationNamespace       = "kyma-integration"
 
 	imageKey     = "image"
 	timestampKey = "timestamp"
@@ -55,7 +56,7 @@ func (ut *UpgradeTest) CreateResources(stop <-chan struct{}, log logrus.FieldLog
 		return errors.Wrap(err, "could not find resources")
 	}
 
-	if err := ut.setVerificationData(namespace); err != nil {
+	if err := ut.setVerificationData(integrationNamespace); err != nil {
 		return errors.Wrap(err, "could not set verification data")
 	}
 
@@ -160,11 +161,11 @@ func (ut *UpgradeTest) createConfigMap(name, namespace, image string, timestamp 
 func (ut *UpgradeTest) TestResources(stop <-chan struct{}, log logrus.FieldLogger, namespace string) error {
 	log.Info("ApplicationOperator UpgradeTest testing resources...")
 
-	if err := ut.verifyResources(namespace); err != nil {
+	if err := ut.verifyResources(integrationNamespace); err != nil {
 		return errors.Wrap(err, "image versions are not upgraded")
 	}
 
-	if err := ut.deleteResources(log, namespace); err != nil {
+	if err := ut.deleteResources(log, integrationNamespace); err != nil {
 		return errors.Wrap(err, "could not delete resources")
 	}
 

--- a/tests/end-to-end/upgrade/pkg/tests/application-operator/application_operator.go
+++ b/tests/end-to-end/upgrade/pkg/tests/application-operator/application_operator.go
@@ -5,7 +5,7 @@ import (
 	"strings"
 	"time"
 
-	"k8s.io/api/apps/v1"
+	v1 "k8s.io/api/apps/v1"
 
 	core "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -201,20 +201,20 @@ func (ut *UpgradeTest) verifyDeployment(name, configmapName, namespace string) e
 	previousImage, ok := configMap.Data[imageKey]
 
 	if !ok {
-		return errors.New("pre-upgrade image not found")
+		return fmt.Errorf("pre-upgrade image not found")
 	}
 
 	previousTimestamp, ok := configMap.Data[timestampKey]
 
 	if !ok {
-		return errors.New("pre-upgrade timestamp not found")
+		return fmt.Errorf("pre-upgrade timestamp not found")
 	}
 
 	if previousImage != image || previousTimestamp != timestamp.String() {
 		return nil
 	}
 
-	return errors.New("image and timestamp not changed")
+	return fmt.Errorf("image and timestamp not changed")
 }
 
 func (ut *UpgradeTest) getDeploymentData(name, namespace string) (image string, timestamp metav1.Time, err error) {
@@ -238,7 +238,7 @@ func getImageVersion(containerName string, containers []core.Container) (string,
 			return c.Image, nil
 		}
 	}
-	return "", errors.New(fmt.Sprintf("container name %s not found", containerName))
+	return "", fmt.Errorf(fmt.Sprintf("container name %s not found", containerName))
 }
 
 func (ut *UpgradeTest) getDeployment(name, namespace string) (*v1.Deployment, error) {


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Add end-to-end Application Operator test checking if Application Operator upgrade manages lifecycle of Event Service and Application Proxy correctly

**Related issue(s)**

See the issue #2788 
See the bump [#4133](https://github.com/kyma-project/kyma/pull/4133)
