### PR TITLE
Add OWNERS files for gophers

### DIFF
--- a/common/OWNERS
+++ b/common/OWNERS
@@ -1,0 +1,14 @@
+approvers:
+  - mszostok
+  - aszecowka
+  - piotrmiskiewicz
+  - sjanota
+  - Tomasz-Smelcerz-SAP
+  - strekm
+  - crabtree
+  - akgalwas
+  - janmedrek
+  - Szymongib
+  - sayanh
+  - radufa
+  - suleymanakbas91

--- a/components/application-broker/OWNERS
+++ b/components/application-broker/OWNERS
@@ -1,0 +1,11 @@
+approvers:
+  - PK85
+  - mszostok
+  - piotrmiskiewicz
+  - polskikiel
+  - jasiu001
+  - adamwalach
+
+labels:
+  - area/service-catalog
+  - area/application-connector

--- a/components/service-binding-usage-controller/OWNERS
+++ b/components/service-binding-usage-controller/OWNERS
@@ -1,0 +1,11 @@
+approvers:
+  - PK85
+  - mszostok
+  - piotrmiskiewicz
+  - polskikiel
+  - jasiu001
+  - adamwalach
+
+
+labels:
+  - area/service-catalog

--- a/resources/application-connector/charts/application-broker/OWNERS
+++ b/resources/application-connector/charts/application-broker/OWNERS
@@ -1,0 +1,11 @@
+approvers:
+  - PK85
+  - mszostok
+  - piotrmiskiewicz
+  - polskikiel
+  - jasiu001
+  - adamwalach
+
+labels:
+  - area/service-catalog
+  - area/application-connector

--- a/resources/cluster-essentials/charts/pod-preset/OWNERS
+++ b/resources/cluster-essentials/charts/pod-preset/OWNERS
@@ -1,0 +1,10 @@
+approvers:
+  - mszostok
+  - PK85
+  - piotrmiskiewicz
+  - polskikiel
+  - jasiu001
+  - adamwalach
+
+labels:
+  - area/service-catalog

--- a/resources/helm-broker/OWNERS
+++ b/resources/helm-broker/OWNERS
@@ -1,0 +1,11 @@
+approvers:
+  - PK85
+  - mszostok
+  - piotrmiskiewicz
+  - polskikiel
+  - jasiu001
+  - adamwalach
+
+
+labels:
+  - area/service-catalog

--- a/resources/service-catalog-addons/OWNERS
+++ b/resources/service-catalog-addons/OWNERS
@@ -1,0 +1,11 @@
+approvers:
+  - PK85
+  - mszostok
+  - piotrmiskiewicz
+  - polskikiel
+  - jasiu001
+  - adamwalach
+
+
+labels:
+  - area/service-catalog

--- a/resources/service-catalog/OWNERS
+++ b/resources/service-catalog/OWNERS
@@ -1,0 +1,11 @@
+approvers:
+  - PK85
+  - mszostok
+  - piotrmiskiewicz
+  - polskikiel
+  - jasiu001
+  - adamwalach
+
+
+labels:
+  - area/service-catalog

--- a/tests/acceptance/OWNERS
+++ b/tests/acceptance/OWNERS
@@ -1,0 +1,8 @@
+approvers:
+  - mszostok
+  - polskikiel
+  - piotrmiskiewicz
+  - aszecowka
+  - PK85
+  - jasiu001
+  - adamwalach

--- a/tests/end-to-end/upgrade/OWNERS
+++ b/tests/end-to-end/upgrade/OWNERS
@@ -1,0 +1,7 @@
+approvers:
+  - mszostok
+  - polskikiel
+  - piotrmiskiewicz
+  - PK85
+  - jasiu001
+  - adamwalach


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Add OWNERS files for gophers

I didn't add owners files for:
- /resources/core/templates/ 
- /resources/core/charts/console-backend-service/
- /resources/tiller/
- /components/console-backend-service/
- /tests/console-backend-service/

because we are not owning those files anymore :) 

**Related issue(s)**

- https://github.com/kyma-project/kyma/issues/5489