### PR TITLE
Remove type metadata from single Overview docs

### DIFF
--- a/docs/console/01-01-console.md
+++ b/docs/console/01-01-console.md
@@ -1,6 +1,5 @@
 ---
 title: Overview
-type: Overview
 ---
 
 The Console is a web-based administrative UI for Kyma. It allows you to administer the Kyma functionality and manage the basic Kubernetes resources.

--- a/docs/tracing/01-01-tracing.md
+++ b/docs/tracing/01-01-tracing.md
@@ -1,6 +1,5 @@
 ---
 title: Overview
-type: Overview
 ---
 
 The microservice architecture differs from the traditional monoliths in many aspects. From the request observability perspective, there are asynchronous boundaries among various different microservices that compose a request flow. Moreover, these microservices can have heterogeneous semantics when it comes to monitoring. A tracing solution that provides a holistic view of the request flow helps you to understand the system and take informed decisions regarding troubleshooting and performance optimization.


### PR DESCRIPTION

**Description**

Changes proposed in this pull request:

- Removed `type` metadata from the Overview docs for Console and Logging

**Reason**
When we have single docs for a given type we should only place `title` metadata for proper doc rendering so that it does not render twice:
![image](https://user-images.githubusercontent.com/40655785/62458044-47cdad00-b77c-11e9-861a-e0da810791cd.png)

