### PR TITLE
Extend the EventBus test utils to allow creating named subscriber deployments and services

### DIFF
--- a/components/event-bus/test/util/subscriber_yaml.go
+++ b/components/event-bus/test/util/subscriber_yaml.go
@@ -7,28 +7,33 @@ import (
 )
 
 const (
-	// SubscriberName used in the tests
+	// SubscriberName is the default subscriber name used in the tests
 	SubscriberName = "test-core-event-bus-subscriber"
 )
 
-// NewSubscriberDeployment creates a new v1.Deployment instance.
-func NewSubscriberDeployment(sbscrImg string) *appsv1.Deployment {
+// NewSubscriberDeployment creates a new Kubernetes v1.Deployment instance with the default subscriber name.
+func NewSubscriberDeployment(subscriberImage string) *appsv1.Deployment {
+	return NewSubscriberDeploymentWithName(SubscriberName, subscriberImage)
+}
+
+// NewSubscriberDeploymentWithName creates a new Kubernetes v1.Deployment instance with the given subscriber name.
+func NewSubscriberDeploymentWithName(subscriberName, subscriberImage string) *appsv1.Deployment {
 	var replicas int32 = 1
 	return &appsv1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: SubscriberName,
+			Name: subscriberName,
 		},
 		Spec: appsv1.DeploymentSpec{
 			Replicas: &replicas,
 			Selector: &metav1.LabelSelector{
 				MatchLabels: map[string]string{
-					"app": SubscriberName,
+					"app": subscriberName,
 				},
 			},
 			Template: apiv1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
 					Labels: map[string]string{
-						"app": SubscriberName,
+						"app": subscriberName,
 					},
 					Annotations: map[string]string{
 						"sidecar.istio.io/inject": "true",
@@ -37,8 +42,8 @@ func NewSubscriberDeployment(sbscrImg string) *appsv1.Deployment {
 				Spec: apiv1.PodSpec{
 					Containers: []apiv1.Container{
 						{
-							Name:            SubscriberName,
-							Image:           sbscrImg,
+							Name:            subscriberName,
+							Image:           subscriberImage,
 							ImagePullPolicy: "IfNotPresent",
 							Ports: []apiv1.ContainerPort{
 								{
@@ -53,18 +58,23 @@ func NewSubscriberDeployment(sbscrImg string) *appsv1.Deployment {
 	}
 }
 
-// NewSubscriberService creates a new v1.Service instance.
+// NewSubscriberService creates a new Kubernetes v1.Service instance with the default subscriber name.
 func NewSubscriberService() *apiv1.Service {
+	return NewSubscriberServiceWithName(SubscriberName)
+}
+
+// NewSubscriberServiceWithName creates a new Kubernetes v1.Service instance with the given subscriber name.
+func NewSubscriberServiceWithName(subscriberName string) *apiv1.Service {
 	return &apiv1.Service{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: SubscriberName,
+			Name: subscriberName,
 			Labels: map[string]string{
-				"app": SubscriberName,
+				"app": subscriberName,
 			},
 		},
 		Spec: apiv1.ServiceSpec{
 			Selector: map[string]string{
-				"app": SubscriberName,
+				"app": subscriberName,
 			},
 			Ports: []apiv1.ServicePort{
 				{


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Extend the EventBus test utils to allow creating named subscriber deployments and services.

**Related issue(s)**
- #4895 
