### PR TITLE
Change file paths because of changed permissions

### DIFF
--- a/components/xip-patch/certhelper.sh
+++ b/components/xip-patch/certhelper.sh
@@ -48,10 +48,10 @@ EOF
 
 function generateCerts() {
   echo "---> Generating Certs for ${DOMAIN}"
-  generateCertificatesForDomain "${DOMAIN}" /root/key.pem /root/cert.pem
-  CERT=$(base64 /root/cert.pem | tr -d '\n')
-  KEY=$(base64 /root/key.pem | tr -d '\n')
-  rm /root/key.pem /root/cert.pem
+  generateCertificatesForDomain "${DOMAIN}" ${HOME}/key.pem ${HOME}/cert.pem
+  CERT=$(base64 ${HOME}/cert.pem | tr -d '\n')
+  KEY=$(base64 ${HOME}/key.pem | tr -d '\n')
+  rm ${HOME}/key.pem ${HOME}/cert.pem
   TLS_CERT_AND_KEY_YAML=$(cat << EOF
 ---
 data:


### PR DESCRIPTION
**Description**

Application-connector-helper job fails because of invalid file permissions.
This happens because the job used to run as root, but from Kyma 1.5 it runs as non-root account.

Changes proposed in this pull request:
- Paths used in script changed so that configured non-root account has access.
