### PR TITLE
Turn off flaky tests

### DIFF
--- a/resources/application-connector/charts/application-operator/values.yaml
+++ b/resources/application-connector/charts/application-operator/values.yaml
@@ -11,6 +11,6 @@ controller:
     installationTimeout: 240
 
 tests:
-  enabled: true
+  enabled: false
   image:
     pullPolicy: IfNotPresent

--- a/resources/application-connector/charts/application-registry/values.yaml
+++ b/resources/application-connector/charts/application-registry/values.yaml
@@ -18,6 +18,6 @@ service:
     port: *externalAPIPort
 
 tests:
-  enabled: true
+  enabled: false
   image:
     pullPolicy: IfNotPresent

--- a/resources/application-connector/charts/connector-service/values.yaml
+++ b/resources/application-connector/charts/connector-service/values.yaml
@@ -65,7 +65,7 @@ istio:
     required: false
 
 tests:
-  enabled: true
+  enabled: false
   skipSslVerify: true
   central: *central
   image:

--- a/resources/application-connector/values.yaml
+++ b/resources/application-connector/values.yaml
@@ -80,7 +80,8 @@ application_connectivity_certs_setup_job:
 
 tests:
   application_connector_tests:
-    enabled: *connectorServiceEnabled
+#    enabled: *connectorServiceEnabled
+    enabled: false
     connector_service:
       central: false
     skipSslVerify: true

--- a/resources/assetstore/templates/tests/rbac.yaml
+++ b/resources/assetstore/templates/tests/rbac.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.tests.enabled }}
 kind: ServiceAccount
 apiVersion: v1
 metadata:
@@ -46,3 +47,4 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
   name: {{ .Chart.Name }}-tests
+{{- end }}

--- a/resources/assetstore/templates/tests/test.yaml
+++ b/resources/assetstore/templates/tests/test.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.tests.enabled }}
 {{- if .Capabilities.APIVersions.Has "testing.kyma-project.io/v1alpha1" }}
 apiVersion: "testing.kyma-project.io/v1alpha1"
 kind: TestDefinition
@@ -60,4 +61,5 @@ spec:
           resources:
             limits:
               memory: 128Mi
+{{- end }}
 {{- end }}

--- a/resources/assetstore/values.yaml
+++ b/resources/assetstore/values.yaml
@@ -58,3 +58,6 @@ minio:
 
   gcsgateway:
     replicas: 2
+
+tests:
+  enabled: false

--- a/resources/core/charts/api-controller/templates/tests/rbac.yaml
+++ b/resources/core/charts/api-controller/templates/tests/rbac.yaml
@@ -44,4 +44,4 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
   name: {{ .Chart.Name }}-tests
-{{ end }}
+{{- end }}

--- a/resources/core/charts/api-controller/templates/tests/test.yaml
+++ b/resources/core/charts/api-controller/templates/tests/test.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.tests.enabled }}
 {{- if .Capabilities.APIVersions.Has "testing.kyma-project.io/v1alpha1" }}
 apiVersion: "testing.kyma-project.io/v1alpha1"
 kind: TestDefinition
@@ -29,4 +30,5 @@ spec:
         - name: INGRESSGATEWAY_ADDRESS
           value: istio-ingressgateway.istio-system.svc.cluster.local
       restartPolicy: Never
+{{- end }}
 {{- end }}

--- a/resources/core/charts/api-controller/values.yaml
+++ b/resources/core/charts/api-controller/values.yaml
@@ -1,5 +1,5 @@
 tests:
-  enabled: true
+  enabled: false
 
 mtls:
   enabled: "true"

--- a/resources/core/charts/apiserver-proxy/templates/tests/test.yaml
+++ b/resources/core/charts/apiserver-proxy/templates/tests/test.yaml
@@ -1,4 +1,5 @@
 ---
+{{- if .Values.tests.enabled }}
 {{- if .Capabilities.APIVersions.Has "testing.kyma-project.io/v1alpha1" }}
 
 apiVersion: "testing.kyma-project.io/v1alpha1"
@@ -58,4 +59,5 @@ spec:
             - name: MAX_TEST_RETRIES
               value: "10"
       restartPolicy: Never
+{{- end}}
 {{- end}}

--- a/resources/core/charts/apiserver-proxy/templates/tests/test.yaml
+++ b/resources/core/charts/apiserver-proxy/templates/tests/test.yaml
@@ -59,5 +59,5 @@ spec:
             - name: MAX_TEST_RETRIES
               value: "10"
       restartPolicy: Never
