### PR TITLE
Enable concurrency testing for core test

### DIFF
--- a/resources/core/templates/tests/test.yaml
+++ b/resources/core/templates/tests/test.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/instance: {{ .Release.Name }}
     helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
 spec:
-  disableConcurrency: true
+  disableConcurrency: false
   template:
     metadata:
       annotations:


### PR DESCRIPTION
Related to #4285 

Referring to this [comment](https://github.com/kyma-project/kyma/issues/4285#issuecomment-518651023), PR enables concurrency testing in the `core` test