### PR TITLE
Add configurable SpecRequestTimeout parameter to Application Registry

### DIFF
--- a/components/application-registry/README.md
+++ b/components/application-registry/README.md
@@ -31,10 +31,10 @@ The Application Registry has the following parameters:
 - **externalAPIPort** - This port exposes the Metadata API to an external solution. The default port is `8081`.
 - **minioURL** - The URL of a Minio service which stores specifications and documentation.
 - **namespace** - Namespace where Application Registry is deployed. The default Namespace is `kyma-system`.
-- **requestTimeout** - A timeout for requests sent through the Application Registry. It is provided in seconds. The default timeout is `1`.
+- **requestTimeout** - A time-out for requests sent through the Application Registry. It is provided in seconds. The default time-out is `1`.
 - **requestLogging** - A flag for logging incoming requests. The default value is `false`.
-- **specRequestTimeout** - A timeout for requests fetching specifications provided by the user. It is provided in seconds. The default timeout is `5`.
-- **assetstoreRequestTimeout** - A timeout for requests fetching specifications from the Asset Store Service. It is provided in seconds. The default timeout is `5`.
+- **specRequestTimeout** - A time-out for requests fetching specifications provided by the user. It is provided in seconds. The default time-out is `5`.
+- **assetstoreRequestTimeout** - A time-out for requests fetching specifications from the Asset Store Service. It is provided in seconds. The default time-out is `5`.
 - **detailedErrorResponse** - A flag for showing detailed internal error messages in response bodies. The default value is `false` and all internal server error messages are shortened to `Internal error`, while all other error messages are shown as usual.
 
 ### Sample calls

--- a/components/application-registry/README.md
+++ b/components/application-registry/README.md
@@ -33,7 +33,7 @@ The Application Registry has the following parameters:
 - **namespace** - Namespace where Application Registry is deployed. The default Namespace is `kyma-system`.
 - **requestTimeout** - A timeout for requests sent through the Application Registry. It is provided in seconds. The default timeout is `1`.
 - **requestLogging** - A flag for logging incoming requests. The default value is `false`.
-- **specRequestTimeout** - A timeout for the requests sent through the Spec Service. It is provided in seconds. The default timeout is `5`.
+- **specRequestTimeout** - A timeout for the requests sent through the Spec Service and Asset Store Service. It is provided in seconds. The default timeout is `5`.
 - **detailedErrorResponse** - A flag for showing detailed internal error messages in response bodies. The default value is `false` and all internal server error messages are shortened to `Internal error`, while all other error messages are shown as usual.
 
 ### Sample calls

--- a/components/application-registry/README.md
+++ b/components/application-registry/README.md
@@ -33,8 +33,8 @@ The Application Registry has the following parameters:
 - **namespace** - Namespace where Application Registry is deployed. The default Namespace is `kyma-system`.
 - **requestTimeout** - A timeout for requests sent through the Application Registry. It is provided in seconds. The default timeout is `1`.
 - **requestLogging** - A flag for logging incoming requests. The default value is `false`.
-- **specRequestTimeout** - A timeout for the requests sent through the Spec Service. It is provided in seconds. The default timeout is `5`.
-- **assetstoreRequestTimeout** - A timeout for the requests sent through the Asset Store Service. It is provided in seconds. The default timeout is `5`.
+- **specRequestTimeout** - A timeout for requests fetching specifications provided by the user. It is provided in seconds. The default timeout is `5`.
+- **assetstoreRequestTimeout** - A timeout for requests fetching specifications from the Asset Store Service. It is provided in seconds. The default timeout is `5`.
 - **detailedErrorResponse** - A flag for showing detailed internal error messages in response bodies. The default value is `false` and all internal server error messages are shortened to `Internal error`, while all other error messages are shown as usual.
 
 ### Sample calls

--- a/components/application-registry/README.md
+++ b/components/application-registry/README.md
@@ -33,7 +33,8 @@ The Application Registry has the following parameters:
 - **namespace** - Namespace where Application Registry is deployed. The default Namespace is `kyma-system`.
 - **requestTimeout** - A timeout for requests sent through the Application Registry. It is provided in seconds. The default timeout is `1`.
 - **requestLogging** - A flag for logging incoming requests. The default value is `false`.
-- **specRequestTimeout** - A timeout for the requests sent through the Spec Service and Asset Store Service. It is provided in seconds. The default timeout is `5`.
+- **specRequestTimeout** - A timeout for the requests sent through the Spec Service. It is provided in seconds. The default timeout is `5`.
+- **assetstoreRequestTimeout** - A timeout for the requests sent through the Asset Store Service. It is provided in seconds. The default timeout is `5`.
 - **detailedErrorResponse** - A flag for showing detailed internal error messages in response bodies. The default value is `false` and all internal server error messages are shortened to `Internal error`, while all other error messages are shown as usual.
 
 ### Sample calls

--- a/components/application-registry/README.md
+++ b/components/application-registry/README.md
@@ -31,8 +31,9 @@ The Application Registry has the following parameters:
 - **externalAPIPort** - This port exposes the Metadata API to an external solution. The default port is `8081`.
 - **minioURL** - The URL of a Minio service which stores specifications and documentation.
 - **namespace** - Namespace where Application Registry is deployed. The default Namespace is `kyma-system`.
-- **requestTimeout** - A time-out for requests sent through the Application Registry. It is provided in seconds. The default time-out is `1`.
+- **requestTimeout** - A timeout for requests sent through the Application Registry. It is provided in seconds. The default timeout is `1`.
 - **requestLogging** - A flag for logging incoming requests. The default value is `false`.
+- **specRequestTimeout** - A timeout for the requests sent through the Spec Service. It is provided in seconds. The default timeout is `5`.
 - **detailedErrorResponse** - A flag for showing detailed internal error messages in response bodies. The default value is `false` and all internal server error messages are shortened to `Internal error`, while all other error messages are shown as usual.
 
 ### Sample calls

