### PR TITLE
Extend the EventBus test utils to allow the test subscriber to handle more endpoints

### DIFF
--- a/components/event-bus/test/util/subscriber.go
+++ b/components/event-bus/test/util/subscriber.go
@@ -5,60 +5,56 @@ import (
 	"fmt"
 	"log"
 	"net/http"
-	"net/http/httptest"
 	"sync"
 )
 
 // Subscribers Servers API paths
 const (
+	// v1 endpoints
 	SubServer1EventsPath  = "/v1/events"
 	SubServer1StatusPath  = "/v1/status"
 	SubServer1ResultsPath = "/v1/results"
+
+	// v2 endpoints
 	SubServer2EventsPath  = "/v2/events"
 	SubServer2StatusPath  = "/v2/status"
 	SubServer2ResultsPath = "/v2/results"
+
+	// v3 endpoints
 	SubServer3EventsPath  = "/v3/events"
 	SubServer3StatusPath  = "/v3/status"
 	SubServer3ResultsPath = "/v3/results"
 )
 
-// NewSubscriberServerV1 ...
-func NewSubscriberServerV1() *httptest.Server {
-	subscriberMux := http.NewServeMux()
-	subscriberMux.HandleFunc(SubServer1EventsPath, eventsHandlerV1)
-	subscriberMux.HandleFunc(SubServer1StatusPath, statusHandler)
-	subscriberMux.HandleFunc(SubServer1ResultsPath, resultsHandlerV1)
-	return httptest.NewServer(Logger(subscriberMux))
-}
-
-// NewSubscriberServerV2 ...
-func NewSubscriberServerV2() *httptest.Server {
-	subscriberMux := http.NewServeMux()
-	subscriberMux.HandleFunc(SubServer2EventsPath, eventsHandlerV2)
-	subscriberMux.HandleFunc(SubServer2StatusPath, statusHandler)
-	subscriberMux.HandleFunc(SubServer2ResultsPath, resultsHandlerV2)
-	return httptest.NewServer(Logger(subscriberMux))
-}
-
-// NewSubscriberServerWithPort ...
+// NewSubscriberServerWithPort creates a new HTTP server with multiple endpoints acting as an event subscriber
 func NewSubscriberServerWithPort(port int, stop chan bool) *http.Server {
-	subscriberMux := http.NewServeMux()
-	subscriberMux.HandleFunc("/v1/events", eventsHandlerV1)
-	subscriberMux.HandleFunc("/v1/status", statusHandler)
-	subscriberMux.HandleFunc("/v1/results", resultsHandlerV1)
-	subscriberMux.HandleFunc(SubServer3EventsPath, eventsHandlerV3)
-	subscriberMux.HandleFunc(SubServer3StatusPath, statusHandler)
-	subscriberMux.HandleFunc(SubServer3ResultsPath, resultsHandlerV3)
-	subscriberMux.Handle("/shutdown", shutdownHandler(stop))
+	// multiplexer
+	serveMux := http.NewServeMux()
 
-	srv := &http.Server{Addr: fmt.Sprintf(":%d", port), Handler: Logger(subscriberMux)}
+	// v1 handlers
+	serveMux.HandleFunc(SubServer1EventsPath, eventsHandlerV1)
+	serveMux.HandleFunc(SubServer1StatusPath, statusHandler)
+	serveMux.HandleFunc(SubServer1ResultsPath, resultsHandlerV1)
+	// v2 handlers
+	serveMux.HandleFunc(SubServer2EventsPath, eventsHandlerV2)
+	serveMux.HandleFunc(SubServer2StatusPath, statusHandler)
+	serveMux.HandleFunc(SubServer2ResultsPath, resultsHandlerV2)
+	// v3 handlers
+	serveMux.HandleFunc(SubServer3EventsPath, eventsHandlerV3)
+	serveMux.HandleFunc(SubServer3StatusPath, statusHandler)
+	serveMux.HandleFunc(SubServer3ResultsPath, resultsHandlerV3)
+	// shutdown handler
+	serveMux.Handle("/shutdown", shutdownHandler(stop))
+
+	server := &http.Server{Addr: fmt.Sprintf(":%d", port), Handler: Logger(serveMux)}
 
 	// start listener and serve requests
 	go func() {
 		log.Printf("Subscriber HTTP server starting on port %d", port)
-		log.Fatal(srv.ListenAndServe())
+		log.Fatal(server.ListenAndServe())
 	}()
-	return srv
+
+	return server
 }
 
 var (
@@ -71,31 +67,31 @@ var (
 func resultsHandlerV1(w http.ResponseWriter, _ *http.Request) {
 	mu.Lock()
 	defer mu.Unlock()
-	json.NewEncoder(w).Encode(subscriberV1Result)
+	_ = json.NewEncoder(w).Encode(subscriberV1Result)
 }
 
 func eventsHandlerV1(_ http.ResponseWriter, r *http.Request) {
 	mu.Lock()
 	defer mu.Unlock()
-	json.NewDecoder(r.Body).Decode(&subscriberV1Result)
+	_ = json.NewDecoder(r.Body).Decode(&subscriberV1Result)
 }
 
 func resultsHandlerV2(w http.ResponseWriter, _ *http.Request) {
 	mu.Lock()
 	defer mu.Unlock()
-	json.NewEncoder(w).Encode(subscriberV2Result)
+	_ = json.NewEncoder(w).Encode(subscriberV2Result)
 }
 
 func eventsHandlerV2(_ http.ResponseWriter, r *http.Request) {
 	mu.Lock()
 	defer mu.Unlock()
-	json.NewDecoder(r.Body).Decode(&subscriberV2Result)
+	_ = json.NewDecoder(r.Body).Decode(&subscriberV2Result)
 }
 
 func resultsHandlerV3(w http.ResponseWriter, _ *http.Request) {
 	mu.Lock()
 	defer mu.Unlock()
-	json.NewEncoder(w).Encode(subscriberV3Result)
+	_ = json.NewEncoder(w).Encode(subscriberV3Result)
 }
 
 func eventsHandlerV3(_ http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Extend the EventBus test utils to allow the test subscriber to handle more endpoints.
- Remove functions not used anywhere.

**Related issue(s)**
#4895