### PR TITLE
Skip failing HelmBroker test

### DIFF
--- a/tests/acceptance/servicecatalog/helpers_test.go
+++ b/tests/acceptance/servicecatalog/helpers_test.go
@@ -23,7 +23,7 @@ import (
 
 func isCatalogForbidden(url string) (bool, error) {
 	config := osb.DefaultClientConfiguration()
-	config.URL = url
+	config.URL = fmt.Sprintf("%s/cluster", url)
 
 	client, err := osb.NewClient(config)
 	if err != nil {

--- a/tests/acceptance/servicecatalog/servicecatalog_test.go
+++ b/tests/acceptance/servicecatalog/servicecatalog_test.go
@@ -37,6 +37,9 @@ const (
 )
 
 func TestBrokerHasIstioRbacAuthorizationRules(t *testing.T) {
+	// TODO: remove skipping the test if issue https://github.com/kyma-project/kyma/issues/5375 will be fixed
+	t.Skip("Test skipped due to istio rbac rules issue.")
+
 	for testName, brokerURL := range map[string]string{
 		"Helm Broker":        os.Getenv(helmBrokerURLEnvName),
 		"Application Broker": os.Getenv(applicationBrokerURLEnvName),


### PR DESCRIPTION
Related to #5375 

Skip HelmBroker test `TestBrokerHasIstioRbacAuthorizationRules` until rbac istio will be fixed.
For more details see [comment](https://github.com/kyma-project/kyma/issues/5375#issuecomment-525708193)