### PR TITLE
Apiserver proxy test should use FQDN of configurations generator service

### DIFF
--- a/tests/apiserver-proxy-tests/test.sh
+++ b/tests/apiserver-proxy-tests/test.sh
@@ -11,7 +11,7 @@ fi
 AUTH_TOKEN=$(/root/app)
 
 getConfigFile() {
-	curl -s -H "Authorization: Bearer ${AUTH_TOKEN}" "${CONFIGURATIONS_GENERATOR_SERVICE_HOST}:${CONFIGURATIONS_GENERATOR_SERVICE_PORT_HTTP}/kube-config" -o "${PWD}/kubeconfig"
+	curl -s -H "Authorization: Bearer ${AUTH_TOKEN}" "${IAM_KUBECONFIG_SVC_FQDN}/kube-config" -o "${PWD}/kubeconfig"
 }
 
 test(){

--- a/tests/apiserver-proxy-tests/test.sh
+++ b/tests/apiserver-proxy-tests/test.sh
@@ -11,7 +11,7 @@ fi
 AUTH_TOKEN=$(/root/app)
 
 getConfigFile() {
-	curl -s -H "Authorization: Bearer ${AUTH_TOKEN}" "${IAM_KUBECONFIG_SVC_FQDN}/kube-config" -o "${PWD}/kubeconfig"
+	curl -s -H "Authorization: Bearer ${AUTH_TOKEN}" "${IAM_KUBECONFIG_SVC_FQDN}:${IAM_KUBECONFIG_SVC_PORT}/kube-config" -o "${PWD}/kubeconfig"
 }
 
 test(){


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/master/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- Apiserver proxy test should use FQDN of configurations generator service

**Related issue(s)**
related to #4438
