### PR TITLE
Enable Application Connector tests

### DIFF
--- a/resources/application-connector/charts/application-operator/values.yaml
+++ b/resources/application-connector/charts/application-operator/values.yaml
@@ -11,6 +11,6 @@ controller:
     installationTimeout: 240
 
 tests:
-  enabled: false
+  enabled: true
   image:
     pullPolicy: IfNotPresent

--- a/resources/application-connector/charts/application-registry/values.yaml
+++ b/resources/application-connector/charts/application-registry/values.yaml
@@ -18,6 +18,6 @@ service:
     port: *externalAPIPort
 
 tests:
-  enabled: false
+  enabled: true
   image:
     pullPolicy: IfNotPresent

--- a/resources/application-connector/charts/connector-service/values.yaml
+++ b/resources/application-connector/charts/connector-service/values.yaml
@@ -65,7 +65,7 @@ istio:
     required: false
 
 tests:
-  enabled: false
+  enabled: true
   skipSslVerify: true
   central: *central
   image:

--- a/resources/application-connector/values.yaml
+++ b/resources/application-connector/values.yaml
@@ -81,7 +81,7 @@ application_connectivity_certs_setup_job:
 tests:
   application_connector_tests:
 #    enabled: *connectorServiceEnabled
-    enabled: false
+    enabled: true
     connector_service:
       central: false
     skipSslVerify: true


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Enable Application Connector tests previously marked as flaky that were tested for stability and passed the stability checks:
  - application-operator
  - application-registry
  - connector-service
  - application-connector.
