### PR TITLE
 Fix kubectl command executed in test perf script.

### DIFF
--- a/tests/perf/prerequisites/application-gateway/setup.sh
+++ b/tests/perf/prerequisites/application-gateway/setup.sh
@@ -230,7 +230,7 @@ echo "Cleaning up..."
 $( rm ${APP_CONNECTOR_CERT_DIR}/generated.csr )
 $( rm ${APP_CONNECTOR_CERT_DIR}/generated.yaml )
 
-$( kubectl kubectl -n app-gateway-test delete TokenRequest perf-app &> /dev/null; )
+$( kubectl -n app-gateway-test delete TokenRequest perf-app &> /dev/null; )
 
 
 echo ""

--- a/tests/perf/prerequisites/application-gateway/setup.sh
+++ b/tests/perf/prerequisites/application-gateway/setup.sh
@@ -230,7 +230,7 @@ echo "Cleaning up..."
 $( rm ${APP_CONNECTOR_CERT_DIR}/generated.csr )
 $( rm ${APP_CONNECTOR_CERT_DIR}/generated.yaml )
 
-$( kubectl delete TokenRequest perf-app &> /dev/null; )
+$( kubectl kubectl -n app-gateway-test delete TokenRequest perf-app &> /dev/null; )
 
 
 echo ""


### PR DESCRIPTION
Add namespace to the kubectl delete command for the deletion of _TokenRequest perf-app_