### PR TITLE
Use ingress.domainName in compass gateway

### DIFF
--- a/resources/compass/charts/gateway/templates/virtualservice.yaml
+++ b/resources/compass/charts/gateway/templates/virtualservice.yaml
@@ -10,7 +10,7 @@ metadata:
     release: {{ .Release.Name }}
 spec:
   hosts:
-    - '{{ .Values.global.gateway.host }}.{{ .Values.global.domainName }}'
+    - '{{ .Values.global.gateway.host }}.{{ .Values.global.ingress.domainName }}'
   gateways:
     - {{ .Values.global.istio.gateway.name }}.{{ .Values.global.istio.gateway.namespace }}.svc.cluster.local
   http:

--- a/resources/compass/templates/test.yaml
+++ b/resources/compass/templates/test.yaml
@@ -18,7 +18,7 @@ spec:
       hostAliases:
         - ip: {{ .Values.global.minikubeIP }}
           hostnames:
-          - "{{ .Values.global.gateway.host }}.{{ .Values.global.domainName }}"
+          - "{{ .Values.global.gateway.host }}.{{ .Values.global.ingress.domainName }}"
     {{ end }}
       shareProcessNamespace: true
       containers:
@@ -29,5 +29,5 @@ spec:
           args: ["-c", "sleep 10; /director.test -test.v; exit_code=$?; pkill -INT pilot-agent; sleep 4; exit $exit_code;"]
           env:
           - name: "DIRECTOR_GRAPHQL_API"
-            value: "https://{{ .Values.global.gateway.host }}.{{ .Values.global.domainName }}/director/graphql"
+            value: "https://{{ .Values.global.gateway.host }}.{{ .Values.global.ingress.domainName }}/director/graphql"
       restartPolicy: Never


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/master/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- Use `global.ingress.domainName` instead of `global.domainName` in compass chart. The latter may be empty in the case of xip.io and the former should be used in charts.

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
