### PR TITLE
Fix Knative Channel Name issue

### DIFF
--- a/components/event-bus/cmd/event-publish-service/publisher/publisher.go
+++ b/components/event-bus/cmd/event-publish-service/publisher/publisher.go
@@ -92,7 +92,7 @@ func (publisher *DefaultKnativePublisher) Publish(knativeLib *knative.KnativeLib
 	knativeChannelLabels[subscriptionEventTypeVersion] = eventTypeVersion
 
 	//Fetch knative channel via label
-	channel, err := knativeLib.GetChannelByLabels(*namespace, &knativeChannelLabels)
+	channel, err := knativeLib.GetChannelByLabels(*namespace, knativeChannelLabels)
 	if err != nil {
 		log.Printf("an error occured while trying to get the knative channel for source: '%v', event-type: '%v', event-type-version: '%v' in namespace '%v'\n"+
 			"error: '%v':", source, eventType, eventTypeVersion, *namespace, err)

--- a/components/event-bus/internal/knative/subscription/controller/subscription/reconcile.go
+++ b/components/event-bus/internal/knative/subscription/controller/subscription/reconcile.go
@@ -153,7 +153,7 @@ func (r *reconciler) reconcile(ctx context.Context, subscription *eventingv1alph
 		KymaSubscriptionsGauge.DeleteKymaSubscriptionsGaugeLabelValues(subscription.Namespace, subscription.Name)
 		if util.ContainsString(&subscription.ObjectMeta.Finalizers, finalizerName) {
 			// our finalizer is present, so lets handle our external dependency
-			if err := r.deleteExternalDependency(ctx, knativeSubsName, &knativeChannelLabels, knativeSubsNamespace,
+			if err := r.deleteExternalDependency(ctx, knativeSubsName, knativeChannelLabels, knativeSubsNamespace,
 				subscription.Name, knativeSubscriptionsGauge, knativeChannelGauge); err != nil {
 				// if fail to delete the external dependency here, return with error
 				// so that it can be retried
@@ -174,7 +174,7 @@ func (r *reconciler) reconcile(ctx context.Context, subscription *eventingv1alph
 	// Check if Kyma Subscription has events-activated condition.
 	if subscription.HasCondition(eventingv1alpha1.SubscriptionCondition{Type: eventingv1alpha1.EventsActivated, Status: eventingv1alpha1.ConditionTrue}) {
 		// Check if Knative Channel already exists, create if not.
-		knativeChannel, err := r.knativeLib.GetChannelByLabels(knativeSubsNamespace, &knativeChannelLabels)
+		knativeChannel, err := r.knativeLib.GetChannelByLabels(knativeSubsNamespace, knativeChannelLabels)
 		if err != nil && !errors.IsNotFound(err) {
 			return false, err
 		} else if errors.IsNotFound(err) {
@@ -250,7 +250,7 @@ func (r *reconciler) reconcile(ctx context.Context, subscription *eventingv1alph
 		}
 
 		// Check if Channel has any other Subscription, if not, delete it.
-		knativeChannel, err := r.knativeLib.GetChannelByLabels(knativeSubsNamespace, &knativeChannelLabels)
+		knativeChannel, err := r.knativeLib.GetChannelByLabels(knativeSubsNamespace, knativeChannelLabels)
 		if err != nil && !errors.IsNotFound(err) {
 			return false, err
 		} else if err == nil && knativeChannel != nil {
@@ -270,7 +270,7 @@ func (r *reconciler) reconcile(ctx context.Context, subscription *eventingv1alph
 	return false, nil
 }
 
-func (r *reconciler) deleteExternalDependency(ctx context.Context, knativeSubsName string, channelLabels *map[string]string,
+func (r *reconciler) deleteExternalDependency(ctx context.Context, knativeSubsName string, channelLabels map[string]string,
 	namespace string, kymaSubscriptionName string, knativeSubscriptionsGauge *metrics.SubscriptionsGauge,
 	knativeChannelGauge *metrics.SubscriptionsGauge) error {
 	log.Info("Deleting the external dependencies")

--- a/components/event-bus/internal/knative/subscription/controller/subscription/reconcile.go
+++ b/components/event-bus/internal/knative/subscription/controller/subscription/reconcile.go
@@ -129,7 +129,6 @@ func (r *reconciler) reconcile(ctx context.Context, subscription *eventingv1alph
 	knativeSubsName := util.GetKnSubscriptionName(&subscription.Name, &subscription.Namespace)
 	knativeSubsNamespace := util.GetDefaultChannelNamespace()
 	knativeSubsURI := subscription.Endpoint
-	//knativeChannelName := eventBusUtil.GetKnativeChannelName(&subscription.SubscriptionSpec.SourceID, &subscription.SubscriptionSpec.EventType, r.opts.MaxChannelNameLength)
 	timeout := r.opts.ChannelTimeout
 
 	//Adding the event-metadata as channel labels

--- a/components/event-bus/internal/knative/subscription/controller/subscription/reconcile.go
+++ b/components/event-bus/internal/knative/subscription/controller/subscription/reconcile.go
@@ -180,7 +180,7 @@ func (r *reconciler) reconcile(ctx context.Context, subscription *eventingv1alph
 		} else if errors.IsNotFound(err) {
 
 			knativeChannel, err = r.knativeLib.CreateChannel(subscription.SubscriptionSpec.EventType,
-				knativeSubsNamespace, &knativeChannelLabels, timeout)
+				knativeSubsNamespace, knativeChannelLabels, timeout)
 			if err != nil {
 				return false, err
 			}

--- a/components/event-bus/internal/knative/subscription/controller/subscription/reconcile.go
+++ b/components/event-bus/internal/knative/subscription/controller/subscription/reconcile.go
@@ -7,7 +7,6 @@ import (
 	"github.com/kyma-project/kyma/components/event-bus/internal/knative/metrics"
 	"github.com/kyma-project/kyma/components/event-bus/internal/knative/subscription/opts"
 	"github.com/kyma-project/kyma/components/event-bus/internal/knative/util"
-	eventBusUtil "github.com/kyma-project/kyma/components/event-bus/pkg/util"
 	"github.com/prometheus/client_golang/prometheus"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -130,7 +129,7 @@ func (r *reconciler) reconcile(ctx context.Context, subscription *eventingv1alph
 	knativeSubsName := util.GetKnSubscriptionName(&subscription.Name, &subscription.Namespace)
 	knativeSubsNamespace := util.GetDefaultChannelNamespace()
 	knativeSubsURI := subscription.Endpoint
-	knativeChannelName := eventBusUtil.GetKnativeChannelName(&subscription.SubscriptionSpec.SourceID, &subscription.SubscriptionSpec.EventType, r.opts.MaxChannelNameLength)
+	//knativeChannelName := eventBusUtil.GetKnativeChannelName(&subscription.SubscriptionSpec.SourceID, &subscription.SubscriptionSpec.EventType, r.opts.MaxChannelNameLength)
 	timeout := r.opts.ChannelTimeout
 
 	//Adding the event-metadata as channel labels
@@ -181,7 +180,7 @@ func (r *reconciler) reconcile(ctx context.Context, subscription *eventingv1alph
 			return false, err
 		} else if errors.IsNotFound(err) {
 
-			knativeChannel, err = r.knativeLib.CreateChannel(knativeChannelName,
+			knativeChannel, err = r.knativeLib.CreateChannel(subscription.SubscriptionSpec.EventType,
 				knativeSubsNamespace, &knativeChannelLabels, timeout)
 			if err != nil {
 				return false, err

--- a/components/event-bus/internal/knative/subscription/controller/subscription/reconcile_test.go
+++ b/components/event-bus/internal/knative/subscription/controller/subscription/reconcile_test.go
@@ -366,7 +366,7 @@ func (k *MockKnativeLib) GetChannelByLabels(namespace string, labels *map[string
 	return k.GetChannel(channelName, namespace)
 }
 
-func (k *MockKnativeLib) CreateChannel(name string, namespace string, labels *map[string]string, timeout time.Duration) (*messagingV1Alpha1.Channel, error) {
+func (k *MockKnativeLib) CreateChannel(name string, namespace string, labels map[string]string, timeout time.Duration) (*messagingV1Alpha1.Channel, error) {
 	channel := makeKnChannel(namespace, name, labels)
 	knChannels[channel.Name] = channel
 	return channel, nil
@@ -405,12 +405,12 @@ func (k *MockKnativeLib) InjectClient(evClient eventingV1Alpha1.EventingV1alpha1
 }
 
 //  make channels
-func makeKnChannel(namespace string, name string, labels *map[string]string) *messagingV1Alpha1.Channel {
+func makeKnChannel(namespace string, name string, labels map[string]string) *messagingV1Alpha1.Channel {
 	return &messagingV1Alpha1.Channel{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: namespace,
 			Name:      name,
-			Labels:    *labels,
+			Labels:    labels,
 			UID:       chanUID,
 		},
 		Status: messagingV1Alpha1.ChannelStatus{
@@ -436,7 +436,7 @@ func makeKnSubscriptionName(kySub *eventingv1alpha1.Subscription) string {
 
 func makeKnativeLibChannel() *messagingV1Alpha1.Channel {
 	chNamespace := util.GetDefaultChannelNamespace()
-	channel, _ := knativeLib.CreateChannel(makeKnChannelName(makeEventsActivatedSubscription()), chNamespace, &labels, time.Second)
+	channel, _ := knativeLib.CreateChannel(makeKnChannelName(makeEventsActivatedSubscription()), chNamespace, labels, time.Second)
 	channel.SetClusterName("fake-channel") // use it as a marker
 	knChannels[channel.Name] = channel
 	return channel

--- a/components/event-bus/internal/knative/subscription/controller/subscription/reconcile_test.go
+++ b/components/event-bus/internal/knative/subscription/controller/subscription/reconcile_test.go
@@ -357,7 +357,7 @@ func (k *MockKnativeLib) GetChannel(name string, namespace string) (*messagingV1
 	return channel, nil
 }
 
-func (k *MockKnativeLib) GetChannelByLabels(namespace string, labels *map[string]string) (*messagingV1Alpha1.Channel, error) {
+func (k *MockKnativeLib) GetChannelByLabels(namespace string, labels map[string]string) (*messagingV1Alpha1.Channel, error) {
 	var channelName string
 	for name := range knChannels {
 		channelName = name

--- a/components/event-bus/internal/knative/util/kn-eventing.go
+++ b/components/event-bus/internal/knative/util/kn-eventing.go
@@ -64,7 +64,7 @@ var once sync.Once
 type KnativeAccessLib interface {
 	GetChannel(name string, namespace string) (*messagingV1Alpha1.Channel, error)
 	GetChannelByLabels(namespace string, labels *map[string]string) (*messagingV1Alpha1.Channel, error)
-	CreateChannel(generatedName string, namespace string, labels *map[string]string,
+	CreateChannel(prefix string, namespace string, labels *map[string]string,
 		timeout time.Duration) (*messagingV1Alpha1.Channel, error)
 	DeleteChannel(name string, namespace string) error
 	CreateSubscription(name string, namespace string, channelName string, uri *string) error
@@ -159,9 +159,9 @@ func (k *KnativeLib) GetChannelByLabels(namespace string, labels *map[string]str
 }
 
 // CreateChannel creates a Knative/Eventing channel controlled by the specified provisioner
-func (k *KnativeLib) CreateChannel(generatedName string, namespace string, labels *map[string]string,
+func (k *KnativeLib) CreateChannel(prefix string, namespace string, labels *map[string]string,
 	timeout time.Duration) (*messagingV1Alpha1.Channel, error) {
-	c := makeChannel(generatedName, namespace, labels)
+	c := makeChannel(prefix, namespace, labels)
 	channel, err := k.messagingChannel.Channels(namespace).Create(c)
 	if err != nil && !k8serrors.IsAlreadyExists(err) {
 		log.Printf("ERROR: CreateChannel(): creating channel: %v", err)
@@ -336,11 +336,11 @@ func resendMessage(httpClient *http.Client, channel *messagingV1Alpha1.Channel, 
 	return nil
 }
 
-func makeChannel(generatedName string, namespace string, labels *map[string]string) *messagingV1Alpha1.Channel {
+func makeChannel(prefix string, namespace string, labels *map[string]string) *messagingV1Alpha1.Channel {
 	return &messagingV1Alpha1.Channel{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace:    namespace,
-			GenerateName: generatedName,
+			GenerateName: prefix,
 			Labels:       *labels,
 		},
 	}

--- a/components/event-bus/internal/knative/util/kn-eventing.go
+++ b/components/event-bus/internal/knative/util/kn-eventing.go
@@ -8,6 +8,7 @@ import (
 	"log"
 	"net/http"
 	"net/http/httputil"
+	"regexp"
 	"sync"
 	"time"
 
@@ -57,6 +58,8 @@ if err := k.CreateSubscription("my-sub", namespace, channelName, &uri); err != n
 }
 return
 */
+
+const HYPHEN = "-"
 
 var once sync.Once
 
@@ -337,6 +340,13 @@ func resendMessage(httpClient *http.Client, channel *messagingV1Alpha1.Channel, 
 }
 
 func makeChannel(prefix string, namespace string, labels *map[string]string) *messagingV1Alpha1.Channel {
+	// Remove all the special characters from the prefix string
+	reg, err := regexp.Compile("[^a-z0-9]+")
+	if err != nil {
+		log.Fatal(err)
+	}
+	prefix = fmt.Sprint(reg.ReplaceAllString(prefix, ""), HYPHEN)
+
 	return &messagingV1Alpha1.Channel{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace:    namespace,

--- a/components/event-bus/internal/knative/util/kn-eventing.go
+++ b/components/event-bus/internal/knative/util/kn-eventing.go
@@ -67,7 +67,7 @@ var once sync.Once
 type KnativeAccessLib interface {
 	GetChannel(name string, namespace string) (*messagingV1Alpha1.Channel, error)
 	GetChannelByLabels(namespace string, labels *map[string]string) (*messagingV1Alpha1.Channel, error)
-	CreateChannel(prefix string, namespace string, labels *map[string]string,
+	CreateChannel(prefix, namespace string, labels map[string]string,
 		timeout time.Duration) (*messagingV1Alpha1.Channel, error)
 	DeleteChannel(name string, namespace string) error
 	CreateSubscription(name string, namespace string, channelName string, uri *string) error

--- a/components/event-bus/internal/knative/util/kn-eventing.go
+++ b/components/event-bus/internal/knative/util/kn-eventing.go
@@ -59,7 +59,7 @@ if err := k.CreateSubscription("my-sub", namespace, channelName, &uri); err != n
 return
 */
 
-const hyphen = "-"
+const generateNameSuffix = "-"
 
 var once sync.Once
 
@@ -345,7 +345,7 @@ func makeChannel(prefix, namespace string, labels map[string]string) *messagingV
 	if err != nil {
 		log.Fatal(err)
 	}
-	prefix = fmt.Sprint(reg.ReplaceAllString(prefix, ""), hyphen)
+	prefix = fmt.Sprint(reg.ReplaceAllString(prefix, ""), generateNameSuffix)
 
 	return &messagingV1Alpha1.Channel{
 		ObjectMeta: metav1.ObjectMeta{

--- a/components/event-bus/internal/knative/util/kn-eventing.go
+++ b/components/event-bus/internal/knative/util/kn-eventing.go
@@ -339,7 +339,7 @@ func resendMessage(httpClient *http.Client, channel *messagingV1Alpha1.Channel, 
 	return nil
 }
 
-func makeChannel(prefix string, namespace string, labels *map[string]string) *messagingV1Alpha1.Channel {
+func makeChannel(prefix, namespace string, labels map[string]string) *messagingV1Alpha1.Channel {
 	// Remove all the special characters from the prefix string
 	reg, err := regexp.Compile("[^a-z0-9]+")
 	if err != nil {

--- a/components/event-bus/internal/knative/util/kn-eventing.go
+++ b/components/event-bus/internal/knative/util/kn-eventing.go
@@ -59,7 +59,7 @@ if err := k.CreateSubscription("my-sub", namespace, channelName, &uri); err != n
 return
 */
 
-const HYPHEN = "-"
+const hyphen = "-"
 
 var once sync.Once
 
@@ -179,7 +179,7 @@ func (k *KnativeLib) CreateChannel(prefix, namespace string, labels map[string]s
 		case <-tout:
 			return nil, errors.New("timed out")
 		case <-tick:
-			if channel, err = k.GetChannelByLabels(namespace, labels); err != nil {
+			if channel, err = k.GetChannelByLabels(namespace, &labels); err != nil {
 				log.Printf("ERROR: CreateChannel(): geting channel: %v", err)
 			} else {
 				isReady = channel.Status.IsReady()
@@ -345,13 +345,13 @@ func makeChannel(prefix, namespace string, labels map[string]string) *messagingV
 	if err != nil {
 		log.Fatal(err)
 	}
-	prefix = fmt.Sprint(reg.ReplaceAllString(prefix, ""), HYPHEN)
+	prefix = fmt.Sprint(reg.ReplaceAllString(prefix, ""), hyphen)
 
 	return &messagingV1Alpha1.Channel{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace:    namespace,
 			GenerateName: prefix,
-			Labels:       *labels,
+			Labels:       labels,
 		},
 	}
 }

--- a/components/event-bus/internal/knative/util/kn-eventing.go
+++ b/components/event-bus/internal/knative/util/kn-eventing.go
@@ -162,7 +162,7 @@ func (k *KnativeLib) GetChannelByLabels(namespace string, labels *map[string]str
 }
 
 // CreateChannel creates a Knative/Eventing channel controlled by the specified provisioner
-func (k *KnativeLib) CreateChannel(prefix string, namespace string, labels *map[string]string,
+func (k *KnativeLib) CreateChannel(prefix, namespace string, labels map[string]string,
 	timeout time.Duration) (*messagingV1Alpha1.Channel, error) {
 	c := makeChannel(prefix, namespace, labels)
 	channel, err := k.messagingChannel.Channels(namespace).Create(c)

--- a/components/event-bus/internal/knative/util/kn-eventing_test.go
+++ b/components/event-bus/internal/knative/util/kn-eventing_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"strings"
 	"testing"
 	"time"
 
@@ -312,4 +313,21 @@ func Test_makeHttpRequest(t *testing.T) {
 		log.Printf("Request Header: %s", k)
 	}
 	assert.Len(t, req.Header, 3, "Headers map should have exactly 3 keys")
+}
+
+func Test_MakeChannelWithPrefix(t *testing.T) {
+	prefix := "order.created"
+	a := makeChannel(prefix, testNS, &labels)
+
+	// makeChannel should rmove all the special characters from the prefix string
+	assert.False(t, strings.Contains(a.GenerateName, "."))
+
+	// makeChannel should add hyphen at the end if not present
+	assert.True(t, strings.HasSuffix(a.GenerateName, "-"))
+
+	prefix = "order.created-"
+	a = makeChannel(prefix, testNS, &labels)
+
+	// makeChannel should not add double hyphens if already present
+	assert.False(t, strings.HasSuffix(a.GenerateName, "--"))
 }

--- a/components/event-bus/internal/knative/util/kn-eventing_test.go
+++ b/components/event-bus/internal/knative/util/kn-eventing_test.go
@@ -117,7 +117,7 @@ func Test_GetChannelByLabels(t *testing.T) {
 	log.Printf("Channel created: %v", ch1)
 	log.Println("Getting Channel By label")
 
-	ch2, err2 := k.GetChannelByLabels(testNS, &labels)
+	ch2, err2 := k.GetChannelByLabels(testNS, labels)
 	assert.Nil(t, err2)
 
 	ignore := cmpopts.IgnoreTypes(apis.VolatileTime{})

--- a/components/event-bus/internal/knative/util/kn-eventing_test.go
+++ b/components/event-bus/internal/knative/util/kn-eventing_test.go
@@ -84,7 +84,7 @@ func Test_CreateChannel(t *testing.T) {
 		evClient:         client.EventingV1alpha1(),
 		messagingChannel: client.MessagingV1alpha1(),
 	}
-	ch, err := k.CreateChannel(channelName, testNS, &labels, 10*time.Second)
+	ch, err := k.CreateChannel(channelName, testNS, labels, 10*time.Second)
 	assert.Nil(t, err)
 	log.Printf("Channel created: %v", ch)
 
@@ -112,7 +112,7 @@ func Test_GetChannelByLabels(t *testing.T) {
 		evClient:         client.EventingV1alpha1(),
 		messagingChannel: client.MessagingV1alpha1(),
 	}
-	ch1, err1 := k.CreateChannel(channelName, testNS, &labels, 10*time.Second)
+	ch1, err1 := k.CreateChannel(channelName, testNS, labels, 10*time.Second)
 	assert.Nil(t, err1)
 	log.Printf("Channel created: %v", ch1)
 	log.Println("Getting Channel By label")
@@ -141,7 +141,7 @@ func Test_CreateChannelWithError(t *testing.T) {
 		evClient:         client.EventingV1alpha1(),
 		messagingChannel: client.MessagingV1alpha1(),
 	}
-	ch, err := k.CreateChannel(channelName, testNS, &labels, 10*time.Second)
+	ch, err := k.CreateChannel(channelName, testNS, labels, 10*time.Second)
 	assert.Nil(t, err)
 	log.Printf("Channel created: %v", ch)
 
@@ -171,7 +171,7 @@ func Test_CreateChannelTimeout(t *testing.T) {
 		evClient:         client.EventingV1alpha1(),
 		messagingChannel: client.MessagingV1alpha1(),
 	}
-	_, err := k.CreateChannel(channelName, testNS, &labels, 1*time.Second)
+	_, err := k.CreateChannel(channelName, testNS, labels, 1*time.Second)
 	assert.NotNil(t, err)
 	log.Printf("Test_CreateChannelTimeout: %v", err)
 }
@@ -202,7 +202,7 @@ func Test_SendMessage(t *testing.T) {
 	k := &KnativeLib{}
 	e := k.InjectClient(client.EventingV1alpha1(), client.MessagingV1alpha1())
 	assert.Nil(t, e)
-	ch, err := k.CreateChannel(channelName, testNS, &labels, 10*time.Second)
+	ch, err := k.CreateChannel(channelName, testNS, labels, 10*time.Second)
 	assert.Nil(t, err)
 	u, err := url.Parse(srv.URL)
 	assert.Nil(t, err)
@@ -252,7 +252,7 @@ func Test_CreateDeleteChannel(t *testing.T) {
 	k := &KnativeLib{}
 	e := k.InjectClient(client.EventingV1alpha1(), client.MessagingV1alpha1())
 	assert.Nil(t, e)
-	ch, err := k.CreateChannel(channelName, testNS, &labels, 1*time.Second)
+	ch, err := k.CreateChannel(channelName, testNS, labels, 1*time.Second)
 	assert.Nil(t, err)
 	err = k.DeleteChannel(ch.Name, ch.Namespace)
 	assert.Nil(t, err)
@@ -317,7 +317,7 @@ func Test_makeHttpRequest(t *testing.T) {
 
 func Test_MakeChannelWithPrefix(t *testing.T) {
 	prefix := "order.created"
-	a := makeChannel(prefix, testNS, &labels)
+	a := makeChannel(prefix, testNS, labels)
 
 	// makeChannel should rmove all the special characters from the prefix string
 	assert.False(t, strings.Contains(a.GenerateName, "."))
@@ -326,7 +326,7 @@ func Test_MakeChannelWithPrefix(t *testing.T) {
 	assert.True(t, strings.HasSuffix(a.GenerateName, "-"))
 
 	prefix = "order.created-"
-	a = makeChannel(prefix, testNS, &labels)
+	a = makeChannel(prefix, testNS, labels)
 
 	// makeChannel should not add double hyphens if already present
 	assert.False(t, strings.HasSuffix(a.GenerateName, "--"))


### PR DESCRIPTION
w.r.t #5677 

While creating a dynamic knative channel name there's a lot of loose ends. as a counter measure we decided to go with this: https://github.com/kyma-project/kyma/issues/5677#issuecomment-532606682 

This PR proposes a change to create knative channel by providing a prefix (event-type) and let kubernetes come up with a unique name for the channel which is compliant.