### PR TITLE
Add the link to the Application Registry API specification in the Application Registry doc

### DIFF
--- a/docs/application-connector/09-02-metadata-service.md
+++ b/docs/application-connector/09-02-metadata-service.md
@@ -7,3 +7,5 @@ You can get the API specification of the Application Registry for a given versio
 ```
 curl https://gateway.{CLUSTER_DOMAIN}/{APP_NAME}/v1/metadata/api.yaml
 ```
+
+>**TIP:** For details on the Application Registry API specification, see [this file](./assets/metadataapi.yaml).

--- a/docs/application-connector/09-02-metadata-service.md
+++ b/docs/application-connector/09-02-metadata-service.md
@@ -8,4 +8,4 @@ You can get the API specification of the Application Registry for a given versio
 curl https://gateway.{CLUSTER_DOMAIN}/{APP_NAME}/v1/metadata/api.yaml
 ```
 
->**TIP:** For details on the Application Registry API specification, see [this file](./assets/metadataapi.yaml).
+>**TIP:** For details on the Application Registry API specification, see [this](./assets/metadataapi.yaml) file.


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- The documents for Connector Service and Event Service have clickable links to download their API specifications. This PR adds one in the Application Registry document as well. 

**Related issue(s)**
None