### PR TITLE
Fix version and deprovision logic in Helm Broker

### DIFF
--- a/components/helm-broker/Gopkg.lock
+++ b/components/helm-broker/Gopkg.lock
@@ -1219,6 +1219,7 @@
     "k8s.io/helm/pkg/proto/hapi/chart",
     "k8s.io/helm/pkg/proto/hapi/release",
     "k8s.io/helm/pkg/proto/hapi/services",
+    "k8s.io/helm/pkg/storage/errors",
     "k8s.io/helm/pkg/tlsutil",
     "sigs.k8s.io/controller-runtime/pkg/client",
     "sigs.k8s.io/controller-runtime/pkg/client/fake",

--- a/components/helm-broker/Gopkg.toml
+++ b/components/helm-broker/Gopkg.toml
@@ -58,6 +58,7 @@ required= [
 
 [[constraint]]
   name = "k8s.io/helm"
+  # If you change that version be aware that you need to align it in the kyma/docs/helm-broker/03-05-bundles-validation.md
   version = "2.8.2"
 
 # etcd(release-3.3) has dependency to bbolt in this version:

--- a/components/helm-broker/internal/broker/broker.go
+++ b/components/helm-broker/internal/broker/broker.go
@@ -189,6 +189,7 @@ func newWithIDProvider(bs bundleStorage, cs chartStorage, os operationStorage, i
 			instanceBindDataRemover: ibd,
 			operationIDProvider:     idp,
 			helmDeleter:             hc,
+			log:                     log.WithField("service", "deprovisioner"),
 		},
 		binder: &bindService{
 			instanceBindDataGetter: ibd,

--- a/components/helm-broker/internal/broker/deprovision.go
+++ b/components/helm-broker/internal/broker/deprovision.go
@@ -115,11 +115,12 @@ func (svc *deprovisionService) doAsync(ctx context.Context, iID internal.Instanc
 func (svc *deprovisionService) do(ctx context.Context, iID internal.InstanceID, opID internal.OperationID, releaseName internal.ReleaseName) {
 
 	fDo := func() error {
-		if err := svc.helmDeleter.Delete(releaseName); err != nil && !isErrReleaseNotFound(err, string(releaseName)) {
+		err := svc.helmDeleter.Delete(releaseName)
+		if err != nil && !isErrReleaseNotFound(err, releaseName) {
 			return errors.Wrapf(err, "while deleting helm release %q", releaseName)
 		}
 
-		err := svc.instanceBindDataRemover.Remove(iID)
+		err = svc.instanceBindDataRemover.Remove(iID)
 		switch {
 		// we are not checking if instance was bindable and because of that NotFound error is also in happy path
 		// BEWARE: such solution can produce false positive errors e.g.
@@ -157,6 +158,6 @@ func (svc *deprovisionService) do(ctx context.Context, iID internal.InstanceID, 
 
 // isErrReleaseNotFound implements the error checking for Helm Releases, copied from
 // https://github.com/helm/helm/blob/HEAD@%7B2019-05-30T10:19:27Z%7D/cmd/helm/upgrade.go#L222
-func isErrReleaseNotFound(err error, releaseName string) bool {
+func isErrReleaseNotFound(err error, releaseName internal.ReleaseName) bool {
 	return strings.Contains(err.Error(), helmErrors.ErrReleaseNotFound(string(releaseName)).Error())
 }

--- a/components/helm-broker/internal/broker/deprovision_test.go
+++ b/components/helm-broker/internal/broker/deprovision_test.go
@@ -123,7 +123,7 @@ func TestDeprovisionServiceDeprovisionFailureAsync(t *testing.T) {
 			ts.InstStorageMock.ExpectOnGet(ts.Exp.InstanceID, ts.FixInstance()).Once()
 
 			ts.OpStorageMock.ExpectOnInsert(ts.FixInstanceOperation()).Once()
-			expDesc := fmt.Sprintf("deprovisioning failed on error: while deleting helm release: %s", fixErr)
+			expDesc := fmt.Sprintf("deprovisioning failed on error: while deleting helm release %q: %s", ts.Exp.ReleaseName, fixErr)
 			ts.OpStorageMock.ExpectOnUpdateStateDesc(ts.Exp.InstanceID, ts.Exp.OperationID, internal.OperationStateFailed, expDesc).
 				Run(func(args mock.Arguments) {
 					close(ts.UpdateStateDescMethodCalled)

--- a/components/helm-broker/internal/broker/provision.go
+++ b/components/helm-broker/internal/broker/provision.go
@@ -4,17 +4,15 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"net/http"
 	"sync"
 
+	jsonhash "github.com/komkom/go-jsonhash"
+	"github.com/kyma-project/kyma/components/helm-broker/internal"
 	"github.com/pkg/errors"
 	osb "github.com/pmorie/go-open-service-broker-client/v2"
 	"github.com/sirupsen/logrus"
 	rls "k8s.io/helm/pkg/proto/hapi/services"
-
-	"net/http"
-
-	jsonhash "github.com/komkom/go-jsonhash"
-	"github.com/kyma-project/kyma/components/helm-broker/internal"
 )
 
 const addonsRepositoryURLName = "addonsRepositoryURL"

--- a/components/helm-broker/internal/storage/driver/etcd/entity_chart.go
+++ b/components/helm-broker/internal/storage/driver/etcd/entity_chart.go
@@ -142,7 +142,7 @@ func (*Chart) nameVersion(name internal.ChartName, ver semver.Version) (k chartN
 		return k, errors.New("both name and version must be set")
 	}
 
-	return chartNameVersion(fmt.Sprintf("%s|%s", name, ver.String())), nil
+	return chartNameVersion(fmt.Sprintf("%s|%s", name, ver.Original())), nil
 }
 
 func (*Chart) key(nv chartNameVersion) string {

--- a/components/helm-broker/internal/storage/driver/memory/entity_chart.go
+++ b/components/helm-broker/internal/storage/driver/memory/entity_chart.go
@@ -108,5 +108,5 @@ func (*Chart) key(name internal.ChartName, ver semver.Version) (k chartNameVersi
 		return k, errors.New("both name and version must be set")
 	}
 
-	return chartNameVersion(fmt.Sprintf("%s|%s", name, ver.String())), nil
+	return chartNameVersion(fmt.Sprintf("%s|%s", name, ver.Original())), nil
 }

--- a/docs/helm-broker/03-05-bundles-validation.md
+++ b/docs/helm-broker/03-05-bundles-validation.md
@@ -1,0 +1,33 @@
+a---
+title: Bundles validation
+type: Details
+---
+
+The Helm Broker validates the bundles which fetches. If some bundle does not meet the requirements, the Helm Broker won't expose it as a Service Class and it will put an information about this in the logs.
+
+To create a correct bundle follow the following rules:
+
+1. The bundle **must** contains a `meta.yaml` file with non-empty values in the following fields:
+
+- id
+- name
+- version (compatible with [Semantic Versioning](https://semver.org/))
+- description
+- displayName
+
+2. Bundle **must** contain at least one plan. Each plan **must** follow the rules:
+
+- If plan `bindable` value in the `meta.yaml` file is set to `true`, the plan **must** contains the `bind.yaml` file which defines the data of the Service Bindings.
+
+The `meta.yaml` file of the plan **must** contain non-empty values in the following fields:
+
+- id
+- name
+- description
+- displayName
+
+3. If the bundle provides documentation for its Service Class it **must** contains the `meta.yaml` file in the `docs` directory. The `meta.yaml` file **must** contain a **single** entry in the `docs` array.
+
+## Checker
+
+The Checker tool is used in the [bundles](https://github.com/kyma-project/bundles) repo. It is triggered there for each pull request. It triggers the validation logic described above for all of the bundles. It's also triggering the `helm lint` command which check the bundle's chart.

--- a/docs/helm-broker/03-05-bundles-validation.md
+++ b/docs/helm-broker/03-05-bundles-validation.md
@@ -1,33 +1,26 @@
-a---
+---
 title: Bundles validation
 type: Details
 ---
 
-The Helm Broker validates the bundles which fetches. If some bundle does not meet the requirements, the Helm Broker won't expose it as a Service Class and it will put an information about this in the logs.
+The Checker tool is used in the [bundles](https://github.com/kyma-project/bundles) repo to validate a bundles on each pull request if all required fields are set. The requirements are described [here](03-01-create-bundles.md).
 
-To create a correct bundle follow the following rules:
+It's also triggers the [helm lint](https://helm.sh/docs/helm/#helm-lint) command using the `helm` in version `2.8.2`, which checks the bundle's chart.
 
-1. The bundle **must** contains a `meta.yaml` file with non-empty values in the following fields:
+### Run locally
 
-- id
-- name
-- version (compatible with [Semantic Versioning](https://semver.org/))
-- description
-- displayName
+You can run the Checker locally to test if your bundles are valid. To run it locally use the following command:
+```
+go run components/helm-broker/cmd/checker/main.go {PATH_TO_YOUR_BUNDLES}
+```
 
-2. Bundle **must** contain at least one plan. Each plan **must** follow the rules:
+## Troubleshooting
 
-- If plan `bindable` value in the `meta.yaml` file is set to `true`, the plan **must** contains the `bind.yaml` file which defines the data of the Service Bindings.
+If some bundle does not meet the requirements, the Helm Broker won't expose it as a Service Class and it will put an information about this in the logs.
 
-The `meta.yaml` file of the plan **must** contain non-empty values in the following fields:
+To check logs from the Helm Broker, execute that commands:
 
-- id
-- name
-- description
-- displayName
-
-3. If the bundle provides documentation for its Service Class it **must** contains the `meta.yaml` file in the `docs` directory. The `meta.yaml` file **must** contain a **single** entry in the `docs` array.
-
-## Checker
-
-The Checker tool is used in the [bundles](https://github.com/kyma-project/bundles) repo. It is triggered there for each pull request. It triggers the validation logic described above for all of the bundles. It's also triggering the `helm lint` command which check the bundle's chart.
+```
+export HELM_BROKER_POD_NAME=kubectl get pod -n kyma-system -l app=helm-broker
+kubectl logs -n kyma-system $HELM_BROKER_POD_NAME helm-broker
+```

--- a/docs/helm-broker/03-05-bundles-validation.md
+++ b/docs/helm-broker/03-05-bundles-validation.md
@@ -3,22 +3,22 @@ title: Bundles validation
 type: Details
 ---
 
-The Checker tool is used in the [bundles](https://github.com/kyma-project/bundles) repo to validate a bundles on each pull request if all required fields are set. The requirements are described [here](03-01-create-bundles.md).
+Checker is a tool that validates bundles in the [`bundles`](https://github.com/kyma-project/bundles) repository on every pull request. It checks whether all [required](#details-create-a-bundle) fields are set in your bundles.
 
-It's also triggers the [helm lint](https://helm.sh/docs/helm/#helm-lint) command using the `helm` in version `2.8.2`, which checks the bundle's chart.
+Checker also triggers the [helm lint](https://helm.sh/docs/helm/#helm-lint) command using `helm` in 2.8.2 version, which checks your bundles' charts.
 
-### Run locally
+### Run Checker locally
 
-You can run the Checker locally to test if your bundles are valid. To run it locally use the following command:
+Run the Checker locally to test if your bundles are valid:
 ```
 go run components/helm-broker/cmd/checker/main.go {PATH_TO_YOUR_BUNDLES}
 ```
 
 ## Troubleshooting
 
-If some bundle does not meet the requirements, the Helm Broker won't expose it as a Service Class and it will put an information about this in the logs.
+If any bundle does not meet the requirements, the Helm Broker does not expose it as a Service Class. This situation is displayed in logs.
 
-To check logs from the Helm Broker, execute that commands:
+To check logs from the Helm Broker, run these commands:
 
 ```
 export HELM_BROKER_POD_NAME=kubectl get pod -n kyma-system -l app=helm-broker

--- a/docs/helm-broker/03-05-bundles-validation.md
+++ b/docs/helm-broker/03-05-bundles-validation.md
@@ -3,11 +3,11 @@ title: Bundles validation
 type: Details
 ---
 
-Checker is a tool that validates bundles in the [`bundles`](https://github.com/kyma-project/bundles) repository on every pull request. It checks whether all [required](#details-create-a-bundle) fields are set in your bundles.
+The Checker is a tool that validates bundles in the [`bundles`](https://github.com/kyma-project/bundles) repository on every pull request. It checks whether all [required](#details-create-a-bundle) fields are set in your bundles.
 
-Checker also triggers the [helm lint](https://helm.sh/docs/helm/#helm-lint) command using `helm` in 2.8.2 version, which checks your bundles' charts.
+The Checker also triggers the [helm lint](https://helm.sh/docs/helm/#helm-lint) command using helm CLI in 2.8.2 version, which checks your bundles' charts.
 
-### Run Checker locally
+### Run the Checker locally
 
 Run the Checker locally to test if your bundles are valid:
 ```


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/master/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- Fix version and deprovision logic in Helm Broker:
- Deprovision will return `200 OK` when release was already deleted or never existed
- Charts are saved to DB using the `key.Orginal()` value, which is always the same 

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->

#3959 