### PR TITLE
Add gql namespace integration tests

### DIFF
--- a/tests/console-backend-service/Gopkg.lock
+++ b/tests/console-backend-service/Gopkg.lock
@@ -2,6 +2,14 @@
 
 
 [[projects]]
+  digest = "1:853d9a1a7b0d3ee96d855dfa22e268fa646667dfae16d25dc5d137f5e2e1f9c1"
+  name = "github.com/avast/retry-go"
+  packages = ["."]
+  pruneopts = "NUT"
+  revision = "88ef2130df9642aa2849152b2985af9ba3676ee9"
+  version = "v2.3.0"
+
+[[projects]]
   digest = "1:ffe9824d294da03b391f44e1ae8281281b4afc1bdaa9588c9097785e3af10cec"
   name = "github.com/davecgh/go-spew"
   packages = ["spew"]
@@ -515,6 +523,7 @@
   analyzer-name = "dep"
   analyzer-version = 1
   input-imports = [
+    "github.com/avast/retry-go",
     "github.com/gorilla/websocket",
     "github.com/kisielk/errcheck",
     "github.com/kubernetes-incubator/service-catalog/pkg/apis/servicecatalog/v1beta1",

--- a/tests/console-backend-service/internal/domain/k8s/namespace_test.go
+++ b/tests/console-backend-service/internal/domain/k8s/namespace_test.go
@@ -1,16 +1,17 @@
+// +build acceptance
+
 package k8s
 
 import (
+	"testing"
+
 	"github.com/kyma-project/kyma/tests/console-backend-service/internal/client"
 	"github.com/kyma-project/kyma/tests/console-backend-service/internal/dex"
 	"github.com/kyma-project/kyma/tests/console-backend-service/internal/graphql"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"testing"
 )
-
-type labels map[string]string
 
 func TestNamespace(t *testing.T) {
 	dex.SkipTestIfSCIEnabled(t)

--- a/tests/console-backend-service/internal/domain/k8s/namespace_test.go
+++ b/tests/console-backend-service/internal/domain/k8s/namespace_test.go
@@ -22,8 +22,8 @@ func TestNamespace(t *testing.T) {
 	k8s, _, err := client.NewClientWithConfig()
 	require.NoError(t, err)
 
-	name := "tesr-namespace"
-	labels := labels{
+	name := "test-namespace"
+	labels := map[string]string{
 		"aaa": "bbb",
 	}
 
@@ -54,8 +54,7 @@ func TestNamespace(t *testing.T) {
 
 func fixNamespaceResponse(name string, labels labels) namespaceResponse {
 	return namespaceResponse{
-		name:   name,
-		labels: labels,
+		namespace: namespaceObj{name: name, labels: labels},
 	}
 }
 
@@ -96,7 +95,11 @@ func fixNamespaceDelete(name string) *graphql.Request {
 	return req
 }
 
-type namespaceResponse struct {
+type namespaceObj struct {
 	name   string
 	labels labels
+}
+
+type namespaceResponse struct {
+	namespace namespaceObj
 }

--- a/tests/console-backend-service/internal/domain/k8s/namespace_test.go
+++ b/tests/console-backend-service/internal/domain/k8s/namespace_test.go
@@ -4,10 +4,11 @@ package k8s
 
 import (
 	"fmt"
+	"testing"
+
 	"github.com/avast/retry-go"
 	v1 "k8s.io/api/core/v1"
 	corev1 "k8s.io/client-go/kubernetes/typed/core/v1"
-	"testing"
 
 	"github.com/kyma-project/kyma/tests/console-backend-service/internal/client"
 	"github.com/kyma-project/kyma/tests/console-backend-service/internal/dex"
@@ -211,7 +212,7 @@ type deleteNamespaceResponse struct {
 	DeleteNamespace namespaceObj `json:"deleteNamespace"`
 }
 
-type namespaceTerminatingError struct{
+type namespaceTerminatingError struct {
 	phase v1.NamespacePhase
 }
 

--- a/tests/console-backend-service/internal/domain/k8s/namespace_test.go
+++ b/tests/console-backend-service/internal/domain/k8s/namespace_test.go
@@ -1,0 +1,101 @@
+package k8s
+
+import (
+	"github.com/kyma-project/kyma/tests/console-backend-service/internal/client"
+	"github.com/kyma-project/kyma/tests/console-backend-service/internal/dex"
+	"github.com/kyma-project/kyma/tests/console-backend-service/internal/graphql"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"testing"
+)
+
+type labels map[string]string
+
+func TestNamespace(t *testing.T) {
+	dex.SkipTestIfSCIEnabled(t)
+
+	c, err := graphql.New()
+	require.NoError(t, err)
+
+	k8s, _, err := client.NewClientWithConfig()
+	require.NoError(t, err)
+
+	name := "tesr-namespace"
+	labels := labels{
+		"aaa": "bbb",
+	}
+
+	var rsp namespaceResponse
+	err = c.Do(fixNamespaceCreate(name, labels), &rsp)
+	require.NoError(t, err)
+	assert.Equal(t, fixNamespaceResponse(name, labels), rsp)
+
+	ns, err := k8s.Namespaces().Get(name, metav1.GetOptions{})
+	require.NoError(t, err)
+	assert.Equal(t, ns.Name, name)
+	assert.Equal(t, ns.Labels, labels)
+
+	rsp = namespaceResponse{}
+	err = c.Do(fixNamespaceQuery(name), &rsp)
+	require.NoError(t, err)
+	assert.Equal(t, fixNamespaceResponse(name, labels), rsp)
+
+	rsp = namespaceResponse{}
+	err = c.Do(fixNamespaceDelete(name), &rsp)
+	require.NoError(t, err)
+	assert.Equal(t, fixNamespaceResponse(name, labels), rsp)
+
+	_, err = k8s.Namespaces().Get(name, metav1.GetOptions{})
+	require.Error(t, err)
+
+}
+
+func fixNamespaceResponse(name string, labels labels) namespaceResponse {
+	return namespaceResponse{
+		name:   name,
+		labels: labels,
+	}
+}
+
+func fixNamespaceCreate(name string, labels labels) *graphql.Request {
+	query := `mutation ($name: String!, $labels: Labels!) {
+				  createNamespace(name: $name, labels: $labels) {
+					name
+					labels
+				  }
+				}`
+	req := graphql.NewRequest(query)
+	req.SetVar("name", name)
+	req.SetVar("labels", labels)
+	return req
+}
+
+func fixNamespaceQuery(name string) *graphql.Request {
+	query := `query ($name: String!) {
+				  namespace(name: $name) {
+					name
+					labels
+				  }
+				}`
+	req := graphql.NewRequest(query)
+	req.SetVar("name", name)
+	return req
+}
+
+func fixNamespaceDelete(name string) *graphql.Request {
+	query := `mutation ($name: String!) {
+				  deleteNamespace(name: $name) {
+					name
+					labels
+				  }
+				}`
+	req := graphql.NewRequest(query)
+	req.SetVar("name", name)
+	return req
+}
+
+type namespaceResponse struct {
+	name   string
+	labels labels
+}


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Add new CBS integration test that verifies full namespace workflow: create, read, delete.

**Related issue(s)**
Issue: kyma-project/console#931
