### PR TITLE
Bump up EventBus image to d90af2a

### DIFF
--- a/resources/event-bus/values.yaml
+++ b/resources/event-bus/values.yaml
@@ -7,7 +7,7 @@ global:
     path: eu.gcr.io/kyma-project
   event_bus:
     dir: develop/
-    version: 435ab4cf
+    version: d90af2ac
     publisherImage: event-publish-service
     subscriptionControllerImage: subscription-controller
   event_bus_tests:


### PR DESCRIPTION
This update fixes a bottleneck in Event Bus Publish service that
causes the throughput to choke.

<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/master/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Update image to the one created in PR-5716

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
