### PR TITLE
Revert "Bump Oathkeeper image to support alternative token location"

### DIFF
--- a/resources/ory/charts/oathkeeper/values.yaml
+++ b/resources/ory/charts/oathkeeper/values.yaml
@@ -5,7 +5,7 @@ image:
   # ORY Oathkeeper image
   repository: oryd/oathkeeper
   # ORY Oathkeeper version
-  tag: v0.19.2-beta.1
+  tag: v0.18.0
   # Image pull policy
   pullPolicy: IfNotPresent
 

--- a/resources/ory/values.yaml
+++ b/resources/ory/values.yaml
@@ -85,39 +85,34 @@ oathkeeper:
           enabled: true
         anonymous:
           enabled: true
-          config:
-            subject: anonymous
+          subject: anonymous
         cookie_session:
           enabled: false
-          config:
-            # REQUIRED IF ENABLED - The session store to forward request method/path/headers to for validation
-            check_session_url: https://session-store-host
-            # Optionally set a list of cookie names to look for in incoming requests.
-            # If unset, all requests are forwarded.
-            # If set, only requests that have at least one of the set cookies will be forwarded, others will be passed to the next authenticator
-            only:
+          # REQUIRED IF ENABLED - The session store to forward request method/path/headers to for validation
+          check_session_url: https://session-store-host
+          # Optionally set a list of cookie names to look for in incoming requests.
+          # If unset, all requests are forwarded.
+          # If set, only requests that have at least one of the set cookies will be forwarded, others will be passed to the next authenticator
+          only:
               - sessionid
         oauth2_client_credentials:
           enabled: true
-          config:
-            # REQUIRED IF ENABLED - The OAuth 2.0 Token Endpoint that will be used to validate the client credentials.
-            token_url: http://ory-hydra-public.kyma-system.svc.cluster.local:4444/oauth2/token
+          # REQUIRED IF ENABLED - The OAuth 2.0 Token Endpoint that will be used to validate the client credentials.
+          token_url: http://ory-hydra-public.kyma-system.svc.cluster.local:4444/oauth2/token
         oauth2_introspection:
           # Set enabled to true if the authenticator should be enabled and false to disable the authenticator. Defaults to false.
           enabled: true
-          config:
-            # REQUIRED IF ENABLED - The OAuth 2.0 Token Introspection endpoint.
-            introspection_url: http://ory-hydra-admin.kyma-system.svc.cluster.local:4445/oauth2/introspect
-            # Sets the strategy to be used to validate/match the token scope. Supports "hierarchic", "exact", "wildcard", "none". Defaults
-            # to "none".
-            scope_strategy: exact
+          # REQUIRED IF ENABLED - The OAuth 2.0 Token Introspection endpoint.
+          introspection_url: http://ory-hydra-admin.kyma-system.svc.cluster.local:4445/oauth2/introspect
+          # Sets the strategy to be used to validate/match the token scope. Supports "hierarchic", "exact", "wildcard", "none". Defaults
+          # to "none".
+          scope_strategy: exact
         # Enable the "jwt" section to allow for jwt authenticator configured for local Dex Id Tokens.
         jwt:
           enabled: true
-          config:
-            jwks_urls:
-              - http://dex-service.kyma-system.svc.cluster.local:5556/keys
-            scope_strategy: wildcard
+          jwks_urls:
+            - http://dex-service.kyma-system.svc.cluster.local:5556/keys
+          scope_strategy: wildcard
       authorizers:
         allow:
           enabled: true
@@ -128,31 +123,21 @@ oathkeeper:
           enabled: true
         id_token:
           enabled: true
-          config:
-            # REQUIRED IF ENABLED - Sets the "iss" value of the ID Token.
-            issuer_url: https://oathkeeper.{{ .Values.global.ingress.domainName }}/
-            # REQUIRED IF ENABLED - Sets the URL where keys should be fetched from. Supports remote locations (http, https) as
-            # well as local filesystem paths.
-            # jwks_url: https://fetch-keys/from/this/location.json
-            # jwks_url: file:///from/this/absolute/location.json
-            # jwks_url: file://../from/this/relative/location.json
-            # Sets the time-to-live of the ID token. Defaults to one minute. Valid time units are: s (second), m (minute), h (hour).
-            ttl: 60s
+          # REQUIRED IF ENABLED - Sets the "iss" value of the ID Token.
+          issuer_url: https://oathkeeper.{{ .Values.global.ingress.domainName }}/
+          # REQUIRED IF ENABLED - Sets the URL where keys should be fetched from. Supports remote locations (http, https) as
+          # well as local filesystem paths.
+          # jwks_url: https://fetch-keys/from/this/location.json
+          # jwks_url: file:///from/this/absolute/location.json
+          # jwks_url: file://../from/this/relative/location.json
+          # Sets the time-to-live of the ID token. Defaults to one minute. Valid time units are: s (second), m (minute), h (hour).
+          ttl: 60s
         header:
           enabled: true
-          config:
-            headers:
-              bar: foo
         cookie:
           enabled: true
-          config:
-            cookies:
-              foo: bar
         hydrator:
           enabled: true
-          config:
-            api:
-              url: https://example.com
       serve:
         proxy:
           port: 4455
@@ -167,7 +152,7 @@ oathkeeper:
         cpu: 50m
         memory: 64Mi
   image:
-    tag: v0.19.2-beta.1
+    tag: v0.18.0-beta.1
   oathkeeper-maester:
     deployment:
       annotations:


### PR DESCRIPTION
This reverts commit 48c63834892bff4aeadb279d6b2c56a338726709.

<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/master/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- reverts #5874 due to a problem with the configuration

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->

See also ory/oathkeeper#257