### PR TITLE
Add configuration documents for Monitoring

### DIFF
--- a/docs/monitoring/05-01-alertmanager.md
+++ b/docs/monitoring/05-01-alertmanager.md
@@ -17,5 +17,7 @@ This table lists the configurable parameters, their descriptions, and default va
 |-----------|-------------|---------------|
 | **global.alertTools.credentials.slack.apiurl** | Specifies the URL endpoint which sends alerts triggered by Prometheus rules.  | None |
 | **global.alertTools.credentials.slack.channel** | Refers to the Slack channel which receives notifications on new alerts. | None |
-| **global.alertTools.credentials.victorOps.routingkey** | Defines the team routing key in VictorOps. | None |
+| **global.alertTools.credentials.victorOps.routingkey** | Defines the team routing key in [VictorOps](https://help.victorops.com/). | None |
 | **global.alertTools.credentials.victorOps.apikey** | Defines the team API key in VictorOps. | None |
+
+>**NOTE:** Override all configurable values for the Alertmanager sub-chart using Secrets (`kind: Secret`).

--- a/docs/monitoring/05-01-alertmanager.md
+++ b/docs/monitoring/05-01-alertmanager.md
@@ -15,7 +15,7 @@ This table lists the configurable parameters, their descriptions, and default va
 
 | Parameter | Description | Default value |
 |-----------|-------------|---------------|
-| **global.alertTools.credentials.slack.apiurl** | Specifies the URL endpoint which sends the alerts fired by Prometheus rules.  | None |
-| **global.alertTools.credentials.slack.channel** | Refers to the Slack channel which receives the alerts notifications. | None |
+| **global.alertTools.credentials.slack.apiurl** | Specifies the URL endpoint which sends alerts triggered by Prometheus rules.  | None |
+| **global.alertTools.credentials.slack.channel** | Refers to the Slack channel which receives notifications on new alerts. | None |
 | **global.alertTools.credentials.victorOps.routingkey** | Defines the team routing key in VictorOps. | None |
 | **global.alertTools.credentials.victorOps.apikey** | Defines the team API key in VictorOps. | None |

--- a/docs/monitoring/05-01-alertmanager.md
+++ b/docs/monitoring/05-01-alertmanager.md
@@ -1,0 +1,21 @@
+---
+title: Alertmanager sub-chart
+type: Configuration
+---
+
+To configure the Alertmanager sub-chart, override the default values of its `values.yaml` file. This document describes parameters that you can configure.
+
+>**TIP:** To learn more about how to use overrides in Kyma, see the following documents:
+>* [Helm overrides for Kyma installation](/root/kyma/#configuration-helm-overrides-for-kyma-installation)
+>* [Sub-charts overrides](/root/kyma/#configuration-helm-overrides-for-kyma-installation-sub-chart-overrides)
+
+## Configurable parameters
+
+This table lists the configurable parameters, their descriptions, and default values:
+
+| Parameter | Description | Default value |
+|-----------|-------------|---------------|
+| **global.alertTools.credentials.slack.apiurl** | Specifies the URL endpoint which sends the alerts fired by Prometheus rules.  | None |
+| **global.alertTools.credentials.slack.channel** | Refers to the Slack channel which receives the alerts notifications. | None |
+| **global.alertTools.credentials.victorOps.routingkey** | Defines the team routing key in VictorOps. | None |
+| **global.alertTools.credentials.victorOps.apikey** | Defines the team API key in VictorOps. | None |

--- a/docs/monitoring/05-02-grafana.md
+++ b/docs/monitoring/05-02-grafana.md
@@ -1,0 +1,18 @@
+---
+title: Grafana sub-chart
+type: Configuration
+---
+
+To configure the Grafana sub-chart, override the default values of its `values.yaml` file. This document describes parameters that you can configure.
+
+>**TIP:** To learn more about how to use overrides in Kyma, see the following documents:
+>* [Helm overrides for Kyma installation](/root/kyma/#configuration-helm-overrides-for-kyma-installation)
+>* [Sub-charts overrides](/root/kyma/#configuration-helm-overrides-for-kyma-installation-sub-chart-overrides)
+
+## Configurable parameters
+
+This table lists the configurable parameters, their descriptions, and default values:
+
+| Parameter | Description | Default value |
+|-----------|-------------|---------------|
+| **users.default.theme** | Specifies the background colour of the Grafana UI. You can change it to `dark`. | `light` |

--- a/docs/monitoring/05-03-prometheus.md
+++ b/docs/monitoring/05-03-prometheus.md
@@ -1,0 +1,19 @@
+---
+title: Prometheus sub-chart
+type: Configuration
+---
+
+To configure the Prometheus sub-chart, override the default values of its `values.yaml` file. This document describes parameters that you can configure.
+
+>**TIP:** To learn more about how to use overrides in Kyma, see the following documents:
+>* [Helm overrides for Kyma installation](/root/kyma/#configuration-helm-overrides-for-kyma-installation)
+>* [Sub-charts overrides](/root/kyma/#configuration-helm-overrides-for-kyma-installation-sub-chart-overrides)
+
+## Configurable parameters
+
+This table lists the configurable parameters, their descriptions, and default values:
+
+| Parameter | Description | Default value |
+|-----------|-------------|---------------|
+| **retention** | Specifies a period of time for which Prometheus stores the metrics. | `6h` |
+| **storageSpec.volumeClaimTemplate.spec.resources.requests.storage** | Specifies the size of a Persistent Volume Claim (PVC). | `4Gi` |


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Created configuration docs for these Monitoring sub-charts:
    -  [`alertmanager`](https://github.com/kyma-project/kyma/blob/master/resources/monitoring/charts/alertmanager)
   - [`grafana`](https://github.com/kyma-project/kyma/tree/master/resources/monitoring/charts/grafana)
   - [`prometheus`](https://github.com/kyma-project/kyma/blob/master/resources/monitoring/charts/prometheus)

**Related issue(s)**
See also #4080  

