### PR TITLE
fix knative-serving test

### DIFF
--- a/resources/knative-serving/values.yaml
+++ b/resources/knative-serving/values.yaml
@@ -38,4 +38,4 @@ global:
 
 test:
   target: "Test Target"
-  enabled: false
+  enabled: true

--- a/resources/knative-serving/values.yaml
+++ b/resources/knative-serving/values.yaml
@@ -38,4 +38,4 @@ global:
 
 test:
   target: "Test Target"
-  enabled: true
+  enabled: false

--- a/tests/knative-serving/Makefile
+++ b/tests/knative-serving/Makefile
@@ -2,6 +2,8 @@ APP_NAME = knative-serving-acceptance-tests
 IMG = $(DOCKER_PUSH_REPOSITORY)$(DOCKER_PUSH_DIRECTORY)/$(APP_NAME)
 TAG = $(DOCKER_TAG)
 
+.DEFAULT_GOAL := build-image
+
 .PHONY: pull-licenses
 pull-licenses:
 ifdef LICENSE_PULLER_PATH

--- a/tests/knative-serving/knative_serving_test.go
+++ b/tests/knative-serving/knative_serving_test.go
@@ -81,7 +81,7 @@ func TestKnativeServingAcceptance(t *testing.T) {
 		t.Fatalf("Cannot create test Service: %v", err)
 	}
 
-	defer deleteService(serviceClient, svc.Name)
+	defer deleteService(t, serviceClient, svc.Name)
 	var testServiceURL string
 
 	err = retry.Do(func() error {
@@ -173,9 +173,9 @@ func loadKubeConfigOrDie(t *testing.T) *rest.Config {
 	return kubeConfig
 }
 
-func deleteService(servingClient servingtyped.ServiceInterface, name string) {
-	var deleteImmediately int64
-	_ = servingClient.Delete(name, &meta.DeleteOptions{
-		GracePeriodSeconds: &deleteImmediately,
-	})
+func deleteService(t *testing.T, servingClient servingtyped.ServiceInterface, name string) {
+	err := servingClient.Delete(name, &meta.DeleteOptions{})
+	if err != nil {
+		t.Fatalf("Cannot delete service %v, Error: %v", name, err)
+	}
 }

--- a/tests/knative-serving/knative_serving_test.go
+++ b/tests/knative-serving/knative_serving_test.go
@@ -174,6 +174,8 @@ func loadKubeConfigOrDie(t *testing.T) *rest.Config {
 }
 
 func deleteService(t *testing.T, servingClient servingtyped.ServiceInterface, name string) {
+	t.Helper()
+
 	err := servingClient.Delete(name, &meta.DeleteOptions{})
 	if err != nil {
 		t.Fatalf("Cannot delete service %v, Error: %v", name, err)


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/master/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

knative serving tests failed probably due to a force delete of the `ksvc` created during the test. The ksvc will now be removed without specifying immediate deletetion and it fails the test if the deletion fails.


**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
#5938 