### PR TITLE
Extend rbac for installer helm-certs-job

### DIFF
--- a/installation/resources/installer-local.yaml
+++ b/installation/resources/installer-local.yaml
@@ -115,6 +115,28 @@ rules:
   resources: ["secrets"]
   verbs: ["get", "list", "create", "patch"]
 ---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: all-psp
+rules:
+- apiGroups: ["extensions"]
+  resources: ["podsecuritypolicies"]
+  verbs: ["use"]
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: all-psp
+subjects:
+- kind: ServiceAccount
+  name: helm-certs-job-sa
+  namespace: kyma-installer
+roleRef:
+  kind: ClusterRole
+  name: all-psp
+  apiGroup: rbac.authorization.k8s.io
+---
 apiVersion: batch/v1
 kind: Job
 metadata:

--- a/installation/resources/installer.yaml
+++ b/installation/resources/installer.yaml
@@ -115,6 +115,28 @@ rules:
   resources: ["secrets"]
   verbs: ["get", "list", "create", "patch"]
 ---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: all-psp
+rules:
+- apiGroups: ["extensions"]
+  resources: ["podsecuritypolicies"]
+  verbs: ["use"]
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: all-psp
+subjects:
+- kind: ServiceAccount
+  name: helm-certs-job-sa
+  namespace: kyma-installer
+roleRef:
+  kind: ClusterRole
+  name: all-psp
+  apiGroup: rbac.authorization.k8s.io
+---
 apiVersion: batch/v1
 kind: Job
 metadata:


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/master/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**
Temporary solution for installing kyma on clusters with PSP enabled and with default PSP which restrict running containers as root. This PR provide access for jobs service account to all PSPs. 
Final solution should look like https://github.com/kyma-project/kyma/pull/5264 but cannot be done because of https://github.com/kyma-project/kyma/issues/5272

Changes proposed in this pull request:

- Extend rbac for installer helm-certs-job

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
