### PR TITLE
Ensure Knative Serving acceptance test runs against GKE using xip.io domain

### DIFF
--- a/resources/knative-serving/Chart.yaml
+++ b/resources/knative-serving/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: knative-serving
-version: 0.4.0
+version: 0.6.1
 tillerVersion: ">=2.7.2-0"
 description: Helm chart for installing knative serving
 keywords:

--- a/tests/knative-serving/Gopkg.lock
+++ b/tests/knative-serving/Gopkg.lock
@@ -2,6 +2,14 @@
 
 
 [[projects]]
+  digest = "1:80004fcc5cf64e591486b3e11b406f1e0d17bf85d475d64203c8494f5da4fcd1"
+  name = "cloud.google.com/go"
+  packages = ["compute/metadata"]
+  pruneopts = "UT"
+  revision = "cdaaf98f9226c39dc162b8e55083b2fbc67b4674"
+  version = "v0.43.0"
+
+[[projects]]
   digest = "1:b28b250b648609be14e0fa4a220b9b991ccaf7b1226781fd9d6e4dd6f4e086fd"
   name = "github.com/avast/retry-go"
   packages = ["."]
@@ -277,11 +285,14 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:9927d6aceb89d188e21485f42a7a254e67e6fdcf4260aba375fe18e3c300dfb4"
+  digest = "1:645cb780e4f3177111b40588f0a7f5950efcfb473e7ff41d8d81b2ba5eaa6ed5"
   name = "golang.org/x/oauth2"
   packages = [
     ".",
+    "google",
     "internal",
+    "jws",
+    "jwt",
   ]
   pruneopts = "UT"
   revision = "9f3314589c9a9136388751d9adae6b0ed400978a"
@@ -329,13 +340,16 @@
   revision = "9d24e82272b4f38b78bc8cff74fa936d31ccd8ef"
 
 [[projects]]
-  digest = "1:6eb6e3b6d9fffb62958cf7f7d88dbbe1dd6839436b0802e194c590667a40412a"
+  digest = "1:04f2ff15fc59e1ddaf9900ad0e19e5b19586b31f9dafd4d592b617642b239d8f"
   name = "google.golang.org/appengine"
   packages = [
+    ".",
     "internal",
+    "internal/app_identity",
     "internal/base",
     "internal/datastore",
     "internal/log",
+    "internal/modules",
     "internal/remote_api",
     "internal/urlfetch",
     "urlfetch",
@@ -452,7 +466,7 @@
   version = "kubernetes-1.12.6"
 
 [[projects]]
-  digest = "1:c1a099abc91bf21e441d87740b19fa9ef931ff180f11836ce59cab21bcab2b7a"
+  digest = "1:cf7dd24a60a10c8092df576341eebbab41b93ba989017b8b55c63d04d17e9a37"
   name = "k8s.io/client-go"
   packages = [
     "discovery",
@@ -566,8 +580,10 @@
     "pkg/apis/clientauthentication/v1beta1",
     "pkg/version",
     "plugin/pkg/client/auth/exec",
+    "plugin/pkg/client/auth/gcp",
     "rest",
     "rest/watch",
+    "third_party/forked/golang/template",
     "tools/auth",
     "tools/cache",
     "tools/clientcmd",
@@ -584,6 +600,7 @@
     "util/flowcontrol",
     "util/homedir",
     "util/integer",
+    "util/jsonpath",
     "util/retry",
   ]
   pruneopts = "UT"
@@ -601,6 +618,7 @@
     "k8s.io/api/core/v1",
     "k8s.io/apimachinery/pkg/api/resource",
     "k8s.io/apimachinery/pkg/apis/meta/v1",
+    "k8s.io/client-go/plugin/pkg/client/auth/gcp",
     "k8s.io/client-go/rest",
     "k8s.io/client-go/tools/clientcmd",
   ]

--- a/tests/knative-serving/knative_serving_test.go
+++ b/tests/knative-serving/knative_serving_test.go
@@ -44,7 +44,8 @@ func TestKnativeServingAcceptance(t *testing.T) {
 
 	kubeConfig := loadKubeConfigOrDie(t)
 	serviceClient := servingtyped.NewForConfigOrDie(kubeConfig).Services("knative-serving")
-	service, err := serviceClient.Create(&serving.Service{
+
+	svc := &serving.Service{
 		ObjectMeta: meta.ObjectMeta{
 			Name: "test-service",
 		},
@@ -72,7 +73,9 @@ func TestKnativeServingAcceptance(t *testing.T) {
 				},
 			},
 		},
-	})
+	}
+
+	service, err := serviceClient.Create(svc)
 	if err != nil {
 		t.Fatalf("Cannot create test service: %v", err)
 	}