-{{- end}}
-{{- end}}
+{{- end }}
+{{- end }}

--- a/resources/core/charts/apiserver-proxy/values.yaml
+++ b/resources/core/charts/apiserver-proxy/values.yaml
@@ -28,3 +28,6 @@ hpa:
     resource:
       name: memory
       targetAverageUtilization: 50
+
+tests:
+  enabled: false

--- a/resources/core/charts/cluster-users/templates/tests/rbac.yaml
+++ b/resources/core/charts/cluster-users/templates/tests/rbac.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.tests.enabled}}
 {{- if .Capabilities.APIVersions.Has "testing.kyma-project.io/v1alpha1" }}
 apiVersion: v1
 kind: ServiceAccount
@@ -28,4 +29,5 @@ subjects:
 - kind: ServiceAccount
   name: {{ .Chart.Name }}-tests
   namespace: {{ .Release.Namespace }}
+{{- end }}
 {{- end }}

--- a/resources/core/charts/cluster-users/templates/tests/test.yaml
+++ b/resources/core/charts/cluster-users/templates/tests/test.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.tests.enabled }}
 {{- if .Capabilities.APIVersions.Has "testing.kyma-project.io/v1alpha1" }}
 apiVersion: "testing.kyma-project.io/v1alpha1"
 kind: TestDefinition
@@ -70,4 +71,5 @@ spec:
           - name: IAM_KUBECONFIG_SVC_FQDN
             value: "https://configurations-generator.{{ .Values.global.ingress.domainName }}"
       restartPolicy: Never
+{{- end }}
 {{- end }}

--- a/resources/core/charts/cluster-users/values.yaml
+++ b/resources/core/charts/cluster-users/values.yaml
@@ -1,3 +1,6 @@
+tests:
+  enabled: false
+
 bindings:
   kymaEssentials:
     groups: []

--- a/resources/core/charts/console-backend-service/values.yaml
+++ b/resources/core/charts/console-backend-service/values.yaml
@@ -20,6 +20,6 @@ tracing:
   serviceSpanName: console-backend-service
   
 tests:
-  enabled: true
+  enabled: false
 
 systemNamespaces: "istio-system knative-eventing knative-serving kube-public kube-system kyma-backup kyma-installer kyma-integration kyma-system natss compass-system"

--- a/resources/core/charts/kubeless/templates/tests/e2e-k8s.yaml
+++ b/resources/core/charts/kubeless/templates/tests/e2e-k8s.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.tests.enabled }}
 {{ define "e2e-k8s.yaml.tpl" }}
 
 apiVersion: gateway.kyma-project.io/v1alpha2
@@ -47,4 +48,5 @@ spec:
   event_type: test
   event_type_version: v1
   source_id: "dummy"
-{{ end }}
+{{- end }}
+{{- end }}

--- a/resources/core/charts/kubeless/templates/tests/e2e-k8s.yaml
+++ b/resources/core/charts/kubeless/templates/tests/e2e-k8s.yaml
@@ -1,4 +1,3 @@
-{{- if .Values.tests.enabled }}
 {{ define "e2e-k8s.yaml.tpl" }}
 
 apiVersion: gateway.kyma-project.io/v1alpha2
@@ -48,5 +47,4 @@ spec:
   event_type: test
   event_type_version: v1
   source_id: "dummy"
-{{- end }}
 {{- end }}

--- a/resources/core/charts/kubeless/templates/tests/e2e-rbac.yaml
+++ b/resources/core/charts/kubeless/templates/tests/e2e-rbac.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.tests.enabled}}
 {{- if not .Values.global.isLocalEnv }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -85,4 +86,5 @@ subjects:
 - kind: ServiceAccount
   name: e2e-{{ .Chart.Name }}-tests
   namespace: {{ .Release.Namespace }}
+{{- end }}
 {{- end }}

--- a/resources/core/charts/kubeless/templates/tests/e2e-svcbind-lambda.yaml
+++ b/resources/core/charts/kubeless/templates/tests/e2e-svcbind-lambda.yaml
@@ -1,4 +1,3 @@
-{{- if .Values.tests.enabled }}
 {{ define "e2e-svcbind-lambda.yaml.tpl" }}
 
 apiVersion: gateway.kyma-project.io/v1alpha2
@@ -78,4 +77,3 @@ spec:
     kind: function
     name: test-svcbind
 {{ end }}
-{{- end }}

--- a/resources/core/charts/kubeless/templates/tests/e2e-svcbind-lambda.yaml
+++ b/resources/core/charts/kubeless/templates/tests/e2e-svcbind-lambda.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.tests.enabled }}
 {{ define "e2e-svcbind-lambda.yaml.tpl" }}
 
 apiVersion: gateway.kyma-project.io/v1alpha2
