### PR TITLE
Add configuration documents for the Event Bus component

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -4,26 +4,26 @@
 
 The `docs` folder contains end-to-end documentation on Kyma and its components.
 
-Start with the overarching [Kyma](kyma/docs) documentation where you can find the general information on Kyma and the Getting Started guides. Then, read about the product in more detail:
+Start with the overarching [Kyma](./kyma) documentation where you can find the general information on Kyma and the Getting Started guides. Then, read about the product in more detail:
 
--   [API Gateway](./api-gateway/docs)
--   [Application Connector](./application-connector/docs/)
--   [Asset Store](./asset-store/docs/)
--   [Backup](./backup/docs/)
--   [Console](./console/docs/)
--   [Event Bus](./event-bus/docs/)
--   [Helm Broker](./helm-broker/docs/)
--   [Logging](./logging/docs/)
--   [Monitoring](./monitoring/docs/)
--   [Security](./security/docs/)
--   [Serverless](./serverless/docs/)
--   [Service Catalog](./service-catalog/docs/)
--   [Service Mesh](./service-mesh/docs/)
--   [Tracing](./tracing/docs/)
+-   [API Gateway](./api-gateway/)
+-   [Application Connector](./application-connector/)
+-   [Asset Store](./asset-store/)
+-   [Backup](./backup/)
+-   [Console](./console/)
+-   [Event Bus](./event-bus/)
+-   [Helm Broker](./helm-broker/)
+-   [Logging](./logging/)
+-   [Monitoring](./monitoring/)
+-   [Security](./security/)
+-   [Serverless](./serverless/)
+-   [Service Catalog](./service-catalog/)
+-   [Service Mesh](./service-mesh/)
+-   [Tracing](./tracing/)
 
 Read it directly in GitHub or inside the Kyma Console if you have access to the Kyma cluster.
 
-The navigation order of the documentation page is based on the [Manifest](manifest.yaml) file.
+The navigation order of the documentation page is based on the **cms.kyma-project.io/order** label specified in the [ClusterDocsTopic](../resources/core/charts/docs/charts/content-ui/templates) for a given Kyma component.
 
 ## Development
 

--- a/docs/event-bus/02-01-event-bus.md
+++ b/docs/event-bus/02-01-event-bus.md
@@ -4,7 +4,7 @@ title: Architecture
 
 ## Event consumption
 