--- a/tests/knative-serving/knative_serving_test.go
+++ b/tests/knative-serving/knative_serving_test.go
@@ -26,8 +26,8 @@ const (
 )
 
 func TestKnativeServing_Acceptance(t *testing.T) {
-	domainName := MustGetenv(t, "DOMAIN_NAME")
-	target := MustGetenv(t, "TARGET")
+	domainName := mustGetenv(t, "DOMAIN_NAME")
+	target := mustGetenv(t, "TARGET")
 
 	testServiceURL := fmt.Sprintf("https://test-service.knative-serving.%s", domainName)
 
@@ -36,7 +36,7 @@ func TestKnativeServing_Acceptance(t *testing.T) {
 		t.Fatalf("Unexpected error when creating ingressgateway client: %s", err)
 	}
 
-	kubeConfig := loadKubeConfigOrDie()
+	kubeConfig := loadKubeConfigOrDie(t)
 	serviceClient := servingtyped.NewForConfigOrDie(kubeConfig).Services("knative-serving")
 	service, err := serviceClient.Create(&serving.Service{
 		ObjectMeta: meta.ObjectMeta{
@@ -105,7 +105,9 @@ func TestKnativeServing_Acceptance(t *testing.T) {
 	}
 }
 
-func MustGetenv(t *testing.T, name string) string {
+func mustGetenv(t *testing.T, name string) string {
+	t.Helper()
+
 	env := os.Getenv(name)
 	if env == "" {
 		t.Fatalf("Missing '%s' variable", name)
@@ -113,7 +115,9 @@ func MustGetenv(t *testing.T, name string) string {
 	return env
 }
 
-func loadKubeConfigOrDie() *rest.Config {
+func loadKubeConfigOrDie(t *testing.T) *rest.Config {
+	t.Helper()
+
 	if _, err := os.Stat(clientcmd.RecommendedHomeFile); os.IsNotExist(err) {
 		cfg, err := rest.InClusterConfig()
 		if err != nil {

--- a/tests/knative-serving/knative_serving_test.go
+++ b/tests/knative-serving/knative_serving_test.go
@@ -21,11 +21,7 @@ import (
 	"github.com/kyma-project/kyma/common/ingressgateway"
 )
 
-const (
-	cpuLimits = "50m"
-)
-
-func TestKnativeServing_Acceptance(t *testing.T) {
+func TestKnativeServingAcceptance(t *testing.T) {
 	domainName := mustGetenv(t, "DOMAIN_NAME")
 	target := mustGetenv(t, "TARGET")
 
@@ -57,7 +53,7 @@ func TestKnativeServing_Acceptance(t *testing.T) {
 								},
 								Resources: core.ResourceRequirements{
 									Requests: core.ResourceList{
-										core.ResourceCPU: resource.MustParse(cpuLimits),
+										core.ResourceCPU: *resource.NewMilliQuantity(50, resource.DecimalSI), // 50m
 									},
 								},
 							},
@@ -88,10 +84,10 @@ func TestKnativeServing_Acceptance(t *testing.T) {
 		t.Logf("Received %d: %q", resp.StatusCode, msg)
 
 		if resp.StatusCode != http.StatusOK {
-			return fmt.Errorf("unexpected status code: %v", resp.StatusCode)
+			return fmt.Errorf("expected status code %d, got %d", http.StatusOK, resp.StatusCode)
 		}
 		if msg != expectedMsg {
-			return fmt.Errorf("unexpected response: '%s'", msg)
+			return fmt.Errorf("expected response to be %q, got %q", expectedMsg, msg)
 		}
 
 		return nil
@@ -101,7 +97,7 @@ func TestKnativeServing_Acceptance(t *testing.T) {
 	)
 
 	if err != nil {
-		t.Fatalf("cannot get test service response: %s", err)
+		t.Fatalf("Cannot get test service response: %s", err)
 	}
 }
 
@@ -110,7 +106,7 @@ func mustGetenv(t *testing.T, name string) string {
 
 	env := os.Getenv(name)
 	if env == "" {
-		t.Fatalf("Missing '%s' variable", name)
+		t.Fatalf("Missing %q variable", name)
 	}
 	return env
 }

--- a/tests/knative-serving/knative_serving_test.go
+++ b/tests/knative-serving/knative_serving_test.go
@@ -21,9 +21,19 @@ import (
 	"github.com/kyma-project/kyma/common/ingressgateway"
 )
 
+const (
+	// Domain name used to build the URL tests send HTTP requests to.
+	// `test-service.knative-serving.DOMAIN` is expected to resolve to the IP of the Istio Ingress Gateway.
+	domainNameEnvVar = "DOMAIN_NAME"
+
+	// Message that should be printed by the sample Hello World service.
+	// https://knative.dev/docs/serving/samples/hello-world/helloworld-go/index.html
+	targetEnvVar = "TARGET"
+)
+
 func TestKnativeServingAcceptance(t *testing.T) {
-	domainName := mustGetenv(t, "DOMAIN_NAME")
-	target := mustGetenv(t, "TARGET")
+	domainName := mustGetenv(t, domainNameEnvVar)
+	target := mustGetenv(t, targetEnvVar)
 
 	testServiceURL := fmt.Sprintf("https://test-service.knative-serving.%s", domainName)
 
@@ -47,7 +57,7 @@ func TestKnativeServingAcceptance(t *testing.T) {
 								Image: "gcr.io/knative-samples/helloworld-go",
 								Env: []core.EnvVar{
 									{
-										Name:  "TARGET",
+										Name:  targetEnvVar,
 										Value: target,
 									},
 								},
@@ -75,12 +85,14 @@ func TestKnativeServingAcceptance(t *testing.T) {
 			return err
 		}
 
-		bytes, err := ioutil.ReadAll(resp.Body)
+		body, err := ioutil.ReadAll(resp.Body)
 		if err != nil {
 			return err
 		}
-		msg := strings.TrimSpace(string(bytes))
+
+		msg := strings.TrimSpace(string(body))
 		expectedMsg := fmt.Sprintf("Hello %s!", target)
+
 		t.Logf("Received %d: %q", resp.StatusCode, msg)
 
 		if resp.StatusCode != http.StatusOK {

--- a/tests/knative-serving/knative_serving_test.go
+++ b/tests/knative-serving/knative_serving_test.go
@@ -75,11 +75,10 @@ func TestKnativeServingAcceptance(t *testing.T) {
 		},
 	}
 
-	service, err := serviceClient.Create(svc)
-	if err != nil {
-		t.Fatalf("Cannot create test service: %v", err)
+	if _, err := serviceClient.Create(svc); err != nil {
+		t.Fatalf("Cannot create test Service: %v", err)
 	}
-	defer deleteService(serviceClient, service)
+	defer deleteService(serviceClient, svc.Name)
 
 	err = retry.Do(func() error {
 		t.Logf("Calling: %s", testServiceURL)
@@ -145,9 +144,9 @@ func loadKubeConfigOrDie(t *testing.T) *rest.Config {
 	return kubeConfig
 }
 
-func deleteService(servingClient servingtyped.ServiceInterface, service *serving.Service) {
+func deleteService(servingClient servingtyped.ServiceInterface, name string) {
 	var deleteImmediately int64
-	_ = servingClient.Delete(service.Name, &meta.DeleteOptions{
+	_ = servingClient.Delete(name, &meta.DeleteOptions{
 		GracePeriodSeconds: &deleteImmediately,
 	})
 }

--- a/tests/knative-serving/knative_serving_test.go
+++ b/tests/knative-serving/knative_serving_test.go
@@ -15,6 +15,9 @@ import (
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 
+	// allow client authentication against GKE clusters
+	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
+
 	serving "github.com/knative/serving/pkg/apis/serving/v1alpha1"
 	servingtyped "github.com/knative/serving/pkg/client/clientset/versioned/typed/serving/v1alpha1"
 


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Enable devs to run tests from their workstation against GKE clusters
- Refactor test for readability

I couldn't reproduce the issue, but proceeded to some improvements anyway. See individual commits for the detail of each improvement.

**Output of the test**

```console
$ export DOMAIN_NAME=35.246.xx.xx.xip.io
$ export INGRESSGATEWAY_ADDRESS=35.246.xx.xx
$ export TARGET=Toni
$ go test -v ./
=== RUN   TestKnativeServingAcceptance
--- PASS: TestKnativeServingAcceptance (51.39s)
    knative_serving_test.go:87: Calling: https://test-service.knative-serving.35.246.xx.xx.xip.io
    knative_serving_test.go:101: Received 404: ""
    knative_serving_test.go:112: [0] try failed: expected status code 200, got 404
    …
    knative_serving_test.go:87: Calling: https://test-service.knative-serving.35.246.xx.xx.xip.io
    knative_serving_test.go:101: Received 200: "Hello Toni!"
PASS
ok      github.com/kyma-project/kyma/tests/knative-serving      51.443s
```
```console
$ kubectl -n knative-serving get services.serving.knative.dev
NAME           URL                                                        LATESTCREATED        LATESTREADY          READY   REASON
test-service   http://test-service.knative-serving.35.246.xx.xx.xip.io   test-service-vhsqf   test-service-vhsqf   True

```

**Related issue(s)**

#5190