### PR TITLE
Add configuration documentation for the Logging component

### DIFF
--- a/docs/logging/03-02-configure-storage.md
+++ b/docs/logging/03-02-configure-storage.md
@@ -1,5 +1,5 @@
 ---
-title: Storage configuration
+title: Storage configuration examples
 type: Details
 ---
 
@@ -35,15 +35,13 @@ data:
         index:
           prefix: index_
           period: 168h
-    storage_configs:
+    storage_config:
       - name: boltdb
         directory: /tmp/loki/index
       - name: filesystem
         directory: /tmp/loki/chunks
 
-``` 
-
-The Loki storage configuration consists of the **schema_config** and **storage_configs** definitions. Use the **schema_config** to define your storage types, and **storage_configs** to configure the already defined storage types.
+```
 
 A sample configuration for GCS looks as follows:
 
@@ -75,11 +73,11 @@ data:
         index:
           prefix: index_
           period: 168h
-    storage_configs:
+    storage_config:
       gcs:
         bucket_name: <YOUR_GCS_BUCKETNAME>
         project: <BIG_TABLE_PROJECT_ID>
         instance: <BIG_TABLE_INSTANCE_ID>
         grpc_client_config: <YOUR_CLIENT_SETTINGS>
-       
+
 ```

--- a/docs/logging/05-01-logging.md
+++ b/docs/logging/05-01-logging.md
@@ -1,0 +1,34 @@
+---
+title: Logging chart
+type: Configuration
+---
+
+To configure the Logging chart, override the default values of its `values.yaml` file. This document describes parameters that you can configure.
+
+>**TIP:** To learn more about how to use overrides in Kyma, see the following documents:
+>* [Helm overrides for Kyma installation](/root/kyma/#configuration-helm-overrides-for-kyma-installation)
+>* [Top-level charts overrides](/root/kyma/#configuration-helm-overrides-for-kyma-installation-top-level-charts-overrides)
+
+## Configurable parameters
+
+This table lists the configurable parameters, their descriptions, and default values:
+
+| Parameter | Description | Default value |
+|-----------|-------------|---------------|
+| **persistence.enabled** | Specifies whether you store logs on persistent volume instead of the volatile mounted volume. | `true` |
+| **persistence.size** | Defines the size of the persistent volume. | `10Gi` |
+| **config.auth_enabled** | Specifies that you use the basic HTTP authentication to access the logging service instead of the Dex authentication. | `false` |
+| **config.ingester.lifecycler.address** | Specifies the address of the lifecycler that coordinates distributed logging services. | `127.0.0.1` |
+| **config.ingester.lifecycler.ring.store** | Specifies the storage for information on logging data and their copies. | `inmemory` |
+| **config.ingester.lifecycler.ring.replication_factor** | Specifies the number of data copies on separate storages. | `1` |
+| **config.schema_configs.from** | Specifies the date from which index data is stored. | `0` |
+| **config.schema_configs.store** | Specifies the storage type. `boltdb` is an embedded key-value storage that stores the index data. | `boltdb` |
+| **config.schema_configs.object_store** | Specifies if you use local or cloud storages for data. | `filesystem` |
+| **config.schema_configs.schema** | Defines the schema version that Loki provides. | `v9` |
+| **config.schema_configs.index.prefix** | Specifies the prefix added to all index file names to distinguish them from log chunks. | `index_` |
+| **config.schema_configs.index.period** | Defines the retention period of logs and indexes. | `168h` |
+| **config.storage_config.boltdb.directory** | Specifies the physical location of indexes in `boltdb`. | `/data/loki/index` |
+| **config.storage_config.filesystem.directory** | Specifies the physical location of log chunks in `filesystem`. | `/data/loki/chunks` |
+
+
+>**NOTE:** The Loki storage configuration consists of the **schema_config** and **storage_config** definitions. Use the **schema_config** to define your storage types, and **storage_config** to configure the already defined storage types.

--- a/docs/logging/05-01-logging.md
+++ b/docs/logging/05-01-logging.md
@@ -26,7 +26,7 @@ This table lists the configurable parameters, their descriptions, and default va
 | **config.schema_configs.object_store** | Specifies if you use local or cloud storages for data. | `filesystem` |
 | **config.schema_configs.schema** | Defines the schema version that Loki provides. | `v9` |
 | **config.schema_configs.index.prefix** | Specifies the prefix added to all index file names to distinguish them from log chunks. | `index_` |
-| **config.schema_configs.index.period** | Defines the retention period of indexes and log chunks. | `168h` |
+| **config.schema_configs.index.period** | Defines how long indexes and log chunks are retained. | `168h` |
 | **config.storage_config.boltdb.directory** | Specifies the physical location of indexes in `boltdb`. | `/data/loki/index` |
 | **config.storage_config.filesystem.directory** | Specifies the physical location of log chunks in `filesystem`. | `/data/loki/chunks` |
 

--- a/docs/logging/05-01-logging.md
+++ b/docs/logging/05-01-logging.md
@@ -17,7 +17,7 @@ This table lists the configurable parameters, their descriptions, and default va
 |-----------|-------------|---------------|
 | **persistence.enabled** | Specifies whether you store logs on a persistent volume instead of a volatile mounted volume. | `true` |
 | **persistence.size** | Defines the size of the persistent volume. | `10Gi` |
-| **config.auth_enabled** | Specifies the authentication mechanism you use to access the logging service. Set it to `false` to use Dex authentication or to `true` to use the basic HTTP authentication instead.  | `false` |
+| **config.auth_enabled** | Specifies the authentication mechanism you use to access the logging service. Set it to `false` to use built-in Istio authentication, or to `true` to use the basic HTTP authentication instead.  | `false` |
 | **config.ingester.lifecycler.address** | Specifies the address of the lifecycler that coordinates distributed logging services. | `127.0.0.1` |
 | **config.ingester.lifecycler.ring.store** | Specifies the storage for information on logging data and their copies. | `inmemory` |
 | **config.ingester.lifecycler.ring.replication_factor** | Specifies the number of data copies on separate storages. | `1` |

--- a/docs/logging/05-01-logging.md
+++ b/docs/logging/05-01-logging.md
@@ -17,7 +17,7 @@ This table lists the configurable parameters, their descriptions, and default va
 |-----------|-------------|---------------|
 | **persistence.enabled** | Specifies whether you store logs on a persistent volume instead of a volatile mounted volume. | `true` |
 | **persistence.size** | Defines the size of the persistent volume. | `10Gi` |
-| **config.auth_enabled** | Specifies the authentication mechanism you use to access the logging service. Set it to `false` to use Dex authentication, or to `true` to use the basic HTTP authentication instead.  | `false` |
+| **config.auth_enabled** | Specifies the authentication mechanism you use to access the logging service. Set it to `false` to use Dex authentication or to `true` to use the basic HTTP authentication instead.  | `false` |
 | **config.ingester.lifecycler.address** | Specifies the address of the lifecycler that coordinates distributed logging services. | `127.0.0.1` |
 | **config.ingester.lifecycler.ring.store** | Specifies the storage for information on logging data and their copies. | `inmemory` |
 | **config.ingester.lifecycler.ring.replication_factor** | Specifies the number of data copies on separate storages. | `1` |

--- a/docs/logging/05-01-logging.md
+++ b/docs/logging/05-01-logging.md
@@ -15,9 +15,9 @@ This table lists the configurable parameters, their descriptions, and default va
 
 | Parameter | Description | Default value |
 |-----------|-------------|---------------|
-| **persistence.enabled** | Specifies whether you store logs on persistent volume instead of the volatile mounted volume. | `true` |
+| **persistence.enabled** | Specifies whether you store logs on a persistent volume instead of a volatile mounted volume. | `true` |
 | **persistence.size** | Defines the size of the persistent volume. | `10Gi` |
-| **config.auth_enabled** | Specifies that you use the basic HTTP authentication to access the logging service instead of the Dex authentication. | `false` |
+| **config.auth_enabled** | Specifies the authentication mechanism you use to access the logging service. Set it to `false` to use Dex authentication, or to `true` to use the basic HTTP authentication instead.  | `false` |
 | **config.ingester.lifecycler.address** | Specifies the address of the lifecycler that coordinates distributed logging services. | `127.0.0.1` |
 | **config.ingester.lifecycler.ring.store** | Specifies the storage for information on logging data and their copies. | `inmemory` |
 | **config.ingester.lifecycler.ring.replication_factor** | Specifies the number of data copies on separate storages. | `1` |
@@ -26,9 +26,9 @@ This table lists the configurable parameters, their descriptions, and default va
 | **config.schema_configs.object_store** | Specifies if you use local or cloud storages for data. | `filesystem` |
 | **config.schema_configs.schema** | Defines the schema version that Loki provides. | `v9` |
 | **config.schema_configs.index.prefix** | Specifies the prefix added to all index file names to distinguish them from log chunks. | `index_` |
-| **config.schema_configs.index.period** | Defines the retention period of logs and indexes. | `168h` |
+| **config.schema_configs.index.period** | Defines the retention period of indexes and log chunks. | `168h` |
 | **config.storage_config.boltdb.directory** | Specifies the physical location of indexes in `boltdb`. | `/data/loki/index` |
 | **config.storage_config.filesystem.directory** | Specifies the physical location of log chunks in `filesystem`. | `/data/loki/chunks` |
 
 
->**NOTE:** The Loki storage configuration consists of the **schema_config** and **storage_config** definitions. Use the **schema_config** to define your storage types, and **storage_config** to configure the already defined storage types.
+>**NOTE:** The Loki storage configuration consists of the **schema_config** and **storage_config** definitions. Use **schema_config** to define the storage types and **storage_config** to configure storage types that are already defined.


### PR DESCRIPTION
Changes proposed in this pull request:

- Created configuration docs for this Logging chart:
   - [`logging`](https://github.com/kyma-project/kyma/tree/master/resources/logging)

**Related issue(s)**
See also #4078  
