### PR TITLE
Turn off flaky event-bus and knative-serving tests

### DIFF
--- a/resources/event-bus/templates/tests/rbac.yaml
+++ b/resources/event-bus/templates/tests/rbac.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.tests.enabled }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -51,3 +52,4 @@ roleRef:
   kind: ClusterRole
   name: {{ .Chart.Name }}-tests
   apiGroup: rbac.authorization.k8s.io
+{{- end }}

--- a/resources/event-bus/templates/tests/test.yaml
+++ b/resources/event-bus/templates/tests/test.yaml
@@ -1,4 +1,4 @@
-
+{{- if .Values.tests.enabled}}
 {{- if .Capabilities.APIVersions.Has "testing.kyma-project.io/v1alpha1" }}
 apiVersion: "testing.kyma-project.io/v1alpha1"
 kind: TestDefinition
@@ -48,3 +48,4 @@ spec:
                 done
       restartPolicy: Never
 {{- end}}
+{{- end }}

--- a/resources/event-bus/values.yaml
+++ b/resources/event-bus/values.yaml
@@ -62,3 +62,6 @@ global:
 e2eTests:
   nameTester: test-event-bus-tester
   nameSubscriber: test-event-bus-subscriber
+
+tests:
+  enabled: false

--- a/resources/knative-serving/templates/tests/rbac.yaml
+++ b/resources/knative-serving/templates/tests/rbac.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.test.enabled }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -43,3 +44,4 @@ subjects:
 - kind: ServiceAccount
   name: {{ .Chart.Name }}-tests
   namespace: {{ .Release.Namespace }}
+{{- end }}

--- a/resources/knative-serving/templates/tests/test.yaml
+++ b/resources/knative-serving/templates/tests/test.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.test.enabled }}
 {{- if .Capabilities.APIVersions.Has "testing.kyma-project.io/v1alpha1" }}
 apiVersion: "testing.kyma-project.io/v1alpha1"
 kind: TestDefinition
@@ -26,4 +27,5 @@ spec:
         - name: TARGET
           value: {{ .Values.test.target }}
       restartPolicy: Never
+{{- end }}
 {{- end }}

--- a/resources/knative-serving/values.yaml
+++ b/resources/knative-serving/values.yaml
@@ -38,3 +38,4 @@ global:
 
 test:
   target: "Test Target"
+  enabled: false


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/master/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

As we agreed here: https://github.com/kyma-project/community/issues/369 we are getting rid of flaky tests. Tests that failed at least once on nightly cluster are turned off

![image](https://user-images.githubusercontent.com/17271979/66458066-1621dc80-ea72-11e9-867d-49d76e8fe4bb.png)

Changes proposed in this pull request:

- Turn off flaky tests of:
   - knative-serving
   - event-bus

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->

Link to accepted proposal: https://github.com/kyma-project/community/issues/369
