### PR TITLE
iam-kubeconfig-service certificates reload bump

### DIFF
--- a/resources/core/values.yaml
+++ b/resources/core/values.yaml
@@ -33,7 +33,7 @@ global:
     version: bdfddb63
   iam_kubeconfig_service:
     dir:
-    version: 22ed8bc7
+    version: 2657de9e
   docs:
     # - Change the value below to the branch from your fork if you want to point to documentation sources from your fork
     # - Change the value below to the release branch during the release


### PR DESCRIPTION
**Description**
iam-kubeconfig-service image bump:
Implement hot config reload in iam-kubeconfig-service to allow updating TLS certificates provided by K8s secrets mounted to the controller Pod
See also: #6089 

Changes proposed in this pull request:
- iam-kubeconfig-service image bump

**Related issue(s)**
Implements #5744 