@@ -77,3 +78,4 @@ spec:
     kind: function
     name: test-svcbind
 {{ end }}
+{{- end }}

--- a/resources/core/charts/kubeless/templates/tests/e2e-test.yaml
+++ b/resources/core/charts/kubeless/templates/tests/e2e-test.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.tests.enabled }}
 {{- if not .Values.global.isLocalEnv }}
 apiVersion: v1
 kind: ConfigMap
@@ -62,5 +63,6 @@ spec:
               - key: svcBindLambdaYaml
                 path: svcbind-lambda.yaml
       restartPolicy: Never
+{{- end }}
 {{- end }}
 {{- end }}

--- a/resources/core/charts/kubeless/values.yaml
+++ b/resources/core/charts/kubeless/values.yaml
@@ -13,3 +13,6 @@ config:
   provision:
     image: kubeless/unzip@sha256:f162c062973cca05459834de6ed14c039d45df8cdb76097f50b028a1621b3697
     secret: ""
+
+tests:
+  enabled: false

--- a/resources/core/values.yaml
+++ b/resources/core/values.yaml
@@ -94,7 +94,7 @@ tests:
 test:
   acceptance:
     external_solution:
-      enabled: true
+      enabled: false
     core:
       enabled: true
       # environments used in application acceptance test

--- a/resources/kiali/templates/tests/test.yaml
+++ b/resources/kiali/templates/tests/test.yaml
@@ -1,4 +1,4 @@
-
+{{- if .Values.tests.enabled }}
 {{- if .Capabilities.APIVersions.Has "testing.kyma-project.io/v1alpha1" }}
 apiVersion: "testing.kyma-project.io/v1alpha1"
 kind: TestDefinition
@@ -31,4 +31,5 @@ spec:
         command: ['curl']
         args: ['-k', 'https://kiali.{{ .Values.global.ingress.domainName }}']
 
+{{- end}}
 {{- end}}

--- a/resources/kiali/values.yaml
+++ b/resources/kiali/values.yaml
@@ -1,3 +1,5 @@
+tests:
+  enabled: false
 
 server:
   # The port that the server will bind to in order to receive console and API requests.

--- a/resources/monitoring/templates/tests/rbac.yaml
+++ b/resources/monitoring/templates/tests/rbac.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.tests.enabled }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
@@ -42,3 +43,4 @@ subjects:
 - kind: ServiceAccount
   name: {{ .Chart.Name }}-tests
   namespace: {{ .Release.Namespace }}
+{{- end }}

--- a/resources/monitoring/templates/tests/test.yaml
+++ b/resources/monitoring/templates/tests/test.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.tests.enabled }}
 {{- if .Capabilities.APIVersions.Has "testing.kyma-project.io/v1alpha1" }}
 apiVersion: "testing.kyma-project.io/v1alpha1"
 kind: TestDefinition
@@ -31,3 +32,4 @@ spec:
             memory: 96Mi
       restartPolicy: Never
 {{- end }}
+{{- end}}

--- a/resources/monitoring/values.yaml
+++ b/resources/monitoring/values.yaml
@@ -12,3 +12,5 @@ global:
     name: monitoring-integration-tests
     dir: develop/
     version: 7a12b224
+tests:
+  enabled: false


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/master/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

As we agreed here: https://github.com/kyma-project/community/issues/369 we are getting rid of flaky tests. Tests that failed at least once on nightly cluster are turned off
![image](https://user-images.githubusercontent.com/17271979/66316546-26be3f80-e918-11e9-80cc-6225571621d6.png)

![image](https://user-images.githubusercontent.com/17271979/66336694-db1e8c80-e93d-11e9-9d71-41516d335a51.png)
 

Changes proposed in this pull request:

- Turn off flaky tests of:
   - core-apiserver-proxy
   - core-test-external-solution
   - core-cluster-users
   - kiali
   - core-api-controller
   - e2e-kubeless
   - assetstore
   - application-registry
   - core-console-backend-service
   - connector-service
   - application-operator
   - application-connector
   - monitoring

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->

Link to accepted proposal: https://github.com/kyma-project/community/issues/369
