### PR TITLE
Remove resource names form Connectivity Certs Controller RBAC

### DIFF
--- a/resources/application-connector/charts/connectivity-certs-controller/templates/role-binding.yaml
+++ b/resources/application-connector/charts/connectivity-certs-controller/templates/role-binding.yaml
@@ -10,7 +10,6 @@ metadata:
 rules:
   - apiGroups: ["*"]
     resources: ["secrets"]
-    resourceNames: ["{{ .Values.secrets.clientCertificate.name }}"]
     verbs: ["create", "get", "update", "delete"]
 ---
 kind: RoleBinding
@@ -43,7 +42,6 @@ metadata:
 rules:
   - apiGroups: ["*"]
     resources: ["secrets"]
-    resourceNames: ["{{ .Values.secrets.caCertificate.name }}"]
     verbs: ["create", "get", "update", "delete"]
 ---
 kind: RoleBinding


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/master/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- Remove `resourceNames` from Connectivity Certs Controller RBAC which prevents the creation of secrets

**Related issue(s)**
#4570 
