### PR TITLE
First Draft

### DIFF
--- a/components/iam-kubeconfig-service/Gopkg.lock
+++ b/components/iam-kubeconfig-service/Gopkg.lock
@@ -2,6 +2,30 @@
 
 
 [[projects]]
+  digest = "1:a2682518d905d662d984ef9959984ef87cecb777d379bfa9d9fe40e78069b3e4"
+  name = "github.com/PuerkitoBio/purell"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "44968752391892e1b0d0b821ee79e9a85fa13049"
+  version = "v1.1.1"
+
+[[projects]]
+  branch = "master"
+  digest = "1:c739832d67eb1e9cc478a19cc1a1ccd78df0397bf8a32978b759152e205f644b"
+  name = "github.com/PuerkitoBio/urlesc"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "de5bf2ad457846296e2031421a34e2568e304e35"
+
+[[projects]]
+  digest = "1:d6afaeed1502aa28e80a4ed0981d570ad91b2579193404256ce672ed0a609e0d"
+  name = "github.com/beorn7/perks"
+  packages = ["quantile"]
+  pruneopts = "UT"
+  revision = "37c8de3658fcb183f997c4e13e8337516ab753e6"
+  version = "v1.0.1"
+
+[[projects]]
   digest = "1:f6e5e1bc64c2908167e6aa9a1fe0c084d515132a1c63ad5b6c84036aa06dc0c1"
   name = "github.com/coreos/go-oidc"
   packages = ["."]
@@ -18,12 +42,71 @@
   version = "v1.1.1"
 
 [[projects]]
+  digest = "1:ed15647db08b6d63666bf9755d337725960c302bbfa5e23754b4b915a4797e42"
+  name = "github.com/go-openapi/jsonpointer"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "ed123515f087412cd7ef02e49b0b0a5e6a79a360"
+  version = "v0.19.3"
+
+[[projects]]
+  digest = "1:451fe53c19443c6941be5d4295edc973a3eb16baccb940efee94284024be03b0"
+  name = "github.com/go-openapi/jsonreference"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "82f31475a8f7a12bc26962f6e26ceade8ea6f66a"
+  version = "v0.19.3"
+
+[[projects]]
+  digest = "1:55d1c09fc8b3320b6842565249a9e4d0f363bead6f9b8be05c3b47f2c4264eda"
+  name = "github.com/go-openapi/spec"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "8557d72e4f077c2dbe1e48df09e596b6fb9b7991"
+  version = "v0.19.4"
+
+[[projects]]
+  digest = "1:43d0f99f53acce97119181dcd592321084690c2d462c57680ccb4472ae084949"
+  name = "github.com/go-openapi/swag"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "c3d0f7896d589f3babb99eea24bbc7de98108e72"
+  version = "v0.19.5"
+
+[[projects]]
+  digest = "1:582e25eccee928dc12416ea4c23b6dae8f3b5687730632aa1473ebebe80a2359"
+  name = "github.com/gogo/protobuf"
+  packages = [
+    "proto",
+    "sortkeys",
+  ]
+  pruneopts = "UT"
+  revision = "5628607bb4c51c3157aacc3a50f0ab707582b805"
+  version = "v1.3.1"
+
+[[projects]]
+  branch = "master"
+  digest = "1:1ba1d79f2810270045c328ae5d674321db34e3aae468eb4233883b473c5c0467"
+  name = "github.com/golang/glog"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "23def4e6c14b4da8ac2ed8007337bc5eb5007998"
+
+[[projects]]
   digest = "1:97df918963298c287643883209a2c3f642e6593379f97ab400c2a2e219ab647d"
   name = "github.com/golang/protobuf"
   packages = ["proto"]
   pruneopts = "UT"
   revision = "aa810b61a9c79d51363740d207bb46cf8e620ed5"
   version = "v1.2.0"
+
+[[projects]]
+  digest = "1:a6181aca1fd5e27103f9a920876f29ac72854df7345a39f3b01e61c8c94cc8af"
+  name = "github.com/google/gofuzz"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "f140a6486e521aad38f5917de355cbf147cc0496"
+  version = "v1.0.0"
 
 [[projects]]
   digest = "1:ca59b1175189b3f0e9f1793d2c350114be36eaabbe5b9f554b35edee1de50aea"
@@ -34,12 +117,99 @@
   version = "v1.7.0"
 
 [[projects]]
+  digest = "1:c77361e611524ec8f2ad37c408c3c916111a70b6acf806a1200855696bf8fa4d"
+  name = "github.com/hashicorp/golang-lru"
+  packages = [
+    ".",
+    "simplelru",
+  ]
+  pruneopts = "UT"
+  revision = "7f827b33c0f158ec5dfbba01bb0b14a4541fd81d"
+  version = "v0.5.3"
+
+[[projects]]
+  digest = "1:7159b4af2aae0c37b088cea9cb5932b8801a289616c5b789e4669558521cff0c"
+  name = "github.com/howeyc/fsnotify"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "441bbc86b167f3c1f4786afae9931403b99fdacf"
+  version = "v0.9.0"
+
+[[projects]]
+  digest = "1:78d28d5b84a26159c67ea51996a230da4bc07cac648adaae1dfb5fc0ec8e40d3"
+  name = "github.com/imdario/mergo"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "1afb36080aec31e0d1528973ebe6721b191b0369"
+  version = "v0.3.8"
+
+[[projects]]
+  digest = "1:beb5b4f42a25056f0aa291b5eadd21e2f2903a05d15dfe7caf7eaee7e12fa972"
+  name = "github.com/json-iterator/go"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "03217c3e97663914aec3faafde50d081f197a0a2"
+  version = "1.1.8"
+
+[[projects]]
   digest = "1:0a69a1c0db3591fcefb47f115b224592c8dfa4368b7ba9fae509d5e16cdc95c8"
   name = "github.com/konsorten/go-windows-terminal-sequences"
   packages = ["."]
   pruneopts = "UT"
   revision = "5c8c8bd35d3832f5d134ae1e1e375b69a4d25242"
   version = "v1.0.1"
