### PR TITLE
apiserver-proxy certificates reload bump

### DIFF
--- a/resources/core/values.yaml
+++ b/resources/core/values.yaml
@@ -30,7 +30,7 @@ global:
     version: 73f8eff7
   apiserver_proxy:
     dir:
-    version: bdfddb63
+    version: dfa5f30d
   iam_kubeconfig_service:
     dir:
     version: 22ed8bc7


### PR DESCRIPTION
**Description**
apiserver-proxy image bump

Implement hot config reload in apiserver-proxy to allow updating TLS certificates provided by K8s secrets mounted to the controller Pod
See also #6069 

Changes proposed in this pull request:

- apiserver-proxy image bump

**Related issue(s)**
Implements #5745 
