### PR TITLE
Ensure users.adminGroup is defined

### DIFF
--- a/installation/resources/installer-config-local.yaml.tpl
+++ b/installation/resources/installer-config-local.yaml.tpl
@@ -38,7 +38,6 @@ data:
   global.etcdBackup.enabled: "false"
   global.adminPassword: ""
   nginx-ingress.controller.service.loadBalancerIP: ""
-  cluster-users.users.adminGroup: ""
 ---
 apiVersion: v1
 kind: ConfigMap
@@ -73,7 +72,7 @@ data:
 
   mixer.policy.autoscaleEnabled: "false"
   mixer.telemetry.autoscaleEnabled: "false"
-  
+
   global.tracer.zipkin.address: zipkin.kyma-system:9411
 ---
 apiVersion: v1

--- a/resources/core/charts/cluster-users/values.yaml
+++ b/resources/core/charts/cluster-users/values.yaml
@@ -43,4 +43,5 @@ clusterRoles:
     view:
       - "get"
       - "list"
-
+users:
+  adminGroup:


### PR DESCRIPTION
**Description**

As a part of simplifying installation process we want to reduce the number of overrides/parameters used during Kyma installation.
At this moment, the override `cluster-users.users.adminGroup` must be always provided, even if it's an empty string, otherwise chart **core/cluster-users** can't properly resolve it's template.
By providing a default, empty value we can reduce number of overrides necessary to install Kyma.
Users are still able to override the default value if necessary.
**NOTE: In this PR only local installation configuration is affected, cluster installation will be handled in subsequent PRs**

Changes proposed in this pull request:

- Provide default, empty value for `users.adminGroup` in **core/cluster-users** chart.
- Remove empty override from local installation configuration.

**Related issue(s)**
See also #4118 