--- a/components/application-registry/cmd/applicationregistry/handlers.go
+++ b/components/application-registry/cmd/applicationregistry/handlers.go
@@ -96,7 +96,7 @@ func NewSpecificationService(dynamicClient dynamic.Interface, opt *options) spec
 
 	docsTopicRepository := assetstore.NewDocsTopicRepository(resourceInterface)
 	uploadClient := upload.NewClient(opt.uploadServiceURL)
-	assetStoreService := assetstore.NewService(docsTopicRepository, uploadClient, opt.insecureAssetDownload)
+	assetStoreService := assetstore.NewService(docsTopicRepository, uploadClient, opt.insecureAssetDownload, opt.specRequestTimeout)
 
 	return specification.NewSpecService(assetStoreService, opt.specRequestTimeout)
 }

--- a/components/application-registry/cmd/applicationregistry/handlers.go
+++ b/components/application-registry/cmd/applicationregistry/handlers.go
@@ -98,7 +98,7 @@ func NewSpecificationService(dynamicClient dynamic.Interface, opt *options) spec
 	uploadClient := upload.NewClient(opt.uploadServiceURL)
 	assetStoreService := assetstore.NewService(docsTopicRepository, uploadClient, opt.insecureAssetDownload)
 
-	return specification.NewSpecService(assetStoreService)
+	return specification.NewSpecService(assetStoreService, opt.specRequestTimeout)
 }
 
 func newApplicationRepository(config *restclient.Config) (applications.ServiceRepository, apperrors.AppError) {

--- a/components/application-registry/cmd/applicationregistry/handlers.go
+++ b/components/application-registry/cmd/applicationregistry/handlers.go
@@ -96,7 +96,7 @@ func NewSpecificationService(dynamicClient dynamic.Interface, opt *options) spec
 
 	docsTopicRepository := assetstore.NewDocsTopicRepository(resourceInterface)
 	uploadClient := upload.NewClient(opt.uploadServiceURL)
-	assetStoreService := assetstore.NewService(docsTopicRepository, uploadClient, opt.insecureAssetDownload, opt.specRequestTimeout)
+	assetStoreService := assetstore.NewService(docsTopicRepository, uploadClient, opt.insecureAssetDownload, opt.assetstoreRequestTimeout)
 
 	return specification.NewSpecService(assetStoreService, opt.specRequestTimeout)
 }

