### PR TITLE
Inline the go-template in testing.sh script

### DIFF
--- a/installation/resources/test-selector.yaml.tpl
+++ b/installation/resources/test-selector.yaml.tpl
@@ -1,6 +1,0 @@
-  selectors:
-    matchNames:
-{{- range .items}}
-      - name: {{.metadata.name}}
-        namespace: {{.metadata.namespace}}
-{{- end}}

--- a/installation/scripts/testing.sh
+++ b/installation/scripts/testing.sh
@@ -23,7 +23,12 @@ ${kc} get cm dex-config -n kyma-system -ojsonpath="{.data}" | grep --silent "#__
 if [[ $? -eq 1 ]]
 then
   # if static users are not available, do not execute tests which requires them
-  matchTests=$(${kc} get testdefinitions --all-namespaces -l 'require-static-users!=true' -o=go-template-file --template='./../resources/test-selector.yaml.tpl')
+  matchTests=$(${kc} get testdefinitions --all-namespaces -l 'require-static-users!=true' -o=go-template='  selectors:
+    matchNames:
+{{- range .items}}
+      - name: {{.metadata.name}}
+        namespace: {{.metadata.namespace}}
+{{- end}}')
   echo "WARNING: following tests will be skipped due to the lack of static users:"
   echo "$(${kc} get testdefinitions --all-namespaces -l 'require-static-users=true' -o=go-template --template='{{- range .items}}{{printf " - %s\n" .metadata.name}}{{- end}}')"
 fi


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Inline the go-template in testing.sh script

The problem with the previous approach was that it was failing in stability-checker 

```
Error from server (Forbidden): configmaps \"dex-config\" is forbidden: User \"system:serviceaccount:kyma-system:stability-checker\" cannot get resource \"configmaps\" in API group \"\" in the namespace \"kyma-system\"
error: error reading template ./../resources/test-selector.yaml.tpl, open ./../resources/test-selector.yaml.tpl: no such file or directory
```

Instead of coping that into stability-checker and reflect the filesystem tree is better to just inline that template. Right now it's used only in one place and inlining it does not decrease the readability. 