### PR TITLE
Stabilize `expose API` UI test

### DIFF
--- a/resources/core/values.yaml
+++ b/resources/core/values.yaml
@@ -23,8 +23,8 @@ global:
     dir:
     version: "PR-5891"
   ui_acceptance_tests:
-    dir: pr/
-    version: PR-1326
+    dir:
+    version: 2ce268ee
   api_controller:
     dir:
     version: 8eb3a417

--- a/resources/core/values.yaml
+++ b/resources/core/values.yaml
@@ -23,8 +23,8 @@ global:
     dir:
     version: "PR-5891"
   ui_acceptance_tests:
-    dir: 
-    version: d1d3246e
+    dir: pr/
+    version: PR-1326
   api_controller:
     dir:
     version: 8eb3a417


### PR DESCRIPTION
**Description**

Use new image version for ui tests, which:
 - removes namespace creation test (as already covered in enzyme tests)
 - fixes 404 error problem for `expose api` test
 
**Related issue(s)**
Fixes https://github.com/kyma-project/kyma/issues/5949
Fixes https://github.com/kyma-project/console/issues/1272

