### PR TITLE
Create OWNERS files for the Framefrogs team

### DIFF
--- a/components/application-connectivity-certs-setup-job/OWNERS
+++ b/components/application-connectivity-certs-setup-job/OWNERS
@@ -1,0 +1,7 @@
+approvers:
+  - akgalwas 
+  - janmedrek 
+  - Szymongib 
+  - franpog859 
+  - Maladie
+  - crabtree

--- a/components/application-connectivity-validator/OWNERS
+++ b/components/application-connectivity-validator/OWNERS
@@ -1,0 +1,7 @@
+approvers:
+  - akgalwas 
+  - janmedrek 
+  - Szymongib 
+  - franpog859 
+  - Maladie
+  - crabtree

--- a/components/application-gateway/OWNERS
+++ b/components/application-gateway/OWNERS
@@ -1,0 +1,7 @@
+approvers:
+  - akgalwas 
+  - janmedrek 
+  - Szymongib 
+  - franpog859 
+  - Maladie
+  - crabtree

--- a/components/application-operator/OWNERS
+++ b/components/application-operator/OWNERS
@@ -1,0 +1,7 @@
+approvers:
+  - akgalwas 
+  - janmedrek 
+  - Szymongib 
+  - franpog859 
+  - Maladie
+  - crabtree

--- a/components/application-registry/OWNERS
+++ b/components/application-registry/OWNERS
@@ -1,0 +1,7 @@
+approvers:
+  - akgalwas 
+  - janmedrek 
+  - Szymongib 
+  - franpog859 
+  - Maladie
+  - crabtree

--- a/components/compass-runtime-agent/OWNERS
+++ b/components/compass-runtime-agent/OWNERS
@@ -1,12 +1,14 @@
 approvers:
-  - PK85
-  - aszecowka
-  - crabtree
-  - pkosiec
-  - kfurgol
-  - tgorgol
   - akgalwas 
   - janmedrek 
   - Szymongib 
   - franpog859 
   - Maladie
+  - crabtree
+
+reviewers:
+  - PK85
+  - aszecowka
+  - pkosiec
+  - kfurgol
+  - tgorgol

--- a/components/compass-runtime-agent/OWNERS
+++ b/components/compass-runtime-agent/OWNERS
@@ -12,3 +12,4 @@ reviewers:
   - pkosiec
   - kfurgol
   - tgorgol
+  - dbadura

--- a/components/compass-runtime-agent/OWNERS
+++ b/components/compass-runtime-agent/OWNERS
@@ -1,0 +1,12 @@
+approvers:
+  - PK85
+  - aszecowka
+  - crabtree
+  - pkosiec
+  - kfurgol
+  - tgorgol
+  - akgalwas 
+  - janmedrek 
+  - Szymongib 
+  - franpog859 
+  - Maladie

--- a/components/connection-token-handler/OWNERS
+++ b/components/connection-token-handler/OWNERS
@@ -1,0 +1,7 @@
+approvers:
+  - akgalwas 
+  - janmedrek 
+  - Szymongib 
+  - franpog859 
+  - Maladie
+  - crabtree

--- a/components/connectivity-certs-controller/OWNERS
+++ b/components/connectivity-certs-controller/OWNERS
@@ -1,0 +1,7 @@
+approvers:
+  - akgalwas 
+  - janmedrek 
+  - Szymongib 
+  - franpog859 
+  - Maladie
+  - crabtree

--- a/components/connector-service/OWNERS
+++ b/components/connector-service/OWNERS
@@ -1,0 +1,7 @@
+approvers:
+  - akgalwas 
+  - janmedrek 
+  - Szymongib 
+  - franpog859 
+  - Maladie
+  - crabtree

--- a/resources/application-connector-helper/OWNERS
+++ b/resources/application-connector-helper/OWNERS
@@ -1,13 +1,15 @@
 approvers:
-  - piotrmsc
-  - kubadz
-  - strekm
-  - jakkab
-  - Tomasz-Smelcerz-SAP
-  - Demonsthere
   - akgalwas 
   - janmedrek 
   - Szymongib 
   - franpog859 
   - Maladie
   - crabtree
