### PR TITLE
Switch api-controller tests to new name

### DIFF
--- a/resources/core/charts/api-controller/templates/tests/test-api-controller.yaml
+++ b/resources/core/charts/api-controller/templates/tests/test-api-controller.yaml
@@ -2,7 +2,7 @@
 apiVersion: "testing.kyma-project.io/v1alpha1"
 kind: TestDefinition
 metadata:
-  name: test-api-controller-acceptance
+  name: test-{{ .Release.Name }}-api-controller
 spec:
   disableConcurrency: true
   template:
@@ -13,8 +13,8 @@ spec:
       shareProcessNamespace: true
       serviceAccount: api-controller-test-account
       containers:
-      - name: test-api-controller-acceptance
-        image: {{ .Values.global.containerRegistry.path }}/{{ .Values.global.api_controller_acceptance_tests.dir }}api-controller-acceptance-tests:{{ .Values.global.api_controller_acceptance_tests.version }}
+      - name: test-api-controller-integration
+        image: {{ .Values.global.containerRegistry.path }}/{{ .Values.global.api_controller_integration_tests.dir }}api-controller-integration-tests:{{ .Values.global.api_controller_integration_tests.version }}
         command: ["/bin/sh"]
         args: ["-c", "sleep 10; /apicontroller.test -test.v; exit_code=$?; pkill -INT pilot-agent; sleep 4; exit $exit_code;"]
         env:

--- a/resources/core/charts/api-controller/templates/tests/test-api-controller.yaml
+++ b/resources/core/charts/api-controller/templates/tests/test-api-controller.yaml
@@ -23,6 +23,6 @@ spec:
         - name: INGRESSGATEWAY_ADDRESS
           value: istio-ingressgateway.istio-system.svc.cluster.local
         - name: NAMESPACE
-          value: {{ .Values.global.api_controller_acceptance_tests.testNamespace }}
+          value: {{ .Values.global.api_controller_integration_tests.testNamespace }}
       restartPolicy: Never
 {{- end }}

--- a/resources/core/values.yaml
+++ b/resources/core/values.yaml
@@ -30,7 +30,7 @@ global:
     version: "PR-4582"
   api_controller_integration_tests:
     dir: pr/
-    version: "PR-4582"
+    version: "PR-4752"
     testNamespace: api-controller-tests
   apiserver_proxy:
     dir: develop/

--- a/resources/core/values.yaml
+++ b/resources/core/values.yaml
@@ -28,7 +28,7 @@ global:
   api_controller:
     dir: pr/
     version: "PR-4582"
-  api_controller_acceptance_tests:
+  api_controller_integration_tests:
     dir: pr/
     version: "PR-4582"
     testNamespace: api-controller-tests

--- a/tests/integration/api-controller/Gopkg.lock
+++ b/tests/integration/api-controller/Gopkg.lock
@@ -371,6 +371,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "e960a90d636b8470127fc262ca6acc4bc2ad268d92777c571518a20543ce14b9"
+  inputs-digest = "65d028fcecc79a4dc5b76d98a218aba7d4ad98614c2d3d889f1b12b81e4d1346"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/tests/integration/api-controller/Makefile
+++ b/tests/integration/api-controller/Makefile
@@ -1,4 +1,4 @@
-APP_NAME = api-controller-acceptance-tests
+APP_NAME = api-controller-integration-tests
 IMG = $(DOCKER_PUSH_REPOSITORY)$(DOCKER_PUSH_DIRECTORY)/$(APP_NAME)
 TAG = $(DOCKER_TAG)
 

--- a/tests/integration/api-controller/README.md
+++ b/tests/integration/api-controller/README.md
@@ -11,4 +11,4 @@ To test your changes and build the image, run the `make build build-image` comma
 
 ## Configuring Kyma
 
-After building and pushing the Docker image, configure it to be used in Kyma by setting proper values for `dir` and `version` in the `global.api_controller_acceptance_tests` property in the `resources/core/values.yaml` file.
+After building and pushing the Docker image, configure it to be used in Kyma by setting proper values for `dir` and `version` in the `global.api_controller_integration_tests` property in the `resources/core/values.yaml` file.

