### PR TITLE
Add securityContext.runAsUser for installer certs job

### DIFF
--- a/installation/resources/installer-local.yaml
+++ b/installation/resources/installer-local.yaml
@@ -132,6 +132,8 @@ spec:
     spec:
       serviceAccountName: helm-certs-job-sa
       restartPolicy: OnFailure
+      securityContext:
+        runAsUser: 2000
       containers:
       - name: certhelper
         image: eu.gcr.io/kyma-project/test-infra/alpine-kubectl:v20190325-ff66a3a

--- a/installation/resources/installer.yaml
+++ b/installation/resources/installer.yaml
@@ -132,6 +132,8 @@ spec:
     spec:
       serviceAccountName: helm-certs-job-sa
       restartPolicy: OnFailure
+      securityContext:
+        runAsUser: 2000
       containers:
       - name: certhelper
         image: eu.gcr.io/kyma-project/test-infra/alpine-kubectl:v20190325-ff66a3a


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/master/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

In case Kyma is installed on a cluster with PSP enabled the default PSP (which will be used by helm-certs-job) may not allow running containers as root. This PR sets the user as 2000 (value is chosen randomly).

Changes proposed in this pull request:

- Add securityContext.runAsUser for installer certs job

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
