### PR TITLE
Allow authorization and content-type headers in api-controller

### DIFF
--- a/resources/core/charts/api-controller/values.yaml
+++ b/resources/core/charts/api-controller/values.yaml
@@ -9,6 +9,6 @@ mtls:
 cors:
   allow_origin: "*"
   allow_methods: "GET,POST,PUT,DELETE" # no possibility to use "*"
-  allow_headers: "*"
+  allow_headers: "Authorization,Content-Type,*" # "*" is not yet supported by all browsers
 
 blacklisted_services: "kubernetes.default,istio-citadel.istio-system,istio-galley.istio-system,istio-ingressgateway.istio-system,istio-pilot.istio-system,istio-policy.istio-system,istio-sidecar-injector.istio-system,istio-telemetry.istio-system,apiserver-proxy.kyma-system, apiserver-proxy-ssl.kyma-system"

--- a/resources/core/values.yaml
+++ b/resources/core/values.yaml
@@ -30,7 +30,7 @@ global:
     version: "PR-4582"
   api_controller_integration_tests:
     dir: pr/
-    version: "PR-4752"
+    version: "PR-4822"
     testNamespace: api-controller-tests
   apiserver_proxy:
     dir: develop/

--- a/tests/integration/api-controller/apicontroller/component_test.go
+++ b/tests/integration/api-controller/apicontroller/component_test.go
@@ -607,7 +607,7 @@ func (componentTestContext) virtualServiceFor(testID string, domainName string, 
 				CorsPolicy: &istioNetApi.CorsPolicy{ //Default policy
 					AllowOrigin:  []string{"*"},
 					AllowMethods: []string{"GET", "POST", "PUT", "DELETE"},
-					AllowHeaders: []string{"Authorizatio", "Content-Type" ,"*"},
+					AllowHeaders: []string{"Authorization", "Content-Type" ,"*"},
 				},
 			},
 		},

--- a/tests/integration/api-controller/apicontroller/component_test.go
+++ b/tests/integration/api-controller/apicontroller/component_test.go
@@ -607,7 +607,7 @@ func (componentTestContext) virtualServiceFor(testID string, domainName string, 
 				CorsPolicy: &istioNetApi.CorsPolicy{ //Default policy
 					AllowOrigin:  []string{"*"},
 					AllowMethods: []string{"GET", "POST", "PUT", "DELETE"},
-					AllowHeaders: []string{"Authorization,Content-Type,*"},
+					AllowHeaders: []string{"Authorizatio", "Content-Type" ,"*"},
 				},
 			},
 		},

--- a/tests/integration/api-controller/apicontroller/component_test.go
+++ b/tests/integration/api-controller/apicontroller/component_test.go
@@ -607,7 +607,7 @@ func (componentTestContext) virtualServiceFor(testID string, domainName string, 
 				CorsPolicy: &istioNetApi.CorsPolicy{ //Default policy
 					AllowOrigin:  []string{"*"},
 					AllowMethods: []string{"GET", "POST", "PUT", "DELETE"},
-					AllowHeaders: []string{"*"},
+					AllowHeaders: []string{"Authorization,Content-Type,*"},
 				},
 			},
 		},


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/master/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- Allow authorization and content-type headers in api-controller to fix Firefox and Safari bug
- Leave the '*' wildcard to not change the previous behaviour and allow all headers in Chrome

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
