### PR TITLE
Update logging parameter description

### DIFF
--- a/docs/logging/05-01-logging.md
+++ b/docs/logging/05-01-logging.md
@@ -18,7 +18,7 @@ This table lists the configurable parameters, their descriptions, and default va
 | **logcollector.name** | Specifies which log collector will be installed with Kyma installation. Currently, Kyma supports Promtail and Fluent Bit. | `promtail` |
 | **persistence.enabled** | Specifies whether you store logs on a persistent volume instead of a volatile mounted volume. | `true` |
 | **persistence.size** | Defines the size of the persistent volume. | `10Gi` |
-| **config.auth_enabled** | Specifies the authentication mechanism you use to access the logging service. Set it to `false` to use built-in Istio authentication, or to `true` to use the basic HTTP authentication instead.  | `false` |
+| **config.auth_enabled** | Authenticates the tenant sending the request to the logging service when Loki runs in the multi-tenant mode. Setting it to `true` requires authentication using the HTTP (`X-Scope-OrgID`) header. Since Kyma supports the single-tenant mode only, you must set this parameter to `false`. This way, Loki does not require the `X-Scope-OrgID` header and the tenant ID defaults to `fake`. | `false` |
 | **config.ingester.lifecycler.address** | Specifies the address of the lifecycler that coordinates distributed logging services. | `127.0.0.1` |
 | **config.ingester.lifecycler.ring.store** | Specifies the storage for information on logging data and their copies. | `inmemory` |
 | **config.ingester.lifecycler.ring.replication_factor** | Specifies the number of data copies on separate storages. | `1` |

--- a/resources/logging/values.schema.json
+++ b/resources/logging/values.schema.json
@@ -24,7 +24,7 @@
             "type": "object",
             "properties": {
                 "auth_enabled": {
-                    "description": "Specifies the authentication mechanism you use to access the logging service. Set it to false to use built-in Istio authentication, or to true to use the basic HTTP authentication instead.",
+                    "description": "Authenticates the tenant sending the request to the logging service when Loki runs in the multi-tenant mode. Setting it to `true` requires authentication using the HTTP (X-Scope-OrgID) header. Since Kyma supports the single-tenant mode only, you must set this parameter to `false`. This way, Loki does not require the `X-Scope-OrgID` and the tenant ID defaults to `fake`. ",
                     "type": "boolean",
                     "default": false
                 },


### PR DESCRIPTION


**Description**

Changes proposed in this pull request:

- Updated description of `config.auth_enabled` parameter to match its real use. The description is based on Loki documentation which states that `config.auth_enabled` is used to authenticate requests in multi- and single-tenant mode. If set to `true` it requires the `X-Scope-OrgID` header that identifies the tenant for the request. If set to `false`, the header is not required and tenant ID defaults to `fake`.
Since Kyma runs in single-tenant mode only, it should be always set to `false`.

more loki docs: 
https://github.com/grafana/loki/blob/2477f70431179e55f7c39fffbf75dc403e91a67f/docs/operations/authentication.md
https://github.com/grafana/loki/blob/2477f70431179e55f7c39fffbf75dc403e91a67f/docs/operations/multi-tenancy.md


**Related issue(s)**
See also #5256 