### PR TITLE
Make kiali template work with release images

### DIFF
--- a/resources/kiali/templates/tests/test.yaml
+++ b/resources/kiali/templates/tests/test.yaml
@@ -26,7 +26,7 @@ spec:
       restartPolicy: Never
       containers:
       - name: tests
-        image: {{ .Values.global.containerRegistry.path }}/{{ .Values.global.alpine_net.dir }}/{{ .Values.global.alpine_net.name }}:{{ .Values.global.alpine_net.version }}
+        image: {{ .Values.global.containerRegistry.path }}/{{ .Values.global.alpine_net.dir }}{{ .Values.global.alpine_net.name }}:{{ .Values.global.alpine_net.version }}
         imagePullPolicy: "{{ .Values.global.imagePullPolicy }}"
         command: ['curl']
         args: ['-k', 'https://kiali.{{ .Values.global.ingress.domainName }}']

--- a/resources/kiali/values.yaml
+++ b/resources/kiali/values.yaml
@@ -75,5 +75,5 @@ global:
     path: eu.gcr.io/kyma-project
   alpine_net:
     name: alpine-net
-    dir: develop
+    dir: develop/
     version: "149967d0"


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/master/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

While doing the Kyma 1.4 release, we had a problem with the kiali template.

Then following the [release process](https://github.com/kyma-project/community/blob/master/guidelines/releases-guidelines/02-release-process.md#kyma-projectkyma) one has to change `develop` with ``.

This ends up with the following image `eu.gcr.io/kyma-project//alpine-net:1.4-rc2` for a release image.
With the non release version there is no double `/`: `eu.gcr.io/kyma-project/develop/alpine-net:149967d0`

Changes proposed in this pull request:

- Make kiali template work with release images

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->

https://github.com/kyma-project/kyma/pull/5175/commits/903409944959bfabe543dc6b9592534ea74476cf