### PR TITLE
Remove xip from compass cluster installer CR

### DIFF
--- a/installation/resources/installer-cr-cluster-compass.yaml.tpl
+++ b/installation/resources/installer-cr-cluster-compass.yaml.tpl
@@ -19,8 +19,6 @@ spec:
       namespace: "istio-system"
     - name: "istio"
       namespace: "istio-system"
-    - name: "xip-patch"
-      namespace: "kyma-installer"
     - name: "istio-kyma-patch"
       namespace: "istio-system"
     - name: "dex"


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/master/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- xip won't be used on non-prow-test clusters so removing it from installer CR

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
