### PR TITLE
Add acceptance test to check CSRF token fetching on retry

### DIFF
--- a/components/application-gateway/internal/proxy/unauthorizedresponseretrier_test.go
+++ b/components/application-gateway/internal/proxy/unauthorizedresponseretrier_test.go
@@ -71,6 +71,7 @@ func TestForbiddenResponseRetrier_CheckResponse(t *testing.T) {
 		ts := NewTestServer(func(req *http.Request) {
 			assert.Equal(t, req.Method, http.MethodGet)
 			assert.Equal(t, req.RequestURI, "/orders/123")
+			assert.Equal(t, "token", req.Header.Get("CSRFToken"))
 		})
 		defer ts.Close()
 
@@ -82,6 +83,10 @@ func TestForbiddenResponseRetrier_CheckResponse(t *testing.T) {
 
 		csrfTokenStrategyMock := &csrfMock.TokenStrategy{}
 		csrfTokenStrategyMock.On("AddCSRFToken", mock.AnythingOfType("*http.Request")).
+			Run(func(args mock.Arguments) {
+				req := args[0].(*http.Request)
+				req.Header.Add("CSRFToken", "token")
+			}).
 			Return(nil)
 		csrfTokenStrategyMock.On("Invalidate").Return()
 

--- a/components/application-gateway/internal/proxy/unauthorizedresponseretrier_test.go
+++ b/components/application-gateway/internal/proxy/unauthorizedresponseretrier_test.go
@@ -277,7 +277,7 @@ func newUpdateCacheEntryFunction(t *testing.T, url string, strategy authorizatio
 		require.NoError(t, err)
 
 		return &CacheEntry{
-			Proxy:                 proxy,
+			Proxy: proxy,
 			AuthorizationStrategy: &authorizationStrategyWrapper{strategy, proxy},
 			CSRFTokenStrategy:     csrfTokenStrategy,
 		}, nil

--- a/docs/application-connector/08-03-register-manage-services.md
+++ b/docs/application-connector/08-03-register-manage-services.md
@@ -32,7 +32,7 @@ Valid certificate signed by the Kyma Certificate Authority.
         },
         "headers": {
           "custom-header": ["foo"]
-        },
+        }
       },
       "credentials": {
         "basic": {

--- a/resources/application-connector/values.yaml
+++ b/resources/application-connector/values.yaml
@@ -47,11 +47,11 @@ global:
     dir: develop/
     version: "36059183"
   application_gateway:
-    dir: develop/
-    version: ba297749
+    dir: pr/
+    version: PR-4546
   application_gateway_tests:
     dir: pr/
-    version: PR-4779
+    version: PR-4546
   application_registry:
     dir: pr/
     version: PR-4681

--- a/resources/application-connector/values.yaml
+++ b/resources/application-connector/values.yaml
@@ -48,7 +48,7 @@ global:
     version: "36059183"
   application_gateway:
     dir: pr/
-    version: PR-4948
+    version: PR-4546
   application_gateway_tests:
     dir: pr/
     version: PR-4546

--- a/resources/application-connector/values.yaml
+++ b/resources/application-connector/values.yaml
@@ -48,7 +48,7 @@ global:
     version: "36059183"
   application_gateway:
     dir: pr/
-    version: PR-4546
+    version: PR-4948
   application_gateway_tests:
     dir: pr/
     version: PR-4546

--- a/tests/application-gateway-tests/Gopkg.lock
+++ b/tests/application-gateway-tests/Gopkg.lock
@@ -237,7 +237,7 @@
     "storage/v1beta1"
   ]
   revision = "73d903622b7391f3312dcbac6483fed484e185f8"
-  version = "kubernetes-1.10.0"
+  version = "kubernetes-1.10.1"
 
 [[projects]]
   name = "k8s.io/apimachinery"
@@ -280,7 +280,7 @@
     "third_party/forked/golang/reflect"
   ]
   revision = "302974c03f7e50f16561ba237db776ab93594ef6"
-  version = "kubernetes-1.10.0"
+  version = "kubernetes-1.10.1"
 
 [[projects]]
   name = "k8s.io/client-go"

