### PR TITLE
Add tests for deprecated API in Application Registry

### DIFF
--- a/resources/application-connector/values.yaml
+++ b/resources/application-connector/values.yaml
@@ -57,7 +57,7 @@ global:
     version: PR-5318
   application_registry_tests:
     dir: pr/
-    version: PR-5397
+    version: PR-5478
   application_broker:
     dir: develop/
     version: d999e831

--- a/tests/application-registry-tests/before-commit.sh
+++ b/tests/application-registry-tests/before-commit.sh
@@ -36,6 +36,7 @@ fi
 #
 # GO FMT
 #
+filesToCheck=$(find . -type f -name "*.go" | egrep -v "\/vendor\/|_*/automock/|_*/testdata/|/pkg\/|_*export_test.go")
 goFmtResult=$(echo "${filesToCheck}" | xargs -L1 go fmt)
 if [ $(echo ${#goFmtResult}) != 0 ]
 	then

--- a/tests/application-registry-tests/test/k8stests/k8sresource_test.go
+++ b/tests/application-registry-tests/test/k8stests/k8sresource_test.go
@@ -416,7 +416,7 @@ func TestK8sResources(t *testing.T) {
 		})
 	})
 
-	t.Run("when creating service only with CertificateGen API", func(t *testing.T) {
+	t.Run("when creating service only with CertificateGen API and CSRF", func(t *testing.T) {
 		csrfInfo := &testkit.CSRFInfo{TokenEndpointURL: "https://csrf.token.endpoint.org"}
 
 		t.Run("when current api with request parameters provided", func(t *testing.T) {

--- a/tests/application-registry-tests/test/testkit/model.go
+++ b/tests/application-registry-tests/test/testkit/model.go
@@ -44,14 +44,14 @@ type ErrorResponse struct {
 }
 
 type API struct {
-	TargetUrl         string             `json:"targetUrl"`
-	Credentials       *Credentials       `json:"credentials,omitempty"`
-	Spec              json.RawMessage    `json:"spec,omitempty"`
-	SpecificationUrl  string             `json:"specificationUrl,omitempty"`
-	ApiType           string             `json:"apiType"`
-	RequestParameters *RequestParameters `json:"requestParameters,omitempty"`
-	Headers         *map[string][]string `json:"headers,omitempty"`
-	QueryParameters *map[string][]string `json:"queryParameters,omitempty"`
+	TargetUrl         string               `json:"targetUrl"`
+	Credentials       *Credentials         `json:"credentials,omitempty"`
+	Spec              json.RawMessage      `json:"spec,omitempty"`
+	SpecificationUrl  string               `json:"specificationUrl,omitempty"`
+	ApiType           string               `json:"apiType"`
+	RequestParameters *RequestParameters   `json:"requestParameters,omitempty"`
+	Headers           *map[string][]string `json:"headers,omitempty"`
+	QueryParameters   *map[string][]string `json:"queryParameters,omitempty"`
 }
 
 type RequestParameters struct {
@@ -118,4 +118,36 @@ func Compact(src []byte) []byte {
 func (sd ServiceDetails) WithAPI(api *API) ServiceDetails {
 	sd.Api = api
 	return sd
+}
+
+func (api *API) WithCSRFInOAuth(csrfInfo *CSRFInfo) *API {
+	if api.Credentials != nil && api.Credentials.Oauth != nil {
+		api.Credentials.Oauth.CSRFInfo = csrfInfo
+	}
+	return api
+}
+
+func (api *API) WithCSRFInBasic(csrfInfo *CSRFInfo) *API {
+	if api.Credentials != nil && api.Credentials.Basic != nil {
+		api.Credentials.Basic.CSRFInfo = csrfInfo
+	}
+	return api
+}
+
+func (api *API) WithCSRFInCertificateGen(csrfInfo *CSRFInfo) *API {
+	if api.Credentials != nil && api.Credentials.CertificateGen != nil {
+		api.Credentials.CertificateGen.CSRFInfo = csrfInfo
+	}
+	return api
+}
+
+func (api *API) WithRequestParameters(requestParameters *RequestParameters) *API {
+	api.RequestParameters = requestParameters
+	return api
+}
+
+func (api *API) WithHeadersAndQueryParameters(headers, queryParameters *map[string][]string) *API {
+	api.Headers = headers
+	api.QueryParameters = queryParameters
+	return api
 }

--- a/tests/application-registry-tests/test/testkit/model.go
+++ b/tests/application-registry-tests/test/testkit/model.go
@@ -50,6 +50,8 @@ type API struct {
 	SpecificationUrl  string             `json:"specificationUrl,omitempty"`
 	ApiType           string             `json:"apiType"`
 	RequestParameters *RequestParameters `json:"requestParameters,omitempty"`
+	Headers         *map[string][]string `json:"headers,omitempty"`
+	QueryParameters *map[string][]string `json:"queryParameters,omitempty"`
 }
 
 type RequestParameters struct {


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Add tests for deprecated API in Application Registry

**Related issue(s)**

See the issue #5449 