-When you create a lambda or a service to perform a given business functionality, you must define which Events trigger it. Define triggers by creating the [Subscription CR](/components/event-bus/#custom-resource-subscription) where you instruct the Event Bus to forward the Events of a particular type to your lambda. 
+When you create a lambda or a service to perform a given business functionality, you must define which Events trigger it. Define triggers by creating the [Subscription CR](/components/event-bus/#custom-resource-subscription) where you instruct the Event Bus to forward the Events of a particular type to your lambda.
 For example, whenever the `order-created` Event comes in, the Event Bus stores it in NATS Streaming. It then dispatches it to the receiver specified in the Subscription CR definition.
 
 > **NOTE:** The Event Bus creates a separate Event trigger for each Subscription.
@@ -12,18 +12,19 @@ For example, whenever the `order-created` Event comes in, the Event Bus stores i
 ![Configure and Consume Events](./assets/configure-consume-events.svg)
 
 
-1. A user creates a lambda or a service that an Event coming from an external solution triggers. 
+1. A user creates a lambda or a service that an Event coming from an external solution triggers.
     >**NOTE**: When creating a service, the user must create a Kyma Subscription resource manually. If the user uses Kyma Console UI to create a lambda, the Subscription resource is created automatically. In any other case, Kyma Subscription must be created manually.
+    
 2. **subscription-controller-knative** reacts to the creation of Kyma Subscription.  It [verifies](#event-validation) if the Event type from the application can be consumed in the Namespace where the Kyma Subscription has been created.  If so, it creates the Knative Channel and Knative Subscription resources.
 3. **nats-controller** reacts to the creation of a Knative Channel and creates the required Kubernetes and Istio services.
-4. **nats-dispatcher** reacts to the creation of a Knative Subscription and creates the NATS Streaming Subscription. 
+4. **nats-dispatcher** reacts to the creation of a Knative Subscription and creates the NATS Streaming Subscription.
 5. **nats-dispatcher** picks the Event and dispatches it to the configured lambda or the service URL as an HTTP POST request. The lambda reacts to the received Event.
 
 ## Event publishing
 
 ![Publish Events](./assets/publish-events.svg)
 
-1. The external application integrated with Kyma makes a REST API request to the Application Connector's Events Gateway to indicate that a new Event is available. The request provides the Application Connector with the Event metadata. 
+1. The external application integrated with Kyma makes a REST API request to the Application Connector's Events Gateway to indicate that a new Event is available. The request provides the Application Connector with the Event metadata.
 2. The Application Connector enriches the Event with the details of its source.
 
     > **NOTE:** There is always one dedicated instance of the Application Connector for every instance of an external solution connected to Kyma.
@@ -35,7 +36,7 @@ For example, whenever the `order-created` Event comes in, the Event Bus stores i
 
 
 
-## Event validation 
+## Event validation
 
  **subscription-controller-knative** checks if the Namespace can receive Events from the application. It performs the check for each Kyma Subscription created in a Namespace for a particular Event type with a version for a specific application.
 

--- a/docs/event-bus/05-01-event-bus.md
+++ b/docs/event-bus/05-01-event-bus.md
@@ -1,0 +1,21 @@
+---
+title: Event Bus chart
+type: Configuration
+---
+
+To configure the Event Bus chart, override the default values of its `values.yaml` file. This document describes parameters that you can configure.
+
+>**TIP:** To learn more about how to use overrides in Kyma, see the following documents:
+>* [Helm overrides for Kyma installation](/root/kyma/#configuration-helm-overrides-for-kyma-installation)
+>* [Top-level charts overrides](/root/kyma/#configuration-helm-overrides-for-kyma-installation-top-level-charts-overrides)
+
+## Configurable parameters
+
+This table lists the configurable parameters, their descriptions, and default values:
+
+| Parameter | Description | Default value |
+|-----------|-------------|---------------|
+| **global.publishKnative.maxRequests** | Specifies the maximum number of parallel Event requests that **publish-knative** can process. If you increase this value, you may also have to increase memory resources for the Event Bus to handle the higher load. | `16` |
+| **global.publishKnative.maxRequestSize** | Specifies the maximum size of one Event. If you increase this value, you may also have to increase memory resources for the Event Bus to handle the higher load. | `65536` |
+| **global.publishKnative.resources.limits.memory** | Specifies memory limits set for **publishKnative**. | `32M` |
+| **global.subscriptionControllerKnative.resources.limits.memory** | Specifies memory limits set for **subscription-controller-knative**. | `32M` |

--- a/docs/event-bus/05-01-event-bus.md
+++ b/docs/event-bus/05-01-event-bus.md
@@ -15,7 +15,7 @@ This table lists the configurable parameters, their descriptions, and default va
 
 | Parameter | Description | Default value |
 |-----------|-------------|---------------|
-| **global.publishKnative.maxRequests** | Specifies the maximum number of parallel Event requests that **publish-knative** can process. If you increase this value, you may also have to increase memory resources for the Event Bus to handle the higher load. | `16` |
-| **global.publishKnative.maxRequestSize** | Specifies the maximum size of one Event. If you increase this value, you may also have to increase memory resources for the Event Bus to handle the higher load. | `65536` |
+| **global.publishKnative.maxRequests** | Specifies the maximum number of parallel Event requests that **publish-knative** can process. If you raise this value, you may also have to increase memory resources for the Event Bus to handle the higher load. | `16` |
+| **global.publishKnative.maxRequestSize** | Specifies the maximum size of one Event. If you raise this value, you may also have to increase memory resources for the Event Bus to handle the higher load. | `65536` |
 | **global.publishKnative.resources.limits.memory** | Specifies memory limits set for **publishKnative**. | `32M` |
 | **global.subscriptionControllerKnative.resources.limits.memory** | Specifies memory limits set for **subscription-controller-knative**. | `32M` |

--- a/docs/event-bus/05-01-event-bus.md
+++ b/docs/event-bus/05-01-event-bus.md
@@ -15,7 +15,7 @@ This table lists the configurable parameters, their descriptions, and default va
 
 | Parameter | Description | Default value |
 |-----------|-------------|---------------|
-| **global.publishKnative.maxRequests** | Specifies the maximum number of parallel Event requests that **publish-knative** can process. If you raise this value, you may also have to increase memory resources for the Event Bus to handle the higher load. | `16` |
+| **global.publishKnative.maxRequests** | Specifies the maximum number of parallel Event requests that **publishKnative** can process. If you raise this value, you may also have to increase memory resources for the Event Bus to handle the higher load. | `16` |
 | **global.publishKnative.maxRequestSize** | Specifies the maximum size of one Event. If you raise this value, you may also have to increase memory resources for the Event Bus to handle the higher load. | `65536` |
 | **global.publishKnative.resources.limits.memory** | Specifies memory limits set for **publishKnative**. | `32M` |
-| **global.subscriptionControllerKnative.resources.limits.memory** | Specifies memory limits set for **subscription-controller-knative**. | `32M` |
+| **global.subscriptionControllerKnative.resources.limits.memory** | Specifies memory limits set for **subscriptionControllerKnative**. | `32M` |

--- a/docs/event-bus/05-02-nats-streaming.md
+++ b/docs/event-bus/05-02-nats-streaming.md
@@ -1,0 +1,21 @@
+---
+title: NATS Streaming chart
+type: Configuration
+---
+
+To configure NATS Streaming chart, override the default values of its `values.yaml` file. This document describes parameters that you can configure.
+
+>**TIP:** To learn more about how to use overrides in Kyma, see the following documents:
+>* [Helm overrides for Kyma installation](/root/kyma/#configuration-helm-overrides-for-kyma-installation)
+>* [Top-level charts overrides](/root/kyma/#configuration-helm-overrides-for-kyma-installation-top-level-charts-overrides)
+
+## Configurable parameters
+
+This table lists the configurable parameters, their descriptions, and default values:
+
+| Parameter | Description | Default value |
+|-----------|-------------|---------------|
+| **global.natsStreaming.persistence.maxAge** | Specifies the time for which the given Event is stored in NATS Streaming. | `24h` |
+| **global.natsStreaming.persistence.size** | Specifies the size of the persistence volume in NATS Streaming. | `1Gi` |
+| **global.natsStreaming.resources.limits.memory** | Specifies the memory limits for NATS Streaming. | `256M` |
+| **global.natsStreaming.channel.maxInactivity** | Specifies the time after which the autocleaner removes from the NATS Streaming database all backing resources related to a given Event type if there is no activity for this Event type. | `48h` |

--- a/docs/event-bus/05-02-nats-streaming.md
+++ b/docs/event-bus/05-02-nats-streaming.md
@@ -18,4 +18,4 @@ This table lists the configurable parameters, their descriptions, and default va
 | **global.natsStreaming.persistence.maxAge** | Specifies the time for which the given Event is stored in NATS Streaming. | `24h` |
 | **global.natsStreaming.persistence.size** | Specifies the size of the persistence volume in NATS Streaming. | `1Gi` |
 | **global.natsStreaming.resources.limits.memory** | Specifies the memory limits for NATS Streaming. | `256M` |
-| **global.natsStreaming.channel.maxInactivity** | Specifies the time after which the autocleaner removes from the NATS Streaming database all backing resources related to a given Event type if there is no activity for this Event type. | `48h` |
+| **global.natsStreaming.channel.maxInactivity** | Specifies the time after which the autocleaner removes all backing resources related to a given Event type from the NATS Streaming database if there is no activity for this Event type. | `48h` |

--- a/docs/kyma/05-01-overview.md
+++ b/docs/kyma/05-01-overview.md
@@ -37,7 +37,7 @@ You can modify local settings, such as memory limits for a given resource, by ch
 
 [Read more](#configuration-helm-overrides-for-kyma-installation) about the types of overrides and the rules for creating them.
 
-> **NOTE:** Under each Kyma component documentation, you can find configuration documents that provide lists of configurable parameters from the `values.yaml` files for a given component chart or sub-chart. Override values only for the parameters exposed in those configuration documents.
+> **CAUTION:** Under each Kyma component documentation, you can find configuration documents that provide lists of configurable parameters from the `values.yaml` files for a given component chart or sub-chart. Override values only for the parameters exposed in those configuration documents.
 
 ## Runtime configuration
 

--- a/docs/kyma/05-01-overview.md
+++ b/docs/kyma/05-01-overview.md
@@ -37,7 +37,7 @@ You can modify local settings, such as memory limits for a given resource, by ch
 
 [Read more](#configuration-helm-overrides-for-kyma-installation) about the types of overrides and the rules for creating them.
 
-> **CAUTION:** Under each Kyma component documentation, you can find configuration documents that provide lists of configurable parameters from the `values.yaml` files for a given component chart or sub-chart. Override values only for the parameters exposed in those configuration documents.
+> **CAUTION:** In documentation for each Kyma component, you can find configuration documents that list configurable parameters from the `values.yaml` files for a given component chart or sub-chart. Override values only for the parameters exposed in those configuration documents.
 
 ## Runtime configuration
 

--- a/docs/kyma/05-01-overview.md
+++ b/docs/kyma/05-01-overview.md
@@ -37,6 +37,8 @@ You can modify local settings, such as memory limits for a given resource, by ch
 
 [Read more](#configuration-helm-overrides-for-kyma-installation) about the types of overrides and the rules for creating them.
 
+> **NOTE:** Under each Kyma component documentation, you can find configuration documents that provide lists of configurable parameters from the `values.yaml` files for a given component chart or sub-chart. You can configure their values with overrides. Do not override values that are not exposed in the configuration documents.
+
 ## Runtime configuration
 
 Once Kyma installation completes, you can still modify the installation artifacts. However, for these changes to take effect, you must trigger the update process:  

--- a/docs/kyma/05-01-overview.md
+++ b/docs/kyma/05-01-overview.md
@@ -37,7 +37,7 @@ You can modify local settings, such as memory limits for a given resource, by ch
 
 [Read more](#configuration-helm-overrides-for-kyma-installation) about the types of overrides and the rules for creating them.
 
-> **NOTE:** Under each Kyma component documentation, you can find configuration documents that provide lists of configurable parameters from the `values.yaml` files for a given component chart or sub-chart. You can configure their values with overrides. Do not override values that are not exposed in the configuration documents.
+> **NOTE:** Under each Kyma component documentation, you can find configuration documents that provide lists of configurable parameters from the `values.yaml` files for a given component chart or sub-chart. Override values only for the parameters exposed in those configuration documents.
 
 ## Runtime configuration
 


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Created configuration docs for these Event Bus charts:
   -  [`event-bus`](https://github.com/kyma-project/kyma/tree/master/resources/event-bus)
   - [`nats-streaming`](https://github.com/kyma-project/kyma/tree/master/resources/nats-streaming)
- Fixed dead links in the main `README.md` document for the `docs` folder

**Related issue(s)**
See also #4070 
