### PR TITLE
added app label to all functions

### DIFF
--- a/docs/application-connector/08-05-trigger-lambda-with-event.md
+++ b/docs/application-connector/08-05-trigger-lambda-with-event.md
@@ -91,6 +91,8 @@ kind: Function
 metadata:
   name: my-events-lambda
   namespace: production
+  labels:
+    app: my-events-lambda
 spec:
   deployment:
     spec:

--- a/docs/application-connector/08-06-call-registered-service-from-kyma.md
+++ b/docs/application-connector/08-06-call-registered-service-from-kyma.md
@@ -58,6 +58,8 @@ kind: Function
 metadata:
   name: my-lambda
   namespace: production
+  labels:
+    app: my-lambda
 spec:
   deployment:
     spec:

--- a/docs/serverless/07-01-cli-reference.md
+++ b/docs/serverless/07-01-cli-reference.md
@@ -44,7 +44,7 @@ kubeless function list hello
 You can deploy a function using the Kubernetes and Kubeless CLI. See the following example:
 
 ```bash
-kubeless function deploy hello --runtime nodejs8 --handler hello.main --from-file https://raw.githubusercontent.com/kyma-project/examples/master/event-subscription/lambda/js/hello-with-data.js --trigger-http
+kubeless function deploy hello --label app=hello --runtime nodejs8 --handler hello.main --from-file https://raw.githubusercontent.com/kyma-project/examples/master/event-subscription/lambda/js/hello-with-data.js --trigger-http
 ```
 
 ### Call a function using the CLI


### PR DESCRIPTION

**Description**
All function examples should use the "app" label in order to have observability functionality working out of the box.

**Related issue(s)**
https://github.com/kyma-project/examples/issues/123
