### PR TITLE
Get rid of custom override in knative-serving chart

### DIFF
--- a/resources/knative-serving/README.md
+++ b/resources/knative-serving/README.md
@@ -11,7 +11,7 @@ Included releases:
 Kyma-specific changes:
  * Every CRD has the `helm.sh/hook: crd-install` annotation set. This forces Helm to install the CRDs before other resources.
  * The duplicate of the `images.caching.internal.knative.dev` CRD is removed from the serving release.
- * The `config-domain` is made configurable by specifying the `.Values.domainName` as the helm template.
+ * The `config-domain` is made configurable by specifying the `.Values.global.domainName` as the helm template.
  * The `knative-serving` Namespace is no longer created. This happens during the installation process.
  * The image versions are changed to use the release tag.
  * Knative Serving uses the Kyma Istio Ingress gateway.

--- a/resources/knative-serving/charts/knative-serving/templates/serving.yaml
+++ b/resources/knative-serving/charts/knative-serving/templates/serving.yaml
@@ -774,8 +774,8 @@ metadata:
 ---
 apiVersion: v1
 data:
-  {{ if (ne "" .Values.domainName) }}
-  {{ .Values.domainName }}: ""
+  {{ if (ne "" .Values.global.domainName) }}
+  {{ .Values.global.domainName }}: ""
   {{ end }}
 kind: ConfigMap
 metadata:

--- a/resources/knative-serving/values.yaml
+++ b/resources/knative-serving/values.yaml
@@ -2,7 +2,6 @@ knative-serving:
   gateway:
     name: kyma-gateway.kyma-system.svc.cluster.local
     serviceUrl: istio-ingressgateway.istio-system.svc.cluster.local
-  domainName: example.com
 
 global:
   isLocalEnv: false
@@ -12,6 +11,7 @@ global:
   test_knative_serving_acceptance:
     dir: develop/
     version: adaa993d
+  domainName: example.com
 
 test:
   target: "Test Target"


### PR DESCRIPTION
**Description**
**knative-serving** chart is currently configured with `knative-serving.domainName` override.
For all identified scenarios, we set this override to exactly the same value as the `global.domain` override.
It means in every scenario we prepare two distinct overrides with the same value.

To simplify our setup we can easily refactor **knative-serving** chart to use `global.domain` override value and that's the goal of this PR.

*Note: we can still override to a different value (if necessary) by providing an override with different value for `global.domain` just for `knative-serving` component - it will not affect any other components then.*

Changes proposed in this pull request:

- refactor `knative-serving` chart to use the domain from `global.domain` Kyma override.


**Related issue(s)**
See also #3932 
