### PR TITLE
Update documentation on how to use quotation marks in metadata

### DIFF
--- a/docs/headless-cms/03-03-markdown-documents.md
+++ b/docs/headless-cms/03-03-markdown-documents.md
@@ -29,7 +29,11 @@ type: {Document type}
 ---
 ```
 
-- The `title` metadata defines the title of your document.
+- The `title` metadata defines the title of your document. If you want the title or its part to display inside quotation marks, place it between additional, single quotation marks or use a backslash (**/**) before the quoted word. See the following examples:
+  - ✅ `title: '"Transport is closing" error'`
+  - ✅ `title: \"Transport is closing" error`
+  - ⛔️ `title: "Transport is closing" error`
+
 - The `type` metadata groups single documents together. Multiple documents that use the same `type` generate a grouping. For example, if you have multiple tutorials, you can group them under a navigation node called **Tutorials**.
 
 >**NOTE:** If there is only one document of a certain type, remove the `type` metadata, so that the document displays well in the UI.

--- a/docs/headless-cms/03-03-markdown-documents.md
+++ b/docs/headless-cms/03-03-markdown-documents.md
@@ -29,10 +29,11 @@ type: {Document type}
 ---
 ```
 
-- The `title` metadata defines the title of your document. If you want the title or its part to display inside quotation marks, place it between additional, single quotation marks or use a backslash (**/**) before the quoted word. See the following examples:
-  - ✅ `title: '"Transport is closing" error'`
-  - ✅ `title: \"Transport is closing" error`
-  - ⛔️ `title: "Transport is closing" error`
+- The `title` metadata defines the title of your document. If you want the title or its part to render inside quotation marks, place it between additional, single quotation marks or use a backslash (**/**) before the quoted word. See the following examples:
+
+  ✅ `title: '"Transport is closing" error'`<br>
+  ✅ `title: \"Transport is closing" error`<br>
+  ⛔️ `title: "Transport is closing" error`<br>
 
 - The `type` metadata groups single documents together. Multiple documents that use the same `type` generate a grouping. For example, if you have multiple tutorials, you can group them under a navigation node called **Tutorials**.
 

--- a/docs/kyma/14-05-transport-closing.md
+++ b/docs/kyma/14-05-transport-closing.md
@@ -1,5 +1,5 @@
 ---
-title: Transport is closing error
+title: '"Transport is closing" error'
 type: Troubleshooting
 ---
 


### PR DESCRIPTION
Changes proposed in this pull request:

- Updated documentation on how to use quotation marks in metadata
- Added quotation marks to the metadata of a troubleshooting document

**Related issue(s)**
See also #4532
