### PR TITLE
Update event publish url references in tests: source update

### DIFF
--- a/tests/end-to-end/backup-restore-test/backupe2e/eventbus.go
+++ b/tests/end-to-end/backup-restore-test/backupe2e/eventbus.go
@@ -31,8 +31,8 @@ const (
 
 	subscriberName           = "test-core-event-bus-subscriber"
 	subscriberImage          = "eu.gcr.io/kyma-project/pr/event-bus-e2e-subscriber:PR-4893"
-	publishEventEndpointURL  = "http://event-bus-publish.kyma-system:8080/v1/events"
-	publishStatusEndpointURL = "http://event-bus-publish.kyma-system:8080/v1/status/ready"
+	publishEventEndpointURL  = "http://event-publish-service.kyma-system:8080/v1/events"
+	publishStatusEndpointURL = "http://event-publish-service.kyma-system:8080/v1/status/ready"
 )
 
 var retryOptions = []retry.Option{

--- a/tests/end-to-end/kubeless-integration/test-kubeless.go
+++ b/tests/end-to-end/kubeless-integration/test-kubeless.go
@@ -378,7 +378,7 @@ func randomString(n int) string {
 }
 
 func publishEvent(testID string) {
-	cmd := exec.Command("curl", "-s", "http://event-bus-publish.kyma-system:8080/v1/events", "-H", "Content-Type: application/json", "-d", `{"source-id": "dummy", "event-type": "test", "event-type-version": "v1", "event-time": "0001-01-01T00:00:00+00:00", "data": "`+testID+`"}`)
+	cmd := exec.Command("curl", "-s", "http://event-publish-service.kyma-system:8080/v1/events", "-H", "Content-Type: application/json", "-d", `{"source-id": "dummy", "event-type": "test", "event-type-version": "v1", "event-time": "0001-01-01T00:00:00+00:00", "data": "`+testID+`"}`)
 	stdoutStderr, err := cmd.CombinedOutput()
 	if err != nil {
 		log.Fatalf("Unable to publish event(error: %s): %s\n", err, string(stdoutStderr))

--- a/tests/end-to-end/upgrade/pkg/tests/event-bus/event_bus.go
+++ b/tests/end-to-end/upgrade/pkg/tests/event-bus/event_bus.go
@@ -29,8 +29,8 @@ const (
 
 	subscriberName           = "test-core-event-bus-subscriber"
 	subscriberImage          = "eu.gcr.io/kyma-project/pr/event-bus-e2e-subscriber:PR-4893"
-	publishEventEndpointURL  = "http://event-bus-publish.kyma-system:8080/v1/events"
-	publishStatusEndpointURL = "http://event-bus-publish.kyma-system:8080/v1/status/ready"
+	publishEventEndpointURL  = "http://event-publish-service.kyma-system:8080/v1/events"
+	publishStatusEndpointURL = "http://event-publish-service.kyma-system:8080/v1/status/ready"
 )
 
 var (

--- a/tests/end-to-end/upgrade/pkg/tests/event-bus/event_bus.go
+++ b/tests/end-to-end/upgrade/pkg/tests/event-bus/event_bus.go
@@ -98,10 +98,6 @@ func (f *eventBusFlow) createResources() error {
 		f.createSubscription,
 		f.createSubscriber,
 		f.checkSubscriberStatus,
-		f.checkPublisherStatus,
-		f.checkSubscriptionReady,
-		f.publishTestEvent,
-		f.checkSubscriberReceivedEvent,
 	} {
 		err := fn()
 		if err != nil {

--- a/tests/event-bus/e2e-tester/e2e-tester.go
+++ b/tests/event-bus/e2e-tester/e2e-tester.go
@@ -95,8 +95,8 @@ func main() {
 	var logLevel log.Level
 
 	//Initialise publisher struct
-	flags.StringVar(&pubDetails.publishEventEndpointURL, "publish-event-uri", "http://event-bus-publish:8080/v1/events", "publish service events endpoint `URL`")
-	flags.StringVar(&pubDetails.publishStatusEndpointURL, "publish-status-uri", "http://event-bus-publish:8080/v1/status/ready", "publish service status endpoint `URL`")
+	flags.StringVar(&pubDetails.publishEventEndpointURL, "publish-event-uri", "http://event-publish-service:8080/v1/events", "publish service events endpoint `URL`")
+	flags.StringVar(&pubDetails.publishStatusEndpointURL, "publish-status-uri", "http://event-publish-service:8080/v1/status/ready", "publish service status endpoint `URL`")
 
 	//Initialise subscriber
 	flags.StringVar(&subDetails.subscriberImage, "subscriber-image", "", "subscriber Docker `image` name")


### PR DESCRIPTION
As per #4956. event-publish-service urls have been modified to http://event-publish-service:8080/v1/events