### PR TITLE
Fix Helm Broker documentation where `authorization` is used in the wrong way

### DIFF
--- a/docs/helm-broker/03-03-create-addons-repo.md
+++ b/docs/helm-broker/03-03-create-addons-repo.md
@@ -193,7 +193,7 @@ spec:
   ```bash
     base64 -b -i {path_to_id_rsa} -o id_rsa-encoded
   ```
-  > **NOTE:** Private SSH key should not be secured by a passphrase.
+  > **NOTE:** Do not secure your private SSH key with a passphrase.
 
   2. Create a corresponding Secret resource:
   ```bash

--- a/docs/helm-broker/03-03-create-addons-repo.md
+++ b/docs/helm-broker/03-03-create-addons-repo.md
@@ -115,9 +115,9 @@ spec:
   </details>
 </div>
 
-## Authorization
+## Authentication
 
-The AddonsConfiguration and ClusterAddonsConfiguration custom resources allow you to define authorization as part of the URL. For more details, read the [go-getter protocols](https://github.com/hashicorp/go-getter/blob/master/README.md#general-all-protocols) description.
+The AddonsConfiguration and ClusterAddonsConfiguration custom resources allow you to define authentication as part of the URL. For more details, read the [go-getter protocols](https://github.com/hashicorp/go-getter/blob/master/README.md#general-all-protocols) description.
 Using sensitive information, such as passwords, directly in the URL is not a good approach. Avoid this by putting such data in a Secret resource and taking advantage of templating. Use placeholders which refer to keys in the Secret. For example:
 ```yaml
 apiVersion: addons.kyma-project.io/v1alpha1
@@ -139,20 +139,20 @@ stringData:
   host: "github.com"
   project: "kyma-project/addons"       
 ```
-The URL resolves into: 
+The URL resolves into:
 ```
 https://github.com/kyma-project/addons/addons/index.yaml
 ```
 
-The Helm Broker supports authorization using these protocols:
- 
+The Helm Broker supports authentication using these protocols:
+
 <div tabs>
   <details>
   <summary>
   HTTP/HTTPS
-  </summary> 
- 
-To define basic authentication credentials, prepend a section `username:password@` to the hostname in the URL . For example:
+  </summary>
+
+To define basic authentication credentials, precede a section `username:password@` to the hostname in the URL. For example:
 ```
 https://admin:secretPassword@repository.addons.com/index.yaml
 ```
@@ -184,24 +184,24 @@ spec:
   <summary>
   Git SSH
   </summary>
-  
-  The Git SSH protocol requires an SSH key to authorize with your repository. Setting SSH keys differs among hosting providers. 
-  > **NOTE**: See [this](https://help.github.com/en/articles/generating-a-new-ssh-key-and-adding-it-to-the-ssh-agent#generating-a-new-ssh-key) document to read about the GitHub service. 
-  
-  The private key must be base64 encoded.
-  
+
+  The Git SSH protocol requires an SSH key to authenticate your repository. Setting SSH keys differs among hosting providers.
+  > **NOTE**: See [this](https://help.github.com/en/articles/generating-a-new-ssh-key-and-adding-it-to-the-ssh-agent#generating-a-new-ssh-key) document to read about the GitHub service.
+
+  The private key must be base64-encoded.
+
   To encode your private key, run this command:
   ```bash
     base64 -b -i {path_to_id_rsa} -o id_rsa-encoded
   ```
-  
+
   > **NOTE:** Private SSH key should not be secured by a passphrase.
 
   Create a corresponding Secret resource:
   ```bash
   kubectl create secret generic auth -n stage --from-file=key=id_rsa-encoded
   ```
-  Define a URL with the required sshkey option:
+  Define a URL with the required SSH key option:
   ```yaml
   apiVersion: addons.kyma-project.io/v1alpha1
   kind: ClusterAddonsConfiguration
@@ -209,12 +209,12 @@ spec:
     name: addons-cfg-sample
   spec:
     repositories:
