### PR TITLE
fix api controller backup restore test

### DIFF
--- a/tests/end-to-end/backup-restore-test/backupe2e/apicontroller.go
+++ b/tests/end-to-end/backup-restore-test/backupe2e/apicontroller.go
@@ -297,6 +297,7 @@ func (t ApiControllerTest) createFunction(namespace string) (*kubelessV1.Functio
 }
 
 func (t ApiControllerTest) getFunctionPodStatus(namespace string, waitmax time.Duration) error {
+	const retriesCount = 10
 	return retry.Do(
 		func() error {
 			pods, err := t.coreInterface.CoreV1().Pods(namespace).List(metav1.ListOptions{LabelSelector: "function=" + t.functionName})
@@ -320,8 +321,9 @@ func (t ApiControllerTest) getFunctionPodStatus(namespace string, waitmax time.D
 			}
 			return errors.Errorf("Function in state %v: \n%+v", pod.Status.Phase, pod)
 		},
+		retry.Attempts(retriesCount),
 		retry.DelayType(retry.FixedDelay),
-		retry.Delay(waitmax/10), //doesn't have to be very precise
+		retry.Delay(waitmax/retriesCount), //doesn't have to be very precise
 		retry.OnRetry(func(n uint, err error) {
 			log.Printf("Function Pod Status exection #%d: %s\n", n, err)
 		}),

--- a/tests/end-to-end/backup-restore-test/backupe2e/apicontroller.go
+++ b/tests/end-to-end/backup-restore-test/backupe2e/apicontroller.go
@@ -320,9 +320,6 @@ func (t ApiControllerTest) getFunctionPodStatus(namespace string, waitmax time.D
 			}
 			return errors.Errorf("Function in state %v: \n%+v", pod.Status.Phase, pod)
 		},
-		retry.RetryIf(func(_ error) bool {
-			return !failed
-		}),
 		retry.DelayType(retry.FixedDelay),
 		retry.Delay(waitmax/10), //doesn't have to be very precise
 		retry.OnRetry(func(n uint, err error) {


### PR DESCRIPTION
**Description**

Fix for api-controller backup-restore e2e test
Changes proposed in this pull request:

- Fix delay settings in the test
- Relax pod count conditions

**Related issue(s)**
See also #4050 
