### PR TITLE
Store additional headers and query parameters in the secret

### DIFF
--- a/components/application-gateway/internal/metadata/applications/repository.go
+++ b/components/application-gateway/internal/metadata/applications/repository.go
@@ -40,7 +40,10 @@ type ServiceAPI struct {
 	GatewayURL      string
 	AccessLabel     string
 	TargetUrl       string
+	//TODO: Add SecretID field pointing to the Secret with Headers and QueryParameters
+	//SecretID string
 	Credentials     *Credentials
+	//TODO: Delete Headers and QueryParameters fields from here
 	Headers         *map[string][]string
 	QueryParameters *map[string][]string
 }

--- a/components/application-gateway/internal/metadata/applications/repository.go
+++ b/components/application-gateway/internal/metadata/applications/repository.go
@@ -37,12 +37,12 @@ type Credentials struct {
 
 // ServiceAPI stores information needed to call an API
 type ServiceAPI struct {
-	GatewayURL      string
-	AccessLabel     string
-	TargetUrl       string
+	GatewayURL  string
+	AccessLabel string
+	TargetUrl   string
 	//TODO: Add SecretID field pointing to the Secret with Headers and QueryParameters
 	//SecretID string
-	Credentials     *Credentials
+	Credentials *Credentials
 	//TODO: Delete Headers and QueryParameters fields from here
 	Headers         *map[string][]string
 	QueryParameters *map[string][]string

--- a/components/application-gateway/internal/metadata/serviceapi/serviceapiservice.go
+++ b/components/application-gateway/internal/metadata/serviceapi/serviceapiservice.go
@@ -38,6 +38,22 @@ func NewService(secretsRepository secrets.Repository) Service {
 }
 
 func (sas defaultService) Read(applicationAPI *applications.ServiceAPI) (*model.API, apperrors.AppError) {
+
+	//TODO: Fetch Secret applicationAPI.SecretID. I decided to create secret per service
+	//		analogical to credentialsSecret
+	//api := &model.API{
+	//	TargetUrl: applicationAPI.TargetUrl,
+	//}
+	//if applicationAPI.SecretID != nil {
+	//	secretName := applicationAPI.SecretID
+	//	serviceSecret, err := sas.secretsRepository.Get(secretName)
+	//	if err != nil {
+	//		return nil, err
+	//	}
+	//	api.Headers = serviceSecret.Headers
+	//	api.QueryParameters = serviceSecret.QueryParameters
+	//}
+
 	api := &model.API{
 		TargetUrl:       applicationAPI.TargetUrl,
 		Headers:         applicationAPI.Headers,

--- a/components/application-registry/cmd/applicationregistry/handlers.go
+++ b/components/application-registry/cmd/applicationregistry/handlers.go
@@ -71,6 +71,7 @@ func newServiceDefinitionService(opt *options, nameResolver k8sconsts.NameResolv
 	}
 
 	accessServiceManager := newAccessServiceManager(coreClientset, opt.namespace, opt.proxyPort)
+	//TODO: Rename to credentialsSecretsService and add new secretsService
 	secretsService := newSecretsRepository(coreClientset, nameResolver, opt.namespace)
 
 	uuidGenerator := metauuid.GeneratorFunc(func() (string, error) {
@@ -81,6 +82,7 @@ func newServiceDefinitionService(opt *options, nameResolver k8sconsts.NameResolv
 		return uuidInstance.String(), nil
 	})
 
+	//TODO: Add also the new secretsService
 	serviceAPIService := serviceapi.NewService(nameResolver, accessServiceManager, secretsService, istioService)
 
 	return metadata.NewServiceDefinitionService(uuidGenerator, serviceAPIService, applicationServiceRepository, specificationService), nil
@@ -122,6 +124,7 @@ func newAccessServiceManager(coreClientset *kubernetes.Clientset, namespace stri
 	return accessservice.NewAccessServiceManager(si, config)
 }
 
+//TODO: Rename to newCredentialsSecretsRepository and add one for the new secret
 func newSecretsRepository(coreClientset *kubernetes.Clientset, nameResolver k8sconsts.NameResolver, namespace string) secrets.Service {
 	sei := coreClientset.CoreV1().Secrets(namespace)
 	strategyFactory := strategy.NewSecretsStrategyFactory(certificates.GenerateKeyAndCertificate)

--- a/components/application-registry/internal/metadata/applications/repository.go
+++ b/components/application-registry/internal/metadata/applications/repository.go
@@ -48,10 +48,9 @@ type CSRFInfo struct {
 type Credentials struct {
 	Type              string
 	SecretName        string
+	RequestParamsSecretName string
 	AuthenticationUrl string
 	CSRFInfo          *CSRFInfo
-	Headers           *map[string][]string
-	QueryParameters   *map[string][]string
 }
 
 // Service represents a service stored in Application RE

--- a/components/application-registry/internal/metadata/model/model.go
+++ b/components/application-registry/internal/metadata/model/model.go
@@ -12,10 +12,8 @@ type API struct {
 	SpecificationUrl string
 	// ApiType is a type of and API ex. OData, OpenApi
 	ApiType string
-	// Headers
-	Headers *map[string][]string
-	// QueryParameters
-	QueryParameters *map[string][]string
+	// Request Parameters
+	RequestParameters *RequestParameters
 }
 
 // Credentials contains OAuth configuration.
@@ -24,6 +22,9 @@ type Credentials struct {
 	Oauth           *Oauth
 	Basic           *Basic
 	CertificateGen  *CertificateGen
+}
+
+type RequestParameters struct {
 	Headers         *map[string][]string
 	QueryParameters *map[string][]string
 }
@@ -42,6 +43,8 @@ type Oauth struct {
 	ClientSecret string
 	// Optional CSRF Data
 	CSRFInfo *CSRFInfo
+	// Request Parameters
+	RequestParameters *RequestParameters
 }
 
 // Basic contains details of Basic configuration.
@@ -52,6 +55,8 @@ type Basic struct {
 	Password string
 	// Optional CSRF Data
 	CSRFInfo *CSRFInfo
+	// Request Parameters
+	RequestParameters *RequestParameters
 }
 
 // CertificateGen contains common name of the certificate to generate
@@ -60,6 +65,8 @@ type CertificateGen struct {
 	Certificate string
 	// Optional CSRF Data
 	CSRFInfo *CSRFInfo
+	// Request Parameters
+	RequestParameters *RequestParameters
 }
 
 // ServiceDefinition is an internal representation of a service.

--- a/components/application-registry/internal/metadata/secrets/service.go
+++ b/components/application-registry/internal/metadata/secrets/service.go
@@ -10,6 +10,7 @@ import (
 
 type modificationFunction func(modStrategy strategy.ModificationStrategy, application, name, serviceID string, newData strategy.SecretData) apperrors.AppError
 
+//TODO: Rename to CredentialsService add new service for the new secret
 type Service interface {
 	Get(application string, credentials applications.Credentials) (model.Credentials, apperrors.AppError)
 	Create(application, serviceID string, credentials *model.Credentials) (applications.Credentials, apperrors.AppError)
@@ -17,12 +18,14 @@ type Service interface {
 	Delete(name string) apperrors.AppError
 }
 
+//TODO: Rename to credentialsService
 type service struct {
 	nameResolver    k8sconsts.NameResolver
 	repository      Repository
 	strategyFactory strategy.Factory
 }
 
+//TODO: Rename to NewCredentialsService
 func NewService(repository Repository, nameResolver k8sconsts.NameResolver, strategyFactory strategy.Factory) Service {
 	return &service{
 		nameResolver:    nameResolver,

--- a/components/application-registry/internal/metadata/secrets/strategy/basicauth.go
+++ b/components/application-registry/internal/metadata/secrets/strategy/basicauth.go
@@ -52,6 +52,7 @@ func (svc *basicAuth) makeBasicAuthMap(username, password string) map[string][]b
 	return map[string][]byte{
 		BasicAuthUsernameKey: []byte(username),
 		BasicAuthPasswordKey: []byte(password),
+		"RequestParameters":
 	}
 }
 

--- a/components/application-registry/internal/metadata/secrets/strategy/basicauth.go
+++ b/components/application-registry/internal/metadata/secrets/strategy/basicauth.go
@@ -9,6 +9,7 @@ import (
 const (
 	BasicAuthUsernameKey = "username"
 	BasicAuthPasswordKey = "password"
+	BasicAuthRequestParametersKey = "requestParameters"
 )
 
 type basicAuth struct{}
@@ -30,7 +31,7 @@ func (svc *basicAuth) CredentialsProvided(credentials *model.Credentials) bool {
 }
 
 func (svc *basicAuth) CreateSecretData(credentials *model.Credentials) (SecretData, apperrors.AppError) {
-	return svc.makeBasicAuthMap(credentials.Basic.Username, credentials.Basic.Password), nil
+	return svc.makeBasicAuthMap(credentials.Basic.Username, credentials.Basic.Password, credentials.Basic.RequestParameters), nil
 }
 
 func (svc *basicAuth) ToCredentialsInfo(credentials *model.Credentials, secretName string) applications.Credentials {
@@ -48,11 +49,10 @@ func (svc *basicAuth) ShouldUpdate(currentData SecretData, newData SecretData) b
 		string(currentData[BasicAuthPasswordKey]) != string(newData[BasicAuthPasswordKey])
 }
 
-func (svc *basicAuth) makeBasicAuthMap(username, password string) map[string][]byte {
+func (svc *basicAuth) makeBasicAuthMap(username, password string, requestParameters *model.RequestParameters) map[string][]byte {
 	return map[string][]byte{
 		BasicAuthUsernameKey: []byte(username),
 		BasicAuthPasswordKey: []byte(password),
-		"RequestParameters":
 	}
 }
 

--- a/components/application-registry/internal/metadata/serviceapi/serviceapiservice.go
+++ b/components/application-registry/internal/metadata/serviceapi/serviceapiservice.go
@@ -29,6 +29,7 @@ type defaultService struct {
 	istioService         istio.Service
 }
 
+//TODO: Add also the new secret service
 func NewService(
 	nameResolver k8sconsts.NameResolver,
 	accessServiceManager accessservice.AccessServiceManager,


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Store additional headers and query parameters handled by Application Registry and Application Gateway in the secret

**Related issue(s)**

See the issue #4204 
See the bump **#WIP**
