### PR TITLE
Modify codeowners for UI resources

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -136,14 +136,8 @@
 # The `binding-usage-controller` subchart
 /resources/service-catalog-addons/charts/binding-usage-controller/ @aszecowka @PK85 @mszostok @piotrmiskiewicz @polskikiel @jasiu001 @adamwalach
 
-# The `brokers-ui` subchart
-/resources/service-catalog-addons/charts/brokers-ui/ @aszecowka @PK85 @mszostok @piotrmiskiewicz @polskikiel @jasiu001 @adamwalach @akucharska @michal-hudy @m00g3n @aerfio @magicmatatjahu @kwiatekus @dariadomagala @y-kkamil @parostatkiem @sjanota
-
-# The `catalog-ui` subchart
-/resources/service-catalog-addons/charts/catalog-ui/ @akucharska @michal-hudy @m00g3n @aerfio @magicmatatjahu @kwiatekus @dariadomagala @y-kkamil @parostatkiem @sjanota
-
-# The `instances-ui` subchart
-/resources/service-catalog-addons/charts/instances-ui/ @akucharska @michal-hudy @m00g3n @aerfio @magicmatatjahu @kwiatekus @dariadomagala @y-kkamil @parostatkiem @sjanota
+# The `service-catalog-ui` subchart
+/resources/service-catalog-addons/charts/service-catalog-ui/ @kwiatekus @dariadomagala @y-kkamil @akucharska @sjanota @parostatkiem
 
 # The `docs` subchart
 /resources/core/charts/docs/ @michal-hudy @m00g3n @aerfio @magicmatatjahu @aszecowka @PK85 @mszostok @piotrmiskiewicz @polskikiel @jasiu001 @adamwalach
@@ -201,6 +195,9 @@
 
 # The `compass` chart
 /resources/compass/ @PK85 @aszecowka @crabtree @pkosiec @kfurgol @tgorgol @akgalwas @janmedrek @Szymongib @franpog859 @Maladie
+
+# The `compass-cockpit` chart
+/resources/compass/charts/cockpit @kwiatekus @dariadomagala @y-kkamil @akucharska @sjanota @parostatkiem
 
 # The `compass-runtime-agent` chart
 /resources/compass-runtime-agent/ @PK85 @aszecowka @crabtree @pkosiec @kfurgol @tgorgol @akgalwas @janmedrek @Szymongib @franpog859 @Maladie


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Make UI team members the code owners for new charts : compass-cockpit and service-catalog-ui

**Related issue(s)**
kyma-project/console#1127
https://github.com/kyma-project/kyma/pull/5261