--- a/tests/integration/api-controller/apicontroller/component_test.go
+++ b/tests/integration/api-controller/apicontroller/component_test.go
@@ -41,6 +41,169 @@ func TestComponentSpec(t *testing.T) {
 
 	Convey("API Controller should", t, func() {
 
+		Convey("update API with explicitly configured authentication to default authentication", func() {
+			t.Log("update API with explicitly configured authentication to default authentication")
+
+			testID := ctx.generateTestID(testIDLength)
+			t.Logf("Running test: %s", testID)
+
+			/*
+				  authentication:
+					- type: JWT
+					  jwt:
+						jwksUri: http://dex-service.kyma-system.svc.cluster.local:5556/keys
+						issuer: https://accounts.google.com
+			*/
+			api := ctx.apiFor(testID, domainName, namespace, apiSecurityDisabled, true)
+			ctx.setCustomJwtAuthenticationConfig(api)
+			api.Spec.AuthenticationEnabled = nil
+
+			createdAPI, err := kymaClient.GatewayV1alpha2().Apis(namespace).Create(api)
+			defer ctx.cleanUpAPI(kymaClient, api, t, true, namespace)
+			So(err, ShouldBeNil)
+			So(createdAPI, ShouldNotBeNil)
+			So(createdAPI.ResourceVersion, ShouldNotBeEmpty)
+
+			createdAPI, err = ctx.awaitAPIChanged(kymaClient, createdAPI, true, false, namespace)
+			So(err, ShouldBeNil)
+			So(createdAPI.ResourceVersion, ShouldNotBeEmpty)
+			So(createdAPI.Spec, ctx.ShouldDeepEqual, api.Spec)
+
+			vs, err := istioNetClient.NetworkingV1alpha3().VirtualServices(namespace).Get(createdAPI.Status.VirtualServiceStatus.Resource.Name, metav1.GetOptions{})
+			expectedVs := ctx.virtualServiceFor(testID, domainName, namespace)
+			So(err, ShouldBeNil)
+			So(vs.Spec, ctx.ShouldDeepEqual, expectedVs)
+
+			lastPolicy, err := istioAuthClient.AuthenticationV1alpha1().Policies(namespace).Get(createdAPI.Status.AuthenticationStatus.Resource.Name, metav1.GetOptions{})
+			expectedPolicy := ctx.policyAndTriggerRuleFor(testID, "https://accounts.google.com", sampleTriggerRule())
+			So(err, ShouldBeNil)
+			So(lastPolicy.Spec, ctx.ShouldDeepEqual, expectedPolicy)
+
+			/*
+				authenticationEnabled: true
+				# no authentication field
+			*/
+			updatedAPI, err := patchApi(*kymaClient, *createdAPI, remove("/spec/authentication"), replace("/spec/authenticationEnabled", true))
+
+			So(err, ShouldBeNil)
+			So(updatedAPI, ShouldNotBeNil)
+			So(updatedAPI.ResourceVersion, ShouldNotBeEmpty)
+
+			updatedAPI, err = ctx.awaitAPIChanged(kymaClient, updatedAPI, false, true, namespace)
+			So(err, ShouldBeNil)
+			So(updatedAPI.ResourceVersion, ShouldNotBeEmpty)
+			createdAPI.Spec.AuthenticationEnabled = boolPtr(true)           // that field was changed to true during the patch
+			createdAPI.Spec.Authentication = []kymaApi.AuthenticationRule{} // api controller changes that field from nil to empty table in the runtime
+			So(updatedAPI.Spec, ctx.ShouldDeepEqual, createdAPI.Spec)
+			So(updatedAPI.Status.AuthenticationStatus.Resource.Uid, ShouldNotBeEmpty)
+
+			vs, err = istioNetClient.NetworkingV1alpha3().VirtualServices(namespace).Get(updatedAPI.Status.VirtualServiceStatus.Resource.Name, metav1.GetOptions{})
+			expectedVs = ctx.virtualServiceFor(testID, domainName, namespace)
+			So(err, ShouldBeNil)
+			So(vs.Spec, ctx.ShouldDeepEqual, expectedVs)
+
+			lastPolicy, err = istioAuthClient.AuthenticationV1alpha1().Policies(namespace).Get(updatedAPI.Status.AuthenticationStatus.Resource.Name, metav1.GetOptions{})
+			expectedPolicy = ctx.policyFor(testID, fmt.Sprintf("https://dex.%s", domainName))
+			So(err, ShouldBeNil)
+			So(lastPolicy.Spec, ctx.ShouldDeepEqual, expectedPolicy)
+
+			// apply the first configuration
+			updatedAPI.Spec = api.Spec
+			finalAPI, err := kymaClient.GatewayV1alpha2().Apis(namespace).Update(updatedAPI)
+			So(err, ShouldBeNil)
+			So(finalAPI, ShouldNotBeNil)
+			So(finalAPI.ResourceVersion, ShouldNotBeEmpty)
+
+			finalAPI, err = ctx.awaitAPIChanged(kymaClient, finalAPI, false, true, namespace)
+			So(err, ShouldBeNil)
+			So(finalAPI.ResourceVersion, ShouldNotBeEmpty)
+			So(finalAPI.Spec, ctx.ShouldDeepEqual, api.Spec)
+			So(finalAPI.Status.AuthenticationStatus.Resource.Uid, ShouldNotBeEmpty)
+
+			vs, err = istioNetClient.NetworkingV1alpha3().VirtualServices(namespace).Get(finalAPI.Status.VirtualServiceStatus.Resource.Name, metav1.GetOptions{})
+			expectedVs = ctx.virtualServiceFor(testID, domainName, namespace)
+			So(err, ShouldBeNil)
+			So(vs.Spec, ctx.ShouldDeepEqual, expectedVs)
+
+			lastPolicy, err = istioAuthClient.AuthenticationV1alpha1().Policies(namespace).Get(finalAPI.Status.AuthenticationStatus.Resource.Name, metav1.GetOptions{})
+			expectedPolicy = ctx.policyAndTriggerRuleFor(testID, "https://accounts.google.com", sampleTriggerRule())
+			So(err, ShouldBeNil)
+			So(lastPolicy.Spec, ctx.ShouldDeepEqual, expectedPolicy)
+
+			// a bugged program will lead to API-controller unable to update/delete policy, so we delete the API and check if policy was deleted
+			ctx.cleanUpAPI(kymaClient, finalAPI, t, false, namespace)
+			err = ctx.verifyIstioResourcesCleanUp(istioAuthClient, istioNetClient, updatedAPI)
+			So(err, ShouldBeNil)
+		})
+
+		Convey("update API with explicitly configured but disabled authentication to default authentication", func() {
+			t.Log("update API with explicitly configured but disabled authentication to default authentication")
+
+			testID := ctx.generateTestID(testIDLength)
+			t.Logf("Running test: %s", testID)
+
+			/*
+				  authenticationEnabled: false
+				  authentication:
+					- type: JWT
+					  jwt:
+						jwksUri: http://dex-service.kyma-system.svc.cluster.local:5556/keys
+						issuer: https://accounts.google.com
+			*/
+			api := ctx.apiFor(testID, domainName, namespace, apiSecurityDisabled, true)
+			ctx.setCustomJwtAuthenticationConfig(api)
+			api.Spec.AuthenticationEnabled = boolPtr(false)
+
+			createdAPI, err := kymaClient.GatewayV1alpha2().Apis(namespace).Create(api)
+			defer ctx.cleanUpAPI(kymaClient, createdAPI, t, true, namespace)
+			So(err, ShouldBeNil)
+			So(createdAPI, ShouldNotBeNil)
+			So(createdAPI.ResourceVersion, ShouldNotBeEmpty)
+
+			createdAPI, err = ctx.awaitAPIChanged(kymaClient, createdAPI, true, false, namespace)
+			So(err, ShouldBeNil)
+			So(createdAPI.ResourceVersion, ShouldNotBeEmpty)
+			So(createdAPI.Spec, ctx.ShouldDeepEqual, api.Spec)
+
+			vs, err := istioNetClient.NetworkingV1alpha3().VirtualServices(namespace).Get(createdAPI.Status.VirtualServiceStatus.Resource.Name, metav1.GetOptions{})
+			expectedVs := ctx.virtualServiceFor(testID, domainName, namespace)
+			So(err, ShouldBeNil)
+			So(vs.Spec, ctx.ShouldDeepEqual, expectedVs)
+
+			/*
+				authenticationEnabled: true
+				# no authentication field
+			*/
+			updatedAPI, err := patchApi(*kymaClient, *createdAPI, remove("/spec/authentication"), replace("/spec/authenticationEnabled", true))
+
+			So(err, ShouldBeNil)
+			So(updatedAPI, ShouldNotBeNil)
+			So(updatedAPI.ResourceVersion, ShouldNotBeEmpty)
+
+			updatedAPI, err = ctx.awaitAPIChanged(kymaClient, updatedAPI, false, true, namespace)
+			So(err, ShouldBeNil)
+			So(updatedAPI.ResourceVersion, ShouldNotBeEmpty)
+			createdAPI.Spec.AuthenticationEnabled = boolPtr(true)           // that field was changed to true during the patch
+			createdAPI.Spec.Authentication = []kymaApi.AuthenticationRule{} // api controller changes that field from nil to empty table in the runtime
+			So(updatedAPI.Spec, ctx.ShouldDeepEqual, createdAPI.Spec)
+			So(updatedAPI.Status.AuthenticationStatus.Resource.Uid, ShouldNotBeEmpty)
+
+			vs, err = istioNetClient.NetworkingV1alpha3().VirtualServices(namespace).Get(updatedAPI.Status.VirtualServiceStatus.Resource.Name, metav1.GetOptions{})
+			expectedVs = ctx.virtualServiceFor(testID, domainName, namespace)
+			So(err, ShouldBeNil)
+			So(vs.Spec, ctx.ShouldDeepEqual, expectedVs)
+
+			lastPolicy, err := istioAuthClient.AuthenticationV1alpha1().Policies(namespace).Get(updatedAPI.Status.AuthenticationStatus.Resource.Name, metav1.GetOptions{})
+			expectedPolicy := ctx.policyFor(testID, fmt.Sprintf("https://dex.%s", domainName))
+			So(err, ShouldBeNil)
+			So(lastPolicy.Spec, ctx.ShouldDeepEqual, expectedPolicy)
+
+			// a bugged program will lead to API-controller unable to update/delete policy, so we delete the API and check if policy was deleted
+			ctx.cleanUpAPI(kymaClient, updatedAPI, t, false, namespace)
+			err = ctx.verifyIstioResourcesCleanUp(istioAuthClient, istioNetClient, updatedAPI)
+			So(err, ShouldBeNil)
+		})
+
 		Convey("create API with authentication disabled", func() {
 			t.Log("create API with authentication disabled")
 
@@ -588,6 +751,25 @@ func (componentTestContext) cleanUpAPI(kymaClient *kyma.Clientset, api *kymaApi.
 	if !allowMissing && err != nil {
 		t.Fatalf("Cannot clean up API %s: %s", api.Name, err)
 	}
+}
+
+func (componentTestContext) verifyIstioResourcesCleanUp(istioAuthClient *istioAuth.Clientset, istioNetClient *istioNet.Clientset, api *kymaApi.Api) error {
+	return retry.Do(func() error {
+		vs, _ := istioNetClient.NetworkingV1alpha3().VirtualServices(api.GetNamespace()).Get(api.Status.VirtualServiceStatus.Resource.Name, metav1.GetOptions{})
+
+		emptyVirtualService := &istioNetApi.VirtualService{}
+		if deep.Equal(vs, emptyVirtualService) != nil {
+			return fmt.Errorf("VirtualService not deleted")
+		}
+
+		lastPolicy, _ := istioAuthClient.AuthenticationV1alpha1().Policies(api.GetNamespace()).Get(api.Status.AuthenticationStatus.Resource.Name, metav1.GetOptions{ResourceVersion: "1"})
+
+		emptyPolicy := &istioAuthApi.Policy{}
+		if deep.Equal(lastPolicy, emptyPolicy) != nil {
+			return fmt.Errorf("Policy not deleted")
+		}
+		return nil
+	}, retry.Attempts(5), retry.Delay(1*time.Second))
 }
 
 func boolPtr(arg bool) *bool {

--- a/tests/integration/api-controller/apicontroller/patch.go
+++ b/tests/integration/api-controller/apicontroller/patch.go
@@ -1,0 +1,54 @@
+package apicontroller
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"k8s.io/apimachinery/pkg/types"
+
+	kymaApi "github.com/kyma-project/kyma/components/api-controller/pkg/apis/gateway.kyma-project.io/v1alpha2"
+	kyma "github.com/kyma-project/kyma/components/api-controller/pkg/clients/gateway.kyma-project.io/clientset/versioned"
+)
+
+// A few utility functions to patch Api resources.
+//
+// Patch uses JSONPatch. There are some functions for specifying which operations should be performed.
+// For the reference of other possible operations use https://tools.ietf.org/html/rfc6902#section-4.
+
+type operation interface{}
+
+type replaceOperation struct {
+	Op    string      `json:"op"`
+	Path  string      `json:"path"`
+	Value interface{} `json:"value"`
+}
+
+type removeOperation struct {
+	Op   string `json:"op"`
+	Path string `json:"path"`
+}
+
+func replace(path string, value interface{}) operation {
+	return replaceOperation{
+		Op:    "replace",
+		Path:  path,
+		Value: value,
+	}
+}
+
+func remove(path string) operation {
+	return removeOperation{
+		Op:   "remove",
+		Path: path,
+	}
+}
+
+func patchApi(client kyma.Clientset, api kymaApi.Api, operations ...operation) (*kymaApi.Api, error) {
+
+	if operations == nil {
+		return nil, fmt.Errorf("no operations to perform in patch specified")
+	}
+
+	payloadBytes, _ := json.Marshal(operations)
+	return client.GatewayV1alpha2().Apis(api.GetNamespace()).Patch(api.GetName(), types.JSONPatchType, payloadBytes)
+}


### PR DESCRIPTION
**Description**

This PR implements a step in the process of renaming api-controller acceptance tests, as outlined in #2504.

Changes proposed in this pull request:

- Switch api-controller integration tests to new name/location
- Rename api-controller-acceptance-tests to api-controller-integration-tests to align with the convention for other tests.

**Related issue(s)**
Implements: #4442
See also: #2504
