### PR TITLE
Adjust label definition to the new Compass API

### DIFF
--- a/tests/compass-runtime-agent/Gopkg.lock
+++ b/tests/compass-runtime-agent/Gopkg.lock
@@ -191,14 +191,16 @@
   version = "v1.0.2"
 
 [[projects]]
-  digest = "1:bdcf690dbe0400221778efd2009249748ecedf9fdac10fcb5d0dc03eaab78437"
+  branch = "fix-schema-as-string"
+  digest = "1:a1bccfad08a451631f68bd47d1beb2e21b8147c44175be661ed2ec5d9d7a7be0"
   name = "github.com/kyma-incubator/compass"
   packages = [
     "components/director/pkg/graphql",
     "components/director/pkg/scalar",
   ]
   pruneopts = "UT"
-  revision = "67216042cc8eff1d5352b9d7f8340dce9f40902c"
+  revision = "56233ec1086ed8b2a97a97a6d4b1d2765f332946"
+  source = "github.com/dbadura/compass"
 
 [[projects]]
   digest = "1:bca259d300baf6a00f5046bda527fcbe4ce8d9b9284565815444814a10d106fe"

--- a/tests/compass-runtime-agent/Gopkg.lock
+++ b/tests/compass-runtime-agent/Gopkg.lock
@@ -191,7 +191,6 @@
   version = "v1.0.2"
 
 [[projects]]
-  branch = "fix-schema-as-string"
   digest = "1:a1bccfad08a451631f68bd47d1beb2e21b8147c44175be661ed2ec5d9d7a7be0"
   name = "github.com/kyma-incubator/compass"
   packages = [
@@ -199,8 +198,7 @@
     "components/director/pkg/scalar",
   ]
   pruneopts = "UT"
-  revision = "56233ec1086ed8b2a97a97a6d4b1d2765f332946"
-  source = "github.com/dbadura/compass"
+  revision = "d07b0a01e87f0bb476f7aaa80119dd0f1bcbd756"
 
 [[projects]]
   digest = "1:bca259d300baf6a00f5046bda527fcbe4ce8d9b9284565815444814a10d106fe"

