### PR TITLE
Disable Application Operator Tests on Minikube

### DIFF
--- a/resources/application-connector/charts/application-operator/templates/tests/test.yaml
+++ b/resources/application-connector/charts/application-operator/templates/tests/test.yaml
@@ -1,4 +1,4 @@
-{{ if .Values.tests.enabled }}
+{{ if and ( .Values.tests.enabled ) ( not .Values.global.isLocalEnv ) }}
 {{- if .Capabilities.APIVersions.Has "testing.kyma-project.io/v1alpha1" }}
 apiVersion: "testing.kyma-project.io/v1alpha1"
 kind: TestDefinition


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/master/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Application Operator tests require a significant amount of resources to run properly. Therefore due to lack of resources on local deployment on Minikube, the tests are failing sometimes. 

Changes proposed in this pull request:

- Disable Application Operator tests on local deployment

**Related issue(s)**
#5637 