### PR TITLE
Fix Split view mode for lambda logs when loki not installed

### DIFF
--- a/resources/core/charts/kubeless/charts/lambdas-ui/values.yaml
+++ b/resources/core/charts/kubeless/charts/lambdas-ui/values.yaml
@@ -5,7 +5,7 @@ replicaCount: 1
 image:
   dir:
   name: lambda
-  tag: da918ff4
+  tag: d3e1d74f
   pullPolicy: IfNotPresent
 service:
   name: nginx


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Do not show split view mode when loki not installed

**Related issue(s)**
Fixes https://github.com/kyma-project/console/issues/1302
