### PR TITLE
Enable adding securityContext to podpreset webhook

### DIFF
--- a/resources/cluster-essentials/charts/pod-preset/templates/webhook/deploy.yaml
+++ b/resources/cluster-essentials/charts/pod-preset/templates/webhook/deploy.yaml
@@ -41,6 +41,10 @@ spec:
         - name: webhook-cert
           mountPath: /keys
           readOnly: true
+      {{- with .Values.webhook.securityContext }}
+      securityContext:
+{{ toYaml . | indent 8 }}
+      {{- end }}
       volumes:
       - name: webhook-cert
         secret:

--- a/resources/cluster-essentials/charts/pod-preset/values.yaml
+++ b/resources/cluster-essentials/charts/pod-preset/values.yaml
@@ -5,6 +5,7 @@ webhook:
     tag: 47f40a09
     pullPolicy: IfNotPresent
   verbosity: 6
+  securityContext: {}
 
 controller:
   enabled: false


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/master/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- With this change, it will be possible to set securityContext for webhook pods in values/overrides (f.e. to run it as non-root)

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
