### PR TITLE
Correct a Conditional statement for event-bus

### DIFF
--- a/components/event-bus/internal/knative/util/kn-eventing.go
+++ b/components/event-bus/internal/knative/util/kn-eventing.go
@@ -136,7 +136,7 @@ func (k *KnativeLib) GetChannel(name string, namespace string) (*messagingV1Alph
 // so based on the labels, we assume that the list of channels should have only one item in it
 // Hence, we'd be returning the item at 0th index.
 func (k *KnativeLib) GetChannelByLabels(namespace string, labels map[string]string) (*messagingV1Alpha1.Channel, error) {
-	if labels == nil {
+	if len(labels) == 0 {
 		return nil, errors.New("no labels were passed to GetChannelByLabels()")
 	}
 	channelList, err := k.messagingChannel.Channels(namespace).List(metav1.ListOptions{


### PR DESCRIPTION
Initially in the function GetChannelByLabels() labels were passed as pointers and its null check was done as if it was a pointer with no reference, After changing the method signature to value based, this null check was not updated.

with this PR we check the map with 0 length instead of nil pointer.