### PR TITLE
Fix incorrect comment of clusterDocsTopicsVersion

### DIFF
--- a/resources/core/values.yaml
+++ b/resources/core/values.yaml
@@ -44,7 +44,7 @@ global:
   docs:
     # - Change the value below to the branch from your fork if you want to point to documentation sources from your fork
     # - Change the value below to the release branch during the release
-    # Example: clusterDocsTopicsVersion: "0.9.0"
+    # Example: clusterDocsTopicsVersion: "release-0.9"
     clusterDocsTopicsVersion: master
   namespace_controller:
     dir: develop/


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/master/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

The comment describing changing `clusterDocsTopicsVersion` in release branches is incorrect and therefore confusing for the person, who is creating the release

Changes proposed in this pull request:

- Update comment regarding `clusterDocsTopicsVersion` in release branches

**Related issue(s)**
https://github.com/kyma-project/community/issues/276