--- a/components/application-registry/cmd/applicationregistry/options.go
+++ b/components/application-registry/cmd/applicationregistry/options.go
@@ -6,16 +6,17 @@ import (
 )
 
 type options struct {
-	externalAPIPort       int
-	proxyPort             int
-	minioURL              string
-	namespace             string
-	requestTimeout        int
-	requestLogging        bool
-	specRequestTimeout    int
-	detailedErrorResponse bool
-	uploadServiceURL      string
-	insecureAssetDownload bool
+	externalAPIPort          int
+	proxyPort                int
+	minioURL                 string
+	namespace                string
+	requestTimeout           int
+	requestLogging           bool
+	specRequestTimeout       int
+	assetstoreRequestTimeout int
+	detailedErrorResponse    bool
+	uploadServiceURL         string
+	insecureAssetDownload    bool
 }
 
 func parseArgs() *options {
@@ -25,6 +26,7 @@ func parseArgs() *options {
 	requestTimeout := flag.Int("requestTimeout", 1, "Timeout for services.")
 	requestLogging := flag.Bool("requestLogging", false, "Flag for logging incoming requests.")
 	specRequestTimeout := flag.Int("specRequestTimeout", 5, "Timeout for Spec Service.")
+	assetstoreRequestTimeout := flag.Int("assetstoreRequestTimeout", 5, "Timeout for Asset Store Service.")
 	detailedErrorResponse := flag.Bool("detailedErrorResponse", false, "Flag for showing full internal error response messages.")
 	uploadServiceURL := flag.String("uploadServiceURL", "http://assetstore-asset-upload-service.kyma-system.svc.cluster.local:3000", "Upload Service URL.")
 	insecureAssetDownload := flag.Bool("insecureAssetDownload", false, "Flag for skipping certificate verification for asset download. ")
@@ -32,21 +34,23 @@ func parseArgs() *options {
 	flag.Parse()
 
 	return &options{
-		externalAPIPort:       *externalAPIPort,
-		proxyPort:             *proxyPort,
-		namespace:             *namespace,
-		requestTimeout:        *requestTimeout,
-		requestLogging:        *requestLogging,
-		specRequestTimeout:    *specRequestTimeout,
-		detailedErrorResponse: *detailedErrorResponse,
-		uploadServiceURL:      *uploadServiceURL,
-		insecureAssetDownload: *insecureAssetDownload,
+		externalAPIPort:          *externalAPIPort,
+		proxyPort:                *proxyPort,
+		namespace:                *namespace,
+		requestTimeout:           *requestTimeout,
+		requestLogging:           *requestLogging,
+		specRequestTimeout:       *specRequestTimeout,
+		assetstoreRequestTimeout: *assetstoreRequestTimeout,
+		detailedErrorResponse:    *detailedErrorResponse,
+		uploadServiceURL:         *uploadServiceURL,
+		insecureAssetDownload:    *insecureAssetDownload,
 	}
 }
 
 func (o *options) String() string {
 	return fmt.Sprintf("--externalAPIPort=%d --proxyPort=%d --uploadServiceURL=%s"+
-		"--namespace=%s --requestTimeout=%d  --requestLogging=%t --specRequestTimeout=%d --detailedErrorResponse=%t --insecureAssetDownload=%t",
+		"--namespace=%s --requestTimeout=%d  --requestLogging=%t --specRequestTimeout=%d"+
+		"--assetstoreRequestTimeout=%d --detailedErrorResponse=%t --insecureAssetDownload=%t",
 		o.externalAPIPort, o.proxyPort, o.uploadServiceURL,
-		o.namespace, o.requestTimeout, o.requestLogging, o.specRequestTimeout, o.detailedErrorResponse, o.insecureAssetDownload)
+		o.namespace, o.requestTimeout, o.requestLogging, o.specRequestTimeout, o.assetstoreRequestTimeout, o.detailedErrorResponse, o.insecureAssetDownload)
 }

--- a/components/application-registry/cmd/applicationregistry/options.go
+++ b/components/application-registry/cmd/applicationregistry/options.go
@@ -12,6 +12,7 @@ type options struct {
 	namespace             string
 	requestTimeout        int
 	requestLogging        bool
+	specRequestTimeout    int
 	detailedErrorResponse bool
 	uploadServiceURL      string
 	insecureAssetDownload bool
@@ -23,6 +24,7 @@ func parseArgs() *options {
 	namespace := flag.String("namespace", "kyma-integration", "Namespace used by Application Registry")
 	requestTimeout := flag.Int("requestTimeout", 1, "Timeout for services.")
 	requestLogging := flag.Bool("requestLogging", false, "Flag for logging incoming requests.")
+	specRequestTimeout := flag.Int("specRequestTimeout", 5, "Timeout for Spec Service.")
 	detailedErrorResponse := flag.Bool("detailedErrorResponse", false, "Flag for showing full internal error response messages.")
 	uploadServiceURL := flag.String("uploadServiceURL", "http://assetstore-asset-upload-service.kyma-system.svc.cluster.local:3000", "Upload Service URL.")
 	insecureAssetDownload := flag.Bool("insecureAssetDownload", false, "Flag for skipping certificate verification for asset download. ")
@@ -35,6 +37,7 @@ func parseArgs() *options {
 		namespace:             *namespace,
 		requestTimeout:        *requestTimeout,
 		requestLogging:        *requestLogging,
+		specRequestTimeout:    *specRequestTimeout,
 		detailedErrorResponse: *detailedErrorResponse,
 		uploadServiceURL:      *uploadServiceURL,
 		insecureAssetDownload: *insecureAssetDownload,
@@ -43,7 +46,7 @@ func parseArgs() *options {
 
 func (o *options) String() string {
 	return fmt.Sprintf("--externalAPIPort=%d --proxyPort=%d --uploadServiceURL=%s"+
-		"--namespace=%s --requestTimeout=%d  --requestLogging=%t --detailedErrorResponse=%t --insecureAssetDownload=%t",
+		"--namespace=%s --requestTimeout=%d  --requestLogging=%t --specRequestTimeout=%d --detailedErrorResponse=%t --insecureAssetDownload=%t",
 		o.externalAPIPort, o.proxyPort, o.uploadServiceURL,
-		o.namespace, o.requestTimeout, o.requestLogging, o.detailedErrorResponse, o.insecureAssetDownload)
+		o.namespace, o.requestTimeout, o.requestLogging, o.specRequestTimeout, o.detailedErrorResponse, o.insecureAssetDownload)
 }

--- a/components/application-registry/internal/metadata/specification/assetstore/service.go
+++ b/components/application-registry/internal/metadata/specification/assetstore/service.go
@@ -39,9 +39,9 @@ type service struct {
 	downloadClient      download.Client
 }
 
-func NewService(repository DocsTopicRepository, uploadClient upload.Client, insecureAssetDownload bool, specRequestTimeout int) Service {
+func NewService(repository DocsTopicRepository, uploadClient upload.Client, insecureAssetDownload bool, assetstoreRequestTimeout int) Service {
 	downloadClient := download.NewClient(&http.Client{
-		Timeout:   time.Duration(specRequestTimeout) * time.Second,
+		Timeout:   time.Duration(assetstoreRequestTimeout) * time.Second,
 		Transport: &http.Transport{TLSClientConfig: &tls.Config{InsecureSkipVerify: insecureAssetDownload}},
 	})
 

--- a/components/application-registry/internal/metadata/specification/assetstore/service.go
+++ b/components/application-registry/internal/metadata/specification/assetstore/service.go
@@ -15,7 +15,6 @@ import (
 const (
 	docTopicDisplayNameFormat = "Documentation topic for service class id=%s"
 	docTopicDescriptionFormat = "Documentation topic for service class id=%s"
-	specRequestTimeout        = time.Duration(5 * time.Second)
 )
 
 const (
@@ -40,9 +39,9 @@ type service struct {
 	downloadClient      download.Client
 }
 
-func NewService(repository DocsTopicRepository, uploadClient upload.Client, insecureAssetDownload bool) Service {
+func NewService(repository DocsTopicRepository, uploadClient upload.Client, insecureAssetDownload bool, specRequestTimeout int) Service {
 	downloadClient := download.NewClient(&http.Client{
-		Timeout:   specRequestTimeout,
+		Timeout:   time.Duration(specRequestTimeout) * time.Second,
 		Transport: &http.Transport{TLSClientConfig: &tls.Config{InsecureSkipVerify: insecureAssetDownload}},
 	})
 

--- a/components/application-registry/internal/metadata/specification/assetstore/service_test.go
+++ b/components/application-registry/internal/metadata/specification/assetstore/service_test.go
@@ -16,6 +16,8 @@ import (
 	"testing"
 )
 
+const defaultSpecRequestTimeout = 5
+
 func TestAddingToAssetStore(t *testing.T) {
 	jsonApiSpec := []byte("{\"productsEndpoint\": \"Endpoint /products returns products.\"}}")
 	documentation := []byte("{\"description\": \"Some docs blah blah blah\"}}")
@@ -27,7 +29,7 @@ func TestAddingToAssetStore(t *testing.T) {
 		// given
 		repositoryMock := &mocks.DocsTopicRepository{}
 		uploadClientMock := &uploadMocks.Client{}
-		service := NewService(repositoryMock, uploadClientMock, false)
+		service := NewService(repositoryMock, uploadClientMock, false, defaultSpecRequestTimeout)
 
 		{
 			urls := map[string]string{
@@ -64,7 +66,7 @@ func TestAddingToAssetStore(t *testing.T) {
 		// given
 		repositoryMock := &mocks.DocsTopicRepository{}
 		uploadClientMock := &uploadMocks.Client{}
-		service := NewService(repositoryMock, uploadClientMock, false)
+		service := NewService(repositoryMock, uploadClientMock, false, defaultSpecRequestTimeout)
 
 		{
 			urls := map[string]string{
@@ -91,7 +93,7 @@ func TestAddingToAssetStore(t *testing.T) {
 		// given
 		repositoryMock := &mocks.DocsTopicRepository{}
 		uploadClientMock := &uploadMocks.Client{}
-		service := NewService(repositoryMock, uploadClientMock, false)
+		service := NewService(repositoryMock, uploadClientMock, false, defaultSpecRequestTimeout)
 
 		{
 			urls := map[string]string{
@@ -118,7 +120,7 @@ func TestAddingToAssetStore(t *testing.T) {
 		// given
 		repositoryMock := &mocks.DocsTopicRepository{}
 		uploadClientMock := &uploadMocks.Client{}
-		service := NewService(repositoryMock, uploadClientMock, false)
+		service := NewService(repositoryMock, uploadClientMock, false, defaultSpecRequestTimeout)
 
 		uploadClientMock.On("Upload", openApiSpecFileName, jsonApiSpec).
 			Return(upload.UploadedFile{}, apperrors.Internal("some error"))
@@ -136,7 +138,7 @@ func TestAddingToAssetStore(t *testing.T) {
 		// given
 		repositoryMock := &mocks.DocsTopicRepository{}
 		uploadClientMock := &uploadMocks.Client{}
-		service := NewService(repositoryMock, uploadClientMock, false)
+		service := NewService(repositoryMock, uploadClientMock, false, defaultSpecRequestTimeout)
 
 		repositoryMock.On("Upsert", mock.Anything).Return(apperrors.Internal("some error"))
 		uploadClientMock.On("Upload", openApiSpecFileName, jsonApiSpec).
@@ -155,7 +157,7 @@ func TestAddingToAssetStore(t *testing.T) {
 		// given
 		repositoryMock := &mocks.DocsTopicRepository{}
 		uploadClientMock := &uploadMocks.Client{}
-		service := NewService(repositoryMock, uploadClientMock, false)
+		service := NewService(repositoryMock, uploadClientMock, false, defaultSpecRequestTimeout)
 
 		// when
 		err := service.Put("id1", "", []byte(nil), []byte(nil), []byte(nil))
@@ -175,7 +177,7 @@ func TestGettingFromAssetStore(t *testing.T) {
 	t.Run("Should get specifications from asset store", func(t *testing.T) {
 		// given
 		repositoryMock := &mocks.DocsTopicRepository{}
-		service := NewService(repositoryMock, nil, false)
+		service := NewService(repositoryMock, nil, false, defaultSpecRequestTimeout)
 
 		apiTestServer := createTestServer(t, jsonApiSpec)
 		defer apiTestServer.Close()
@@ -212,7 +214,7 @@ func TestGettingFromAssetStore(t *testing.T) {
 	t.Run("Should fail when failed to read DocsTopic CR", func(t *testing.T) {
 		// given
 		repositoryMock := &mocks.DocsTopicRepository{}
-		service := NewService(repositoryMock, nil, false)
+		service := NewService(repositoryMock, nil, false, defaultSpecRequestTimeout)
 
 		repositoryMock.On("Get", "id1").
 			Return(docstopic.Entry{}, apperrors.Internal("some error"))
@@ -232,7 +234,7 @@ func TestGettingFromAssetStore(t *testing.T) {
 	t.Run("Should return nil specs if Docs Topic CR doesn't exist", func(t *testing.T) {
 		// given
 		repositoryMock := &mocks.DocsTopicRepository{}
-		service := NewService(repositoryMock, nil, false)
+		service := NewService(repositoryMock, nil, false, defaultSpecRequestTimeout)
 
 		repositoryMock.On("Get", "id1").
 			Return(docstopic.Entry{}, apperrors.NotFound("object not found"))
@@ -265,7 +267,7 @@ func TestGettingFromAssetStoreIfStatusIsNotReady(t *testing.T) {
 			// given
 			repositoryMock := &mocks.DocsTopicRepository{}
 			uploadClientMock := &uploadMocks.Client{}
-			service := NewService(repositoryMock, uploadClientMock, false)
+			service := NewService(repositoryMock, uploadClientMock, false, defaultSpecRequestTimeout)
 
 			{
 				repositoryMock.On("Get", "id1").Return(createDocsTopic("id1", nil, testData.status), nil)

--- a/components/application-registry/internal/metadata/specification/assetstore/service_test.go
+++ b/components/application-registry/internal/metadata/specification/assetstore/service_test.go
@@ -16,7 +16,7 @@ import (
 	"testing"
 )
 
-const defaultSpecRequestTimeout = 5
+const defaultAssetstoreRequestTimeout = 5
 
 func TestAddingToAssetStore(t *testing.T) {
 	jsonApiSpec := []byte("{\"productsEndpoint\": \"Endpoint /products returns products.\"}}")
@@ -29,7 +29,7 @@ func TestAddingToAssetStore(t *testing.T) {
 		// given
 		repositoryMock := &mocks.DocsTopicRepository{}
 		uploadClientMock := &uploadMocks.Client{}
-		service := NewService(repositoryMock, uploadClientMock, false, defaultSpecRequestTimeout)
+		service := NewService(repositoryMock, uploadClientMock, false, defaultAssetstoreRequestTimeout)
 
 		{
 			urls := map[string]string{
@@ -66,7 +66,7 @@ func TestAddingToAssetStore(t *testing.T) {
 		// given
 		repositoryMock := &mocks.DocsTopicRepository{}
 		uploadClientMock := &uploadMocks.Client{}
-		service := NewService(repositoryMock, uploadClientMock, false, defaultSpecRequestTimeout)
+		service := NewService(repositoryMock, uploadClientMock, false, defaultAssetstoreRequestTimeout)
 
 		{
 			urls := map[string]string{
@@ -93,7 +93,7 @@ func TestAddingToAssetStore(t *testing.T) {
 		// given
 		repositoryMock := &mocks.DocsTopicRepository{}
 		uploadClientMock := &uploadMocks.Client{}
-		service := NewService(repositoryMock, uploadClientMock, false, defaultSpecRequestTimeout)
+		service := NewService(repositoryMock, uploadClientMock, false, defaultAssetstoreRequestTimeout)
 
 		{
 			urls := map[string]string{
@@ -120,7 +120,7 @@ func TestAddingToAssetStore(t *testing.T) {
 		// given
 		repositoryMock := &mocks.DocsTopicRepository{}
 		uploadClientMock := &uploadMocks.Client{}
-		service := NewService(repositoryMock, uploadClientMock, false, defaultSpecRequestTimeout)
+		service := NewService(repositoryMock, uploadClientMock, false, defaultAssetstoreRequestTimeout)
 
 		uploadClientMock.On("Upload", openApiSpecFileName, jsonApiSpec).
 			Return(upload.UploadedFile{}, apperrors.Internal("some error"))
@@ -138,7 +138,7 @@ func TestAddingToAssetStore(t *testing.T) {
 		// given
 		repositoryMock := &mocks.DocsTopicRepository{}
 		uploadClientMock := &uploadMocks.Client{}
-		service := NewService(repositoryMock, uploadClientMock, false, defaultSpecRequestTimeout)
+		service := NewService(repositoryMock, uploadClientMock, false, defaultAssetstoreRequestTimeout)
 
 		repositoryMock.On("Upsert", mock.Anything).Return(apperrors.Internal("some error"))
 		uploadClientMock.On("Upload", openApiSpecFileName, jsonApiSpec).
@@ -157,7 +157,7 @@ func TestAddingToAssetStore(t *testing.T) {
 		// given
 		repositoryMock := &mocks.DocsTopicRepository{}
 		uploadClientMock := &uploadMocks.Client{}
-		service := NewService(repositoryMock, uploadClientMock, false, defaultSpecRequestTimeout)
+		service := NewService(repositoryMock, uploadClientMock, false, defaultAssetstoreRequestTimeout)
 
 		// when
 		err := service.Put("id1", "", []byte(nil), []byte(nil), []byte(nil))
@@ -177,7 +177,7 @@ func TestGettingFromAssetStore(t *testing.T) {
 	t.Run("Should get specifications from asset store", func(t *testing.T) {
 		// given
 		repositoryMock := &mocks.DocsTopicRepository{}
-		service := NewService(repositoryMock, nil, false, defaultSpecRequestTimeout)
+		service := NewService(repositoryMock, nil, false, defaultAssetstoreRequestTimeout)
 
 		apiTestServer := createTestServer(t, jsonApiSpec)
 		defer apiTestServer.Close()
@@ -214,7 +214,7 @@ func TestGettingFromAssetStore(t *testing.T) {
 	t.Run("Should fail when failed to read DocsTopic CR", func(t *testing.T) {
 		// given
 		repositoryMock := &mocks.DocsTopicRepository{}
-		service := NewService(repositoryMock, nil, false, defaultSpecRequestTimeout)
+		service := NewService(repositoryMock, nil, false, defaultAssetstoreRequestTimeout)
 
 		repositoryMock.On("Get", "id1").
 			Return(docstopic.Entry{}, apperrors.Internal("some error"))
@@ -234,7 +234,7 @@ func TestGettingFromAssetStore(t *testing.T) {
 	t.Run("Should return nil specs if Docs Topic CR doesn't exist", func(t *testing.T) {
 		// given
 		repositoryMock := &mocks.DocsTopicRepository{}
-		service := NewService(repositoryMock, nil, false, defaultSpecRequestTimeout)
+		service := NewService(repositoryMock, nil, false, defaultAssetstoreRequestTimeout)
 
 		repositoryMock.On("Get", "id1").
 			Return(docstopic.Entry{}, apperrors.NotFound("object not found"))
@@ -267,7 +267,7 @@ func TestGettingFromAssetStoreIfStatusIsNotReady(t *testing.T) {
 			// given
 			repositoryMock := &mocks.DocsTopicRepository{}
 			uploadClientMock := &uploadMocks.Client{}
-			service := NewService(repositoryMock, uploadClientMock, false, defaultSpecRequestTimeout)
+			service := NewService(repositoryMock, uploadClientMock, false, defaultAssetstoreRequestTimeout)
 
 			{
 				repositoryMock.On("Get", "id1").Return(createDocsTopic("id1", nil, testData.status), nil)

--- a/components/application-registry/internal/metadata/specification/service.go
+++ b/components/application-registry/internal/metadata/specification/service.go
@@ -20,8 +20,6 @@ const (
 	oDataSpecFormat      = "%s/$metadata"
 	oDataSpecType        = "odata"
 	targetSwaggerVersion = "2.0"
-
-	specRequestTimeout = time.Duration(5 * time.Second)
 )
 
 type Service interface {
@@ -35,11 +33,11 @@ type specService struct {
 	downloadClient    download.Client
 }
 
-func NewSpecService(assetStoreService assetstore.Service) Service {
+func NewSpecService(assetStoreService assetstore.Service, specRequestTimeout int) Service {
 	return &specService{
 		assetStoreService: assetStoreService,
 		downloadClient: download.NewClient(&http.Client{
-			Timeout: specRequestTimeout,
+			Timeout: time.Duration(specRequestTimeout) * time.Second,
 		}),
 	}
 }

--- a/components/application-registry/internal/metadata/specification/service_test.go
+++ b/components/application-registry/internal/metadata/specification/service_test.go
@@ -16,6 +16,7 @@ import (
 const (
 	serviceId  = "1234"
 	gatewayUrl = "http://app-1234.io"
+	defaultSpecRequestTimeout = 5
 )
 
 var (
@@ -36,7 +37,7 @@ func TestSpecService_PutSpec(t *testing.T) {
 		assetStoreSvc := &mocks.Service{}
 		assetStoreSvc.On("Put", serviceId, docstopic.OpenApiType, baseDocs, baseApiSpec, baseEventSpec).Return(nil)
 
-		specService := NewSpecService(assetStoreSvc, 5)
+		specService := NewSpecService(assetStoreSvc, defaultSpecRequestTimeout)
 
 		// when
 		err := specService.PutSpec(serviceDef, gatewayUrl)
@@ -53,7 +54,7 @@ func TestSpecService_PutSpec(t *testing.T) {
 		assetStoreSvc := &mocks.Service{}
 		assetStoreSvc.On("Put", serviceId, docstopic.OpenApiType, baseDocs, modifiedSwaggerSpec, baseEventSpec).Return(nil)
 
-		specService := NewSpecService(assetStoreSvc, 5)
+		specService := NewSpecService(assetStoreSvc, defaultSpecRequestTimeout)
 
 		// when
 		err := specService.PutSpec(serviceDef, gatewayUrl)
@@ -70,7 +71,7 @@ func TestSpecService_PutSpec(t *testing.T) {
 		assetStoreSvc := &mocks.Service{}
 		assetStoreSvc.On("Put", serviceId, docstopic.ODataApiType, baseDocs, swaggerApiSpec, baseEventSpec).Return(nil)
 
-		specService := NewSpecService(assetStoreSvc, 5)
+		specService := NewSpecService(assetStoreSvc, defaultSpecRequestTimeout)
 
 		// when
 		err := specService.PutSpec(serviceDef, gatewayUrl)
@@ -92,7 +93,7 @@ func TestSpecService_PutSpec(t *testing.T) {
 		assetStoreSvc := &mocks.Service{}
 		assetStoreSvc.On("Put", serviceId, docstopic.OpenApiType, baseDocs, baseApiSpec, baseEventSpec).Return(nil)
 
-		specService := NewSpecService(assetStoreSvc, 5)
+		specService := NewSpecService(assetStoreSvc, defaultSpecRequestTimeout)
 
 		// when
 		err := specService.PutSpec(serviceDef, gatewayUrl)
@@ -114,7 +115,7 @@ func TestSpecService_PutSpec(t *testing.T) {
 		assetStoreSvc := &mocks.Service{}
 		assetStoreSvc.On("Put", serviceId, docstopic.OpenApiType, baseDocs, baseApiSpec, baseEventSpec).Return(nil)
 
-		specService := NewSpecService(assetStoreSvc, 5)
+		specService := NewSpecService(assetStoreSvc, defaultSpecRequestTimeout)
 
 		// when
 		err := specService.PutSpec(serviceDef, gatewayUrl)
@@ -136,7 +137,7 @@ func TestSpecService_PutSpec(t *testing.T) {
 		assetStoreSvc := &mocks.Service{}
 		assetStoreSvc.On("Put", serviceId, docstopic.OpenApiType, baseDocs, modifiedSwaggerSpec, baseEventSpec).Return(nil)
 
-		specService := NewSpecService(assetStoreSvc, 5)
+		specService := NewSpecService(assetStoreSvc, defaultSpecRequestTimeout)
 
 		// when
 		err := specService.PutSpec(serviceDef, gatewayUrl)
@@ -154,7 +155,7 @@ func TestSpecService_PutSpec(t *testing.T) {
 
 		assetStoreSvc := &mocks.Service{}
 
-		specService := NewSpecService(assetStoreSvc, 5)
+		specService := NewSpecService(assetStoreSvc, defaultSpecRequestTimeout)
 
 		// when
 		err := specService.PutSpec(serviceDef, gatewayUrl)
@@ -176,7 +177,7 @@ func TestSpecService_PutSpec(t *testing.T) {
 		assetStoreSvc := &mocks.Service{}
 		assetStoreSvc.On("Put", serviceId, docstopic.ODataApiType, baseDocs, baseApiSpec, baseEventSpec).Return(nil)
 
-		specService := NewSpecService(assetStoreSvc, 5)
+		specService := NewSpecService(assetStoreSvc, defaultSpecRequestTimeout)
 
 		// when
 		err := specService.PutSpec(serviceDef, gatewayUrl)
@@ -193,7 +194,7 @@ func TestSpecService_PutSpec(t *testing.T) {
 		assetStoreSvc := &mocks.Service{}
 		assetStoreSvc.On("Put", serviceId, docstopic.OpenApiType, baseDocs, []byte(nil), baseEventSpec).Return(nil)
 
-		specService := NewSpecService(assetStoreSvc, 5)
+		specService := NewSpecService(assetStoreSvc, defaultSpecRequestTimeout)
 
 		// when
 		err := specService.PutSpec(serviceDef, gatewayUrl)
@@ -210,7 +211,7 @@ func TestSpecService_PutSpec(t *testing.T) {
 		assetStoreSvc := &mocks.Service{}
 		assetStoreSvc.On("Put", serviceId, docstopic.NoneApiType, baseDocs, []byte(nil), baseEventSpec).Return(nil)
 
-		specService := NewSpecService(assetStoreSvc, 5)
+		specService := NewSpecService(assetStoreSvc, defaultSpecRequestTimeout)
 
 		// when
 		err := specService.PutSpec(serviceDef, gatewayUrl)
@@ -227,7 +228,7 @@ func TestSpecService_PutSpec(t *testing.T) {
 		assetStoreSvc := &mocks.Service{}
 		assetStoreSvc.On("Put", serviceId, docstopic.OpenApiType, baseDocs, baseApiSpec, baseEventSpec).Return(apperrors.Internal("Error"))
 
-		specService := NewSpecService(assetStoreSvc, 5)
+		specService := NewSpecService(assetStoreSvc, defaultSpecRequestTimeout)
 
 		// when
 		err := specService.PutSpec(serviceDef, gatewayUrl)
@@ -246,7 +247,7 @@ func TestSpecService_GetSpec(t *testing.T) {
 		assetStoreSvc := &mocks.Service{}
 		assetStoreSvc.On("Get", serviceId).Return(baseDocs, baseApiSpec, baseEventSpec, nil)
 
-		specService := NewSpecService(assetStoreSvc, 5)
+		specService := NewSpecService(assetStoreSvc, defaultSpecRequestTimeout)
 
 		// when
 		docs, apiSpec, eventsSpec, err := specService.GetSpec(serviceId)
@@ -263,7 +264,7 @@ func TestSpecService_GetSpec(t *testing.T) {
 		assetStoreSvc := &mocks.Service{}
 		assetStoreSvc.On("Get", serviceId).Return(nil, nil, nil, apperrors.Internal("Error"))
 
-		specService := NewSpecService(assetStoreSvc, 5)
+		specService := NewSpecService(assetStoreSvc, defaultSpecRequestTimeout)
 
 		// when
 		docs, apiSpec, eventsSpec, err := specService.GetSpec(serviceId)
@@ -284,7 +285,7 @@ func TestSpecService_RemoveSpec(t *testing.T) {
 		assetStoreSvc := &mocks.Service{}
 		assetStoreSvc.On("Remove", serviceId).Return(nil)
 
-		specService := NewSpecService(assetStoreSvc, 5)
+		specService := NewSpecService(assetStoreSvc, defaultSpecRequestTimeout)
 
 		// when
 		err := specService.RemoveSpec(serviceId)
@@ -298,7 +299,7 @@ func TestSpecService_RemoveSpec(t *testing.T) {
 		assetStoreSvc := &mocks.Service{}
 		assetStoreSvc.On("Remove", serviceId).Return(apperrors.Internal("Error"))
 
-		specService := NewSpecService(assetStoreSvc, 5)
+		specService := NewSpecService(assetStoreSvc, defaultSpecRequestTimeout)
 
 		// when
 		err := specService.RemoveSpec(serviceId)

--- a/components/application-registry/internal/metadata/specification/service_test.go
+++ b/components/application-registry/internal/metadata/specification/service_test.go
@@ -36,7 +36,7 @@ func TestSpecService_PutSpec(t *testing.T) {
 		assetStoreSvc := &mocks.Service{}
 		assetStoreSvc.On("Put", serviceId, docstopic.OpenApiType, baseDocs, baseApiSpec, baseEventSpec).Return(nil)
 
-		specService := NewSpecService(assetStoreSvc)
+		specService := NewSpecService(assetStoreSvc, 5)
 
 		// when
 		err := specService.PutSpec(serviceDef, gatewayUrl)
@@ -53,7 +53,7 @@ func TestSpecService_PutSpec(t *testing.T) {
 		assetStoreSvc := &mocks.Service{}
 		assetStoreSvc.On("Put", serviceId, docstopic.OpenApiType, baseDocs, modifiedSwaggerSpec, baseEventSpec).Return(nil)
 
-		specService := NewSpecService(assetStoreSvc)
+		specService := NewSpecService(assetStoreSvc, 5)
 
 		// when
 		err := specService.PutSpec(serviceDef, gatewayUrl)
@@ -70,7 +70,7 @@ func TestSpecService_PutSpec(t *testing.T) {
 		assetStoreSvc := &mocks.Service{}
 		assetStoreSvc.On("Put", serviceId, docstopic.ODataApiType, baseDocs, swaggerApiSpec, baseEventSpec).Return(nil)
 
-		specService := NewSpecService(assetStoreSvc)
+		specService := NewSpecService(assetStoreSvc, 5)
 
 		// when
 		err := specService.PutSpec(serviceDef, gatewayUrl)
@@ -92,7 +92,7 @@ func TestSpecService_PutSpec(t *testing.T) {
 		assetStoreSvc := &mocks.Service{}
 		assetStoreSvc.On("Put", serviceId, docstopic.OpenApiType, baseDocs, baseApiSpec, baseEventSpec).Return(nil)
 
-		specService := NewSpecService(assetStoreSvc)
+		specService := NewSpecService(assetStoreSvc, 5)
 
 		// when
 		err := specService.PutSpec(serviceDef, gatewayUrl)
@@ -114,7 +114,7 @@ func TestSpecService_PutSpec(t *testing.T) {
 		assetStoreSvc := &mocks.Service{}
 		assetStoreSvc.On("Put", serviceId, docstopic.OpenApiType, baseDocs, baseApiSpec, baseEventSpec).Return(nil)
 
-		specService := NewSpecService(assetStoreSvc)
+		specService := NewSpecService(assetStoreSvc, 5)
 
 		// when
 		err := specService.PutSpec(serviceDef, gatewayUrl)
@@ -136,7 +136,7 @@ func TestSpecService_PutSpec(t *testing.T) {
 		assetStoreSvc := &mocks.Service{}
 		assetStoreSvc.On("Put", serviceId, docstopic.OpenApiType, baseDocs, modifiedSwaggerSpec, baseEventSpec).Return(nil)
 
-		specService := NewSpecService(assetStoreSvc)
+		specService := NewSpecService(assetStoreSvc, 5)
 
 		// when
 		err := specService.PutSpec(serviceDef, gatewayUrl)
@@ -154,7 +154,7 @@ func TestSpecService_PutSpec(t *testing.T) {
 
 		assetStoreSvc := &mocks.Service{}
 
-		specService := NewSpecService(assetStoreSvc)
+		specService := NewSpecService(assetStoreSvc, 5)
 
 		// when
 		err := specService.PutSpec(serviceDef, gatewayUrl)
@@ -176,7 +176,7 @@ func TestSpecService_PutSpec(t *testing.T) {
 		assetStoreSvc := &mocks.Service{}
 		assetStoreSvc.On("Put", serviceId, docstopic.ODataApiType, baseDocs, baseApiSpec, baseEventSpec).Return(nil)
 
-		specService := NewSpecService(assetStoreSvc)
+		specService := NewSpecService(assetStoreSvc, 5)
 
 		// when
 		err := specService.PutSpec(serviceDef, gatewayUrl)
@@ -193,7 +193,7 @@ func TestSpecService_PutSpec(t *testing.T) {
 		assetStoreSvc := &mocks.Service{}
 		assetStoreSvc.On("Put", serviceId, docstopic.OpenApiType, baseDocs, []byte(nil), baseEventSpec).Return(nil)
 
-		specService := NewSpecService(assetStoreSvc)
+		specService := NewSpecService(assetStoreSvc, 5)
 
 		// when
 		err := specService.PutSpec(serviceDef, gatewayUrl)
@@ -210,7 +210,7 @@ func TestSpecService_PutSpec(t *testing.T) {
 		assetStoreSvc := &mocks.Service{}
 		assetStoreSvc.On("Put", serviceId, docstopic.NoneApiType, baseDocs, []byte(nil), baseEventSpec).Return(nil)
 
-		specService := NewSpecService(assetStoreSvc)
+		specService := NewSpecService(assetStoreSvc, 5)
 
 		// when
 		err := specService.PutSpec(serviceDef, gatewayUrl)
@@ -227,7 +227,7 @@ func TestSpecService_PutSpec(t *testing.T) {
 		assetStoreSvc := &mocks.Service{}
 		assetStoreSvc.On("Put", serviceId, docstopic.OpenApiType, baseDocs, baseApiSpec, baseEventSpec).Return(apperrors.Internal("Error"))
 
-		specService := NewSpecService(assetStoreSvc)
+		specService := NewSpecService(assetStoreSvc, 5)
 
 		// when
 		err := specService.PutSpec(serviceDef, gatewayUrl)
@@ -246,7 +246,7 @@ func TestSpecService_GetSpec(t *testing.T) {
 		assetStoreSvc := &mocks.Service{}
 		assetStoreSvc.On("Get", serviceId).Return(baseDocs, baseApiSpec, baseEventSpec, nil)
 
-		specService := NewSpecService(assetStoreSvc)
+		specService := NewSpecService(assetStoreSvc, 5)
 
 		// when
 		docs, apiSpec, eventsSpec, err := specService.GetSpec(serviceId)
@@ -263,7 +263,7 @@ func TestSpecService_GetSpec(t *testing.T) {
 		assetStoreSvc := &mocks.Service{}
 		assetStoreSvc.On("Get", serviceId).Return(nil, nil, nil, apperrors.Internal("Error"))
 
-		specService := NewSpecService(assetStoreSvc)
+		specService := NewSpecService(assetStoreSvc, 5)
 
 		// when
 		docs, apiSpec, eventsSpec, err := specService.GetSpec(serviceId)
@@ -284,7 +284,7 @@ func TestSpecService_RemoveSpec(t *testing.T) {
 		assetStoreSvc := &mocks.Service{}
 		assetStoreSvc.On("Remove", serviceId).Return(nil)
 
-		specService := NewSpecService(assetStoreSvc)
+		specService := NewSpecService(assetStoreSvc, 5)
 
 		// when
 		err := specService.RemoveSpec(serviceId)
@@ -298,7 +298,7 @@ func TestSpecService_RemoveSpec(t *testing.T) {
 		assetStoreSvc := &mocks.Service{}
 		assetStoreSvc.On("Remove", serviceId).Return(apperrors.Internal("Error"))
 
-		specService := NewSpecService(assetStoreSvc)
+		specService := NewSpecService(assetStoreSvc, 5)
 
 		// when
 		err := specService.RemoveSpec(serviceId)

--- a/resources/application-connector/charts/application-registry/README.md
+++ b/resources/application-connector/charts/application-registry/README.md
@@ -12,6 +12,4 @@ This service has the following parameters:
 - **namespace** - The Namespace to which you deploy the Proxy Service. The default Namespace is `kyma-integration`.
 - **requestTimeout** - A time-out for requests sent through the Proxy Service. Provide it in seconds. The default time-out is `10`.
 - **requestLogging** - The flag to enable logging of incoming requests. The default value is `false`.
-- **specRequestTimeout** - A timeout for requests fetching specifications provided by the user. It is provided in seconds. The default timeout is `5`.
-- **assetstoreRequestTimeout** - A timeout for requests fetching specifications from the Asset Store Service. It is provided in seconds. The default timeout is `5`.
 - **detailedErrorResponse** - A flag for showing detailed internal error messages in response bodies. The default value is `false` and all internal server error messages are shortened to `Internal error`, while all other error messages are shown as usual.

--- a/resources/application-connector/charts/application-registry/README.md
+++ b/resources/application-connector/charts/application-registry/README.md
@@ -12,4 +12,6 @@ This service has the following parameters:
 - **namespace** - The Namespace to which you deploy the Proxy Service. The default Namespace is `kyma-integration`.
 - **requestTimeout** - A time-out for requests sent through the Proxy Service. Provide it in seconds. The default time-out is `10`.
 - **requestLogging** - The flag to enable logging of incoming requests. The default value is `false`.
+- **specRequestTimeout** - A timeout for requests fetching specifications provided by the user. It is provided in seconds. The default timeout is `5`.
+- **assetstoreRequestTimeout** - A timeout for requests fetching specifications from the Asset Store Service. It is provided in seconds. The default timeout is `5`.
 - **detailedErrorResponse** - A flag for showing detailed internal error messages in response bodies. The default value is `false` and all internal server error messages are shortened to `Internal error`, while all other error messages are shown as usual.


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Add configurable specRequestTimeout parameter to Application Registry
- Add configurable assetstoreRequestTimeout parameter to Application Registry
- Add the `specRequestTimeout` flag to the `README.md` file
- Add the `assetstoreRequestTimeout` flag to the `README.md` file

**Related issue(s)**

- See the issue #4124 
- See the bump + chart change #4154 
