### PR TITLE
Add retries to test to improve resilience

### DIFF
--- a/resources/core/values.yaml
+++ b/resources/core/values.yaml
@@ -65,7 +65,7 @@ global:
     version: b3441db9
   cluster_users_integration_tests:
     dir: pr/
-    version: PR-4837
+    version: PR-5178
   xip_patch:
     dir: develop/
     version: "d20b1c29"

--- a/tests/integration/cluster-users/sar-test.sh
+++ b/tests/integration/cluster-users/sar-test.sh
@@ -2,7 +2,7 @@
 
 # Description: This script performs a SelfSubjectAccessReview test by asking the k8s apiserver what permissions does each user have
 # Tested users: admin@kyma.cx, developer@kyma.cx, user@kyma.cx
-# Required ENVS: 
+# Required ENVS:
 #  - ADMIN_EMAIL: email address of the admin user (used as username)
 #  - ADMIN_PASSWORD: password for the admin user
 #  - DEVELOPER_EMAIL: email address of the developer user (used as username)
@@ -11,11 +11,51 @@
 #  - VIEW_PASSWORD: password for the view user
 #  - NAMESPACE: namespace in which we perform the tests
 
+RETRY_TIME=3 #Seconds
+MAX_RETRIES=5
+
+# Helper used to count retry attempts
+function __retry() {
+    local current="${1}"
+    if [[ "${current}" -eq "${MAX_RETRIES}" ]]; then return 1; fi
+    echo "---> Retrying in ${RETRY_TIME} seconds..."
+    sleep "${RETRY_TIME}"
+}
+
+# Helper used to end retrying after max failed attempts
+function __failRetry() {
+    echo "---> Fatal! Retires failed for: $1"
+    exit 1
+}
+
+function __createTestBindings() {
+	echo "---> $1"
+	kubectl create -f ./kyma-test-bindings.yaml -n "${NAMESPACE}"
+}
+
+function __deleteTestBindings() {
+	echo "---> $1"
+	kubectl delete -f ./kyma-test-bindings.yaml -n "${NAMESPACE}"
+}
+
+# Retries on errors. Note it is not "clever" and retries even on obvious non-retryable errors.
+function createTestBindingsRetry() {
+	local MSG="Create test RoleBinding(s)"
+	for i in $(seq 1 "${MAX_RETRIES}"); do __createTestBindings "${MSG}" && break || __retry "${i}" || __failRetry "${MSG}" ; done
+}
+
+# Retries on errors. Note it is not "clever" and retries even on obvious non-retryable errors.
+function deleteTestBindingsRetry() {
+	local MSG="Delete test RoleBinding(s)"
+	for i in $(seq 1 "${MAX_RETRIES}"); do __deleteTestBindings "${MSG}" && break || __retry "${i}" || __failRetry "${MSG}" ; done
+}
+
 function testPermissions() {
 	OPERATION="$1"
 	RESOURCE="$2"
 	TEST_NS="$3"
 	EXPECTED="$4"
+
 	set +e
 	TEST=$(kubectl auth can-i "${OPERATION}" "${RESOURCE}" -n "${TEST_NS}")
 	set -e
@@ -23,18 +63,90 @@ function testPermissions() {
 		echo "----> PASSED"
 		return 0
 	fi
-	echo "----> |FAIL| Expected: ${EXPECTED} got: ${TEST}"
+
+	echo "----> |FAIL| Expected: ${EXPECTED}, Actual: ${TEST}"
+
+	# If previous attempt failed (network error?), repeat just one time
+	echo "Re-trying one more time..."
+	sleep ${RETRY_TIME}
+
+	set +e
+	TEST=$(kubectl auth can-i "${OPERATION}" "${RESOURCE}" -n "${TEST_NS}")
+	set -e
+	if [[ ${TEST} == ${EXPECTED}* ]]; then
+		echo "----> PASSED"
+		return 0
+	fi
+
+	echo "----> |FAIL| Expected: ${EXPECTED}, Actual: ${TEST}"
 	return 1
 }
 
-function getConfigFile() {
+function __registrationRequest() {
+	echo "---> $1"
 	curl -s -k -f -X GET -H 'Content-Type: application/x-www-form-urlencoded' "${DEX_SERVICE_SERVICE_HOST}:${DEX_SERVICE_SERVICE_PORT_HTTP}/auth?response_type=id_token%20token&client_id=kyma-client&redirect_uri=http://127.0.0.1:5555/callback&scope=openid%20profile%20email%20groups&nonce=vF7FAQlqq41CObeUFYY0ggv1qEELvfHaXQ0ER4XM" > registration_request
-	REQUEST_ID=$(cat registration_request | grep '/auth/local?req' | cut -d '"' -f 2 | cut -d '?' -f 2)
-	rm -f registration_request
+}
+
+function __loginRequest() {
+	local REQUEST_ID="$1"
+	echo "---> $2"
 	curl -X POST -F "login=${EMAIL}" -F "password=${PASSWORD}" "${DEX_SERVICE_SERVICE_HOST}:${DEX_SERVICE_SERVICE_PORT_HTTP}/auth/local?${REQUEST_ID}"
-	RESPONSE=$(curl -X GET "${DEX_SERVICE_SERVICE_HOST}:${DEX_SERVICE_SERVICE_PORT_HTTP}/approval?${REQUEST_ID}")
-	AUTH_TOKEN=$(echo "${RESPONSE}" | grep -o -P '(?<=id_token=).*(?=&amp;state)')
+}
+
+# Modifies external APPROVAL_RESPONSE variable!
+function __approvalRequest() {
+	local REQUEST_ID="$1"
+	echo "---> $2"
+	APPROVAL_RESPONSE=$(curl -X GET "${DEX_SERVICE_SERVICE_HOST}:${DEX_SERVICE_SERVICE_PORT_HTTP}/approval?${REQUEST_ID}")
+}
+
+function __configFileRequest() {
+	local AUTH_TOKEN="$1"
+	echo "---> $2"
 	curl -s -k -f -H "Authorization: Bearer ${AUTH_TOKEN}" "${IAM_KUBECONFIG_SVC_FQDN}/kube-config" -o "${PWD}/kubeconfig"
+}
+
+#Creates a file "registration_request"
+function registrationRequestRetry() {
+	local MSG="Make registration request"
+	for i in $(seq 1 "${MAX_RETRIES}"); do __registrationRequest "${MSG}" && break || __retry "${i}" || __failRetry "${MSG}" ; done
+}
+
+function loginRequestRetry() {
+	local REQUEST_ID="$1"
+	local MSG="Make login request"
+	for i in $(seq 1 "${MAX_RETRIES}"); do __loginRequest "${REQUEST_ID}" "${MSG}" && break || __retry "${i}" || __failRetry "${MSG}" ; done
+}
+
+function approvalRequestRetry() {
+	local REQUEST_ID="$1"
+	local MSG="Make approval request"
+	for i in $(seq 1 "${MAX_RETRIES}"); do __approvalRequest "${REQUEST_ID}" "${MSG}" && break || __retry "${i}" || __failRetry "${MSG}" ; done
+}
+
+function configFileRequestRetry() {
+	local AUTH_TOKEN="$1"
+	local MSG="Make config file request"
+	for i in $(seq 1 "${MAX_RETRIES}"); do __configFileRequest "${AUTH_TOKEN}" "${MSG}" && break || __retry "${i}" || __failRetry "${MSG}" ; done
+}
+
+function getConfigFile() {
+	registrationRequestRetry
+
+	local REQUEST_ID
+	REQUEST_ID=$(grep '/auth/local?req' < registration_request | cut -d '"' -f 2 | cut -d '?' -f 2)
+	rm -f registration_request
+
+	loginRequestRetry "${REQUEST_ID}"
+
+	#APPROVAL_RESPONSE is altered by approvalRequestRetry function!
+	APPROVAL_RESPONSE=""
+	approvalRequestRetry "${REQUEST_ID}"
+
+	local AUTH_TOKEN
+	AUTH_TOKEN=$(echo "${APPROVAL_RESPONSE}" | grep -o -P '(?<=id_token=).*(?=&amp;state)')
+	configFileRequestRetry "${AUTH_TOKEN}"
+
 	if [[ ! -s "${PWD}/kubeconfig" ]]; then
 		echo "---> KUBECONFIG not created, or is empty!"
 		exit 1
@@ -89,7 +201,7 @@ function runTests() {
 
 	EMAIL=${VIEW_EMAIL} PASSWORD=${VIEW_PASSWORD} getConfigFile
 	export KUBECONFIG="${PWD}/kubeconfig"
-	
+
 	echo "--> ${VIEW_EMAIL} should be able to get ClusterRole"
 	testPermissions "get" "clusterrole" "${NAMESPACE}" "yes"
 
@@ -112,9 +224,10 @@ function cleanup() {
 	if [ "${ERROR_LOGGING_GUARD}" = "true" ]; then
 		echo "AN ERROR OCCURED! Take a look at preceding log entries."
 	fi
-	echo "---> Deleting bindings for tests"
-	kubectl delete -f ./kyma-test-bindings.yaml -n "${NAMESPACE}"
-	MSG=""
+
+	deleteTestBindingsRetry
+
+	local MSG=""
 	if [[ ${EXIT_STATUS} -ne 0 ]]; then MSG="(exit status: ${EXIT_STATUS})"; fi
 	echo "Job is finished ${MSG}"
 	set -e
@@ -136,8 +249,7 @@ fi
 trap cleanup EXIT
 ERROR_LOGGING_GUARD="true"
 
-echo "---> Create testing RoleBinding"
-kubectl create -f ./kyma-test-bindings.yaml -n "${NAMESPACE}"
+createTestBindingsRetry
 runTests
 
 echo "ALL TESTS PASSED"


### PR DESCRIPTION
**Description**

Add retries to network operations to improve test resilience

Changes proposed in this pull request:

- Add retries to network operations (kubectl, curl)

**Related issue(s)**
Implements #5165 
