### PR TITLE
improve apiserver-proxy tests resilience

### DIFF
--- a/tests/apiserver-proxy-tests/Gopkg.lock
+++ b/tests/apiserver-proxy-tests/Gopkg.lock
@@ -2,29 +2,48 @@
 
 
 [[projects]]
+  digest = "1:2abc390f92f9fa449eeca529b708a22c76be09a03917b084efa616c93f0e1d04"
+  name = "github.com/avast/retry-go"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "88ef2130df9642aa2849152b2985af9ba3676ee9"
+  version = "v2.3.0"
+
+[[projects]]
+  digest = "1:cf31692c14422fa27c83a05292eb5cbe0fb2775972e8f1f8446a71549bd8980b"
   name = "github.com/pkg/errors"
   packages = ["."]
+  pruneopts = "UT"
   revision = "ba968bfe8b2f7e042a574c888954fccecfa385b4"
   version = "v0.8.1"
 
 [[projects]]
+  digest = "1:1b8282c02f3cbf27de019d739246eaf8231f5dbcaaf9d0d7c7524184ee7b2d24"
   name = "github.com/vrischmann/envconfig"
   packages = ["."]
+  pruneopts = "UT"
   revision = "7a443243d539c9595dd8aa7f03a6f68707b80e66"
   version = "v1.1.0"
 
 [[projects]]
   branch = "master"
+  digest = "1:de4815ce3ca5b624af2733716ecd471de1ef50cda8afec39491aab517f73139c"
   name = "golang.org/x/net"
   packages = [
     "html",
-    "html/atom"
+    "html/atom",
   ]
+  pruneopts = "UT"
   revision = "92fc7df08ae7536330f5a21328292abfa70520a8"
 
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "f4fab96382a37b227a20b0551821e8245ccb4f3a26a29eab3603db4b92a56e29"
+  input-imports = [
+    "github.com/avast/retry-go",
+    "github.com/pkg/errors",
+    "github.com/vrischmann/envconfig",
+    "golang.org/x/net/html",
+  ]
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/tests/apiserver-proxy-tests/Gopkg.toml
+++ b/tests/apiserver-proxy-tests/Gopkg.toml
@@ -24,7 +24,12 @@
 #   go-tests = true
 #   unused-packages = true
 
+[[constraint]]
+  name = "github.com/avast/retry-go"
+  version = "2.1.0"
 
 [prune]
   go-tests = true
   unused-packages = true
+
+

--- a/tests/apiserver-proxy-tests/fetch-token/internal/auth.go
+++ b/tests/apiserver-proxy-tests/fetch-token/internal/auth.go
@@ -10,6 +10,7 @@ func Authenticate(config idProviderConfig) (string, error) {
 		Transport: &http.Transport{
 			TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
 		},
+		Timeout: config.ClientConfig.TimeoutSeconds,
 	}
 
 	idTokenProvider := newDexIdTokenProvider(httpClient, config)

--- a/tests/apiserver-proxy-tests/fetch-token/internal/idtokenprovider.go
+++ b/tests/apiserver-proxy-tests/fetch-token/internal/idtokenprovider.go
@@ -47,6 +47,7 @@ func (p *dexIdTokenProvider) implicitFlow() (map[string]string, error) {
 
 	var result map[string]string = nil
 
+	happyRun := true
 	err := retry.Do(
 		func() error {
 
@@ -72,13 +73,19 @@ func (p *dexIdTokenProvider) implicitFlow() (map[string]string, error) {
 		retry.Delay(p.config.RetryConfig.Delay),
 		retry.DelayType(retry.FixedDelay),
 		retry.OnRetry(func(retryNo uint, err error) {
-			log.Printf("[%d / %d] Status: %s", retryNo, p.config.RetryConfig.Delay, err)
+			happyRun = false
+			log.Printf("Retry: [%d / %d], error: %s", retryNo, p.config.RetryConfig.MaxAttempts, err)
 		}),
 	)
 
 	if err != nil {
 		return nil, err
 	}
+
+	if happyRun {
+		log.Println("Flow finished flawlessly")
+	}
+
 	return result, nil
 }
 


### PR DESCRIPTION
**Description**

Increase resilience of apiserver-proxy tests

Changes proposed in this pull request:

- Add retries to apiserver-proxy test
- Add configurable HTTP client timeout
- Refactor the test to be more readable

**Related issue(s)**
See also #3607 
