### PR TITLE
Add optional destination rule for Connector Service

### DIFF
--- a/resources/application-connector/charts/connector-service/templates/destination-rule.yaml
+++ b/resources/application-connector/charts/connector-service/templates/destination-rule.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.istio.mtlsDestinationRule.required }}
+apiVersion: networking.istio.io/v1alpha3
+kind: DestinationRule
+metadata:
+  name: {{ .Chart.Name }}-external-api-rule
+  namespace: {{ .Values.global.istio.namespace }}
+spec:
+  host: connector-service-external-api.kyma-integration.svc.cluster.local
+  trafficPolicy:
+    tls:
+      mode: ISTIO_MUTUAL
+{{- end }}

--- a/resources/application-connector/charts/connector-service/values.yaml
+++ b/resources/application-connector/charts/connector-service/values.yaml
@@ -60,6 +60,9 @@ istio:
       - user: cluster.local/ns/kyma-integration/sa/connection-token-handler
       - user: cluster.local/ns/kyma-integration/sa/{{ .Chart.Name }}-tests
       - user: cluster.local/ns/kyma-system/sa/core-console-backend-service
+  mtlsDestinationRule:
+    required: false
+
 tests:
   enabled: true
   skipSslVerify: true


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/master/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Connector Service is using the default Destination Rule which may be configured differently with other Istio configurations. Without such Destination Rule present Connector Service is not working due to the usage of some Istio specific headers.

Changes proposed in this pull request:

- Add optional Destination Rule that will ensure that the Connector Service is working correctly with other Istio configurations.


