### PR TITLE
Allow k8s client to omit Authentication field in the Api

### DIFF
--- a/components/api-controller/pkg/apis/gateway.kyma-project.io/v1alpha2/types.go
+++ b/components/api-controller/pkg/apis/gateway.kyma-project.io/v1alpha2/types.go
@@ -26,7 +26,7 @@ type ApiSpec struct {
 	DisableIstioAuthPolicyMTLS *bool   `json:"disableIstioAuthPolicyMTLS,omitempty"`
 	AuthenticationEnabled      *bool   `json:"authenticationEnabled,omitempty"`
 	// +optional
-	Authentication []AuthenticationRule `json:"authentication"`
+	Authentication []AuthenticationRule `json:"authentication,omitempty"`
 }
 
 type Service struct {


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/master/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- add "omitempty" jsontag to Authentication field in the Api

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
Related to #3827