--- a/tests/application-gateway-tests/test/executor/proxy/mock/applicationserver.go
+++ b/tests/application-gateway-tests/test/executor/proxy/mock/applicationserver.go
@@ -36,6 +36,10 @@ func NewAppMockServer(port int32) *AppMockServer {
 	router.Path("/queryparams/{param}/{value}").HandlerFunc(queryParams.QueryParamsHandler)
 	router.Path("/spec/queryparams/{param}/{value}").HandlerFunc(queryParams.QueryParamsHandlerSpec)
 
+	csrf := NewCsrfHandler()
+	router.Path("/csrftoken").HandlerFunc(csrf.CsrfToken)
+	router.Path("/target").HandlerFunc(csrf.Target)
+
 	router.NotFoundHandler = NewErrorHandler(404, "Requested resource could not be found.")
 	router.MethodNotAllowedHandler = NewErrorHandler(405, "Method not allowed.")
 

--- a/tests/application-gateway-tests/test/executor/proxy/mock/csrfhandler.go
+++ b/tests/application-gateway-tests/test/executor/proxy/mock/csrfhandler.go
@@ -70,7 +70,7 @@ func (ch *csrfHandler) Target(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	if cookieToken.Value != expectedToken {
-		ch.logger.Errorf("Invalid cookie: %s with CSRF token value: %s", cookieName, cookieToken)
+		ch.logger.Errorf("Invalid cookie: %s with CSRF token value: %s", cookieName, cookieToken.Value)
 		w.WriteHeader(http.StatusForbidden)
 		return
 	}

--- a/tests/application-gateway-tests/test/executor/proxy/mock/csrfhandler.go
+++ b/tests/application-gateway-tests/test/executor/proxy/mock/csrfhandler.go
@@ -1,0 +1,57 @@
+package mock
+
+import (
+	"net/http"
+
+	log "github.com/sirupsen/logrus"
+)
+
+const (
+	correctToken    = "correctToken"
+	incorrectToken  = "incorrectToken"
+	HeaderCSRFToken = "X-csrf-token"
+)
+
+type csrfHandler struct {
+	logger                  *log.Entry
+	willProvideCorrectToken bool
+}
+
+func NewCsrfHandler() *csrfHandler {
+	return &csrfHandler{
+		logger:                  log.WithField("Handler", "CSRF"),
+		willProvideCorrectToken: false,
+	}
+}
+
+func (ch *csrfHandler) CsrfToken(w http.ResponseWriter, r *http.Request) {
+	ch.logger.Infof("Handling CSRF request")
+
+	var token string
+	if ch.willProvideCorrectToken {
+		ch.logger.Infof("Providing correct token: %s", correctToken)
+		token = correctToken
+	} else {
+		ch.logger.Infof("Providing incorrect token: %s", incorrectToken)
+		token = incorrectToken
+	}
+
+	w.Header().Set(HeaderCSRFToken, token)
+	http.SetCookie(w, nil)
+
+	ch.willProvideCorrectToken = true
+	successResponse(w)
+}
+
+func (ch *csrfHandler) Target(w http.ResponseWriter, r *http.Request) {
+	ch.logger.Infof("Handling request. Expected: header: %s, with value: %s", HeaderCSRFToken, correctToken)
+
+	token := r.Header.Get(HeaderCSRFToken)
+	if token != correctToken {
+		ch.logger.Errorf("Invalid CSRF token: %s", token)
+		w.WriteHeader(http.StatusForbidden)
+		return
+	}
+
+	successResponse(w)
+}

--- a/tests/application-gateway-tests/test/executor/proxy/mock/csrfhandler.go
+++ b/tests/application-gateway-tests/test/executor/proxy/mock/csrfhandler.go
@@ -13,16 +13,14 @@ const (
 )
 
 type csrfHandler struct {
-	logger            *log.Entry
-	provideFirstToken bool
-	expectFirstToken  bool
+	logger       *log.Entry
+	isFirstToken bool
 }
 
 func NewCsrfHandler() *csrfHandler {
 	return &csrfHandler{
-		logger:            log.WithField("Handler", "CSRF"),
-		provideFirstToken: true,
-		expectFirstToken:  true,
+		logger:       log.WithField("Handler", "CSRF"),
+		isFirstToken: true,
 	}
 }
 
@@ -30,26 +28,24 @@ func (ch *csrfHandler) CsrfToken(w http.ResponseWriter, r *http.Request) {
 	ch.logger.Infof("Handling CSRF request")
 
 	var token string
-	if ch.provideFirstToken {
-		ch.logger.Infof("Providing correct token: %s", firstToken)
+	if ch.isFirstToken {
+		ch.logger.Infof("Providing first token: %s", firstToken)
 		token = firstToken
 	} else {
-		ch.logger.Infof("Providing incorrect token: %s", secondToken)
+		ch.logger.Infof("Providing second token: %s", secondToken)
 		token = secondToken
 	}
 
 	w.Header().Set(HeaderCSRFToken, token)
 	http.SetCookie(w, nil)
 
-	ch.provideFirstToken = false
 	successResponse(w)
 }
 
 func (ch *csrfHandler) Target(w http.ResponseWriter, r *http.Request) {
 	var expectedToken string
-	if ch.expectFirstToken {
+	if ch.isFirstToken {
 		expectedToken = firstToken
-		ch.provideFirstToken = true
 	} else {
 		expectedToken = secondToken
 	}
@@ -63,6 +59,6 @@ func (ch *csrfHandler) Target(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	ch.expectFirstToken = false
+	ch.isFirstToken = false
 	successResponse(w)
 }

--- a/tests/application-gateway-tests/test/executor/proxy/suite.go
+++ b/tests/application-gateway-tests/test/executor/proxy/suite.go
@@ -154,10 +154,16 @@ func (ts *TestSuite) CallAccessService(t *testing.T, apiId, path string) *http.R
 		defer resp.Body.Close()
 
 		if resp.StatusCode != http.StatusOK {
-			t.Logf("Access service not ready: Invalid response from access service, status: %d.", resp.StatusCode)
+			t.Logf("Invalid response from access service, status: %d.", resp.StatusCode)
 			bytes, err := ioutil.ReadAll(resp.Body)
 			require.NoError(t, err)
 			t.Log(string(bytes))
+
+			if resp.StatusCode == http.StatusForbidden {
+				t.Logf("Access service is ready but responded with status forbidden. Failing.")
+				t.Fail()
+			}
+			t.Logf("Access service is not ready. Retrying.")
 
 			return false
 		}

--- a/tests/application-gateway-tests/test/executor/proxy/suite.go
+++ b/tests/application-gateway-tests/test/executor/proxy/suite.go
@@ -161,7 +161,7 @@ func (ts *TestSuite) CallAccessService(t *testing.T, apiId, path string) *http.R
 
 			if resp.StatusCode == http.StatusForbidden {
 				t.Logf("Access service is ready but responded with status forbidden. Failing.")
-				t.Fail()
+				t.FailNow()
 			}
 			t.Logf("Access service is not ready. Retrying.")
 

--- a/tests/application-gateway-tests/test/executor/proxy/tests/proxy_test.go
+++ b/tests/application-gateway-tests/test/executor/proxy/tests/proxy_test.go
@@ -128,8 +128,12 @@ func TestProxyService(t *testing.T) {
 		t.Log("Labeling tests pod with denier label")
 		testSuit.AddDenierLabel(t, apiID)
 
-		t.Log("Calling Access Service with incorrect CSRF token and retry with the correct one")
+		t.Log("Calling Access Service with correct CSRF token")
 		resp := testSuit.CallAccessService(t, apiID, "target")
+		util.RequireStatus(t, http.StatusOK, resp)
+
+		t.Log("Calling Access Service with incorrect CSRF token and retry with the correct one")
+		resp = testSuit.CallAccessService(t, apiID, "target")
 		util.RequireStatus(t, http.StatusOK, resp)
 
 		t.Log("Successfully accessed application")

--- a/tests/application-gateway-tests/test/executor/proxy/tests/proxy_test.go
+++ b/tests/application-gateway-tests/test/executor/proxy/tests/proxy_test.go
@@ -113,6 +113,28 @@ func TestProxyService(t *testing.T) {
 		t.Log("Successfully accessed application")
 	})
 
+	t.Run("retry with new CSRF token for basic auth test", func(t *testing.T) {
+		username := "username"
+		password := "password"
+		csrfURL := fmt.Sprintf("%s%s", testSuit.GetMockServiceURL(), "/csrftoken")
+
+		apiID := client.CreateCSRFAndBasicSecuredAPI(t, testSuit.GetMockServiceURL(), username, password, csrfURL)
+		t.Logf("Created service with apiID: %s", apiID)
+		defer func() {
+			t.Logf("Cleaning up service %s", apiID)
+			client.CleanupService(t, apiID)
+		}()
+
+		t.Log("Labeling tests pod with denier label")
+		testSuit.AddDenierLabel(t, apiID)
+
+		t.Log("Calling Access Service with incorrect CSRF token and retry with the correct one")
+		resp := testSuit.CallAccessService(t, apiID, "target")
+		util.RequireStatus(t, http.StatusOK, resp)
+
+		t.Log("Successfully accessed application")
+	})
+
 	//Protected spec fetching tests
 	t.Run("basic auth spec url test", func(t *testing.T) {
 		userName := "myUser"

--- a/tests/application-gateway-tests/test/executor/testkit/registry/client.go
+++ b/tests/application-gateway-tests/test/executor/testkit/registry/client.go
@@ -43,8 +43,15 @@ func (arc *AppRegistryClient) CreateNotSecuredAPI(t *testing.T, targetURL string
 	return arc.createAPI(t, arc.baseAPI(targetURL))
 }
 
+func (arc *AppRegistryClient) CreateCSRFAndBasicSecuredAPI(t *testing.T, targetURL, username, password, csrfURL string) string {
+	api := arc.baseAPI(targetURL).WithBasicAndCSRFAuth(username, password, csrfURL)
+
+	return arc.createAPI(t, api)
+}
+
 func (arc *AppRegistryClient) CreateBasicAuthSecuredAPI(t *testing.T, targetURL, username, password string) string {
 	api := arc.baseAPI(targetURL).WithBasicAuth(username, password)
+
 	return arc.createAPI(t, api)
 }
 

--- a/tests/application-gateway-tests/test/executor/testkit/registry/model.go
+++ b/tests/application-gateway-tests/test/executor/testkit/registry/model.go
@@ -60,19 +60,26 @@ type Credentials struct {
 	Basic *Basic `json:"basic,omitempty"`
 }
 
+type CSRFInfo struct {
+	TokenEndpointURL string `json:"tokenEndpointURL" valid:"url,required~tokenEndpointURL field cannot be empty"`
+}
+
 type Oauth struct {
-	URL          string `json:"url"`
-	ClientID     string `json:"clientId"`
-	ClientSecret string `json:"clientSecret"`
+	URL          string    `json:"url"`
+	ClientID     string    `json:"clientId"`
+	ClientSecret string    `json:"clientSecret"`
+	CSRFInfo     *CSRFInfo `json:"csrfInfo,omitempty"`
 }
 
 type Basic struct {
-	Username string `json:"username"`
-	Password string `json:"password"`
+	Username string    `json:"username"`
+	Password string    `json:"password"`
+	CSRFInfo *CSRFInfo `json:"csrfInfo,omitempty"`
 }
 
 type CertificateGen struct {
-	CommonName string `json:"commonName"`
+	CommonName string    `json:"commonName"`
+	CSRFInfo   *CSRFInfo `json:"csrfInfo,omitempty"`
 }
 
 type Events struct {
@@ -107,6 +114,22 @@ func (api *API) WithBasicAuth(username, password string) *API {
 	api.Credentials.Basic = &Basic{
 		Username: username,
 		Password: password,
+	}
+
+	return api
+}
+
+func (api *API) WithBasicAndCSRFAuth(username, password, csrfUrl string) *API {
+	if api.Credentials == nil {
+		api.Credentials = &CredentialsWithCSRF{}
+	}
+
+	api.Credentials.Basic = &Basic{
+		Username: username,
+		Password: password,
+		CSRFInfo: &CSRFInfo{
+			TokenEndpointURL: csrfUrl,
+		},
 	}
 
 	return api


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Add acceptance test to check CSRF token fetching on retry
- Bump Application Gateway Tests image
- Minor documentation fix

**Related issue(s)**

See the issue: #4238 