--- a/tests/compass-runtime-agent/Gopkg.toml
+++ b/tests/compass-runtime-agent/Gopkg.toml
@@ -13,7 +13,9 @@ required = [
 
 [[constraint]]
   name = "github.com/kyma-incubator/compass"
-  revision = "67216042cc8eff1d5352b9d7f8340dce9f40902c"
+  source = "github.com/dbadura/compass"
+  branch = "fix-schema-as-string"
+#  revision = "67216042cc8eff1d5352b9d7f8340dce9f40902c"
 
 [[constraint]]
   name = "k8s.io/client-go"

--- a/tests/compass-runtime-agent/Gopkg.toml
+++ b/tests/compass-runtime-agent/Gopkg.toml
@@ -13,9 +13,7 @@ required = [
 
 [[constraint]]
   name = "github.com/kyma-incubator/compass"
-  source = "github.com/dbadura/compass"
-  branch = "fix-schema-as-string"
-#  revision = "67216042cc8eff1d5352b9d7f8340dce9f40902c"
+  revision = "d07b0a01e87f0bb476f7aaa80119dd0f1bcbd756"
 
 [[constraint]]
   name = "k8s.io/client-go"

--- a/tests/compass-runtime-agent/test/runtimeagent/test/runtime_agent_test.go
+++ b/tests/compass-runtime-agent/test/runtimeagent/test/runtime_agent_test.go
@@ -230,6 +230,7 @@ func TestCompassRuntimeAgentSynchronization(t *testing.T) {
 			},
 		},
 		// TODO: CSRF Tokens does not work properly with Director (https://github.com/kyma-incubator/compass/issues/207)
+		// TODO: Issue is closed
 		//{
 		//	description: "Test case 4:Fetch new CSRF token and retry if token expired",
 		//	initialPhaseInput: func() *applications.ApplicationInput {

--- a/tests/compass-runtime-agent/test/testkit/compass/client.go
+++ b/tests/compass-runtime-agent/test/testkit/compass/client.go
@@ -3,7 +3,6 @@ package compass
 import (
 	"context"
 	"crypto/tls"
-	"fmt"
 	"net/http"
 
 	"github.com/sirupsen/logrus"
@@ -104,7 +103,7 @@ func (c *Client) getScenarios() (ScenariosSchema, error) {
 	if err != nil {
 		return ScenariosSchema{}, errors.Wrap(err, "Failed to get scenarios label definition")
 	}
-	fmt.Println(response)
+
 	scenarioSchema, err := ToScenarioSchema(response)
 	if err != nil {
 		return ScenariosSchema{}, errors.Wrap(err, "Failed to get scenario schema")

--- a/tests/compass-runtime-agent/test/testkit/compass/client.go
+++ b/tests/compass-runtime-agent/test/testkit/compass/client.go
@@ -108,7 +108,12 @@ func (c *Client) getScenarios() (ScenariosSchema, error) {
 }
 
 func (c *Client) updateScenarios(schema ScenariosSchema) (ScenariosSchema, error) {
-	gqlInput, err := c.graphqlizer.LabelDefinitionInputToGQL(schema.ToLabelDefinitionInput(ScenariosLabelName))
+	labelDef, err := schema.ToLabelDefinitionInput(ScenariosLabelName)
+	if err != nil {
+		return ScenariosSchema{}, errors.Wrap(err, "Failed to convert ScenarioSchema")
+	}
+
+	gqlInput, err := c.graphqlizer.LabelDefinitionInputToGQL(labelDef)
 	if err != nil {
 		return ScenariosSchema{}, errors.Wrap(err, "Failed to convert LabelDefinitionInput")
 	}

--- a/tests/compass-runtime-agent/test/testkit/compass/client.go
+++ b/tests/compass-runtime-agent/test/testkit/compass/client.go
@@ -3,6 +3,7 @@ package compass
 import (
 	"context"
 	"crypto/tls"
+	"fmt"
 	"net/http"
 
 	"github.com/sirupsen/logrus"
@@ -103,8 +104,13 @@ func (c *Client) getScenarios() (ScenariosSchema, error) {
 	if err != nil {
 		return ScenariosSchema{}, errors.Wrap(err, "Failed to get scenarios label definition")
 	}
+	fmt.Println(response)
+	scenarioSchema, err := ToScenarioSchema(response)
+	if err != nil {
+		return ScenariosSchema{}, errors.Wrap(err, "Failed to get scenario schema")
+	}
 
-	return response.Result.Schema, nil
+	return scenarioSchema, nil
 }
 
 func (c *Client) updateScenarios(schema ScenariosSchema) (ScenariosSchema, error) {
@@ -126,7 +132,12 @@ func (c *Client) updateScenarios(schema ScenariosSchema) (ScenariosSchema, error
 		return ScenariosSchema{}, errors.Wrap(err, "Failed to update scenarios label definition")
 	}
 
-	return response.Result.Schema, nil
+	scenarioSchema, err := ToScenarioSchema(response)
+	if err != nil {
+		return ScenariosSchema{}, errors.Wrap(err, "Failed to get scenario schema")
+	}
+
+	return scenarioSchema, nil
 }
 
 func (c *Client) labelRuntime(values []string) error {

--- a/tests/compass-runtime-agent/test/testkit/compass/model.go
+++ b/tests/compass-runtime-agent/test/testkit/compass/model.go
@@ -43,7 +43,7 @@ type SetRuntimeLabelResponse struct {
 
 type ScenarioLabelDefinitionResponse struct {
 	Result struct {
-		Key    string
-		Schema ScenariosSchema
-	}
+		Key    string             `json:"key"`
+		Schema graphql.JSONSchema `json:"schema"`
+	} `json:"result"`
 }

--- a/tests/compass-runtime-agent/test/testkit/compass/model.go
+++ b/tests/compass-runtime-agent/test/testkit/compass/model.go
@@ -43,7 +43,7 @@ type SetRuntimeLabelResponse struct {
 
 type ScenarioLabelDefinitionResponse struct {
 	Result struct {
-		Key    string             `json:"key"`
-		Schema graphql.JSONSchema `json:"schema"`
+		Key    string              `json:"key"`
+		Schema *graphql.JSONSchema `json:"schema"`
 	} `json:"result"`
 }

--- a/tests/compass-runtime-agent/test/testkit/compass/scenarios.go
+++ b/tests/compass-runtime-agent/test/testkit/compass/scenarios.go
@@ -21,7 +21,12 @@ type ScenariosItems struct {
 
 func ToScenarioSchema(response ScenarioLabelDefinitionResponse) (ScenariosSchema, error) {
 	var scenarioSchema ScenariosSchema
-	err := json.Unmarshal([]byte(response.Result.Schema), &scenarioSchema)
+
+	if response.Result.Schema == nil {
+		return ScenariosSchema{}, nil
+	}
+
+	err := json.Unmarshal([]byte(*response.Result.Schema), &scenarioSchema)
 	if err != nil {
 		return ScenariosSchema{}, errors.Wrap(err, "Failed to unmarshall scenario schema")
 	}

--- a/tests/compass-runtime-agent/test/testkit/compass/scenarios.go
+++ b/tests/compass-runtime-agent/test/testkit/compass/scenarios.go
@@ -1,6 +1,11 @@
 package compass
 
-import "github.com/kyma-incubator/compass/components/director/pkg/graphql"
+import (
+	"encoding/json"
+
+	"github.com/kyma-incubator/compass/components/director/pkg/graphql"
+	"github.com/pkg/errors"
+)
 
 type ScenariosSchema struct {
 	Type        string         `json:"type"`
@@ -12,6 +17,15 @@ type ScenariosSchema struct {
 type ScenariosItems struct {
 	Type string   `json:"type"`
 	Enum []string `json:"enum"`
+}
+
+func ToScenarioSchema(response ScenarioLabelDefinitionResponse) (ScenariosSchema, error) {
+	var scenarioSchema ScenariosSchema
+	err := json.Unmarshal([]byte(response.Result.Schema), &scenarioSchema)
+	if err != nil {
+		return ScenariosSchema{}, errors.Wrap(err, "Failed to unmarshall scenario schema")
+	}
+	return scenarioSchema, nil
 }
 
 func (ss *ScenariosSchema) ToLabelDefinitionInput(key string) (graphql.LabelDefinitionInput, error) {

--- a/tests/compass-runtime-agent/test/testkit/compass/scenarios.go
+++ b/tests/compass-runtime-agent/test/testkit/compass/scenarios.go
@@ -14,13 +14,17 @@ type ScenariosItems struct {
 	Enum []string `json:"enum"`
 }
 
-func (ss *ScenariosSchema) ToLabelDefinitionInput(key string) graphql.LabelDefinitionInput {
-	var schema interface{} = ss
+func (ss *ScenariosSchema) ToLabelDefinitionInput(key string) (graphql.LabelDefinitionInput, error) {
+	var inputSchema interface{} = ss
+	schema, err := graphql.MarshalSchema(&inputSchema)
+	if err != nil {
+		return graphql.LabelDefinitionInput{}, err
+	}
 
 	return graphql.LabelDefinitionInput{
 		Key:    key,
-		Schema: &schema,
-	}
+		Schema: schema,
+	}, nil
 }
 
 func (ss *ScenariosSchema) AddScenario(value string) {

--- a/tests/compass-runtime-agent/test/testkit/graphql/graphqlizer.go
+++ b/tests/compass-runtime-agent/test/testkit/graphql/graphqlizer.go
@@ -293,7 +293,7 @@ func (g *Graphqlizer) LabelFilterToGQL(in graphql.LabelFilter) (string, error) {
 	}`)
 }
 
-func (g *Graphqlizer) SchemaToGQL(in *interface{}) (string, error) {
+func (g *Graphqlizer) SchemaToGQL(in graphql.JSONSchema) (string, error) {
 	out, err := json.Marshal(in)
 	if err != nil {
 		return "", errors.Wrap(err, "while marshalling json schema")

--- a/tests/compass-runtime-agent/test/testkit/graphql/graphqlizer.go
+++ b/tests/compass-runtime-agent/test/testkit/graphql/graphqlizer.go
@@ -293,8 +293,12 @@ func (g *Graphqlizer) LabelFilterToGQL(in graphql.LabelFilter) (string, error) {
 	}`)
 }
 
-func (g *Graphqlizer) SchemaToGQL(in graphql.JSONSchema) (string, error) {
-	out, err := json.Marshal(in)
+func (g *Graphqlizer) SchemaToGQL(in *graphql.JSONSchema) (string, error) {
+	if in == nil {
+		return "", nil
+	}
+
+	out, err := json.Marshal(*in)
 	if err != nil {
 		return "", errors.Wrap(err, "while marshalling json schema")
 	}


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/master/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**
Compass changed input type `schema` for `label definition` from `interface{}` to `string`. 
Changes proposed in this pull request:
- Adjust compass client to be compatible with new API

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
Related issue https://github.com/kyma-incubator/compass/issues/258
Not ready to merge, only shows that this change works with new changes in compass API. After merging [Schema change](https://github.com/kyma-incubator/compass/issues/258), need to point dep to master and then change.