### PR TITLE
Change order of arguments to match the function in Connector Service

### DIFF
--- a/components/connector-service/cmd/connectorservice/handlers.go
+++ b/components/connector-service/cmd/connectorservice/handlers.go
@@ -73,7 +73,7 @@ func newExternalHandler(tokenManager tokens.Manager, tokenCreatorProvider tokens
 
 	lookupService := middlewares.NewGraphQLLookupService()
 
-	headerParser := certificates.NewHeaderParser(env.country, env.locality, env.province, env.organization, env.organizationalUnit, opts.central)
+	headerParser := certificates.NewHeaderParser(env.country, env.province, env.locality, env.organization, env.organizationalUnit, opts.central)
 
 	appCertificateService := certificates.NewCertificateService(secretsRepository, certificates.NewCertificateUtility(opts.appCertificateValidityTime), opts.caSecretName, opts.rootCACertificateSecretName)
 

--- a/docs/migration-guides/1.4-1.5.md
+++ b/docs/migration-guides/1.4-1.5.md
@@ -1,7 +1,0 @@
-# Migrate from v1.4 to v1.5
-
->**TIP:** To learn more about upgrading Kyma, read [this](https://kyma-project.io/docs/master/root/kyma/#installation-upgrade-kyma) document.
-
-## Connector Service
-
-We have fixed checking certificate subject in Connector Service. If you have problem with your current certificate generate new one. You can find how to do that in [this](https://kyma-project.io/docs/master/components/application-connector/#tutorials-get-the-client-certificate) document.

--- a/docs/migration-guides/1.4-1.5.md
+++ b/docs/migration-guides/1.4-1.5.md
@@ -1,0 +1,7 @@
+# Migrate from v1.4 to v1.5
+
+>**TIP:** To learn more about upgrading Kyma, read [this](https://kyma-project.io/docs/master/root/kyma/#installation-upgrade-kyma) document.
+
+## Connector Service
+
+We have fixed checking certificate subject in Connector Service. If you have problem with your current certificate generate new one. You can find how to do that in [this](https://kyma-project.io/docs/master/components/application-connector/#tutorials-get-the-client-certificate) document.

--- a/resources/application-connector/values.yaml
+++ b/resources/application-connector/values.yaml
@@ -24,7 +24,7 @@ global:
     version: PR-5397
   connector_service:
     dir: pr/
-    version: PR-5318
+    version: PR-5468
   connector_service_tests:
     dir: pr/
     version: PR-5397


### PR DESCRIPTION
**Description**

Currently header parser is created in a wrong way. Therefore it compares certificate subject locality to the env variable province and cert province to the env locality. It may cause bugs. 
The fix could cause validation current certificates failing.

Changes proposed in this pull request:

- Change order of arguments to match the function

**Remember to include it in Release Notes!**
