### PR TITLE
added system namespace filter for alert KubeDeploymentReplicasNotUpdated

### DIFF
--- a/resources/monitoring/charts/exporter-kube-state/templates/_helpers.tpl
+++ b/resources/monitoring/charts/exporter-kube-state/templates/_helpers.tpl
@@ -34,3 +34,7 @@ Return the appropriate apiVersion value to use for the prometheus-operator manag
 {{- printf "%s" "monitoring.coreos.com/v1alpha1" -}}
 {{- end -}}
 {{- end -}}
+
+{{- define "filter.system-namespaces" -}}
+{{- printf "{namespace=\"%s\"}" .Values.systemNamespaceFilter -}}
+{{- end -}}

--- a/resources/monitoring/charts/exporter-kube-state/templates/kube-state-metrics.rules.yaml
+++ b/resources/monitoring/charts/exporter-kube-state/templates/kube-state-metrics.rules.yaml
@@ -23,9 +23,9 @@ spec:
         message: Observed deployment generation does not match expected one for deployment {{`{{$labels.namespaces}}`}}/{{`{{$labels.deployment}}`}}, this indicates that the Deployment has failed but has not been rolled back.
         summary: Deployment is outdated
     - alert: KubeDeploymentReplicasNotUpdated
-      expr: ((kube_deployment_status_replicas_updated != kube_deployment_spec_replicas)
-        or (kube_deployment_status_replicas_available != kube_deployment_spec_replicas))
-        unless (kube_deployment_spec_paused == 1)
+      expr: ((kube_deployment_status_replicas_updated{{ template "filter.system-namespaces" . }} != kube_deployment_spec_replicas{{ template "filter.system-namespaces" . }})
+        or (kube_deployment_status_replicas_available{{ template "filter.system-namespaces" . }} != kube_deployment_spec_replicas{{ template "filter.system-namespaces" . }}))
+        unless (kube_deployment_spec_paused{{ template "filter.system-namespaces" . }} == 1)
       for: 15m
       labels:
         severity: critical

--- a/resources/monitoring/charts/exporter-kube-state/values.yaml
+++ b/resources/monitoring/charts/exporter-kube-state/values.yaml
@@ -49,3 +49,5 @@ additionalServiceMonitorLabels: {}
 ##Custom Labels to be added to Prometheus Rules ConfigMap
 ##
 additionalRulesConfigMapLabels: {}
+
+systemNamespaceFilter: "kyma-.*|knative-.*|kube-.*|istio-.*"


### PR DESCRIPTION

**Description**

Changes proposed in this pull request:

- .filter system namespaces for the specific alert to not alert for customer related problems

**Related issue(s)**
#3941 
