### PR TITLE
Consistent naming of test docker images

### DIFF
--- a/resources/core/charts/apiserver-proxy/templates/tests/test-apiserver-proxy.yaml
+++ b/resources/core/charts/apiserver-proxy/templates/tests/test-apiserver-proxy.yaml
@@ -26,7 +26,7 @@ spec:
       shareProcessNamespace: true
       containers:
       - name: test-{{ .Release.Name }}-apiserver-proxy
-        image: {{ .Values.global.containerRegistry.path }}/{{ .Values.global.apiserver_proxy_integration_tests.dir }}apiserver-proxy-test:{{ .Values.global.apiserver_proxy_integration_tests.version }}
+        image: {{ .Values.global.containerRegistry.path }}/{{ .Values.global.apiserver_proxy_integration_tests.dir }}apiserver-proxy-integration-tests:{{ .Values.global.apiserver_proxy_integration_tests.version }}
         imagePullPolicy: Always
         command: ["/bin/bash"]
         args: ["-c", "sleep 10; ./test.sh; exit_code=$?; pkill -INT pilot-agent; exit $exit_code;"]

--- a/resources/core/charts/cluster-users/templates/tests/test-cluster-users.yaml
+++ b/resources/core/charts/cluster-users/templates/tests/test-cluster-users.yaml
@@ -20,7 +20,7 @@ spec:
       serviceAccount: cluster-users-test
       containers:
         - name: test-cluster-users
-          image: {{ .Values.global.containerRegistry.path }}/{{ .Values.global.cluster_users_test.dir }}cluster-users-test:{{ .Values.global.cluster_users_test.version }}
+          image: {{ .Values.global.containerRegistry.path }}/{{ .Values.global.cluster_users_integration_tests.dir }}cluster-users-integration-tests:{{ .Values.global.cluster_users_integration_tests.version }}
           command: 
             - /bin/bash
             - -c

--- a/resources/core/values.yaml
+++ b/resources/core/values.yaml
@@ -53,8 +53,8 @@ global:
     dir: develop/
     version: a9bfa9fc
   apiserver_proxy_integration_tests:
-    dir: develop/
-    version: 8026b77c
+    dir: pr/
+    version: PR-4837
   test_namespace_controller:
     dir: develop/
     version: 6b4c356f
@@ -64,9 +64,9 @@ global:
   console_backend_service_test:
     dir: develop/
     version: b3441db9
-  cluster_users_test:
+  cluster_users_integration_tests:
     dir: pr/
-    version: "PR-4821"
+    version: PR-4837
   xip_patch:
     dir: develop/
     version: "d20b1c29"

--- a/resources/dex/templates/tests/test-dex-integration.yaml
+++ b/resources/dex/templates/tests/test-dex-integration.yaml
@@ -12,7 +12,7 @@ spec:
       shareProcessNamespace: true
       containers:
       - name: test-{{ template "fullname" . }}-integration
-        image: {{ .Values.global.containerRegistry.path }}/{{ .Values.global.dex_integration_tests.dir }}integration-dex:{{ .Values.global.dex_integration_tests.version }}
+        image: {{ .Values.global.containerRegistry.path }}/{{ .Values.global.dex_integration_tests.dir }}dex-integration-tests:{{ .Values.global.dex_integration_tests.version }}
         env:
         - name: DOMAIN_NAME
           value: {{ .Values.global.ingress.domainName }}

--- a/resources/dex/values.yaml
+++ b/resources/dex/values.yaml
@@ -27,4 +27,4 @@ global:
     path: eu.gcr.io/kyma-project
   dex_integration_tests:
     dir: pr/
-    version: "PR-4615"
+    version: PR-4837

--- a/tests/integration/apiserver-proxy/Makefile
+++ b/tests/integration/apiserver-proxy/Makefile
@@ -1,4 +1,4 @@
-APP_NAME = apiserver-proxy-test
+APP_NAME = apiserver-proxy-integration-tests
 IMG = $(DOCKER_PUSH_REPOSITORY)$(DOCKER_PUSH_DIRECTORY)/$(APP_NAME)
 TAG = $(DOCKER_TAG)
 

--- a/tests/integration/cluster-users/Makefile
+++ b/tests/integration/cluster-users/Makefile
@@ -1,4 +1,4 @@
-APP_NAME = cluster-users-test
+APP_NAME = cluster-users-integration-tests
 IMG = $(DOCKER_PUSH_REPOSITORY)$(DOCKER_PUSH_DIRECTORY)/$(APP_NAME)
 TAG = $(DOCKER_TAG)
 

--- a/tests/integration/dex/Makefile
+++ b/tests/integration/dex/Makefile
@@ -1,4 +1,4 @@
-APP_NAME = integration-dex
+APP_NAME = dex-integration-tests
 IMG = $(DOCKER_PUSH_REPOSITORY)$(DOCKER_PUSH_DIRECTORY)/$(APP_NAME)
 TAG = $(DOCKER_TAG)
 


### PR DESCRIPTION
**Description**
Consistent naming of test docker images

Changes proposed in this pull request:

- Renamed image of apiserver-proxy tests
- Renamed image of dex tests
- Renamed image of cluster-users tests

