### PR TITLE
Fix api controller tests error handling

### DIFF
--- a/resources/core/values.yaml
+++ b/resources/core/values.yaml
@@ -30,7 +30,7 @@ global:
     version: "b8c31ef4"
   api_controller_acceptance_tests:
     dir: pr/
-    version: "PR-4656"
+    version: "PR-4686"
     testNamespace: api-controller-tests
   apiserver_proxy:
     dir: develop/

--- a/tests/api-controller-acceptance-tests/apicontroller/fixture.go
+++ b/tests/api-controller-acceptance-tests/apicontroller/fixture.go
@@ -13,11 +13,11 @@ import (
 )
 
 const (
-	namespaceEnv                                   = "NAMESPACE"
-	domainNameEnv                                  = "DOMAIN_NAME"
-	testIDLength                                   = 8
-	apiSecurityDisabled                APISecurity = false
-	apiSecurityEnabled                 APISecurity = true
+	namespaceEnv                    = "NAMESPACE"
+	domainNameEnv                   = "DOMAIN_NAME"
+	testIDLength                    = 8
+	apiSecurityDisabled APISecurity = false
+	apiSecurityEnabled  APISecurity = true
 )
 
 //APISecurity Enable/disable security in API
@@ -40,16 +40,17 @@ func setUpOrExit(k8sInterface kubernetes.Interface, namespace string, testID str
 
 	sampleAppDepl, deplErr := sampleAppCtrl.createDeployment()
 	if deplErr != nil {
-
 		if errors.IsAlreadyExists(deplErr) {
 			log.Debug("SampleApp deployment already exists.")
 			if sampleAppDepl2, getDeplErr := sampleAppCtrl.getDeployment(); getDeplErr != nil {
-				log.Fatalf("error getting existing SampleApp deployment. Root cause: %v", getDeplErr)
+				log.Errorf("error getting existing SampleApp deployment. Root cause: %v", getDeplErr)
+				panic(getDeplErr)
 			} else {
 				sampleAppDepl = sampleAppDepl2
 			}
 		} else {
-			log.Fatalf("error creating SampleApp deployment. Root cause: %v", deplErr)
+			log.Errorf("error creating SampleApp deployment. Root cause: %v", deplErr)
+			panic(deplErr)
 		}
 	}
 	sampleAppService, svcErr := sampleAppCtrl.createService(&sampleAppDepl.Spec.Template)
@@ -57,12 +58,14 @@ func setUpOrExit(k8sInterface kubernetes.Interface, namespace string, testID str
 		if errors.IsAlreadyExists(deplErr) {
 			log.Debug("SampleApp service already exists.")
 			if sampleAppSvc2, getSvcErr := sampleAppCtrl.getService(); getSvcErr != nil {
-				log.Fatalf("error getting existing SampleApp service. Root cause: %v", getSvcErr)
+				log.Errorf("error getting existing SampleApp service. Root cause: %v", getSvcErr)
+				panic(getSvcErr)
 			} else {
 				sampleAppService = sampleAppSvc2
 			}
 		} else {
-			log.Fatalf("error creating SampleApp service. Root cause: %v", svcErr)
+			log.Errorf("error creating SampleApp service. Root cause: %v", svcErr)
+			panic(svcErr)
 		}
 	}
 

--- a/tests/api-controller-acceptance-tests/apicontroller/integration_test.go
+++ b/tests/api-controller-acceptance-tests/apicontroller/integration_test.go
@@ -36,7 +36,7 @@ func TestIntegrationSpec(t *testing.T) {
 
 	httpClient, err := ingressgateway.FromEnv().Client()
 	if err != nil {
-		t.Fatalf("Cannot get ingressgateway client: %s", err)
+		t.Fatalf("Can't get ingressgateway client: %s", err)
 	}
 
 	t.Logf("Set up...")
@@ -57,7 +57,7 @@ func TestIntegrationSpec(t *testing.T) {
 
 		kymaInterface, kymaErr := kyma.NewForConfig(kubeConfig)
 		if kymaErr != nil {
-			log.Fatalf("can create kyma clientset. Root cause: %v", kymaErr)
+			t.Fatalf("Can't create kyma clientset. Root cause: %v", kymaErr)
 		}
 
 		suiteFinished = false

--- a/tests/api-controller-acceptance-tests/apicontroller/main_test.go
+++ b/tests/api-controller-acceptance-tests/apicontroller/main_test.go
@@ -24,11 +24,7 @@ func TestMain(m *testing.M) {
 		os.Exit(2)
 	}
 
-	kubeConfig, err := loadKubeConfigOrDie()
-	if err != nil {
-		os.Exit(2)
-	}
-
+	kubeConfig := loadKubeConfigOrDie()
 	k8sClient = kubernetes.NewForConfigOrDie(kubeConfig)
 
 	os.Exit(testWithNamespace(m))
@@ -74,23 +70,23 @@ func catchInterrupt() {
 	}()
 }
 
-func loadKubeConfigOrDie() (*rest.Config, error) {
+func loadKubeConfigOrDie() *rest.Config {
 	if _, err := os.Stat(clientcmd.RecommendedHomeFile); os.IsNotExist(err) {
 		cfg, err := rest.InClusterConfig()
 		if err != nil {
 			log.Errorf("Cannot create in-cluster config: %v", err)
-			return nil, err
+			panic(err)
 		}
-		return cfg, nil
+		return cfg
 	}
 
 	var err error
 	kubeConfig, err = clientcmd.BuildConfigFromFlags("", clientcmd.RecommendedHomeFile)
 	if err != nil {
 		log.Errorf("Cannot read kubeconfig: %s", err)
-		return nil, err
+		panic(err)
 	}
-	return kubeConfig, nil
+	return kubeConfig
 }
 
 func testWithNamespace(m *testing.M) int {

--- a/tests/api-controller-acceptance-tests/apicontroller/main_test.go
+++ b/tests/api-controller-acceptance-tests/apicontroller/main_test.go
@@ -24,7 +24,7 @@ func TestMain(m *testing.M) {
 		os.Exit(2)
 	}
 
-	kubeConfig := loadKubeConfigOrDie()
+	kubeConfig = loadKubeConfigOrDie()
 	k8sClient = kubernetes.NewForConfigOrDie(kubeConfig)
 
 	os.Exit(testWithNamespace(m))
@@ -80,13 +80,12 @@ func loadKubeConfigOrDie() *rest.Config {
 		return cfg
 	}
 
-	var err error
-	kubeConfig, err = clientcmd.BuildConfigFromFlags("", clientcmd.RecommendedHomeFile)
+	cfg, err := clientcmd.BuildConfigFromFlags("", clientcmd.RecommendedHomeFile)
 	if err != nil {
 		log.Errorf("Cannot read kubeconfig: %s", err)
 		panic(err)
 	}
-	return kubeConfig
+	return cfg
 }
 
 func testWithNamespace(m *testing.M) int {


### PR DESCRIPTION
**Description**

Error handling in `api-controller-tests` is broken.
It's based partially on `t.Fatalf` (good) and partially on `log.Fatalf` (bad).
Usage of `log.Fatalf` causes `os.Exit` call, which terminates current call stack and skips deferred function execution. This breaks our "cleanup" mechanisms which depends on deferred calls.
Changes proposed in this pull request:

- Remove log.Fatalf from the code.
- Replace with explicit logging +`panic` and explicit `os.Exist`in few places.

**Related issue(s)**
Implements #4655