+
+reviewers:
+  - piotrmsc
+  - kubadz
+  - strekm
+  - jakkab
+  - Tomasz-Smelcerz-SAP
+  - Demonsthere

--- a/resources/application-connector-helper/OWNERS
+++ b/resources/application-connector-helper/OWNERS
@@ -1,0 +1,13 @@
+approvers:
+  - piotrmsc
+  - kubadz
+  - strekm
+  - jakkab
+  - Tomasz-Smelcerz-SAP
+  - Demonsthere
+  - akgalwas 
+  - janmedrek 
+  - Szymongib 
+  - franpog859 
+  - Maladie
+  - crabtree

--- a/resources/application-connector-ingress/OWNERS
+++ b/resources/application-connector-ingress/OWNERS
@@ -1,0 +1,7 @@
+approvers:
+  - akgalwas 
+  - janmedrek 
+  - Szymongib 
+  - franpog859 
+  - Maladie
+  - crabtree

--- a/resources/application-connector/OWNERS
+++ b/resources/application-connector/OWNERS
@@ -1,0 +1,7 @@
+approvers:
+  - akgalwas 
+  - janmedrek 
+  - Szymongib 
+  - franpog859 
+  - Maladie
+  - crabtree

--- a/resources/application-connector/charts/application-operator/OWNERS
+++ b/resources/application-connector/charts/application-operator/OWNERS
@@ -1,0 +1,7 @@
+approvers:
+  - akgalwas 
+  - janmedrek 
+  - Szymongib 
+  - franpog859 
+  - Maladie
+  - crabtree

--- a/resources/application-connector/charts/application-registry/OWNERS
+++ b/resources/application-connector/charts/application-registry/OWNERS
@@ -1,0 +1,7 @@
+approvers:
+  - akgalwas 
+  - janmedrek 
+  - Szymongib 
+  - franpog859 
+  - Maladie
+  - crabtree

--- a/resources/application-connector/charts/connection-token-handler/OWNERS
+++ b/resources/application-connector/charts/connection-token-handler/OWNERS
@@ -1,0 +1,7 @@
+approvers:
+  - akgalwas 
+  - janmedrek 
+  - Szymongib 
+  - franpog859 
+  - Maladie
+  - crabtree

--- a/resources/application-connector/charts/connectivity-certs-controller/OWNERS
+++ b/resources/application-connector/charts/connectivity-certs-controller/OWNERS
@@ -1,0 +1,7 @@
+approvers:
+  - akgalwas 
+  - janmedrek 
+  - Szymongib 
+  - franpog859 
+  - Maladie
+  - crabtree

--- a/resources/application-connector/charts/connector-service/OWNERS
+++ b/resources/application-connector/charts/connector-service/OWNERS
@@ -1,0 +1,7 @@
+approvers:
+  - akgalwas 
+  - janmedrek 
+  - Szymongib 
+  - franpog859 
+  - Maladie
+  - crabtree

--- a/resources/compass-runtime-agent/OWNERS
+++ b/resources/compass-runtime-agent/OWNERS
@@ -1,12 +1,14 @@
 approvers:
-  - PK85
-  - aszecowka
-  - crabtree
-  - pkosiec
-  - kfurgol
-  - tgorgol
   - akgalwas 
   - janmedrek 
   - Szymongib 
   - franpog859 
   - Maladie
+  - crabtree
+
+reviewers:
+  - PK85
+  - aszecowka
+  - pkosiec
+  - kfurgol
+  - tgorgol

--- a/resources/compass-runtime-agent/OWNERS
+++ b/resources/compass-runtime-agent/OWNERS
@@ -1,0 +1,12 @@
+approvers:
+  - PK85
+  - aszecowka
+  - crabtree
+  - pkosiec
+  - kfurgol
+  - tgorgol
+  - akgalwas 
+  - janmedrek 
+  - Szymongib 
+  - franpog859 
+  - Maladie

--- a/resources/compass/OWNERS
+++ b/resources/compass/OWNERS
@@ -10,3 +10,4 @@ approvers:
   - Szymongib 
   - franpog859 
   - Maladie
+  - dbadura

