### PR TITLE
Expand istio limits on cluster settings

### DIFF
--- a/installation/resources/installer-config-cluster.yaml.tpl
+++ b/installation/resources/installer-config-cluster.yaml.tpl
@@ -67,6 +67,22 @@ data:
   gateways.istio-ingressgateway.loadBalancerIP: "__EXTERNAL_PUBLIC_IP__"
   global.proxy.excludeIPRanges: "__PROXY_EXCLUDE_IP_RANGES__"
   global.tracer.zipkin.address: zipkin.kyma-system:9411
+
+  pilot.resources.limits.memory: 1024Mi
+  pilot.resources.limits.cpu: 500m
+  pilot.resources.requests.memory: 512Mi
+  pilot.resources.requests.cpu: 250m
+
+  mixer.policy.resources.limits.memory: 2048Mi
+  mixer.policy.resources.limits.cpu: 500m
+  mixer.policy.resources.requests.memory: 512Mi
+  mixer.policy.resources.requests.cpu: 300m
+
+  mixer.telemetry.resources.limits.memory: 2048Mi
+  mixer.telemetry.resources.limits.cpu: 500m
+  mixer.telemetry.resources.requests.memory: 512Mi
+  mixer.telemetry.resources.requests.cpu: 300m
+  mixer.loadshedding.mode: disabled
 ---
 apiVersion: v1
 kind: ConfigMap


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/master/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

We have seen on nightly clusters that there was not enough system resources (cpu and mem) for creating even a simple test lambda pod. A fair amount of those resources was used by istio. 

Changes proposed in this pull request:

- Introduce the same cpu and mem limitations we have on minikube in a cluster setup

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