+
+[[projects]]
+  digest = "1:eecbe092a19e4daecdb9dbcbc2e18c718b9ca6c4a4f41df3ebc83ee3059f3ca4"
+  name = "github.com/kubernetes/kubernetes"
+  packages = ["staging/src/k8s.io/apiserver/pkg/authentication/authenticator"]
+  pruneopts = "UT"
+  revision = "c97fe5036ef3df2967d086711e6c0c405941e14b"
+  version = "v1.16.2"
+
+[[projects]]
+  digest = "1:43fa88d32fbffd6d098355fb87a659a2bcaf101e22490bcd4e46d16e5a23f056"
+  name = "github.com/kyma-project/kyma"
+  packages = ["components/apiserver-proxy/internal/authn"]
+  pruneopts = "UT"
+  revision = "91bb50b7b6a4501ff44b01664ed68c50a0705164"
+  version = "1.6.0"
+
+[[projects]]
+  digest = "1:927762c6729b4e72957ba3310e485ed09cf8451c5a637a52fd016a9fe09e7936"
+  name = "github.com/mailru/easyjson"
+  packages = [
+    "buffer",
+    "jlexer",
+    "jwriter",
+  ]
+  pruneopts = "UT"
+  revision = "1b2b06f5f209fea48ff5922d8bfb2b9ed5d8f00b"
+  version = "v0.7.0"
+
+[[projects]]
+  digest = "1:ff5ebae34cfbf047d505ee150de27e60570e8c394b3b8fdbb720ff6ac71985fc"
+  name = "github.com/matttproud/golang_protobuf_extensions"
+  packages = ["pbutil"]
+  pruneopts = "UT"
+  revision = "c12348ce28de40eed0136aa2b644d0ee0650e56c"
+  version = "v1.0.1"
+
+[[projects]]
+  digest = "1:33422d238f147d247752996a26574ac48dcf472976eda7f5134015f06bf16563"
+  name = "github.com/modern-go/concurrent"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "bacd9c7ef1dd9b15be4a9909b8ac7a4e313eec94"
+  version = "1.0.3"
+
+[[projects]]
+  digest = "1:e32bdbdb7c377a07a9a46378290059822efdce5c8d96fe71940d87cb4f918855"
+  name = "github.com/modern-go/reflect2"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "4b7aa43c6742a2c18fdef89dd197aaae7dac7ccd"
+  version = "1.0.1"
 
 [[projects]]
   digest = "1:cf31692c14422fa27c83a05292eb5cbe0fb2775972e8f1f8446a71549bd8980b"
@@ -69,12 +239,63 @@
   revision = "1555304b9b35fdd2b425bccf1a5613677705e7d0"
 
 [[projects]]
+  digest = "1:7097829edd12fd7211fca0d29496b44f94ef9e6d72f88fb64f3d7b06315818ad"
+  name = "github.com/prometheus/client_golang"
+  packages = [
+    "prometheus",
+    "prometheus/internal",
+  ]
+  pruneopts = "UT"
+  revision = "170205fb58decfd011f1550d4cfb737230d7ae4f"
+  version = "v1.1.0"
+
+[[projects]]
+  branch = "master"
+  digest = "1:2d5cd61daa5565187e1d96bae64dbbc6080dacf741448e9629c64fd93203b0d4"
+  name = "github.com/prometheus/client_model"
+  packages = ["go"]
+  pruneopts = "UT"
+  revision = "14fe0d1b01d4d5fc031dd4bec1823bd3ebbe8016"
+
+[[projects]]
+  digest = "1:f119e3205d3a1f0f19dbd7038eb37528e2c6f0933269dc344e305951fb87d632"
+  name = "github.com/prometheus/common"
+  packages = [
+    "expfmt",
+    "internal/bitbucket.org/ww/goautoneg",
+    "model",
+  ]
+  pruneopts = "UT"
+  revision = "287d3e634a1e550c9e463dd7e5a75a422c614505"
+  version = "v0.7.0"
+
+[[projects]]
+  digest = "1:a210815b437763623ecca8eb91e6a0bf4f2d6773c5a6c9aec0e28f19e5fd6deb"
+  name = "github.com/prometheus/procfs"
+  packages = [
+    ".",
+    "internal/fs",
+    "internal/util",
+  ]
+  pruneopts = "UT"
+  revision = "499c85531f756d1129edd26485a5f73871eeb308"
+  version = "v0.0.5"
+
+[[projects]]
   digest = "1:87c2e02fb01c27060ccc5ba7c5a407cc91147726f8f40b70cceeedbc52b1f3a8"
   name = "github.com/sirupsen/logrus"
   packages = ["."]
   pruneopts = "UT"
   revision = "e1e72e9de974bd926e5c56f83753fba2df402ce5"
   version = "v1.3.0"
