### PR TITLE
Fix ClusterAddonConfiguration informer interface

### DIFF
--- a/components/helm-broker/Makefile
+++ b/components/helm-broker/Makefile
@@ -21,6 +21,9 @@ else
 	mkdir -p licenses
 endif
 
+# Caution! remove "namespace: v.namespace" after regenerate file.
+# (components/helm-broker/pkg/client/informers/externalversions/addons/v1alpha1/interface.go)
+# clusterAddonsConfigurationInformer doesn't have the field
 .PHONY: generates
 # Generate CRD manifests, clients etc.
 generates: crd-manifests client

--- a/components/helm-broker/Makefile
+++ b/components/helm-broker/Makefile
@@ -21,9 +21,9 @@ else
 	mkdir -p licenses
 endif
 
-# Caution! remove "namespace: v.namespace" after regenerate file.
-# (components/helm-broker/pkg/client/informers/externalversions/addons/v1alpha1/interface.go)
-# clusterAddonsConfigurationInformer doesn't have the field
+# Caution! Remove the “namespace: v.namespace” parameter after regeneration of
+# “components/helm-broker/pkg/client/informers/externalversions/addons/v1alpha1/interface.go” file.
+# clusterAddonsConfigurationInformer doesn’t have the “namespace” field
 .PHONY: generates
 # Generate CRD manifests, clients etc.
 generates: crd-manifests client

--- a/components/helm-broker/pkg/client/informers/externalversions/addons/v1alpha1/interface.go
+++ b/components/helm-broker/pkg/client/informers/externalversions/addons/v1alpha1/interface.go
@@ -31,7 +31,7 @@ func (v *version) AddonsConfigurations() AddonsConfigurationInformer {
 }
 
 // ClusterAddonsConfigurations returns a ClusterAddonsConfigurationInformer.
-// Caution! remove "namespace: v.namespace" after regenerate file. clusterAddonsConfigurationInformer doesn't have the field
+// Caution! remove "namespace: v.namespace" after file regeneration. clusterAddonsConfigurationInformer doesn't have the “namespace” field
 func (v *version) ClusterAddonsConfigurations() ClusterAddonsConfigurationInformer {
 	return &clusterAddonsConfigurationInformer{factory: v.factory, tweakListOptions: v.tweakListOptions}
 }

--- a/components/helm-broker/pkg/client/informers/externalversions/addons/v1alpha1/interface.go
+++ b/components/helm-broker/pkg/client/informers/externalversions/addons/v1alpha1/interface.go
@@ -31,6 +31,7 @@ func (v *version) AddonsConfigurations() AddonsConfigurationInformer {
 }
 
 // ClusterAddonsConfigurations returns a ClusterAddonsConfigurationInformer.
+// Caution! remove "namespace: v.namespace" after regenerate file. clusterAddonsConfigurationInformer doesn't have the field
 func (v *version) ClusterAddonsConfigurations() ClusterAddonsConfigurationInformer {
-	return &clusterAddonsConfigurationInformer{factory: v.factory, namespace: v.namespace, tweakListOptions: v.tweakListOptions}
+	return &clusterAddonsConfigurationInformer{factory: v.factory, tweakListOptions: v.tweakListOptions}
 }


### PR DESCRIPTION
Bug related to [code-generator](https://github.com/kubernetes/code-generator). After generate  informer interface of ClusterAddonConfiguration, extra, unused field `namespace` is added in spite of `+genclient:nonNamespaced` parameter.
(`components/helm-broker/pkg/client/informers/externalversions/addons/v1alpha1/interface.go` -> `ClusterAddonsConfigurations` method)
This PR removes manually `namespace` field.