### PR TITLE
Move description subsection to info section, remove initial tags section

### DIFF
--- a/docs/application-connector/assets/connectorapi.yaml
+++ b/docs/application-connector/assets/connectorapi.yaml
@@ -3,6 +3,9 @@ info:
   version: '1.0.0'
   title: 'Kyma Connector Service API'
   description: 'API for connecting Applications to Kyma'
+  license:
+    name: Apache 2.0
+    url: https://www.apache.org/licenses/LICENSE-2.0
 paths:
   /v1/health:
     get:

--- a/docs/application-connector/assets/connectorapi.yaml
+++ b/docs/application-connector/assets/connectorapi.yaml
@@ -2,6 +2,7 @@ openapi: '3.0.0'
 info:
   version: '1.0.0'
   title: 'Kyma Connector Service API'
+  description: 'API for connecting Applications to Kyma'
 paths:
   /v1/health:
     get:

--- a/docs/application-connector/assets/eventsapi.yaml
+++ b/docs/application-connector/assets/eventsapi.yaml
@@ -2,7 +2,10 @@ openapi: '3.0.0'
 info:
   version: '1.0.0'
   title: 'Kyma Events API'
-  description: 'API for eventing' 
+  description: 'API for eventing'
+  license:
+    name: Apache 2.0
+    url: https://www.apache.org/licenses/LICENSE-2.0 
 paths:
   /v1/health:
     get:

--- a/docs/application-connector/assets/eventsapi.yaml
+++ b/docs/application-connector/assets/eventsapi.yaml
@@ -2,9 +2,7 @@ openapi: '3.0.0'
 info:
   version: '1.0.0'
   title: 'Kyma Events API'
-tags:
-- name: 'Kyma events'
-  description: 'API for eventing.'
+  description: 'API for eventing' 
 paths:
   /v1/health:
     get:

--- a/docs/application-connector/assets/metadataapi.yaml
+++ b/docs/application-connector/assets/metadataapi.yaml
@@ -2,9 +2,7 @@ openapi: '3.0.0'
 info:
   version: '1.0.0'
   title: 'Kyma Application Registry API'
-tags:
-- name: 'Application Registry'
-  description: 'API for registering services in Kyma.'
+  description: 'API for registering services in Kyma' 
 paths:
   /v1/health:
     get:

--- a/docs/application-connector/assets/metadataapi.yaml
+++ b/docs/application-connector/assets/metadataapi.yaml
@@ -3,6 +3,9 @@ info:
   version: '1.0.0'
   title: 'Kyma Application Registry API'
   description: 'API for registering services in Kyma' 
+  license:
+    name: Apache 2.0
+    url: https://www.apache.org/licenses/LICENSE-2.0
 paths:
   /v1/health:
     get:


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

In Application Connector APIs specifications
- Move the `description` subsection to the `info` section
- Remove the initial `tags` section
- Add the `license` section.


**Related issue(s)**
#4239 
