### PR TITLE
Adding watch Verb in event-publish-service ClusterRole

### DIFF
--- a/resources/event-bus/charts/event-publish-service/templates/service-account.yaml
+++ b/resources/event-bus/charts/event-publish-service/templates/service-account.yaml
@@ -17,6 +17,7 @@ rules:
     verbs:
       - get
       - list
+      - watch
   - apiGroups:
       - messaging.knative.dev
     resources:
@@ -24,6 +25,7 @@ rules:
     verbs:
       - get
       - list
+      - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRoleBinding


### PR DESCRIPTION
evennt publish service is continuously overwhelmed with logs as the knative channel informer is unable to retrieve knative channels due to missing permission. with this PR we introduce the missing verb required for the channel informer to retrieve those Knative Channels