### PR TITLE
Update application operator's event url reference w.r.t #4956

### DIFF
--- a/components/application-operator/charts/application/values.yaml
+++ b/components/application-operator/charts/application/values.yaml
@@ -40,8 +40,8 @@ eventService:
       pullPolicy: IfNotPresent
     args:
       externalAPIPort: &eventServiceExternalAPIPort 8081
-      eventsTargetURLV1: http://event-bus-publish.kyma-system.svc.cluster.local:8080/v1/events
-      eventsTargetURLV2: http://event-bus-publish.kyma-system.svc.cluster.local:8080/v2/events
+      eventsTargetURLV1: http://event-publish-service.kyma-system.svc.cluster.local:8080/v1/events
+      eventsTargetURLV2: http://event-publish-service.kyma-system.svc.cluster.local:8080/v2/events
       maxRequestSize: 65536
       requestTimeout: 10
       requestLogging: false


### PR DESCRIPTION
As per #4956. event-publish-service urls have been modified to http://event-publish-service.kyma-system.svc.cluster.local:8080/v1/events 