### PR TITLE
Fix test assertions for checking elem list

### DIFF
--- a/components/console-backend-service/internal/domain/apicontroller/api_service_test.go
+++ b/components/console-backend-service/internal/domain/apicontroller/api_service_test.go
@@ -43,7 +43,7 @@ func TestApiService_List(t *testing.T) {
 		result, err := service.List(namespace, nil, nil)
 
 		require.NoError(t, err)
-		assert.Equal(t, []*v1alpha2.Api{
+		assert.ElementsMatch(t, []*v1alpha2.Api{
 			api1, api3,
 		}, result)
 	})
@@ -64,7 +64,7 @@ func TestApiService_List(t *testing.T) {
 		result, err := service.List(namespace, nil, &hostname)
 
 		require.NoError(t, err)
-		assert.Equal(t, []*v1alpha2.Api{
+		assert.ElementsMatch(t, []*v1alpha2.Api{
 			api1,
 		}, result)
 	})
@@ -87,7 +87,7 @@ func TestApiService_List(t *testing.T) {
 		result, err := service.List(namespace, &serviceName, nil)
 
 		require.NoError(t, err)
-		assert.Equal(t, []*v1alpha2.Api{
+		assert.ElementsMatch(t, []*v1alpha2.Api{
 			api1,
 		}, result)
 	})
@@ -111,7 +111,7 @@ func TestApiService_List(t *testing.T) {
 		result, err := service.List(namespace, &serviceName, nil)
 
 		require.NoError(t, err)
-		assert.Equal(t, []*v1alpha2.Api{
+		assert.ElementsMatch(t, []*v1alpha2.Api{
 			api1,
 		}, result)
 	})

--- a/components/console-backend-service/internal/domain/k8s/deployment_service_test.go
+++ b/components/console-backend-service/internal/domain/k8s/deployment_service_test.go
@@ -31,7 +31,7 @@ func TestDeploymentService_List(t *testing.T) {
 		result, err := svc.List("ns1")
 
 		require.NoError(t, err)
-		assert.Equal(t, []*v1beta2.Deployment{
+		assert.ElementsMatch(t, []*v1beta2.Deployment{
 			deployment1, deployment2,
 		}, result)
 	})
@@ -47,7 +47,7 @@ func TestDeploymentService_List(t *testing.T) {
 		result, err := svc.List("ns1")
 
 		require.NoError(t, err)
-		assert.Equal(t, expected, result)
+		assert.ElementsMatch(t, expected, result)
 	})
 }
 
@@ -66,7 +66,7 @@ func TestDeploymentService_ListWithoutFunctions(t *testing.T) {
 		result, err := svc.ListWithoutFunctions("ns1")
 
 		require.NoError(t, err)
-		assert.Equal(t, []*v1beta2.Deployment{
+		assert.ElementsMatch(t, []*v1beta2.Deployment{
 			deployment1,
 		}, result)
 	})
@@ -82,7 +82,7 @@ func TestDeploymentService_ListWithoutFunctions(t *testing.T) {
 		result, err := svc.ListWithoutFunctions("ns1")
 
 		require.NoError(t, err)
-		assert.Equal(t, expected, result)
+		assert.ElementsMatch(t, expected, result)
 	})
 }
 

--- a/components/console-backend-service/internal/domain/k8s/resourcequota_service_test.go
+++ b/components/console-backend-service/internal/domain/k8s/resourcequota_service_test.go
@@ -115,9 +115,9 @@ func TestResourceQuotaService_ListStatefulSets(t *testing.T) {
 
 	// THEN
 	require.NoError(t, err)
-	assert.Equal(t, result[0], rs1)
-	assert.Equal(t, result[1], rs2)
-	assert.Len(t, result, 2)
+	assert.ElementsMatch(t, []*apps.StatefulSet{
+		rs1, rs2,
+	}, result)
 }
 
 func TestResourceQuotaService_ListPods(t *testing.T) {

--- a/components/console-backend-service/internal/domain/servicecatalog/clusterserviceplan_service_test.go
+++ b/components/console-backend-service/internal/domain/servicecatalog/clusterserviceplan_service_test.go
@@ -18,7 +18,7 @@ func TestClusterServicePlanService_Find(t *testing.T) {
 	t.Run("Success", func(t *testing.T) {
 		planName := "testExample"
 		servicePlan := fixClusterServicePlan(planName, "test", planName)
-		client := fake.NewSimpleClientset(servicePlan)
+		client := fake.NewSimpleClientset(&servicePlan)
 
 		informerFactory := externalversions.NewSharedInformerFactory(client, 0)
 		servicePlanInformer := informerFactory.Servicecatalog().V1beta1().ClusterServicePlans().Informer()
@@ -30,7 +30,7 @@ func TestClusterServicePlanService_Find(t *testing.T) {
 
 		plan, err := svc.Find(planName)
 		require.NoError(t, err)
-		assert.Equal(t, servicePlan, plan)
+		assert.Equal(t, &servicePlan, plan)
 	})
 
 	t.Run("NotFound", func(t *testing.T) {
@@ -56,7 +56,7 @@ func TestClusterServicePlanService_FindByExternalNameForClass(t *testing.T) {
 		planName := "testExample"
 		externalName := "testExternal"
 		servicePlan := fixClusterServicePlan(planName, className, externalName)
-		client := fake.NewSimpleClientset(servicePlan)
+		client := fake.NewSimpleClientset(&servicePlan)
 
 		informerFactory := externalversions.NewSharedInformerFactory(client, 0)
 		servicePlanInformer := informerFactory.Servicecatalog().V1beta1().ClusterServicePlans().Informer()
@@ -68,7 +68,7 @@ func TestClusterServicePlanService_FindByExternalNameForClass(t *testing.T) {
 
 		plan, err := svc.FindByExternalName(externalName, className)
 		require.NoError(t, err)
-		assert.Equal(t, servicePlan, plan)
+		assert.Equal(t, &servicePlan, plan)
 	})
 
 	t.Run("NotFound", func(t *testing.T) {
@@ -91,10 +91,11 @@ func TestClusterServicePlanService_FindByExternalNameForClass(t *testing.T) {
 	t.Run("Error", func(t *testing.T) {
 		className := "duplicateName"
 		externalName := "duplicateName"
+		servicePlan1 := fixClusterServicePlan("1", className, externalName)
+		servicePlan2 := fixClusterServicePlan("2", className, externalName)
+		servicePlan3 := fixClusterServicePlan("3", className, externalName)
 		client := fake.NewSimpleClientset(
-			fixClusterServicePlan("1", className, externalName),
-			fixClusterServicePlan("2", className, externalName),
-			fixClusterServicePlan("3", className, externalName),
+			&servicePlan1, &servicePlan2, &servicePlan3,
 		)
 
 		informerFactory := externalversions.NewSharedInformerFactory(client, 0)
@@ -118,7 +119,7 @@ func TestClusterServicePlanService_ListForClass(t *testing.T) {
 		servicePlan1 := fixClusterServicePlan("1", className, "1")
 		servicePlan2 := fixClusterServicePlan("2", className, "2")
 		servicePlan3 := fixClusterServicePlan("3", className, "3")
-		client := fake.NewSimpleClientset(servicePlan1, servicePlan2, servicePlan3)
+		client := fake.NewSimpleClientset(&servicePlan1, &servicePlan2, &servicePlan3)
 
 		informerFactory := externalversions.NewSharedInformerFactory(client, 0)
 		servicePlanInformer := informerFactory.Servicecatalog().V1beta1().ClusterServicePlans().Informer()
@@ -130,8 +131,8 @@ func TestClusterServicePlanService_ListForClass(t *testing.T) {
 
 		plans, err := svc.ListForClusterServiceClass(className)
 		require.NoError(t, err)
-		assert.Equal(t, []*v1beta1.ClusterServicePlan{
-			servicePlan1, servicePlan2, servicePlan3,
+		assert.ElementsMatch(t, []*v1beta1.ClusterServicePlan{
+			&servicePlan1, &servicePlan2, &servicePlan3,
 		}, plans)
 	})
 
@@ -153,7 +154,7 @@ func TestClusterServicePlanService_ListForClass(t *testing.T) {
 
 }
 
-func fixClusterServicePlan(name, relatedServiceClassName, externalName string) *v1beta1.ClusterServicePlan {
+func fixClusterServicePlan(name, relatedServiceClassName, externalName string) v1beta1.ClusterServicePlan {
 	plan := v1beta1.ClusterServicePlan{
 		Spec: v1beta1.ClusterServicePlanSpec{
 			CommonServicePlanSpec: v1beta1.CommonServicePlanSpec{
@@ -168,5 +169,5 @@ func fixClusterServicePlan(name, relatedServiceClassName, externalName string) *
 		},
 	}
 
-	return &plan
+	return plan
 }

--- a/components/console-backend-service/internal/domain/servicecatalog/serviceplan_service_test.go
+++ b/components/console-backend-service/internal/domain/servicecatalog/serviceplan_service_test.go
@@ -19,7 +19,7 @@ func TestServicePlanService_Find(t *testing.T) {
 		nsName := "ns"
 		planName := "testExample"
 		servicePlan := fixServicePlan(planName, "test", planName, nsName)
-		client := fake.NewSimpleClientset(servicePlan)
+		client := fake.NewSimpleClientset(&servicePlan)
 
 		informerFactory := externalversions.NewSharedInformerFactory(client, 0)
 		servicePlanInformer := informerFactory.Servicecatalog().V1beta1().ServicePlans().Informer()
@@ -31,7 +31,7 @@ func TestServicePlanService_Find(t *testing.T) {
 
 		plan, err := svc.Find(planName, nsName)
 		require.NoError(t, err)
-		assert.Equal(t, servicePlan, plan)
+		assert.Equal(t, &servicePlan, plan)
 	})
 
 	t.Run("NotFound", func(t *testing.T) {
@@ -58,7 +58,7 @@ func TestServicePlanService_FindByExternalNameForClass(t *testing.T) {
 		planName := "testExample"
 		externalName := "testExternal"
 		servicePlan := fixServicePlan(planName, className, externalName, nsName)
-		client := fake.NewSimpleClientset(servicePlan)
+		client := fake.NewSimpleClientset(&servicePlan)
 
 		informerFactory := externalversions.NewSharedInformerFactory(client, 0)
 		servicePlanInformer := informerFactory.Servicecatalog().V1beta1().ServicePlans().Informer()
@@ -70,7 +70,7 @@ func TestServicePlanService_FindByExternalNameForClass(t *testing.T) {
 
 		plan, err := svc.FindByExternalName(externalName, className, nsName)
 		require.NoError(t, err)
-		assert.Equal(t, servicePlan, plan)
+		assert.Equal(t, &servicePlan, plan)
 	})
 
 	t.Run("NotFound", func(t *testing.T) {
@@ -94,11 +94,11 @@ func TestServicePlanService_FindByExternalNameForClass(t *testing.T) {
 		nsName := "ns"
 		className := "duplicateName"
 		externalName := "duplicateName"
-		client := fake.NewSimpleClientset(
-			fixServicePlan("1", className, externalName, nsName),
-			fixServicePlan("2", className, externalName, nsName),
-			fixServicePlan("3", className, externalName, nsName),
-		)
+
+		servicePlan1 := fixServicePlan("1", className, externalName, nsName)
+		servicePlan2 := fixServicePlan("2", className, externalName, nsName)
+		servicePlan3 := fixServicePlan("3", className, externalName, nsName)
+		client := fake.NewSimpleClientset(&servicePlan1, &servicePlan2, &servicePlan3)
 
 		informerFactory := externalversions.NewSharedInformerFactory(client, 0)
 		servicePlanInformer := informerFactory.Servicecatalog().V1beta1().ServicePlans().Informer()
@@ -122,7 +122,7 @@ func TestServicePlanService_ListForClass(t *testing.T) {
 		servicePlan1 := fixServicePlan("1", className, "1", nsName)
 		servicePlan2 := fixServicePlan("2", className, "2", nsName)
 		servicePlan3 := fixServicePlan("3", className, "3", nsName)
-		client := fake.NewSimpleClientset(servicePlan1, servicePlan2, servicePlan3)
+		client := fake.NewSimpleClientset(&servicePlan1, &servicePlan2, &servicePlan3)
 
 		informerFactory := externalversions.NewSharedInformerFactory(client, 0)
 		servicePlanInformer := informerFactory.Servicecatalog().V1beta1().ServicePlans().Informer()
@@ -134,8 +134,8 @@ func TestServicePlanService_ListForClass(t *testing.T) {
 
 		plans, err := svc.ListForServiceClass(className, nsName)
 		require.NoError(t, err)
-		assert.Equal(t, []*v1beta1.ServicePlan{
-			servicePlan1, servicePlan2, servicePlan3,
+		assert.ElementsMatch(t, []*v1beta1.ServicePlan{
+			&servicePlan1, &servicePlan2, &servicePlan3,
 		}, plans)
 	})
 
@@ -152,12 +152,11 @@ func TestServicePlanService_ListForClass(t *testing.T) {
 		var emptyArray []*v1beta1.ServicePlan
 		plans, err := svc.ListForServiceClass("doesntExist", "ns")
 		require.NoError(t, err)
-		assert.Equal(t, emptyArray, plans)
+		assert.ElementsMatch(t, emptyArray, plans)
 	})
-
 }
 
-func fixServicePlan(name, relatedServiceClassName, externalName, namespace string) *v1beta1.ServicePlan {
+func fixServicePlan(name, relatedServiceClassName, externalName, namespace string) v1beta1.ServicePlan {
 	plan := v1beta1.ServicePlan{
 		Spec: v1beta1.ServicePlanSpec{
 			CommonServicePlanSpec: v1beta1.CommonServicePlanSpec{
@@ -173,5 +172,5 @@ func fixServicePlan(name, relatedServiceClassName, externalName, namespace strin
 		},
 	}
 
-	return &plan
+	return plan
 }

--- a/components/console-backend-service/internal/domain/servicecatalogaddons/addonsconfiguration_service_test.go
+++ b/components/console-backend-service/internal/domain/servicecatalogaddons/addonsconfiguration_service_test.go
@@ -445,7 +445,7 @@ func TestAddonsConfigurationService_ListAddonsConfigurations(t *testing.T) {
 
 			// then
 			require.NoError(t, err)
-			assert.Equal(t, tc.expectedAddonsCfgs, result)
+			assert.ElementsMatch(t, tc.expectedAddonsCfgs, result)
 		})
 	}
 }


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Fix test assertions for checking elem list


The previous approach requires that returned elements will be in the specified order. We cannot have such a contract for listers.

I've fixed the only test in `internal/domain` pkg. I've executed tests with `--count 50` to check stability.