### PR TITLE
Tweak event-bus resource consumption

### DIFF
--- a/resources/event-bus/values.yaml
+++ b/resources/event-bus/values.yaml
@@ -30,8 +30,11 @@ global:
     maxEventTypeLength: 253
     maxEventTypeVersionLength: 4
     resources:
+      requests:
+        cpu: 20m
+        memory: 32Mi
       limits:
-        memory: "32M"
+        memory: 32Mi
   push:
     http:
       subscriptionNameHeader: "Kyma-Subscription"
@@ -47,8 +50,11 @@ global:
     resyncPeriod: "10s"
     channelTimeout: "10s"
     resources:
+      requests:
+        cpu: 20m
+        memory: 32Mi
       limits:
-        memory: "32M"
+        memory: 32Mi
   trace:
     apiURL: http://zipkin.kyma-system:9411/api/v1/spans
   eventBusVersion: "0.2.34"


### PR DESCRIPTION
w.r.t #4856 

### Resource Consumption Study for Kyma Eventing Components
- #### Event Bus Publish Service
Event Bus Publish service is configured to limit its Memory consumption at *32MiB*, as the deployment has no configuration for *requested* memory, kubernetes sets the requested memory consumption same as the limit mentioned i.e. *32MiB*. But from the Monitoring study we found that the publish Service has reached a peak of **11.6Mib**.

CPU consumption for the component has not been configured at all, which instructs kubernetes to make this pod as an *unbounded* resource and this can be dangerous at production level, because there's no limit set for throttling up this component. But from our Observation, we found out that the max cpu consumption recorded for publish service is about **7.3m**
<img width="1595" alt="Screen Shot 2019-08-07 at 11 22 54 AM" src="https://user-images.githubusercontent.com/30645797/62598429-f7368b00-b906-11e9-9d12-a3319f2419d9.png">
***Inference***
Component requested resource can be adjusted to:
**Memory: 15Mi and cpu: 10m**
- #### Event Bus Subscription Controller
Event Bus Subscription Controller is configured to limit its Memory consumption at *32MiB*, again as the deployment has no configuration for *requested* memory, kubernetes sets the requested memory consumption same as the limit mentioned i.e. *32MiB*. But from the Monitoring study we found that the publish Service has reached a peak of **12.7Mib**.

CPU consumption for the component has not been configured at all, which instructs kubernetes to make this pod as an *unbounded* resource like our publish service. From our Observation, we found out that the max cpu consumption recorded for subscription controller is about **14.17m**
<img width="1602" alt="Screen Shot 2019-08-07 at 11 24 06 AM" src="https://user-images.githubusercontent.com/30645797/62599350-99577280-b909-11e9-903c-c0fa64fabb7f.png">
***Inference***
Component requested resource can be adjusted to:
**Memory: 20Mi and cpu: 20m**

## Overall Inference
- Keep Memory QoS as Guaranteed by keeping requested memory = limits = 32MiB
- CPU Request = 20m with no limits for full throttle (QoS Burstable)