### PR TITLE
Add azure docs example and add azure support to velero chart

### DIFF
--- a/docs/backup/03-01-install-velero.md
+++ b/docs/backup/03-01-install-velero.md
@@ -68,7 +68,33 @@ Follow the instructions below:
     Azure
     </summary>
 
-    Coming soon...
+    ```yaml
+    apiVersion: v1
+    kind: Secret
+    metadata:
+    name: velero-credentials-overrides
+    namespace: kyma-installer
+    labels:
+        kyma-project.io/installation: ""
+        installer: overrides
+        component: velero
+    type: Opaque
+    data:
+    configuration.provider: "azure"
+    configuration.volumeSnapshotLocation.name: "azure"
+    configuration.volumeSnapshotLocation.bucket: "my-storage-container"
+    configuration.volumeSnapshotLocation.config.apitimeout: "3m0s"
+    configuration.backupStorageLocation.name: "azure"
+    configuration.backupStorageLocation.bucket: "my-storage-container"
+    configuration.backupStorageLocation.config.resourceGroup: "my-resource-group"
+    configuration.backupStorageLocation.config.storageAccount: "my-storage-account"
+    credentials.secretContents.cloud: |
+                    AZURE_SUBSCRIPTION_ID=my-subscription-ID
+                    AZURE_TENANT_ID=my-tenant-ID
+                    AZURE_CLIENT_ID=my-client-ID
+                    AZURE_CLIENT_SECRET=my-client-secret
+                    AZURE_RESOURCE_GROUP=my-resource-group
+    ```
 
     >**NOTE:** For details on configuring and installing Velero in Azure,  see [this](https://velero.io/docs/v1.0.0/azure-config/) document.
     

--- a/resources/velero/templates/deployment.yaml
+++ b/resources/velero/templates/deployment.yaml
@@ -72,24 +72,24 @@ spec:
           volumeMounts:
             - name: plugins
               mountPath: /plugins
-        {{- if and .Values.credentials.useSecret (or (eq $provider "aws") (eq $provider "gcp")) }}
+        {{- if .Values.credentials.useSecret }}
             - name: cloud-credentials
               mountPath: /credentials
             - name: scratch
               mountPath: /scratch
         {{- end }}
-          {{- if (or (and .Values.credentials.useSecret (or (eq $provider "aws") (eq $provider "gcp"))) .Values.configuration.extraEnvVars) }}
+          {{- if or .Values.credentials.useSecret .Values.configuration.extraEnvVars }}
           env:
           {{- end }}
-          {{- if and .Values.credentials.useSecret (or (eq $provider "aws") (eq $provider "gcp")) }}
-            {{- if eq $provider "aws" }}
-            - name: AWS_SHARED_CREDENTIALS_FILE
-            {{- else }}
-            - name: GOOGLE_APPLICATION_CREDENTIALS
-            {{- end }}
-              value: /credentials/cloud
+          {{- if .Values.credentials.useSecret }}
             - name: VELERO_SCRATCH_DIR
               value: /scratch
+            - name: AWS_SHARED_CREDENTIALS_FILE
+              value: /credentials/cloud
+            - name: GOOGLE_APPLICATION_CREDENTIALS
+              value: /credentials/cloud
+            - name: AZURE_CREDENTIALS_FILE
+              value: /credentials/cloud
           {{- end }}
           {{- with .Values.configuration.extraEnvVars }}
           {{- range $key, $value := . }}
@@ -102,7 +102,7 @@ spec:
         {{- toYaml .Values.initContainers | nindent 8 }}
 {{- end }}
       volumes:
-        {{- if and .Values.credentials.useSecret (or (eq $provider "aws") (eq $provider "gcp")) }}
+        {{- if .Values.credentials.useSecret }}
         - name: cloud-credentials
           secret:
             secretName: {{ include "velero.secretName" . }}


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Fix the velero chart to produce a correct deployment when the provider is `Azure`
- Add Azure sample overrides YAML to documentation.

**Related issue(s)**
#4972 
