### PR TITLE
adjusting istio-pilot traceSampling rate to 100

### DIFF
--- a/resources/istio/charts/pilot/values.yaml
+++ b/resources/istio/charts/pilot/values.yaml
@@ -9,7 +9,7 @@ autoscaleMax: 5
 # replicaCount: 1
 image: pilot
 sidecar: true
-traceSampling: 1.0
+traceSampling: 100.0
 # Resources for a small pilot install
 resources:
   requests:


### PR DESCRIPTION
**Description**
Adjusted trace sampling rate of istio-pilot to 100% in order to send all traces to jaeger.

**Related issue(s)**
https://github.com/kyma-project/kyma/issues/4103
