### PR TITLE
Define default promtail value

### DIFF
--- a/resources/logging/templates/promtail/daemonset.yaml
+++ b/resources/logging/templates/promtail/daemonset.yaml
@@ -1,4 +1,3 @@
-{{- $configFileName :=  .Values.global.logging.promtail.config.name | default "promtail.yaml" -}}
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
@@ -37,7 +36,7 @@ spec:
           image: "{{ .Values.promtail.image.repository }}:{{ .Values.promtail.image.tag }}"
           imagePullPolicy: {{ .Values.promtail.image.pullPolicy }}
           args:
-            - "-config.file=/etc/promtail/{{ $configFileName }}"
+            - "-config.file=/etc/promtail/{{ .Values.global.logging.promtail.config.name }}"
             - "-client.url=http://{{ template "loki.fullname" . }}:{{ .Values.loki.service.port }}/api/prom/push"
           volumeMounts:
             - name: config

--- a/resources/logging/values.yaml
+++ b/resources/logging/values.yaml
@@ -167,7 +167,6 @@ promtail:
   #  prometheus.io/port: "http-metrics"
   #For pods running sidecars w/o service there's a problem with envoy readiness probe.
   #Details https://github.com/istio/istio/issues/9504#issuecomment-439432130
-
     readiness.status.sidecar.istio.io/applicationPorts: ""
 
   ## Deployment annotations

--- a/resources/logging/values.yaml
+++ b/resources/logging/values.yaml
@@ -167,8 +167,9 @@ promtail:
   #  prometheus.io/port: "http-metrics"
   #For pods running sidecars w/o service there's a problem with envoy readiness probe.
   #Details https://github.com/istio/istio/issues/9504#issuecomment-439432130
+
     readiness.status.sidecar.istio.io/applicationPorts: ""
-    
+
   ## Deployment annotations
   annotations: {}
 
@@ -203,8 +204,8 @@ global:
   logging:
     promtail:
       config:
-        name:
+        name: promtail-k8s-1-14.yaml
 test:
   image:
     name: test-logging
-    
+


### PR DESCRIPTION
**Description**

The value of `promtail.config.name` attribute in the **logging** chart is not defined (empty).
We set it to empty anyway for local installations, but we always override it to the same value `promtail-k8s-1-14.yaml` in cluster installations.
Because of simplification of Kyma installation and because values in charts should reflect a default cluster installation, the default value should be defined in the logging chart.

Changes proposed in this pull request:

- Define default value for `promtail.config.name` attribute in **logging** chart.

**Related issue(s)**
- #4118 
- #3932 
