### PR TITLE
Prevent main application-broker service removal in the migration

### DIFF
--- a/components/application-broker/internal/nsbroker/facade.go
+++ b/components/application-broker/internal/nsbroker/facade.go
@@ -100,7 +100,7 @@ func (f *Facade) Create(destinationNs string) error {
 
 // createServiceBroker returns just created or existing ServiceBroker
 func (f *Facade) createServiceBroker(svcURL, namespace string) (*v1beta1.ServiceBroker, error) {
-	url := fmt.Sprintf("%s/%s/", svcURL, namespace)
+	url := fmt.Sprintf("%s/%s", svcURL, namespace)
 	broker := &v1beta1.ServiceBroker{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      NamespacedBrokerName,

--- a/components/application-broker/internal/nsbroker/facade_test.go
+++ b/components/application-broker/internal/nsbroker/facade_test.go
@@ -30,7 +30,7 @@ func TestNsBrokerCreateHappyPath(t *testing.T) {
 	mockBrokerSyncer := &automock.BrokerSyncer{}
 	defer mockBrokerSyncer.AssertExpectations(t)
 
-	svcURL := fmt.Sprintf("http://%s.%s.svc.cluster.local/%s/", fixABService(), fixWorkingNs(), "stage")
+	svcURL := fmt.Sprintf("http://%s.%s.svc.cluster.local/%s", fixABService(), fixWorkingNs(), "stage")
 	mockBrokerSyncer.On("SyncBroker", "stage").Once().Return(nil)
 
 	sut := nsbroker.NewFacade(scFakeClientset.ServicecatalogV1beta1(), k8sFakeClientset.CoreV1(), mockBrokerSyncer, fixWorkingNs(), fixABSelectorKey(), fixABSelectorValue(), fixABService(), fixTargetPort(), spy.NewLogDummy())

--- a/components/application-broker/internal/nsbroker/migration.go
+++ b/components/application-broker/internal/nsbroker/migration.go
@@ -89,9 +89,13 @@ func (s *MigrationService) migrateServiceBroker(broker *v1beta1.ServiceBroker) e
 		return errors.Wrapf(err, "while updating ServiceBroker in namespace %s", broker.Namespace)
 	}
 
+	// do not delete the main service for application-broker
+	if broker.Namespace == s.workingNs && existingServiceName == s.serviceName {
+		return nil
+	}
 	// ensure the service is deleted
-	s.log.Infof("Deleting service %s/%s", s.workingNs, existingServiceName)
-	err = s.serviceInterface.Services(s.workingNs).Delete(existingServiceName, &v1.DeleteOptions{})
+	s.log.Infof("Deleting service %s/%s", broker.Namespace, existingServiceName)
+	err = s.serviceInterface.Services(broker.Namespace).Delete(existingServiceName, &v1.DeleteOptions{})
 	switch {
 	case err == nil:
 	case apierrors.IsNotFound(err):


### PR DESCRIPTION
… migration

<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/master/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:
- Application broker contains migration code, which should not delete existing main service for application broker

**Related issue(s)**
Related: #3843 
