### PR TITLE
fix broken helm links in docs

### DIFF
--- a/docs/kyma/04-11-update.md
+++ b/docs/kyma/04-11-update.md
@@ -14,7 +14,7 @@ This guide describes how to update Kyma deployed locally or on a cluster.
 
 ## Overview
 
-Kyma consists of multiple components, installed as [Helm](https://github.com/helm/helm/tree/master/docs) releases.
+Kyma consists of multiple components, installed as [Helm](https://helm.sh/docs/) releases.
 
 Update of an existing deployment can include:
 
@@ -58,7 +58,7 @@ Read about each update step in the following sections.
 
    ```bash
    ./installation/scripts/build-kyma-installer.sh
-   ```  
+   ```
 
    > **NOTE:** If you started Kyma with the `run.sh` script with a `--vm-driver {value}` parameter, provide the same parameter to the `build-kyma-installer.sh` script.
 

--- a/docs/kyma/05-03-overrides.md
+++ b/docs/kyma/05-03-overrides.md
@@ -3,8 +3,8 @@ title: Helm overrides for Kyma installation
 type: Configuration
 ---
 
-Kyma packages its components into [Helm](https://github.com/helm/helm/tree/master/docs) charts that the [Kyma Operator](https://github.com/kyma-project/kyma/tree/master/components/kyma-operator) uses during installation and updates.
-This document describes how to configure the Kyma Installer with new values for Helm [charts](https://github.com/helm/helm/blob/master/docs/charts.md) to override the default settings in `values.yaml` files.
+Kyma packages its components into [Helm](https://helm.sh/docs/) charts that the [Kyma Operator](https://github.com/kyma-project/kyma/tree/master/components/kyma-operator) uses during installation and updates.
+This document describes how to configure the Kyma Installer with new values for Helm [charts](https://helm.sh/docs/developing_charts/) to override the default settings in `values.yaml` files.
 
 ## Overview
 

--- a/docs/security/03-04-tiller-tls.md
+++ b/docs/security/03-04-tiller-tls.md
@@ -3,40 +3,40 @@ title: TLS in Tiller
 type: Details
 ---
 
-Kyma comes with a custom installation of [Tiller](https://helm.sh/docs/glossary/#tiller) which secures all incoming traffic with TLS certificate verification. To enable communication with Tiller, you must save the client certificate, key, and the cluster Certificate Authority (CA) to [Helm Home](https://helm.sh/docs/glossary/#helm-home-helm-home). 
+Kyma comes with a custom installation of [Tiller](https://helm.sh/docs/glossary/#tiller) which secures all incoming traffic with TLS certificate verification. To enable communication with Tiller, you must save the client certificate, key, and the cluster Certificate Authority (CA) to [Helm Home](https://helm.sh/docs/glossary/#helm-home-helm-home).
 
-Saving the client certificate, key, and CA to [Helm Home](https://helm.sh/docs/glossary/#helm-home-helm-home) is manual on cluster deployments. When you install Kyma locally, this process is handled by the `run.sh` script. 
+Saving the client certificate, key, and CA to [Helm Home](https://helm.sh/docs/glossary/#helm-home-helm-home) is manual on cluster deployments. When you install Kyma locally, this process is handled by the `run.sh` script.
 
-Additionally, you must add the `--tls` flag to every Helm command. 
-If you don't save the required certificates in Helm Home, or you don't include the `--tls` flag when you run a Helm command, you get this error: 
+Additionally, you must add the `--tls` flag to every Helm command.
+If you don't save the required certificates in Helm Home, or you don't include the `--tls` flag when you run a Helm command, you get this error:
 ```
 Error: transport is closing
 ```
 
 ## Add certificates to Helm Home
 
-To get the client certificate, key, and the cluster CA and add them to [Helm Home](https://helm.sh/docs/glossary/#helm-home-helm-home), run these commands: 
+To get the client certificate, key, and the cluster CA and add them to [Helm Home](https://helm.sh/docs/glossary/#helm-home-helm-home), run these commands:
   ```bash
   kubectl get -n kyma-installer secret helm-secret -o jsonpath="{.data['global\.helm\.ca\.crt']}" | base64 --decode > "$(helm home)/ca.pem";
   kubectl get -n kyma-installer secret helm-secret -o jsonpath="{.data['global\.helm\.tls\.crt']}" | base64 --decode > "$(helm home)/cert.pem";
   kubectl get -n kyma-installer secret helm-secret -o jsonpath="{.data['global\.helm\.tls\.key']}" | base64 --decode > "$(helm home)/key.pem";
   ```
 
-> **CAUTION:** All certificates are saved to Helm Home under the same, default path. When you save certificates of multiple clusters to Helm Home, one set of certificates overwrites the ones that already exist in Helm Home. As a result, you must save the cluster certificate set to Helm Home every time you switch the cluster context you work in. 
+> **CAUTION:** All certificates are saved to Helm Home under the same, default path. When you save certificates of multiple clusters to Helm Home, one set of certificates overwrites the ones that already exist in Helm Home. As a result, you must save the cluster certificate set to Helm Home every time you switch the cluster context you work in.
 
 ## Development
 
-To connect to the Tiller server, for example, using the [Helm GO library](https://godoc.org/k8s.io/helm/pkg/helm#pkg-index), mount the Helm client certificates into the application you want to connect. These certificates are stored as a Kubernertes Secret. 
+To connect to the Tiller server, mount the [Helm](https://helm.sh/) client certificates into the application you want to connect. These certificates are stored as a Kubernertes Secret.
 
-To get this Secret, run: 
+To get this Secret, run:
   ```bash
-  kubectl get secret -n kyma-installer helm-secret                            
+  kubectl get secret -n kyma-installer helm-secret
   ```
 
 Additionally, those secrets are also available as overrides during Kyma installation:
 
 | Override | Description |
-| --- | --- | 
+| --- | --- |
 | **global.helm.ca.crt** | Certificate Authority for the Helm client |
-| **global.helm.tls.crt** | Client certificate for the Helm client | 
-| **global.helm.tls.key** | Client certificate key for the Helm client |  
+| **global.helm.tls.crt** | Client certificate for the Helm client |
+| **global.helm.tls.key** | Client certificate key for the Helm client |


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- fix broken links in docs 

Reason: 

There were broken links to Helm as can be seen on https://storage.googleapis.com/kyma-prow-logs/logs/kyma-governance-nightly/1186447314839932930/build-log.txt 

It appears that Helm moved its documentation from GitHub to a dedicated website. Additionally, a missing GoDoc link was removed.


