### PR TITLE
Revert "Run xip-patch job as non-root user"

### DIFF
--- a/resources/xip-patch/templates/job.yaml
+++ b/resources/xip-patch/templates/job.yaml
@@ -11,8 +11,6 @@ spec:
       name: {{ .Release.Name }}
     spec:
       serviceAccountName: {{ .Release.Name }}-service-account
-      securityContext:
-        runAsUser: 2000
       restartPolicy: Never
       containers:
       - name: {{ .Release.Name }}


### PR DESCRIPTION
Reverts kyma-project/kyma#5390

There was an issue with clusters created with xip domain, looks like that is not tested before merge...