### PR TITLE
Use env variable secretName in the gcp broker provider

### DIFF
--- a/tools/gcp-broker-provider/bin/gcp-broker.sh
+++ b/tools/gcp-broker-provider/bin/gcp-broker.sh
@@ -4,6 +4,7 @@
 #
 # Expected environment variables:
 #   - WORKING_NAMESPACE - name of the namespace where GCP Broker should be installed
+#   - GCP_SECRET_NAME - name of the secret for the GCP Broker which should exist in the WORKING_NAMESPACE
 #
 # Input flags:
 #   - action - possible values: provision or deprovision
@@ -11,7 +12,6 @@
 set -o errexit # exit immediately if a command exits with a non-zero status.
 
 readonly CURRENT_DIR="$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)"
-readonly GCP_SECRET_NAME="gcp-broker-data"
 
 trap cleanup EXIT SIGINT SIGTERM
 


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/master/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- GCP-broker-provider now will use the GCP_SECRET_NAME variable injected as the environment variable 

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