+
+[[projects]]
+  digest = "1:524b71991fc7d9246cc7dc2d9e0886ccb97648091c63e30eef619e6862c955dd"
+  name = "github.com/spf13/pflag"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "2e9d26c8c37aae03e3f9d4e90b7116f5accb7cab"
+  version = "v1.0.5"
 
 [[projects]]
   digest = "1:972c2427413d41a1e06ca4897e8528e5a1622894050e2f527b38ddf0f343f759"
@@ -99,7 +320,7 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:414b14a8bf684d66472d704db11557afffb5391da7ce4808b013c37c1f9911d7"
+  digest = "1:46855468e49fba4ac93ca296da052e97079146e4d248a13bd2410d84bd99f28a"
   name = "golang.org/x/net"
   packages = [
     "context",
@@ -108,6 +329,7 @@
     "http2",
     "http2/hpack",
     "idna",
+    "websocket",
   ]
   pruneopts = "UT"
   revision = "3a22650c66bd7f4fb6d1e8072ffd7b75c8a27898"
@@ -135,7 +357,7 @@
   revision = "983097b1a8a340cd1cc7df17d735154d89e10b1a"
 
 [[projects]]
-  digest = "1:a2ab62866c75542dd18d2b069fec854577a20211d7c0ea6ae746072a1dccdd18"
+  digest = "1:0c56024909189aee3364b7f21a95a27459f718aa7c199a5c111c36cfffd9eaef"
   name = "golang.org/x/text"
   packages = [
     "collate",
@@ -152,10 +374,19 @@
     "unicode/cldr",
     "unicode/norm",
     "unicode/rangetable",
+    "width",
   ]
   pruneopts = "UT"
   revision = "f21a4dfb5e38f5895301dc265a8def02365cc3d0"
   version = "v0.3.0"
+
+[[projects]]
+  branch = "master"
+  digest = "1:32a1c8a24e8d0259416f84720d6c32e5c52cf10d01c19a7d23dcfa868f6b6235"
+  name = "golang.org/x/time"
+  packages = ["rate"]
+  pruneopts = "UT"
+  revision = "6d3f0bb11be5e03f8353894b7240e7d793e40a8f"
 
 [[projects]]
   branch = "master"
@@ -196,6 +427,14 @@
   version = "v1.4.0"
 
 [[projects]]
