### PR TITLE
Add a configuration document for the Tracing component

### DIFF
--- a/docs/tracing/05-01-jaeger.md
+++ b/docs/tracing/05-01-jaeger.md
@@ -1,0 +1,19 @@
+---
+title: Jaeger chart
+type: Configuration
+---
+
+To configure the Jaeger chart, override the default values of its `values.yaml` file. This document describes parameters that you can configure.
+
+>**TIP:** To learn more about how to use overrides in Kyma, see the following documents:
+>* [Helm overrides for Kyma installation](/root/kyma/#configuration-helm-overrides-for-kyma-installation)
+>* [Top-level charts overrides](/root/kyma/#configuration-helm-overrides-for-kyma-installation-top-level-charts-overrides)
+
+## Configurable parameters
+
+This table lists the configurable parameters, their descriptions, and default values:
+
+| Parameter | Description | Default value |
+|-----------|-------------|---------------|
+| **jaeger.memory.maxTraces** | Defines the maximum amount of traces that Jaeger can store. | `40000` |
+| **resources.limits.memory** | Defines limits for memory resources. | `512M` |

--- a/docs/tracing/05-01-jaeger.md
+++ b/docs/tracing/05-01-jaeger.md
@@ -16,4 +16,4 @@ This table lists the configurable parameters, their descriptions, and default va
 | Parameter | Description | Default value |
 |-----------|-------------|---------------|
 | **jaeger.memory.maxTraces** | Defines the maximum amount of traces that Jaeger can store. | `40000` |
-| **resources.limits.memory** | Defines limits for memory resources. | `512M` |
+| **resources.limits.memory** | Defines the maximum amount of memory that is available for storing traces in Jaeger. | `512M` |

--- a/docs/tracing/05-01-jaeger.md
+++ b/docs/tracing/05-01-jaeger.md
@@ -15,5 +15,5 @@ This table lists the configurable parameters, their descriptions, and default va
 
 | Parameter | Description | Default value |
 |-----------|-------------|---------------|
-| **jaeger.memory.maxTraces** | Defines the maximum amount of traces that Jaeger can store. | `40000` |
+| **jaeger.memory.maxTraces** | Defines the maximum number of traces that Jaeger can store. | `40000` |
 | **resources.limits.memory** | Defines the maximum amount of memory that is available for storing traces in Jaeger. | `512M` |


### PR DESCRIPTION
Changes proposed in this pull request:

- Created configuration docs for this Tracing chart:
    -  [`jaeger`](https://github.com/kyma-project/kyma/tree/master/resources/jaeger)

**Related issue(s)**
See also #4077 
