### PR TITLE
Fix typo on Private Docker Registry documentation section

### DIFF
--- a/docs/kyma/03-04-deploy-private-registry.md
+++ b/docs/kyma/03-04-deploy-private-registry.md
@@ -67,7 +67,7 @@ spec:
         - name: example-secret-name # Specify your Namespace Secret, named `example-secret-name`.
 
 ```
-3. Submit you deployment file using this command:
+3. Submit your deployment file using this command:
 
 ```bash
 kubectl apply -f deployment.yml


### PR DESCRIPTION
**Description**
While following the steps on how to use a [private Docker registry](https://kyma-project.io/docs/root/kyma#details-deploy-with-a-private-docker-registry) with Kyma, I noticed a small typo.
This PR fixes this typo on the [private Docker registry](https://kyma-project.io/docs/root/kyma#details-deploy-with-a-private-docker-registry) documentation section.