### PR TITLE
Override CSRF cookies on retry in Application Gateway

### DIFF
--- a/components/application-gateway/internal/csrf/strategy/csrf.go
+++ b/components/application-gateway/internal/csrf/strategy/csrf.go
@@ -41,9 +41,8 @@ func (s *strategy) AddCSRFToken(apiRequest *http.Request) apperrors.AppError {
 	}
 
 	apiRequest.Header.Set(httpconsts.HeaderCSRFToken, tokenResponse.CSRFToken)
-	for _, cookie := range tokenResponse.Cookies {
-		apiRequest.AddCookie(cookie)
-	}
+
+	mergeCookiesWithOverride(apiRequest, tokenResponse.Cookies)
 
 	return nil
 }
@@ -59,4 +58,31 @@ func (nts *noTokenStrategy) AddCSRFToken(apiRequest *http.Request) apperrors.App
 }
 
 func (nts *noTokenStrategy) Invalidate() {
+}
+
+// Adds newCookies to the request. If the cookie is already present, overrides it.
+func mergeCookiesWithOverride(request *http.Request, newCookies []*http.Cookie) {
+	existingCookies := request.Cookies()
+
+	for _, exCookie := range existingCookies {
+		if !containsCookie(exCookie.Name, newCookies) {
+			newCookies = append(newCookies, exCookie)
+		}
+	}
+
+	request.Header.Del(httpconsts.HeaderCookie)
+
+	for _, c := range newCookies {
+		request.AddCookie(c)
+	}
+}
+
+func containsCookie(name string, cookies []*http.Cookie) bool {
+	for _, c := range cookies {
+		if c.Name == name {
+			return true
+		}
+	}
+
+	return false
 }

--- a/components/application-gateway/internal/proxy/unauthorizedresponseretrier_test.go
+++ b/components/application-gateway/internal/proxy/unauthorizedresponseretrier_test.go
@@ -263,7 +263,7 @@ func newUpdateCacheEntryFunction(t *testing.T, url string, strategy authorizatio
 		require.NoError(t, err)
 
 		return &CacheEntry{
-			Proxy: proxy,
+			Proxy:                 proxy,
 			AuthorizationStrategy: &authorizationStrategyWrapper{strategy, proxy},
 			CSRFTokenStrategy:     csrfTokenStrategy,
 		}, nil

--- a/components/application-gateway/internal/proxy/unauthorizedresponseretrier_test.go
+++ b/components/application-gateway/internal/proxy/unauthorizedresponseretrier_test.go
@@ -263,7 +263,7 @@ func newUpdateCacheEntryFunction(t *testing.T, url string, strategy authorizatio
 		require.NoError(t, err)
 
 		return &CacheEntry{
-			Proxy:                 proxy,
+			Proxy: proxy,
 			AuthorizationStrategy: &authorizationStrategyWrapper{strategy, proxy},
 			CSRFTokenStrategy:     csrfTokenStrategy,
 		}, nil

--- a/components/application-gateway/pkg/httpconsts/httpconsts.go
+++ b/components/application-gateway/pkg/httpconsts/httpconsts.go
@@ -15,6 +15,7 @@ const (
 	HeaderAcceptVal            = "*/*"
 	HeaderCacheControl         = "cache-control"
 	HeaderCacheControlVal      = "no-cache"
+	HeaderCookie               = "Cookie"
 )
 
 const (


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/master/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- CSRF cookies are being overridden if the request is retried

**Related issue(s)**
#4238
