### PR TITLE
disabling test bundle for test execution to see the dependencies

### DIFF
--- a/installation/scripts/testing.sh
+++ b/installation/scripts/testing.sh
@@ -103,14 +103,14 @@ else
 fi
 
 # creates a ClusterAddonsConfiguration which provides the testing addons
-injectTestingAddons
-if [[ $? -eq 1 ]]; then
-  exit 1
-fi
+#injectTestingAddons
+#if [[ $? -eq 1 ]]; then
+#  exit 1
+#fi
 
-if [[ ${CLEANUP} = "true" ]]; then
-  trap removeTestingAddons EXIT
-fi
+#if [[ ${CLEANUP} = "true" ]]; then
+#  trap removeTestingAddons EXIT
+#fi
 
 cat <<EOF | ${kc} apply -f -
 apiVersion: testing.kyma-project.io/v1alpha1

--- a/resources/testing/Chart.yaml
+++ b/resources/testing/Chart.yaml
@@ -4,4 +4,5 @@ description: Testing
 version: 0.0.1
 keywords:
 - testing
+- octopus
 - kyma


### PR DESCRIPTION

**Description**
The testing.sh script contains custom logic to create the testing bundle upfront test execution. In order to have a test execution only based on octopus, no custom things around, we need to figure out what is relying really on that dependency in order to change it.

That PR should not be merged, it is only there for analysis.
