### PR TITLE
Always perform namespace cleanup

### DIFF
--- a/resources/core/values.yaml
+++ b/resources/core/values.yaml
@@ -29,8 +29,8 @@ global:
     dir: develop/
     version: "b8c31ef4"
   api_controller_acceptance_tests:
-    dir: develop/
-    version: "52e36665"
+    dir: pr/
+    version: "PR-4656"
     testNamespace: api-controller-tests
   apiserver_proxy:
     dir: develop/

--- a/tests/api-controller-acceptance-tests/apicontroller/main_test.go
+++ b/tests/api-controller-acceptance-tests/apicontroller/main_test.go
@@ -1,15 +1,16 @@
 package apicontroller
 
 import (
+	"os"
+	"os/signal"
+	"testing"
+
 	log "github.com/sirupsen/logrus"
 	"k8s.io/api/core/v1"
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
-	"os"
-	"os/signal"
-	"testing"
 )
 
 var kubeConfig *rest.Config
@@ -85,8 +86,8 @@ func loadKubeConfigOrDie() *rest.Config {
 
 func testWithNamespace(m *testing.M) int {
 	catchInterrupt()
-	createNamespace()
 	defer deleteNamespace()
+	createNamespace()
 
 	return m.Run()
 }


### PR DESCRIPTION

**Description**
Test namespace should always be deleted in the test, even if namespace creation failed.
This guards the test from falling into permanent error state, where namespace already exists and it cannot be created and is not deleted because of the error.

Changes proposed in this pull request:
- Ensure namespace cleanup is always executed

**Related issue(s)**
See also #4655 
