### PR TITLE
Save certificate chain to cluster secret in Connectivity Certs Controller

### DIFF
--- a/components/connectivity-certs-controller/internal/centralconnection/controller.go
+++ b/components/connectivity-certs-controller/internal/centralconnection/controller.go
@@ -196,15 +196,15 @@ func (c *Controller) getCertificateCredentials() (connectorservice.CertificateCr
 		return connectorservice.CertificateCredentials{}, errors.Wrap(err, "Failed to get client key and certificate")
 	}
 
-	caCertificates, err := c.certificateProvider.GetCACertificates()
+	certificateChain, err := c.certificateProvider.GetCertificateChain()
 	if err != nil {
 		return connectorservice.CertificateCredentials{}, errors.Wrap(err, "Failed to get CA certificate")
 	}
 
 	return connectorservice.CertificateCredentials{
-		ClientKey:  clientKey,
-		ClientCert: clientCert,
-		CACerts:    caCertificates,
+		ClientKey:        clientKey,
+		ClientCert:       clientCert,
+		CertificateChain: certificateChain,
 	}, nil
 }
 

--- a/components/connectivity-certs-controller/internal/centralconnection/controller.go
+++ b/components/connectivity-certs-controller/internal/centralconnection/controller.go
@@ -198,7 +198,7 @@ func (c *Controller) getCertificateCredentials() (connectorservice.CertificateCr
 
 	certificateChain, err := c.certificateProvider.GetCertificateChain()
 	if err != nil {
-		return connectorservice.CertificateCredentials{}, errors.Wrap(err, "Failed to get CA certificate")
+		return connectorservice.CertificateCredentials{}, errors.Wrap(err, "Failed to get certificate chain")
 	}
 
 	return connectorservice.CertificateCredentials{
@@ -292,6 +292,7 @@ func (c *Controller) updateCentralConnectionCR(connection *v1alpha1.CentralConne
 		return c.centralConnectionClient.Update(context.Background(), existingConnection)
 	})
 	if err != nil {
+		c.logger.Errorf("Failed to update Central Connection: %s", err.Error())
 		return errors.Wrap(err, "Failed to update Central Connection")
 	}
 

--- a/components/connectivity-certs-controller/internal/centralconnection/controller_test.go
+++ b/components/connectivity-certs-controller/internal/centralconnection/controller_test.go
@@ -180,9 +180,9 @@ func TestController_Reconcile(t *testing.T) {
 	}
 
 	certificateCredentials := connectorservice.CertificateCredentials{
-		ClientKey:  clientKey,
-		ClientCert: clientCert,
-		CACerts:    caCert,
+		ClientKey:        clientKey,
+		ClientCert:       clientCert,
+		CertificateChain: caCert,
 	}
 
 	t.Run("should check connection and renew certificate", func(t *testing.T) {
@@ -207,7 +207,7 @@ func TestController_Reconcile(t *testing.T) {
 
 		certProvider := &certMocks.Provider{}
 		certProvider.On("GetClientCredentials").Return(clientKey, clientCert, nil)
-		certProvider.On("GetCACertificates").Return(caCert, nil)
+		certProvider.On("GetCertificateChain").Return(caCert, nil)
 
 		mutualTLSClient := &connectorMocks.EstablishedConnectionClient{}
 		mutualTLSClient.On("GetManagementInfo", managementInfoURL).Return(managementInfo, nil)
@@ -255,7 +255,7 @@ func TestController_Reconcile(t *testing.T) {
 
 		certProvider := &certMocks.Provider{}
 		certProvider.On("GetClientCredentials").Return(clientKey, clientCert, nil)
-		certProvider.On("GetCACertificates").Return(caCert, nil)
+		certProvider.On("GetCertificateChain").Return(caCert, nil)
 
 		mutualTLSClient := &connectorMocks.EstablishedConnectionClient{}
 		mutualTLSClient.On("GetManagementInfo", managementInfoURL).Return(managementInfo, nil)
@@ -295,7 +295,7 @@ func TestController_Reconcile(t *testing.T) {
 
 		certProvider := &certMocks.Provider{}
 		certProvider.On("GetClientCredentials").Return(clientKey, clientCert, nil)
-		certProvider.On("GetCACertificates").Return(caCert, nil)
+		certProvider.On("GetCertificateChain").Return(caCert, nil)
 
 		mutualTLSClient := &connectorMocks.EstablishedConnectionClient{}
 		mutualTLSClient.On("GetManagementInfo", managementInfoURL).Return(managementInfo, nil)
@@ -388,7 +388,7 @@ func TestController_Reconcile(t *testing.T) {
 		certPreserver := &certMocks.Preserver{}
 		certProvider := &certMocks.Provider{}
 		certProvider.On("GetClientCredentials").Return(clientKey, clientCert, nil)
-		certProvider.On("GetCACertificates").Return(nil, errors.New("error"))
+		certProvider.On("GetCertificateChain").Return(nil, errors.New("error"))
 
 		mTLSClientProvider := &connectorMocks.EstablishedConnectionClientProvider{}
 
@@ -414,7 +414,7 @@ func TestController_Reconcile(t *testing.T) {
 
 		certProvider := &certMocks.Provider{}
 		certProvider.On("GetClientCredentials").Return(clientKey, clientCert, nil)
-		certProvider.On("GetCACertificates").Return(caCert, nil)
+		certProvider.On("GetCertificateChain").Return(caCert, nil)
 
 		mutualTLSClient := &connectorMocks.EstablishedConnectionClient{}
 		mutualTLSClient.On("GetManagementInfo", managementInfoURL).
@@ -445,7 +445,7 @@ func TestController_Reconcile(t *testing.T) {
 
 		certProvider := &certMocks.Provider{}
 		certProvider.On("GetClientCredentials").Return(clientKey, clientCert, nil)
-		certProvider.On("GetCACertificates").Return(caCert, nil)
+		certProvider.On("GetCertificateChain").Return(caCert, nil)
 
 		mutualTLSClient := &connectorMocks.EstablishedConnectionClient{}
 		mutualTLSClient.On("GetManagementInfo", managementInfoURL).Return(managementInfo, nil)
@@ -477,7 +477,7 @@ func TestController_Reconcile(t *testing.T) {
 
 		certProvider := &certMocks.Provider{}
 		certProvider.On("GetClientCredentials").Return(clientKey, clientCert, nil)
-		certProvider.On("GetCACertificates").Return(caCert, nil)
+		certProvider.On("GetCertificateChain").Return(caCert, nil)
 
 		mutualTLSClient := &connectorMocks.EstablishedConnectionClient{}
 		mutualTLSClient.On("GetManagementInfo", managementInfoURL).Return(managementInfo, nil)
@@ -513,7 +513,7 @@ func TestController_Reconcile(t *testing.T) {
 
 		certProvider := &certMocks.Provider{}
 		certProvider.On("GetClientCredentials").Return(clientKey, clientCert, nil)
-		certProvider.On("GetCACertificates").Return(caCert, nil)
+		certProvider.On("GetCertificateChain").Return(caCert, nil)
 
 		mutualTLSClient := &connectorMocks.EstablishedConnectionClient{}
 		mutualTLSClient.On("GetManagementInfo", managementInfoURL).Return(managementInfo, nil)

--- a/components/connectivity-certs-controller/internal/certificates/mocks/Provider.go
+++ b/components/connectivity-certs-controller/internal/certificates/mocks/Provider.go
@@ -10,8 +10,8 @@ type Provider struct {
 	mock.Mock
 }
 
-// GetCACertificates provides a mock function with given fields:
-func (_m *Provider) GetCACertificates() ([]*x509.Certificate, error) {
+// GetCertificateChain provides a mock function with given fields:
+func (_m *Provider) GetCertificateChain() ([]*x509.Certificate, error) {
 	ret := _m.Called()
 
 	var r0 []*x509.Certificate

--- a/components/connectivity-certs-controller/internal/certificates/preserver.go
+++ b/components/connectivity-certs-controller/internal/certificates/preserver.go
@@ -9,6 +9,7 @@ import (
 const (
 	clusterCertificateSecretKey = "crt"
 	clusterKeySecretKey         = "key"
+	certificateChainSecretKey   = "crtChain"
 
 	caCertificateSecretKey = "cacert"
 )
@@ -32,7 +33,7 @@ func NewCertificatePreserver(clusterCertSecret types.NamespacedName, caCertSecre
 }
 
 func (cp *certificatePreserver) PreserveCertificates(certificates Certificates) error {
-	err := cp.saveClusterCertificateAndKey(certificates.ClientKey, certificates.ClientCRT)
+	err := cp.saveClusterCertificateAndKey(certificates.ClientKey, certificates.ClientCRT, certificates.CRTChain)
 	if err != nil {
 		return err
 	}
@@ -40,10 +41,11 @@ func (cp *certificatePreserver) PreserveCertificates(certificates Certificates) 
 	return cp.saveCACertificate(certificates.CaCRT)
 }
 
-func (cp *certificatePreserver) saveClusterCertificateAndKey(clientKey, certificateChain []byte) error {
+func (cp *certificatePreserver) saveClusterCertificateAndKey(clientKey, clientCert, certificateChain []byte) error {
 	clusterSecretData := map[string][]byte{
-		clusterCertificateSecretKey: certificateChain,
+		clusterCertificateSecretKey: clientCert,
 		clusterKeySecretKey:         clientKey,
+		certificateChainSecretKey:   certificateChain,
 	}
 
 	err := cp.secretsRepository.UpsertWithMerge(cp.clusterCertSecretName, clusterSecretData)

--- a/components/connectivity-certs-controller/internal/certificates/preserver.go
+++ b/components/connectivity-certs-controller/internal/certificates/preserver.go
@@ -50,7 +50,7 @@ func (cp *certificatePreserver) saveClusterCertificateAndKey(clientKey, clientCe
 
 	err := cp.secretsRepository.UpsertWithMerge(cp.clusterCertSecretName, clusterSecretData)
 	if err != nil {
-		return errors.Wrap(err, "Failed to preserve client certificate in secret")
+		return errors.Wrap(err, "Failed to preserve client certificate and key in secret")
 	}
 
 	return nil

--- a/components/connectivity-certs-controller/internal/certificates/preserver_test.go
+++ b/components/connectivity-certs-controller/internal/certificates/preserver_test.go
@@ -30,6 +30,7 @@ func TestCertificatePreserver_PreserveCertificates(t *testing.T) {
 		clusterSecretData := map[string][]byte{
 			clusterCertificateSecretKey: clientCRT,
 			clusterKeySecretKey:         clientKey,
+			certificateChainSecretKey:   crtChain,
 		}
 		caSecretData := map[string][]byte{caCertificateSecretKey: caCRT}
 
@@ -52,6 +53,7 @@ func TestCertificatePreserver_PreserveCertificates(t *testing.T) {
 		clusterSecretData := map[string][]byte{
 			clusterCertificateSecretKey: clientCRT,
 			clusterKeySecretKey:         clientKey,
+			certificateChainSecretKey:   crtChain,
 		}
 
 		secretsRepository := &mocks.Repository{}
@@ -72,6 +74,7 @@ func TestCertificatePreserver_PreserveCertificates(t *testing.T) {
 		clusterSecretData := map[string][]byte{
 			clusterCertificateSecretKey: clientCRT,
 			clusterKeySecretKey:         clientKey,
+			certificateChainSecretKey:   crtChain,
 		}
 		caSecretData := map[string][]byte{caCertificateSecretKey: caCRT}
 

--- a/components/connectivity-certs-controller/internal/certificates/provider.go
+++ b/components/connectivity-certs-controller/internal/certificates/provider.go
@@ -15,7 +15,7 @@ import (
 
 type Provider interface {
 	GetClientCredentials() (*rsa.PrivateKey, *x509.Certificate, error)
-	GetCACertificates() ([]*x509.Certificate, error)
+	GetCertificateChain() ([]*x509.Certificate, error)
 }
 
 type certificateProvider struct {
@@ -32,13 +32,13 @@ func NewCertificateProvider(clusterCertSecretName types.NamespacedName, caCertSe
 	}
 }
 
-func (cp *certificateProvider) GetCACertificates() ([]*x509.Certificate, error) {
-	secretData, err := cp.secretsRepository.Get(cp.caCertSecretName)
+func (cp *certificateProvider) GetCertificateChain() ([]*x509.Certificate, error) {
+	secretData, err := cp.secretsRepository.Get(cp.clusterCertSecretName)
 	if err != nil {
 		return nil, errors.Wrap(err, fmt.Sprintf("Failed to read %s secret with certificates", cp.clusterCertSecretName))
 	}
 
-	caCerts, err := decodeCertificates(secretData[caCertificateSecretKey])
+	caCerts, err := decodeCertificates(secretData[certificateChainSecretKey])
 	if err != nil {
 		return nil, errors.Wrap(err, "Failed to read client certificate")
 	}

--- a/components/connectivity-certs-controller/internal/certificates/provider_test.go
+++ b/components/connectivity-certs-controller/internal/certificates/provider_test.go
@@ -71,6 +71,32 @@ Jmzph7W9iNkezfUsC1nR3Dw9jVU0TkUz0tnlr57M0jKn3vAzmzMHeil4bnbcmaoC
 bnJlJkQ9Uv2OZSfRxc6irVmefC/u97KJPzmGjAlG/KrTVPm/gZtn46szwKKepMqd
 7iQJK/xxgHd2kKuOcSVDf2g2ygHbIE7mwofRZLM3VsfaFqIvWBmT1mbC6pzZs30C
 m0BmlwDa5ONBGAqjBP9TTm42f4ufzsGF/eFLXZ8lAbpJmLqx
+-----END CERTIFICATE-----
+-----BEGIN CERTIFICATE-----
+MIIEcDCCA1igAwIBAgIBAjANBgkqhkiG9w0BAQsFADBfMQ8wDQYDVQQLDAZDNGNv
+cmUxDDAKBgNVBAoMA1NBUDEQMA4GA1UEBwwHV2FsZG9yZjEQMA4GA1UECAwHV2Fs
+ZG9yZjELMAkGA1UEBhMCREUxDTALBgNVBAMMBEt5bWEwHhcNMTkwMjEyMTIwNDM4
+WhcNMjAwMjEyMTIwNDM4WjBvMQswCQYDVQQGEwJERTEQMA4GA1UECBMHV2FsZG9y
+ZjEQMA4GA1UEBxMHV2FsZG9yZjEVMBMGA1UEChMMT3JnYW5pemF0aW9uMRAwDgYD
+VQQLEwdPcmdVbml0MRMwEQYDVQQDEwplYy1kZWZhdWx0MIICIjANBgkqhkiG9w0B
+AQEFAAOCAg8AMIICCgKCAgEAq4TMGWybHjvhF9RSSZJG8zfp73RJlRhPj3e4EJgr
+z0Ai/PmHa8WeK2eVAfsoky9UVE+1t+cn+5trejIzSMf1R8AKpgcvTDkO9RPRLqKm
+3u8CjvOrJn0tKSk1Jf9kdSY9xQzd4SOnzSjhbL44MV3zpQ5qdlA2vIvCVNK0SwwS
+xqVQbI4FEmbOjtvQKpxnkov2fjviAqcRd+PhR5lNnCGKGtNoVi9lEnXRCdfQsn5C
+V67+y8MQkdswBdGrAdSgjTwLvI9kp7eiHAFyRJsLxcFT4VwDFJ2LrEm1hcs/5mDp
+UnJWig3g6yVW9ME9oxy7F2etxUsJ4WRFfxixma0hW1AQk1LZduPVmRIHroIDKJA3
+79C2gk4b75usaH3gL9s7HUOQeBTyaOcz3RRQWztwnM09A0AfSTxmutBHasrMSUbE
+zumznBNkI2dMPiCdrojrCTmcRJceh8cI/Mx8BIm3+Z0OQiPpZaZxxFxyBQuAf6/z
+8TyEgT0B+RNGMZ+771h+8t4ysYt9SPK7IHodyse814F9wxApTc+Ut5KJfnSmN/hu
+UvTwssqXX0puFuxPJ61uKkbTUD+y/FqHQmG93cUzC0xYCWDbL/+Rr81MzzMhfBvm
+qf/JQl0zI8VXHHz0m1JGXwZRQ6ZsWa5b+hwkYFP8CRkzXvgl/zXKrdvPUuIVo36b
+qG8CAwEAAaMnMCUwDgYDVR0PAQH/BAQDAgeAMBMGA1UdJQQMMAoGCCsGAQUFBwMC
+MA0GCSqGSIb3DQEBCwUAA4IBAQCrc7O91DuLk17S6iH0786AxH0IEk4fXoHlr0oi
+B+tuzO4ccaYxxG0bVwgYIRFqz35YioAoOEdk/xlDbWEn03/ibIqizPkEPwU/JnMY
+Jmzph7W9iNkezfUsC1nR3Dw9jVU0TkUz0tnlr57M0jKn3vAzmzMHeil4bnbcmaoC
+bnJlJkQ9Uv2OZSfRxc6irVmefC/u97KJPzmGjAlG/KrTVPm/gZtn46szwKKepMqd
+7iQJK/xxgHd2kKuOcSVDf2g2ygHbIE7mwofRZLM3VsfaFqIvWBmT1mbC6pzZs30C
+m0BmlwDa5ONBGAqjBP9TTm42f4ufzsGF/eFLXZ8lAbpJmLqx
 -----END CERTIFICATE-----`
 )
 
@@ -85,36 +111,36 @@ var (
 	}
 )
 
-func TestCertificateProvider_GetCACertificate(t *testing.T) {
+func TestCertificateProvider_GetCertificateChain(t *testing.T) {
 	t.Run("should get ca certificate", func(t *testing.T) {
 		// given
 		secretData := map[string][]byte{
-			caCertificateSecretKey: []byte(pemCertificate),
+			certificateChainSecretKey: []byte(pemCertificate),
 		}
 
 		secretRepository := &mocks.Repository{}
-		secretRepository.On("Get", caCertSecretNamespaceName).Return(secretData, nil)
+		secretRepository.On("Get", clusterCertSecretNamespaceName).Return(secretData, nil)
 
 		certificateProvider := NewCertificateProvider(clusterCertSecretNamespaceName, caCertSecretNamespaceName, secretRepository)
 
 		// when
-		certs, err := certificateProvider.GetCACertificates()
+		certs, err := certificateProvider.GetCertificateChain()
 
 		// then
 		require.NoError(t, err)
 		require.NotNil(t, certs)
-		assert.Equal(t, 2, len(certs))
+		assert.Equal(t, 3, len(certs))
 	})
 
 	t.Run("should return error when failed to read secret", func(t *testing.T) {
 		// given
 		secretRepository := &mocks.Repository{}
-		secretRepository.On("Get", caCertSecretNamespaceName).Return(nil, errors.New("error"))
+		secretRepository.On("Get", clusterCertSecretNamespaceName).Return(nil, errors.New("error"))
 
 		certificateProvider := NewCertificateProvider(clusterCertSecretNamespaceName, caCertSecretNamespaceName, secretRepository)
 
 		// when
-		_, err := certificateProvider.GetCACertificates()
+		_, err := certificateProvider.GetCertificateChain()
 
 		// then
 		require.Error(t, err)
@@ -125,12 +151,12 @@ func TestCertificateProvider_GetCACertificate(t *testing.T) {
 		secretData := map[string][]byte{}
 
 		secretRepository := &mocks.Repository{}
-		secretRepository.On("Get", caCertSecretNamespaceName).Return(secretData, nil)
+		secretRepository.On("Get", clusterCertSecretNamespaceName).Return(secretData, nil)
 
 		certificateProvider := NewCertificateProvider(clusterCertSecretNamespaceName, caCertSecretNamespaceName, secretRepository)
 
 		// when
-		_, err := certificateProvider.GetCACertificates()
+		_, err := certificateProvider.GetCertificateChain()
 
 		// then
 		require.Error(t, err)
@@ -143,12 +169,12 @@ func TestCertificateProvider_GetCACertificate(t *testing.T) {
 		}
 
 		secretRepository := &mocks.Repository{}
-		secretRepository.On("Get", caCertSecretNamespaceName).Return(secretData, nil)
+		secretRepository.On("Get", clusterCertSecretNamespaceName).Return(secretData, nil)
 
 		certificateProvider := NewCertificateProvider(clusterCertSecretNamespaceName, caCertSecretNamespaceName, secretRepository)
 
 		// when
-		_, err := certificateProvider.GetCACertificates()
+		_, err := certificateProvider.GetCertificateChain()
 
 		// then
 		require.Error(t, err)

--- a/components/connectivity-certs-controller/internal/connectorservice/establishedconnectionclientprovider.go
+++ b/components/connectivity-certs-controller/internal/connectorservice/establishedconnectionclientprovider.go
@@ -9,9 +9,9 @@ import (
 )
 
 type CertificateCredentials struct {
-	ClientKey  *rsa.PrivateKey
-	ClientCert *x509.Certificate
-	CACerts    []*x509.Certificate
+	ClientKey        *rsa.PrivateKey
+	ClientCert       *x509.Certificate
+	CertificateChain []*x509.Certificate
 }
 
 type EstablishedConnectionClientProvider interface {
@@ -29,10 +29,9 @@ func NewEstablishedConnectionClientProvider(csrProvider certificates.CSRProvider
 }
 
 func (cp *establishedConnectionClientProvider) CreateClient(credentials CertificateCredentials) EstablishedConnectionClient {
+	var rawCerts [][]byte
 
-	rawCerts := [][]byte{credentials.ClientCert.Raw}
-
-	for _, cert := range credentials.CACerts {
+	for _, cert := range credentials.CertificateChain {
 		rawCerts = append(rawCerts, cert.Raw)
 	}
 

--- a/components/connectivity-certs-controller/internal/connectorservice/establishedconnectionclientprovider_test.go
+++ b/components/connectivity-certs-controller/internal/connectorservice/establishedconnectionclientprovider_test.go
@@ -15,9 +15,9 @@ func TestMutualTLSClientProvider_CreateClient(t *testing.T) {
 	t.Run("should create Mutual TLS Connector InitialConnectionClient", func(t *testing.T) {
 		// given
 		credentials := CertificateCredentials{
-			ClientKey:  &rsa.PrivateKey{},
-			ClientCert: &x509.Certificate{Subject: subject},
-			CACerts:    []*x509.Certificate{},
+			ClientKey:        &rsa.PrivateKey{},
+			ClientCert:       &x509.Certificate{Subject: subject},
+			CertificateChain: []*x509.Certificate{},
 		}
 
 		csrProvider := &mocks.CSRProvider{}

--- a/resources/application-connector/values.yaml
+++ b/resources/application-connector/values.yaml
@@ -35,8 +35,8 @@ global:
     dir: develop/
     version: 00d7f520
   connectivity_certs_controller:
-    dir: develop/
-    version: f1454344
+    dir: pr/
+    version: PR-4789
   event_service:
     dir: develop/
     version: 42e65688


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/master/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- Connectivity Certs Controller saves the certificate chain and uses it for communication instead of using CA certificate combined with client cert

**Related issue(s)**
#4375
