### PR TITLE
Add labels to Framefrogs OWNERS files

### DIFF
--- a/components/application-connectivity-certs-setup-job/OWNERS
+++ b/components/application-connectivity-certs-setup-job/OWNERS
@@ -5,3 +5,5 @@ approvers:
   - franpog859 
   - Maladie
   - crabtree
+labels:
+  - area/application-connector

--- a/components/application-connectivity-validator/OWNERS
+++ b/components/application-connectivity-validator/OWNERS
@@ -5,3 +5,5 @@ approvers:
   - franpog859 
   - Maladie
   - crabtree
+labels:
+  - area/application-connector

--- a/components/application-gateway/OWNERS
+++ b/components/application-gateway/OWNERS
@@ -5,3 +5,5 @@ approvers:
   - franpog859 
   - Maladie
   - crabtree
+labels:
+  - area/application-connector

--- a/components/application-operator/OWNERS
+++ b/components/application-operator/OWNERS
@@ -5,3 +5,5 @@ approvers:
   - franpog859 
   - Maladie
   - crabtree
+labels:
+  - area/application-connector

--- a/components/application-registry/OWNERS
+++ b/components/application-registry/OWNERS
@@ -5,3 +5,5 @@ approvers:
   - franpog859 
   - Maladie
   - crabtree
+labels:
+  - area/application-connector

--- a/components/connection-token-handler/OWNERS
+++ b/components/connection-token-handler/OWNERS
@@ -5,3 +5,5 @@ approvers:
   - franpog859 
   - Maladie
   - crabtree
+labels:
+  - area/application-connector

--- a/components/connectivity-certs-controller/OWNERS
+++ b/components/connectivity-certs-controller/OWNERS
@@ -5,3 +5,5 @@ approvers:
   - franpog859 
   - Maladie
   - crabtree
+labels:
+  - area/application-connector

--- a/components/connector-service/OWNERS
+++ b/components/connector-service/OWNERS
@@ -5,3 +5,5 @@ approvers:
   - franpog859 
   - Maladie
   - crabtree
+labels:
+  - area/application-connector

--- a/resources/application-connector-helper/OWNERS
+++ b/resources/application-connector-helper/OWNERS
@@ -13,3 +13,6 @@ reviewers:
   - jakkab
   - Tomasz-Smelcerz-SAP
   - Demonsthere
+
+labels:
+  - area/application-connector

--- a/resources/application-connector-ingress/OWNERS
+++ b/resources/application-connector-ingress/OWNERS
@@ -5,3 +5,5 @@ approvers:
   - franpog859 
   - Maladie
   - crabtree
+labels:
+  - area/application-connector

--- a/resources/application-connector/charts/application-operator/OWNERS
+++ b/resources/application-connector/charts/application-operator/OWNERS
@@ -5,3 +5,5 @@ approvers:
   - franpog859 
   - Maladie
   - crabtree
+labels:
+  - area/application-connector

--- a/resources/application-connector/charts/application-registry/OWNERS
+++ b/resources/application-connector/charts/application-registry/OWNERS
@@ -5,3 +5,5 @@ approvers:
   - franpog859 
   - Maladie
   - crabtree
+labels:
+  - area/application-connector

--- a/resources/application-connector/charts/connection-token-handler/OWNERS
+++ b/resources/application-connector/charts/connection-token-handler/OWNERS
@@ -5,3 +5,5 @@ approvers:
   - franpog859 
   - Maladie
   - crabtree
+labels:
+  - area/application-connector

--- a/resources/application-connector/charts/connectivity-certs-controller/OWNERS
+++ b/resources/application-connector/charts/connectivity-certs-controller/OWNERS
@@ -5,3 +5,5 @@ approvers:
   - franpog859 
   - Maladie
   - crabtree
+labels:
+  - area/application-connector

--- a/resources/application-connector/charts/connector-service/OWNERS
+++ b/resources/application-connector/charts/connector-service/OWNERS
@@ -5,3 +5,5 @@ approvers:
   - franpog859 
   - Maladie
   - crabtree
+labels:
+  - area/application-connector

--- a/tests/application-connector-tests/OWNERS
+++ b/tests/application-connector-tests/OWNERS
@@ -5,3 +5,5 @@ approvers:
   - franpog859 
   - Maladie
   - crabtree
+labels:
+  - area/application-connector

--- a/tests/application-gateway-tests/OWNERS
+++ b/tests/application-gateway-tests/OWNERS
@@ -5,3 +5,5 @@ approvers:
   - franpog859 
   - Maladie
   - crabtree
+labels:
+  - area/application-connector

--- a/tests/application-operator-tests/OWNERS
+++ b/tests/application-operator-tests/OWNERS
@@ -5,3 +5,5 @@ approvers:
   - franpog859 
   - Maladie
   - crabtree
+labels:
+  - area/application-connector

--- a/tests/application-registry-tests/OWNERS
+++ b/tests/application-registry-tests/OWNERS
@@ -5,3 +5,5 @@ approvers:
   - franpog859 
   - Maladie
   - crabtree
+labels:
+  - area/application-connector

--- a/tests/connection-token-handler-tests/OWNERS
+++ b/tests/connection-token-handler-tests/OWNERS
@@ -5,3 +5,5 @@ approvers:
   - franpog859 
   - Maladie
   - crabtree
+labels:
+  - area/application-connector

--- a/tests/connector-service-tests/OWNERS
+++ b/tests/connector-service-tests/OWNERS
@@ -5,3 +5,5 @@ approvers:
   - franpog859 
   - Maladie
   - crabtree
+labels:
+  - area/application-connector


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Add the `area/application-connector` label to the OWNERS files for the Framefrogs team in:

	- The `application-connector` chart
	- The `connector-service` subchart
	- The `connection-token-handler` subchart
	- The `connectivity-certs-controller` subchart
	- The `application-registry` subchart
	- The `application-operator` subchart
	- Connector Service Component
	- Connection Token Handler Component
	- Connectivity Certs Controller Component
	- Application Registry Component
	- Application Operator Component
	- Application Gateway Component
	- Application Connectivity Validator Component
	- Application Connectivity Certs Setup Job Component
	- Connector Service Tests
	- Application Registry Tests
	- Application Gateway Tests
	- Application Operator Tests
	- Application Connector Tests
	- Connection Token Handler Tests
	- The `application-connector-helper` chart


**Related issue(s)**
None