### PR TITLE
Revert names in toggles

### DIFF
--- a/docs/headless-cms/03-03-markdown-documents.md
+++ b/docs/headless-cms/03-03-markdown-documents.md
@@ -36,7 +36,7 @@ type: {Document type}
 
 ### Display
 
-In the Documentation view (Docs UI), that is available in the Console UI under the question mark icon on the top navigation panel, the metadata allow you to create the left-side navigation structure. The Docs UI displays documents grouped under a common `type` in alphanumeric order as per files names. The following example shows four documents, their metadata, and corresponding places in the left-side navigation:
+In the Documentation view (Docs UI), that is available in the Console UI under the questoion mark icon on the top navigation panel, the metadata allow you to create the left-side navigation structure. The Docs UI displays documents grouped under a common `type` in alphanumeric order as per files names. The following example shows four documents, their metadata, and corresponding places in the left-side navigation:
 
 <div tabs>
   <details>

--- a/docs/kyma/04-03-cluster-installation.md
+++ b/docs/kyma/04-03-cluster-installation.md
@@ -13,7 +13,7 @@ If you need to use Helm and access Tiller, complete the [additional configuratio
 
 Choose your cloud provider and get started:
 
-<div tabs name="provider-installation">
+<div tabs>
   <details>
   <summary>
   GKE

--- a/docs/kyma/04-04-use-your-own-domain.md
+++ b/docs/kyma/04-04-use-your-own-domain.md
@@ -11,7 +11,7 @@ Choose your cloud provider and get started:
 
 >**CAUTION:** These instructions are valid starting with Kyma 1.2. If you want to install older releases, refer to the respective documentation versions.
 
-<div tabs name="provider-domain">
+<div tabs>
   <details>
   <summary>
   GKE


### PR DESCRIPTION
Reverts kyma-project/kyma#4236
This PR reverts changes in the documentation toggles as adding the name resulted in toggles not displaying correctly on the website.