--- a/resources/compass/OWNERS
+++ b/resources/compass/OWNERS
@@ -1,0 +1,12 @@
+approvers:
+  - PK85
+  - aszecowka
+  - crabtree
+  - pkosiec
+  - kfurgol
+  - tgorgol
+  - akgalwas 
+  - janmedrek 
+  - Szymongib 
+  - franpog859 
+  - Maladie

--- a/tests/application-connector-tests/OWNERS
+++ b/tests/application-connector-tests/OWNERS
@@ -1,0 +1,7 @@
+approvers:
+  - akgalwas 
+  - janmedrek 
+  - Szymongib 
+  - franpog859 
+  - Maladie
+  - crabtree

--- a/tests/application-gateway-tests/OWNERS
+++ b/tests/application-gateway-tests/OWNERS
@@ -1,0 +1,7 @@
+approvers:
+  - akgalwas 
+  - janmedrek 
+  - Szymongib 
+  - franpog859 
+  - Maladie
+  - crabtree

--- a/tests/application-operator-tests/OWNERS
+++ b/tests/application-operator-tests/OWNERS
@@ -1,0 +1,7 @@
+approvers:
+  - akgalwas 
+  - janmedrek 
+  - Szymongib 
+  - franpog859 
+  - Maladie
+  - crabtree

--- a/tests/application-registry-tests/OWNERS
+++ b/tests/application-registry-tests/OWNERS
@@ -1,0 +1,7 @@
+approvers:
+  - akgalwas 
+  - janmedrek 
+  - Szymongib 
+  - franpog859 
+  - Maladie
+  - crabtree

--- a/tests/compass-runtime-agent/OWNERS
+++ b/tests/compass-runtime-agent/OWNERS
@@ -1,12 +1,14 @@
 approvers:
-  - PK85
-  - aszecowka
-  - crabtree
-  - pkosiec
-  - kfurgol
-  - tgorgol
   - akgalwas 
   - janmedrek 
   - Szymongib 
   - franpog859 
   - Maladie
+  - crabtree
+
+reviewers:
+  - PK85
+  - aszecowka
+  - pkosiec
+  - kfurgol
+  - tgorgol

--- a/tests/compass-runtime-agent/OWNERS
+++ b/tests/compass-runtime-agent/OWNERS
@@ -12,3 +12,4 @@ reviewers:
   - pkosiec
   - kfurgol
   - tgorgol
+  - dbadura

--- a/tests/compass-runtime-agent/OWNERS
+++ b/tests/compass-runtime-agent/OWNERS
@@ -1,0 +1,12 @@
+approvers:
+  - PK85
+  - aszecowka
+  - crabtree
+  - pkosiec
+  - kfurgol
+  - tgorgol
+  - akgalwas 
+  - janmedrek 
+  - Szymongib 
+  - franpog859 
+  - Maladie

--- a/tests/connection-token-handler-tests/OWNERS
+++ b/tests/connection-token-handler-tests/OWNERS
@@ -1,0 +1,7 @@
+approvers:
+  - akgalwas 
+  - janmedrek 
+  - Szymongib 
+  - franpog859 
+  - Maladie
+  - crabtree

--- a/tests/connector-service-tests/OWNERS
+++ b/tests/connector-service-tests/OWNERS
@@ -1,0 +1,7 @@
+approvers:
+  - akgalwas 
+  - janmedrek 
+  - Szymongib 
+  - franpog859 
+  - Maladie
+  - crabtree


### PR DESCRIPTION
Create OWNER files for the Framefrogs team in:

- The `application-connector` chart
- The `connector-service` subchart
- The `connection-token-handler` subchart
- The `connectivity-certs-controller` subchart
- The `application-registry` subchart
- The `application-operator` subchart
- The `application-connector-helper` chart
- The `application-connector-ingress` chart
- The `compass` chart
- The `compass-runtime-agent` chart
- Connector Service Component
- Connection Token Handler Component
- Connectivity Certs Controller Component
- Application Registry Component
- Application Operator Component
- Application Gateway Component
- Application Connectivity Validator Component
- Application Connectivity Certs Setup Job Component
- Compass Runtime Agent
- Connector Service Tests
- Application Registry Tests
- Application Gateway Tests
- Application Operator Tests
- Application Connector Tests
- Connection Token Handler Tests
- Compass Runtime Agent Tests

**Related issue(s)**
--