-      # Git SSH protocol with a reference to a secret containing base64 encoded SSH private key
+      # Git SSH protocol with a reference to a Secret that contains base64-encoded SSH private key
       - url: "git::ssh://git@github.com/kyma-project/private-addons.git//addons/index.yaml?sshkey={key}"
         secretRef:
           name: auth
           namespace: stage
   ```
-  
+
 </details>
 </div>  

--- a/docs/helm-broker/03-03-create-addons-repo.md
+++ b/docs/helm-broker/03-03-create-addons-repo.md
@@ -184,7 +184,7 @@ spec:
   Git SSH
   </summary>
 
-  The Git SSH protocol requires an SSH key to authenticate your repository. Setting SSH keys differs among hosting providers. Read [this](https://help.github.com/en/articles/generating-a-new-ssh-key-and-adding-it-to-the-ssh-agent#generating-a-new-ssh-key) document to learn how to generate a new SSH key in the GitHub service.
+  The Git SSH protocol requires an SSH key to authenticate with your repository. Setting SSH keys differs among hosting providers. Read [this](https://help.github.com/en/articles/generating-a-new-ssh-key-and-adding-it-to-the-ssh-agent#generating-a-new-ssh-key) document to learn how to generate a new SSH key in the GitHub service.
   >**NOTE:** The Git SSH private key must be base64-encoded.
 
   Follow these steps to secure your addons repository with basic authentication credentials:

--- a/docs/helm-broker/03-03-create-addons-repo.md
+++ b/docs/helm-broker/03-03-create-addons-repo.md
@@ -208,7 +208,7 @@ spec:
     name: addons-cfg-sample
   spec:
     repositories:
-      # Git SSH protocol with a reference to a Secret that contains base64-encoded SSH private key
+      # Git SSH protocol with the reference to the Secret that contains base64-encoded SSH private key
       - url: "git::ssh://git@github.com/kyma-project/private-addons.git//addons/index.yaml?sshkey={key}"
         secretRef:
           name: auth

--- a/docs/helm-broker/06-01-clusteraddonsconfiguration.md
+++ b/docs/helm-broker/06-01-clusteraddonsconfiguration.md
@@ -83,7 +83,7 @@ This table lists all possible parameters of a given resource together with their
 | **spec.reprocessRequest**                | **NO**             | Allows you to manually trigger the reprocessing action of this CR. It is a strictly increasing, non-negative integer counter.    |
 | **spec.repositories.url**                | **YES**            | Provides the full URL to the index file of addons repositories.    |
 | **spec.repositories.secretRef.name**     | **NO**             | Defines the name of a Secret which provides values for the URL template.    |
-| **spec.repositories.secretRef.namespace**| **NO**             | Defines the name of a Secret which provides values for the URL template.    |
+| **spec.repositories.secretRef.namespace**| **NO**             | Defines the Namespace which stores a Secret that provides values for the URL template.    |
 | **status.phase**                       | **Not applicable** | Describes the status of processing the CR by the Helm Broker Controller. It can be `Ready`, `Failed`, or `Pending`.       |
 | **status.lastProcessedTime**           | **Not applicable** | Specifies the last time when the Helm Broker Controller processed the CR.     |
 | **status.observedGeneration**          | **Not applicable** | Specifies the most recent generation that the Helm Broker Controller observed.               |

--- a/docs/helm-broker/06-01-clusteraddonsconfiguration.md
+++ b/docs/helm-broker/06-01-clusteraddonsconfiguration.md
@@ -79,11 +79,11 @@ This table lists all possible parameters of a given resource together with their
 |---------------------------|:------------------:|-------------------------------|
 | **metadata.name**                        | **YES**            | Specifies the name of the CR.    |
 | **metadata.finalizers**                  | **YES**            | Specifies the finalizer which prevents the CR from deletion until the Controller completes the deletion logic. The default finalizer is `addons.kyma-project.io`.       |
-| **metadata.labels**                      | **NO**            | Specifies a key-value pair that helps you to organize and filter your CRs. The label indicating the default addon configuration is `addons.kyma-project.io/managed: "true"`.       |
+| **metadata.labels**                      | **NO**            | Specifies a key-value pair that helps you to organize and filter your CRs. The label that indicates the default addon configuration is `addons.kyma-project.io/managed: "true"`.       |
 | **spec.reprocessRequest**                | **NO**             | Allows you to manually trigger the reprocessing action of this CR. It is a strictly increasing, non-negative integer counter.    |
 | **spec.repositories.url**                | **YES**            | Provides the full URL to the index file of addons repositories.    |
-| **spec.repositories.secretRef.name**     | **NO**             | Defines the name of a Secret, which is used to provide values for URL template.    |
-| **spec.repositories.secretRef.namespace**| **NO**             | Defines the name of a Secret, which is used to provide values for the URL template.    |
+| **spec.repositories.secretRef.name**     | **NO**             | Defines the name of a Secret which provides values for the URL template.    |
+| **spec.repositories.secretRef.namespace**| **NO**             | Defines the name of a Secret which provides values for the URL template.    |
 | **status.phase**                       | **Not applicable** | Describes the status of processing the CR by the Helm Broker Controller. It can be `Ready`, `Failed`, or `Pending`.       |
 | **status.lastProcessedTime**           | **Not applicable** | Specifies the last time when the Helm Broker Controller processed the CR.     |
 | **status.observedGeneration**          | **Not applicable** | Specifies the most recent generation that the Helm Broker Controller observed.               |

--- a/docs/helm-broker/06-02-addonsconfiguration.md
+++ b/docs/helm-broker/06-02-addonsconfiguration.md
@@ -84,8 +84,8 @@ This table lists all possible parameters of a given resource together with their
 | **metadata.labels**                   | **NO**            | Specifies a key-value pair that helps you to organize and filter your CRs. The label indicating the default addon configuration is `addons.kyma-project.io/managed: "true"`.       |
 | **spec.reprocessRequest**              | **NO**             | Allows you to manually trigger the reprocessing action of this CR. It is a strictly increasing, non-negative integer counter.   |
 | **spec.repositories.url**              | **YES**            | Provides the full URL to the index file of addons repositories.    |
-| **spec.repositories.secretRef.name**     | **NO**           | Defines the name of a Secret, which is used to provide values for URL template.    |
-| **spec.repositories.secretRef.namespace**| **NO**           | Defines the namespace of a Secret, which is used to provide values for the URL template.    |
+| **spec.repositories.secretRef.name**     | **NO**           | Defines the name of a Secret which provides values for the URL template.    |
+| **spec.repositories.secretRef.namespace**| **NO**           | Defines the Namespace of a Secret which provides values for the URL template.    |
 | **status.phase**                       | **Not applicable** | Describes the status of processing the CR by the Helm Broker Controller. It can be `Ready`, `Failed`, or `Pending`.       |
 | **status.lastProcessedTime**           | **Not applicable** | Specifies the last time when the Helm Broker Controller processed the CR.     |
 | **status.observedGeneration**          | **Not applicable** | Specifies the most recent generation that the Helm Broker Controller observed.               |

--- a/docs/helm-broker/06-02-addonsconfiguration.md
+++ b/docs/helm-broker/06-02-addonsconfiguration.md
@@ -85,7 +85,7 @@ This table lists all possible parameters of a given resource together with their
 | **spec.reprocessRequest**              | **NO**             | Allows you to manually trigger the reprocessing action of this CR. It is a strictly increasing, non-negative integer counter.   |
 | **spec.repositories.url**              | **YES**            | Provides the full URL to the index file of addons repositories.    |
 | **spec.repositories.secretRef.name**     | **NO**           | Defines the name of a Secret which provides values for the URL template.    |
-| **spec.repositories.secretRef.namespace**| **NO**           | Defines the Namespace of a Secret which provides values for the URL template.    |
+| **spec.repositories.secretRef.namespace**| **NO**           | Defines the Namespace which stores a Secret that provides values for the URL template.    |
 | **status.phase**                       | **Not applicable** | Describes the status of processing the CR by the Helm Broker Controller. It can be `Ready`, `Failed`, or `Pending`.       |
 | **status.lastProcessedTime**           | **Not applicable** | Specifies the last time when the Helm Broker Controller processed the CR.     |
 | **status.observedGeneration**          | **Not applicable** | Specifies the most recent generation that the Helm Broker Controller observed.               |

--- a/docs/service-catalog/13-02-gcp-broker.md
+++ b/docs/service-catalog/13-02-gcp-broker.md
@@ -3,7 +3,7 @@ title: Google Cloud Platform Service Broker
 type: Service Brokers
 ---
 
->**NOTE:** This addon is in the preview mode and is not available in Kyma by default. To enable it, add a proper AddonsConfiguration as described [here](#enable-gcp-service-broker).
+>**NOTE:** This addon is in the preview mode and is not available in Kyma by default. To enable it, add a proper AddonsConfiguration as described [here](#service-brokers-google-cloud-platform-service-broker-enable-gcp-service-broker).
 
 The Google Cloud Platform (GCP) Service Broker is an open-source, [Open Service Broker](https://www.openservicebrokerapi.org/)-compatible API server that provisions managed services in the Google Cloud Platform public cloud. Kyma provides Namespace-scoped GCP Service Broker. In each Namespace, you can configure the GCP Service Broker against different subscriptions. Install the GCP Service Broker by provisioning the **Google Cloud Platform Service Broker** class provided by the Helm Broker.
 


### PR DESCRIPTION
…ong context

<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/master/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- Change wrong use of the `authorization` word in the HB docs
- Improve the description of the protocols with authentication  