+  digest = "1:2d1fbdc6777e5408cabeb02bf336305e724b925ff4546ded0fa8715a7267922a"
+  name = "gopkg.in/inf.v0"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "d2d2541c53f18d2a059457998ce2876cc8e67cbf"
+  version = "v0.9.1"
+
+[[projects]]
   digest = "1:377f8ccfbf9d7ff3997ea7454b894de46cd1d9fe6ec1e724c93ad59eb716c5c0"
   name = "gopkg.in/square/go-jose.v2"
   packages = [
@@ -208,35 +447,149 @@
   version = "v2.2.2"
 
 [[projects]]
+  digest = "1:59f10c1537d2199d9115d946927fe31165959a95190849c82ff11e05803528b0"
+  name = "gopkg.in/yaml.v2"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "f221b8435cfb71e54062f6c6e99e9ade30b124d5"
+  version = "v2.2.4"
+
+[[projects]]
+  branch = "release-1.13"
+  digest = "1:86b38004415341a2f678a19f9312213bc851a3620bb42b3dca005c8ad0d3485c"
+  name = "k8s.io/api"
+  packages = [
+    "admissionregistration/v1alpha1",
+    "admissionregistration/v1beta1",
+    "apps/v1",
+    "apps/v1beta1",
+    "apps/v1beta2",
+    "auditregistration/v1alpha1",
+    "authentication/v1",
+    "authentication/v1beta1",
+    "authorization/v1",
+    "authorization/v1beta1",
+    "autoscaling/v1",
+    "autoscaling/v2beta1",
+    "autoscaling/v2beta2",
+    "batch/v1",
+    "batch/v1beta1",
+    "batch/v2alpha1",
+    "certificates/v1beta1",
+    "coordination/v1beta1",
+    "core/v1",
+    "events/v1beta1",
+    "extensions/v1beta1",
+    "networking/v1",
+    "policy/v1beta1",
+    "rbac/v1",
+    "rbac/v1alpha1",
+    "rbac/v1beta1",
+    "scheduling/v1alpha1",
+    "scheduling/v1beta1",
+    "settings/v1alpha1",
+    "storage/v1",
+    "storage/v1alpha1",
+    "storage/v1beta1",
+  ]
+  pruneopts = "UT"
+  revision = "dacd7df5a50b93833c2a2c2f81348f910be8bfc7"
+
+[[projects]]
   branch = "master"
-  digest = "1:f871f0d18251a09871013ba8d55b07d3773e5983e184ec2f066efdd24a8f48dc"
+  digest = "1:e57ea07cf90b2a204155c53dd573e22e0216b6402b26f012d45cc2d431f58694"
   name = "k8s.io/apimachinery"
   packages = [
+    "pkg/api/errors",
+    "pkg/api/resource",
+    "pkg/apis/meta/v1",
+    "pkg/apis/meta/v1/unstructured",
+    "pkg/conversion",
+    "pkg/conversion/queryparams",
+    "pkg/fields",
+    "pkg/labels",
+    "pkg/runtime",
+    "pkg/runtime/schema",
+    "pkg/runtime/serializer",
+    "pkg/runtime/serializer/json",
+    "pkg/runtime/serializer/protobuf",
+    "pkg/runtime/serializer/recognizer",
+    "pkg/runtime/serializer/streaming",
+    "pkg/runtime/serializer/versioning",
+    "pkg/selection",
+    "pkg/types",
+    "pkg/util/cache",
+    "pkg/util/clock",
+    "pkg/util/errors",
+    "pkg/util/framer",
+    "pkg/util/intstr",
+    "pkg/util/json",
+    "pkg/util/naming",
     "pkg/util/net",
     "pkg/util/runtime",
     "pkg/util/sets",
+    "pkg/util/validation",
+    "pkg/util/validation/field",
     "pkg/util/wait",
+    "pkg/util/yaml",
+    "pkg/version",
+    "pkg/watch",
+    "third_party/forked/golang/reflect",
   ]
   pruneopts = "UT"
   revision = "5eb658cbe970c2fa8aaeeb343ab8f9a3cae0783a"
 
 [[projects]]
-  digest = "1:3c18189c0470d0e1bc194cc492efabe26e833707e5376c84b4c7215d84785811"
+  digest = "1:03b4e840ecea379618ea3e265c1e9d86e68ef13ec76b73e8aaaf231b59747b66"
   name = "k8s.io/apiserver"
   packages = [
     "pkg/authentication/authenticator",
+    "pkg/authentication/authenticatorfactory",
+    "pkg/authentication/group",
+    "pkg/authentication/request/anonymous",
     "pkg/authentication/request/bearertoken",
+    "pkg/authentication/request/headerrequest",
+    "pkg/authentication/request/union",
+    "pkg/authentication/request/websocket",
+    "pkg/authentication/request/x509",
+    "pkg/authentication/token/cache",
+    "pkg/authentication/token/tokenfile",
     "pkg/authentication/user",
+    "pkg/util/webhook",
+    "pkg/util/wsstream",
     "plugin/pkg/authenticator/token/oidc",
+    "plugin/pkg/authenticator/token/webhook",
   ]
   pruneopts = "UT"
   revision = "92cc630367d00d05752f0cf0d6eca534bcd1e5a3"
   version = "kubernetes-1.15.3"
 
 [[projects]]
-  digest = "1:af06f5b45d94188d271a04c21f7aa5360008fbb87e8f4f40110681e7aa095de2"
+  digest = "1:c43f2c0e47d8e56f88b9c0a71f19487baf7efc79a5736767473f6ebf23f3a0f1"
   name = "k8s.io/client-go"
-  packages = ["util/cert"]
+  packages = [
+    "kubernetes/scheme",
+    "kubernetes/typed/authentication/v1beta1",
+    "pkg/apis/clientauthentication",
+    "pkg/apis/clientauthentication/v1alpha1",
+    "pkg/apis/clientauthentication/v1beta1",
+    "pkg/version",
+    "plugin/pkg/client/auth/exec",
+    "rest",
+    "rest/watch",
+    "tools/auth",
+    "tools/clientcmd",
+    "tools/clientcmd/api",
+    "tools/clientcmd/api/latest",
+    "tools/clientcmd/api/v1",
+    "tools/metrics",
+    "transport",
+    "util/cert",
+    "util/connrotation",
+    "util/flowcontrol",
+    "util/homedir",
+    "util/integer",
+  ]
   pruneopts = "UT"
   revision = "e64494209f554a6723674bd494d69445fb76a1d4"
   version = "v10.0.0"
@@ -249,11 +602,37 @@
   revision = "71442cd4037d612096940ceb0f3fec3f7fff66e0"
   version = "v0.2.0"
 
+[[projects]]
+  branch = "master"
+  digest = "1:0c5376eb8e9fb490a58f2a69faeb399add573ecbfdd9b6af4dab9ba9826a1a39"
+  name = "sigs.k8s.io/structured-merge-diff"
+  packages = [
+    "fieldpath",
+    "merge",
+    "schema",
+    "typed",
+    "value",
+  ]
+  pruneopts = "UT"
+  revision = "e660f95f9d845656100dbfc853645ec095589193"
+
+[[projects]]
+  digest = "1:7719608fe0b52a4ece56c2dde37bedd95b938677d1ab0f84b8a7852e4c59f849"
+  name = "sigs.k8s.io/yaml"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "fd68e9863619f6ec2fdd8625fe1f02e7c877e480"
+  version = "v1.1.0"
+
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
   input-imports = [
+    "github.com/golang/glog",
     "github.com/gorilla/mux",
+    "github.com/howeyc/fsnotify",
+    "github.com/kubernetes/kubernetes/staging/src/k8s.io/apiserver/pkg/authentication/authenticator",
+    "github.com/kyma-project/kyma/components/apiserver-proxy/internal/authn",
     "github.com/pkg/errors",
     "github.com/sirupsen/logrus",
     "github.com/stretchr/testify/assert",

--- a/components/iam-kubeconfig-service/Gopkg.toml
+++ b/components/iam-kubeconfig-service/Gopkg.toml
@@ -44,6 +44,10 @@ required = [
   name = "github.com/stretchr/testify"
   version = "1.2.1"
 
+[[constraint]]
+  name = "github.com/howeyc/fsnotify"
+  version = "0.9.0"
+
 [prune]
   go-tests = true
   unused-packages = true

--- a/components/iam-kubeconfig-service/cmd/generator/runtime/doc.go
+++ b/components/iam-kubeconfig-service/cmd/generator/runtime/doc.go
@@ -1,0 +1,9 @@
+package runtime
+
+/*
+* Package runtime provides support for detecting changes to data files while the controller is running.
+* In addition this package contains types for plugging into controller logic in order to reload the data from the files once changes are detected.
+* These features are necessary for things like SSL certificates that must be updated at runtime without downtime.
+* Otherwise, the controller Pod must be re-deployed after updating secrets with new SSL certificate data.
+* The file-watch facilites are separated from data-reloading components for better extensibility and reusability.
+ */

--- a/components/iam-kubeconfig-service/cmd/generator/runtime/reload.go
+++ b/components/iam-kubeconfig-service/cmd/generator/runtime/reload.go
@@ -1,0 +1,179 @@
+package runtime
+
+import (
+	"crypto/tls"
+	"fmt"
+	"net/http"
+	"sync"
+
+	"github.com/golang/glog"
+	"github.com/kyma-project/kyma/components/iam-kubeconfig-service/internal/authn"
+	"k8s.io/apiserver/pkg/authentication/authenticator"
+)
+
+//TLSCertConstructor knows how to construct a tls.Certificate instance
+type TLSCertConstructor func() (*tls.Certificate, error)
+
+//ReloadableTLSCertProvider enables to create and re-create an instance of tls.Certificate in a thread-safe way.
+//It's GetCertificateFunc conforms to tls.Config.GetCertificate function type.
+type ReloadableTLSCertProvider struct {
+	constructor TLSCertConstructor
+	holder      *TLSCrtKeyPairHolder
+}
+
+//NewReloadableTLSCertProvider creates a new instance of ReloadableTLSCertProvider.
+//notifier parameter is used register a data reloading callback.
+//External code can make use of this callback to trigger data reloading from outside.
+//It's safe to trigger reloading from other goroutines.
+func NewReloadableTLSCertProvider(constructor TLSCertConstructor) (*ReloadableTLSCertProvider, error) {
+
+	result := &ReloadableTLSCertProvider{
+		constructor: constructor,
+		holder:      NewTLSCrtKeyPairHolder(),
+	}
+
+	//Initial read
+	err := result.reload()
+	if err != nil {
+		return nil, err
+	}
+
+	return result, nil
+}
+
+//Reload reloads the internal instance.
+func (ckpr *ReloadableTLSCertProvider) Reload() {
+	err := ckpr.reload()
+	if err != nil {
+		glog.Errorf("Failed to reload certificate: %v", err)
+	}
+}
+
+//reloads the internal instance using provided constructor function
+//Note: It must NOT modify the existing value in case of an error!
+func (ckpr *ReloadableTLSCertProvider) reload() error {
+	newCert, err := ckpr.constructor()
+	if err != nil {
+		return err
+	}
+	ckpr.holder.Set(newCert)
+	return nil
+}
+
+//GetCertificateFunc conforms to tls.Config.GetCertificate function type
+func (ckpr *ReloadableTLSCertProvider) GetCertificateFunc(*tls.ClientHelloInfo) (*tls.Certificate, error) {
+	fmt.Println("getCertificateFunc")
+	return ckpr.holder.Get(), nil
+}
+
+//TLSCrtKeyPairHolder keeps a tls.Certificate instance and allows for Get/Set operations in a thread-safe way
+type TLSCrtKeyPairHolder struct {
+	rwmu  sync.RWMutex
+	value *tls.Certificate
+}
+
+//NewTLSCrtKeyPairHolder returns new TLSCrtKeyPairHolder instance
+func NewTLSCrtKeyPairHolder() *TLSCrtKeyPairHolder {
+	return &TLSCrtKeyPairHolder{}
+}
+
+//Get returns the tls.Certificate instance stored in the TLSCrtKeyPairHolder
+func (tlsh *TLSCrtKeyPairHolder) Get() *tls.Certificate {
+	tlsh.rwmu.RLock()
+	defer tlsh.rwmu.RUnlock()
+	return tlsh.value
+}
+
+//Set stores given tls.Certificate in the TLSCrtKeyPairHolder
+func (tlsh *TLSCrtKeyPairHolder) Set(v *tls.Certificate) {
+	tlsh.rwmu.Lock()
+	defer tlsh.rwmu.Unlock()
+	tlsh.value = v
+}
+
+//AuthReqConstructor knows how to construct an authn.CancellableAuthRequest instance
+type AuthReqConstructor func() (authn.CancellableAuthRequest, error)
+
+//ReloadableAuthReq enables to create and re-create an instance of authenticator.Request in a thread-safe way.
+//It's used to re-create authenticator.Request instance every time a change in oidc-ca-file is detected.
+//It implements authenticator.Request interface so it can be easily plugged in instead of a "real" instance.
+type ReloadableAuthReq struct {
+	constructor AuthReqConstructor
+	holder      *AuthReqHolder
+}
+
+//NewReloadableAuthReq creates a new instance of ReloadableAuthReq.
+//notifier parameter allows to control when the instance is re-created from outside.
+//It's safe to trigger re-creation from other goroutines.
+func NewReloadableAuthReq(constructor AuthReqConstructor) (*ReloadableAuthReq, error) {
+	result := ReloadableAuthReq{
+		constructor: constructor,
+		holder:      NewAuthReqHolder(),
+	}
+
+	//Initial read
+	err := result.reload()
+	if err != nil {
+		return nil, err
+	}
+
+	return &result, nil
+}
+
+//Reload reloads internal instance.
+func (rar *ReloadableAuthReq) Reload() {
+	err := rar.reload()
+	if err != nil {
+		glog.Errorf("Failed to reload OIDC Authenticator instance: %v", err)
+	}
+}
+
+//reloads the internal instance using provided constructor function
+//Note: It must NOT modify the existing value in case of an error!
+func (rar *ReloadableAuthReq) reload() error {
+	newAuthReq, err := rar.constructor()
+	if err != nil {
+		return err
+	}
+
+	oldAuthReq := rar.holder.Get()
+	if oldAuthReq != nil {
+		glog.Info("Cancelling previous OIDC Authenticator instance")
+		oldAuthReq.Cancel()
+	}
+
+	rar.holder.Set(newAuthReq)
+	return nil
+}
+
+//AuthenticateRequest implements authenticator.Request interface
+func (rar *ReloadableAuthReq) AuthenticateRequest(req *http.Request) (*authenticator.Response, bool, error) {
+	//Delegate to internally-stored instance (thread-safe)
+	return rar.holder.Get().AuthenticateRequest(req)
+}
+
+//AuthReqHolder keeps an authenticator.Request and an authn.AuthenticatorCancelFunc instance.
+//It allows for Get/Set operations in a thread-safe way
+type AuthReqHolder struct {
+	rwmu  sync.RWMutex
+	value authn.CancellableAuthRequest
+}
+
+//NewAuthReqHolder returns new AuthReqHolder instance
+func NewAuthReqHolder() *AuthReqHolder {
+	return &AuthReqHolder{}
+}
+
+//Get returns the instances stored in the AuthReqHolder
+func (arh *AuthReqHolder) Get() authn.CancellableAuthRequest {
+	arh.rwmu.RLock()
+	defer arh.rwmu.RUnlock()
+	return arh.value
+}
+
+//Set stores given instances in the AuthReqHolder
+func (arh *AuthReqHolder) Set(v authn.CancellableAuthRequest) {
+	arh.rwmu.Lock()
+	defer arh.rwmu.Unlock()
+	arh.value = v
+}

--- a/components/iam-kubeconfig-service/cmd/generator/runtime/watch.go
+++ b/components/iam-kubeconfig-service/cmd/generator/runtime/watch.go
@@ -1,0 +1,142 @@
+package runtime
+
+import (
+	"context"
+	"path/filepath"
+	"time"
+
+	"github.com/howeyc/fsnotify"
+
+	"github.com/golang/glog"
+)
+
+// Watcher is designed to provide notifications about changes to files mounted inside kubernetes Pod, like Secrets or ConfigMaps
+// Because file watches breaks in kubernetes when mounts are updated, we watch for directories instead.
+// This happens because files mounted in a Pod are actually symbolic links pointing to "real" files.
+// On updating mounted files, kubernetes deletes the existing file, which sends a DELETE file event and breaks the watch
+type Watcher interface {
+	// Run start the watcher loop (blocking call)
+	// context is used to terminate the loop
+	Run(context.Context)
+}
+
+type watcher struct {
+	name                   string   //name of the watcher to improve logging
+	filePaths              []string //a single watcher can react to changes to many files
+	eventBatchDelaySeconds uint8    //changes that occur within this time window are batched in a single notification
+	notifyFunc             func()   //notification function invoked when changes are detected, but only after configured eventBatchDelaySeconds time
+}
+
+// NewWatcher creates a new watcher instance
+// name is used in logging
+// filePaths parameter is a list of file paths to watch
+// notifyFunc is a function that is invoked after watcher detects changes to monitored files.
+func NewWatcher(name string, filePaths []string, evBatchDelaySeconds uint8, notifyFunc func()) Watcher {
+	return &watcher{
+		name:                   name,
+		filePaths:              filePaths,
+		eventBatchDelaySeconds: evBatchDelaySeconds,
+		notifyFunc:             notifyFunc,
+	}
+}
+
+//Run implements Watcher interface
+func (w *watcher) Run(ctx context.Context) {
+	glog.Infof("Watcher [%s] starts watching for files: %v", w.name, w.filePaths)
+
+	watchFileEventsFunc := func(fEventChan <-chan *fsnotify.FileEvent) {
+		w.watchFileEvents(ctx, fEventChan)
+	}
+
+	dirs := uniqeDirNames(w.filePaths)
+
+	// monitor files
+	go func() {
+		w.watchForDirs(dirs, watchFileEventsFunc)
+	}()
+
+	<-ctx.Done()
+	glog.Infof("Watcher [%s] has successfully terminated", w.name)
+}
+
+// watchFileEvents watches for changes on a channel and notifies via notifyFn().
+// The function batches changes so that related changes are processed together in a single step.
+// The function ensures that notifyFn() is called no more than one time per eventBatchDelaySeconds.
+// The function does not return until the the context is canceled.
+func (w *watcher) watchFileEvents(ctx context.Context, wch <-chan *fsnotify.FileEvent) {
+	minDelay := time.Second * time.Duration(w.eventBatchDelaySeconds)
+
+	// timer and channel for managing minDelay.
+	var timeChan <-chan time.Time
+	var timer *time.Timer
+
+	for {
+		select {
+		case ev := <-wch:
+			glog.Infof("Watcher[%s]: watchFileEvents: %s", w.name, ev.String())
+			if timer != nil {
+				continue
+			}
+			// create new timer
+			timer = time.NewTimer(minDelay)
+			timeChan = timer.C
+		case <-timeChan:
+			// reset timer
+			timeChan = nil
+			timer.Stop()
+			timer = nil
+
+			glog.Infof("Watcher[%s]: watchFileEvents: notifying", w.name)
+			w.notifyFunc()
+		case <-ctx.Done():
+			glog.Infof("Watcher[%s]: watchFileEvents has successfully terminated", w.name)
+			return
+		}
+	}
+}
+
+// watchForDirs configures a watch for every directory path in dirs.
+// It then invokes provided watchFunc with configured Watchers.
+// This function is blocking so it should be run in a goroutine.
+func (w *watcher) watchForDirs(dirs []string, watchFunc func(fEventChan <-chan *fsnotify.FileEvent)) {
+	fw, err := fsnotify.NewWatcher()
+	if err != nil {
+		glog.Warningf("Watcher[%s]: failed to create a watcher for certificate files: %v", w.name, err)
+		return
+	}
+	defer func() {
+		if err := fw.Close(); err != nil {
+			glog.Warningf("Watcher[%s]: closing watcher encounters an error %v", w.name, err)
+		}
+	}()
+
+	for _, dir := range dirs {
+		if err := fw.Watch(dir); err != nil {
+			glog.Warningf("Watcher[%s]: watching %s encountered an error %v", w.name, dir, err)
+			return
+		}
+		glog.Infof("Watcher[%s]: watching %s for changes", w.name, dir)
+	}
+
+	watchFunc(fw.Event)
+}
+
+//Extracts directory paths from provided filePaths list and returns a list of paths with duplicates removed.
+func uniqeDirNames(filePaths []string) []string {
+	if len(filePaths) == 0 {
+		return []string{}
+	}
+
+	dirMap := make(map[string]bool)
+	for _, c := range filePaths {
+		dirMap[filepath.Dir(c)] = true
+	}
+
+	i := 0
+	res := make([]string, len(dirMap))
+	for d := range dirMap {
+		res[i] = d
+		i++
+	}
+	return res
+}

--- a/components/iam-kubeconfig-service/cmd/generator/runtime/watch_test.go
+++ b/components/iam-kubeconfig-service/cmd/generator/runtime/watch_test.go
@@ -1,0 +1,255 @@
+package runtime
+
+import (
+	"context"
+	"io/ioutil"
+	"os"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/howeyc/fsnotify"
+)
+
+type TestAgent struct {
+	configCh chan interface{}
+}
+
+func (ta *TestAgent) Restart(c interface{}) {
+	ta.configCh <- c
+}
+
+func (ta *TestAgent) Run(ctx context.Context) {
+	<-ctx.Done()
+}
+
+func TestEventsBatchingDelay(t *testing.T) {
+
+	lock := sync.Mutex{}
+	called := 0
+
+	//This function is invoked by Watcher after processing events in configured minDelaySeconds time window
+	notifyFunc := func() {
+		lock.Lock()
+		defer lock.Unlock()
+		called++
+	}
+
+	var minDelaySeconds uint8 = 1 //collect events for one second before notifying
+
+	initialDelay := 900 * time.Millisecond
+	nextDelay := 200 * time.Millisecond
+
+	ctx, cancel := context.WithCancel(context.Background())
+	wch := make(chan *fsnotify.FileEvent, 10)
+
+	w := watcher{
+		"test",
+		[]string{}, //We don't really look for any files, hence the empty slice
+		minDelaySeconds,
+		notifyFunc,
+	}
+	go w.watchFileEvents(ctx, wch)
+
+	// fire off multiple events
+	wch <- &fsnotify.FileEvent{Name: "event1"}
+	wch <- &fsnotify.FileEvent{Name: "event2"}
+	wch <- &fsnotify.FileEvent{Name: "event3"}
+
+	// sleep for less than a second
+	time.Sleep(initialDelay)
+
+	// Expect no events to be delivered within initialDelay.
+	lock.Lock()
+	if called != 0 {
+		t.Fatalf("Called %d times, want 0", called)
+	}
+	lock.Unlock()
+
+	// wait for long enough to ensure notification
+	time.Sleep(nextDelay)
+
+	// Expect exactly 1 event to be delivered.
+	lock.Lock()
+	defer lock.Unlock()
+	if called != 1 {
+		t.Fatalf("Called %d times, want 1", called)
+	}
+
+	cancel()
+}
+
+func TestWatchSingleFile(t *testing.T) {
+	// create a temp dir
+	tmpDir, err := ioutil.TempDir(os.TempDir(), "certs")
+	if err != nil {
+		t.Fatalf("failed to create a temp dir: %v", err)
+	}
+	defer func() {
+		if err := os.RemoveAll(tmpDir); err != nil {
+			t.Errorf("failed to remove temp dir: %v", err)
+		}
+	}()
+
+	// create a temp file
+	tmpFile, err := ioutil.TempFile(tmpDir, "test.file")
+	if err != nil {
+		t.Fatalf("failed to create a temp file in testdata/certs: %v", err)
+	}
+	defer func() {
+		if err := tmpFile.Close(); err != nil {
+			t.Errorf("failed to close file %s: %v", tmpFile.Name(), err)
+		}
+	}()
+
+	called := make(chan bool)
+	callbackFunc := func() {
+		called <- true
+	}
+
+	// test modify file event
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	watcher := NewWatcher("test", []string{tmpFile.Name()}, 1, callbackFunc)
+	go watcher.Run(ctx)
+
+	// sleep for a bit to make sure the watcher is set up before change is made
+	time.Sleep(time.Millisecond * 500)
+
+	// modify file
+	if _, err := tmpFile.Write([]byte("foo")); err != nil {
+		t.Fatalf("failed to update file %s: %v", tmpFile.Name(), err)
+	}
+
+	if err := tmpFile.Sync(); err != nil {
+		t.Fatalf("failed to sync file %s: %v", tmpFile.Name(), err)
+	}
+
+	t.Logf("Waiting for notification after file data change")
+	select {
+	case <-called:
+		// expected
+		break
+	case <-time.After(time.Millisecond * 1100):
+		t.Fatalf("The callback is not called within time limit " + time.Now().String() + " when file was modified")
+	}
+
+	// test delete file event
+	// delete the file
+	err = os.Remove(tmpFile.Name())
+	if err != nil {
+		t.Fatalf("failed to delete file %s: %v", tmpFile.Name(), err)
+	}
+
+	t.Logf("Waiting for notification after file is deleted")
+	select {
+	case <-called:
+		// expected
+		break
+	case <-time.After(time.Millisecond * 1100):
+		t.Fatalf("The callback is not called within time limit " + time.Now().String() + " when file was deleted")
+	}
+}
+
+func TestWatchMultipleFiles(t *testing.T) {
+	// create a temp dir
+	tmpDir, err := ioutil.TempDir(os.TempDir(), "certs")
+	if err != nil {
+		t.Fatalf("failed to create a temp dir: %v", err)
+	}
+	defer func() {
+		if err := os.RemoveAll(tmpDir); err != nil {
+			t.Errorf("failed to remove temp dir: %v", err)
+		}
+	}()
+
+	// create a temp file
+	tmpFile1, err := ioutil.TempFile(tmpDir, "test1.file")
+	if err != nil {
+		t.Fatalf("failed to create a temp file in testdata/certs: %v", err)
+	}
+	defer func() {
+		if err := tmpFile1.Close(); err != nil {
+			t.Errorf("failed to close file %s: %v", tmpFile1.Name(), err)
+		}
+	}()
+
+	// create a temp file
+	tmpFile2, err := ioutil.TempFile(tmpDir, "test2.file")
+	if err != nil {
+		t.Fatalf("failed to create a temp file in testdata/certs: %v", err)
+	}
+	defer func() {
+		if err := tmpFile2.Close(); err != nil {
+			t.Errorf("failed to close file %s: %v", tmpFile2.Name(), err)
+		}
+	}()
+
+	called := make(chan bool)
+	callbackFunc := func() {
+		called <- true
+	}
+
+	// test modify file event
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	watcher := NewWatcher("test", []string{tmpFile1.Name(), tmpFile2.Name()}, 1, callbackFunc)
+	go watcher.Run(ctx)
+
+	// sleep for a bit to make sure the watcher is set up before change is made
+	time.Sleep(time.Millisecond * 500)
+
+	// modify first file
+	if _, err := tmpFile1.Write([]byte("foo")); err != nil {
+		t.Fatalf("failed to update file %s: %v", tmpFile1.Name(), err)
+	}
+
+	if err := tmpFile1.Sync(); err != nil {
+		t.Fatalf("failed to sync file %s: %v", tmpFile1.Name(), err)
+	}
+
+	t.Logf("Waiting for notification after the first file data change")
+	select {
+	case <-called:
+		// expected
+		break
+	case <-time.After(time.Millisecond * 1100):
+		t.Fatalf("The callback is not called within time limit " + time.Now().String() + " when file was modified")
+	}
+
+	// modify second file
+	if _, err := tmpFile2.Write([]byte("bar")); err != nil {
+		t.Fatalf("failed to update file %s: %v", tmpFile2.Name(), err)
+	}
+
+	if err := tmpFile2.Sync(); err != nil {
+		t.Fatalf("failed to sync file %s: %v", tmpFile2.Name(), err)
+	}
+
+	t.Logf("Waiting for notification after the second file data change")
+	select {
+	case <-called:
+		// expected
+		break
+	case <-time.After(time.Millisecond * 1100):
+		t.Fatalf("The callback is not called within time limit " + time.Now().String() + " when file was modified")
+	}
+
+	// test delete file event
+	// delete the file
+	err = os.Remove(tmpFile1.Name())
+	if err != nil {
+		t.Fatalf("failed to delete file %s: %v", tmpFile1.Name(), err)
+	}
+
+	t.Logf("Waiting for notification after the first file is deleted")
+	select {
+	case <-called:
+		// expected
+		break
+	case <-time.After(time.Millisecond * 1100):
+		t.Fatalf("The callback is not called within time limit " + time.Now().String() + " when file was deleted")
+	}
+}


### PR DESCRIPTION
**Description**
Implement hot config reload in apiserver-proxy to allow updating TLS certificates provided by K8s secrets mounted to the controller Pod

Changes proposed in this pull request:

- Added mechanism to watch for file changes
- Added ability to reload oidc_ca_file (ingress-tls-cert)

**Related issue(s)**
Implements #5744 