### PR TITLE
Add resource limitations for Service Management containers

### DIFF
--- a/resources/application-connector/charts/application-broker/templates/deployment.yaml
+++ b/resources/application-connector/charts/application-broker/templates/deployment.yaml
@@ -33,6 +33,13 @@ spec:
       - name: ctrl
         image: "{{ .Values.global.containerRegistry.path }}/{{ .Values.global.application_broker.dir }}application-broker:{{ .Values.global.application_broker.version }}"
         imagePullPolicy: {{ .Values.image.pullPolicy }}
+        resources:
+          limits:
+            memory: 76Mi
+            cpu: 100m
+          requests:
+            memory: 24Mi
+            cpu: 80m
         env:
           - name: APP_PORT
             value: "{{ .Values.service.internalPort }}"

--- a/resources/helm-broker/templates/deploy.yaml
+++ b/resources/helm-broker/templates/deploy.yaml
@@ -36,6 +36,13 @@ spec:
       - name: broker
         image: "{{ .Values.global.containerRegistry.path }}/{{ .Values.global.helm_broker.dir }}helm-broker:{{ .Values.global.helm_broker.version }}"
         imagePullPolicy: {{ .Values.image.pullPolicy }}
+        resources:
+          limits:
+            memory: 76Mi
+            cpu: 60m
+          requests:
+            memory: 32Mi
+            cpu: 30m
         env:
           - name: APP_TMP_DIR
             value: /tmp
@@ -92,6 +99,13 @@ spec:
       - name: ctrl
         image: "{{ .Values.global.containerRegistry.path }}/{{ .Values.global.helm_broker.dir }}helm-controller:{{ .Values.global.helm_broker.version }}"
         imagePullPolicy: {{ .Values.image.pullPolicy }}
+        resources:
+          limits:
+            memory: 76Mi
+            cpu: 100m
+          requests:
+            memory: 32Mi
+            cpu: 80m
         env:
           - name: APP_TMP_DIR
             value: /tmp

--- a/resources/service-catalog-addons/charts/service-binding-usage-controller/templates/deployment.yaml
+++ b/resources/service-catalog-addons/charts/service-binding-usage-controller/templates/deployment.yaml
@@ -29,6 +29,13 @@ spec:
         - name: {{ .Chart.Name }}
           image: "{{ .Values.global.containerRegistry.path }}/{{ .Values.global.service_binding_usage_controller.dir }}binding-usage-controller:{{ .Values.global.service_binding_usage_controller.version }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
+          resources:
+            limits:
+              memory: 76Mi
+              cpu: 50m
+            requests:
+              memory: 24Mi
+              cpu: 30m
           env:
             - name: APP_LOGGER_LEVEL
               value: "debug"


### PR DESCRIPTION
Related to #4859 

Reffering to this [comment](https://github.com/kyma-project/kyma/issues/4859#issuecomment-514953490) new container limits were introduced:

- Helm Broker - broker:
  - memory limit: from default 96MiB to **76MiB**
  - memory requested: without change, default **32MiB**
   (beacuse of the possibility of occurrence of high demand during process connected with bundles)
  - cpu limit: from without limits to **60ms**
  - cpu requested: from without limits to **30ms**
    (the highest measured peak 0.02s = 20ms)
- Helm Broker - controller:
  - memory limit: from default 96MiB to **76MiB**
  - memory requested: without change, default **32MiB**
    (the highest measured peak 29MiB with stress test and 24MiB without)
  - cpu limit: from without limits to **100ms**
  - cpu requested: from without limits to **80ms**
    (the highest measured peak 0.05s = 50ms)
- ServiceBindingUsage controller:
  - memory limit: from default 96MiB to **76MiB**
  - memory requested: from default 32MiB to **24MiB**
    (the highest measured peak 29MiB, without stress test 14MiB)
  - cpu limit: from without limits to **50ms**
  - cpu requested: from without limits to **30ms**
    (the highest measured peak 0.025s = 25ms)
- ApplicationBroker controller:
  - memory limit: from default 96MiB to **76MiB**
  - memory requested: from default 32MiB to **24MiB**
    (the highest measured peak 14MiB, without stress test 30MiB)
  - cpu limit: from without limits to **100ms**
  - cpu requested: from without limits to **80ms**
    (the highest measured peak 0.05s = 50ms)