### PR TITLE
Fix default jwksuri when exposing secured lambda

### DIFF
--- a/resources/core/charts/kubeless/charts/lambdas-ui/values.yaml
+++ b/resources/core/charts/kubeless/charts/lambdas-ui/values.yaml
@@ -4,7 +4,7 @@
 replicaCount: 1
 image:
   name: lambda
-  tag: 1a18174f
+  tag: 9267543e
   pullPolicy: IfNotPresent
 service:
   name: nginx


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Update lambda image to fix default jwks uri when exposing secured lambda

**Related issue(s)**
Fixes https://github.com/kyma-project/console/issues/949
