### PR TITLE
Add service broker proxy component

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -198,6 +198,9 @@
 # The `ory` chart
 /resources/ory/ @piotrmsc @kubadz @strekm @jakkab @Tomasz-Smelcerz-SAP @Demonsthere
 
+# The `service-broker-proxy` chart
+/resource/service-broker-proxy/ @PK85 @mszostok @piotrmiskiewicz @polskikiel @jasiu001
+
 # The `api-gateway` chart
 /resources/api-gateway/ @piotrmsc @kubadz @strekm @jakkab @Tomasz-Smelcerz-SAP @Demonsthere
 

--- a/installation/resources/installer-config-local.yaml.tpl
+++ b/installation/resources/installer-config-local.yaml.tpl
@@ -96,6 +96,21 @@ metadata:
     kyma-project.io/installation: ""
 data:
   global.isDevelopMode: "true" # global, because subcharts also use it
+
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: service-broker-proxy-overrides
+  namespace: kyma-installer
+  labels:
+    installer: overrides
+    component: service-broker-proxy
+    kyma-project.io/installation: ""
+data:
+  sm.user: "Yb5W1rCQUm5nCVTsHd2A8bJ3JrCxgNeZqbYNcfalng8="
+  sm.password: "k1bKtV9beduQ1Yr9HwJU+vIEyMBSHTeIR+aRTDiQExY="
+
 ---
 apiVersion: v1
 kind: ConfigMap

--- a/installation/resources/installer-cr-cluster-runtime.yaml.tpl
+++ b/installation/resources/installer-cr-cluster-runtime.yaml.tpl
@@ -47,6 +47,8 @@ spec:
       namespace: "kyma-system"
     - name: "helm-broker"
       namespace: "kyma-system"
+    - name: "service-broker-proxy"
+      namespace: "kyma-system"
     - name: "nats-streaming"
       namespace: "natss"
     - name: "assetstore"

--- a/installation/resources/installer-cr-cluster-with-compass.yaml.tpl
+++ b/installation/resources/installer-cr-cluster-with-compass.yaml.tpl
@@ -47,6 +47,8 @@ spec:
       namespace: "kyma-system"
     - name: "helm-broker"
       namespace: "kyma-system"
+    - name: "service-broker-proxy"
+      namespace: "kyma-system"
     - name: "nats-streaming"
       namespace: "natss"
     - name: "assetstore"

--- a/installation/resources/installer-cr-cluster.yaml.tpl
+++ b/installation/resources/installer-cr-cluster.yaml.tpl
@@ -47,6 +47,8 @@ spec:
       namespace: "kyma-system"
     - name: "helm-broker"
       namespace: "kyma-system"
+    - name: "service-broker-proxy"
+      namespace: "kyma-system"
     - name: "nats-streaming"
       namespace: "natss"
     - name: "assetstore"

--- a/installation/resources/installer-cr.yaml.tpl
+++ b/installation/resources/installer-cr.yaml.tpl
@@ -47,6 +47,8 @@ spec:
       namespace: "kyma-system"
     - name: "helm-broker"
       namespace: "kyma-system"
+    - name: "service-broker-proxy"
+      namespace: "kyma-system"
     - name: "nats-streaming"
       namespace: "natss"
     - name: "assetstore"

--- a/resources/service-broker-proxy/Chart.yaml
+++ b/resources/service-broker-proxy/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "master"
 description: A Helm chart for Service Broker Proxy for Kubernetes
 name: service-broker-proxy
-version: 0.5.0
+version: 0.1.0

--- a/resources/service-broker-proxy/Chart.yaml
+++ b/resources/service-broker-proxy/Chart.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+appVersion: "master"
+description: A Helm chart for Service Broker Proxy for Kubernetes
+name: service-broker-proxy
+version: 0.5.0

--- a/resources/service-broker-proxy/README.md
+++ b/resources/service-broker-proxy/README.md
@@ -1,0 +1,11 @@
+# Service Broker Proxy k8s
+
+## Overview
+This helm chart bootstraps the Service Broker Proxy for Kubernetes to connect Kyma with Service Manager.
+
+## Prerequisites
+
+Before provision the Service Broker Proxy credential to Service Manager should be updated.
+Credential are located in `values.yaml` under two fields `sm.user` and `sm.password` and used by `smsecret.yaml` file.
+
+The URL to Service Manager can be overridden. Default URL is located in `values.yaml` under the `config.sm.url` key.

--- a/resources/service-broker-proxy/templates/_helpers.tpl
+++ b/resources/service-broker-proxy/templates/_helpers.tpl
@@ -1,0 +1,32 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "service-broker-proxy.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "service-broker-proxy.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "service-broker-proxy.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}

--- a/resources/service-broker-proxy/templates/configmap.yaml
+++ b/resources/service-broker-proxy/templates/configmap.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ template "service-broker-proxy.fullname" . }}-config
+  labels:
+    app: {{ template "service-broker-proxy.name" . }}
+    chart: {{ template "service-broker-proxy.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+data:
+  {{ .Values.file.name }}.{{ .Values.file.format }}: |-
+{{ toYaml .Values.config | indent 4 }}

--- a/resources/service-broker-proxy/templates/configmap.yaml
+++ b/resources/service-broker-proxy/templates/configmap.yaml
@@ -1,3 +1,4 @@
+{{ if .Values.sm.user }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -10,3 +11,5 @@ metadata:
 data:
   {{ .Values.file.name }}.{{ .Values.file.format }}: |-
 {{ toYaml .Values.config | indent 4 }}
+
+{{ end }}

--- a/resources/service-broker-proxy/templates/deployment.yaml
+++ b/resources/service-broker-proxy/templates/deployment.yaml
@@ -1,3 +1,4 @@
+{{ if .Values.sm.user }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -75,3 +76,5 @@ spec:
           - "--file.location={{ .Values.file.location }}"
           - "--file.name={{ .Values.file.name }}"
           - "--file.format={{ .Values.file.format }}"
+
+{{ end }}

--- a/resources/service-broker-proxy/templates/deployment.yaml
+++ b/resources/service-broker-proxy/templates/deployment.yaml
@@ -1,0 +1,77 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ template "service-broker-proxy.fullname" . }}
+  labels:
+    app: {{ template "service-broker-proxy.name" . }}
+    chart: {{ template "service-broker-proxy.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      app: {{ template "service-broker-proxy.name" . }}
+      release: {{ .Release.Name }}
+  template:
+    metadata:
+      labels:
+        app: {{ template "service-broker-proxy.name" . }}
+        release: {{ .Release.Name }}
+    spec:
+      {{- with .Values.securityContext }}
+      securityContext:
+{{ toYaml . | indent 8 }}
+      {{- end }}
+      volumes:
+        - name: config-volume
+          configMap:
+            name: {{ template "service-broker-proxy.fullname" . }}-config
+      serviceAccountName: {{ template "service-broker-proxy.fullname" . }}
+      {{- if .Values.image.pullsecret }}
+      imagePullSecrets:
+      - name: {{.Values.image.pullsecret}}
+      {{- end }}
+      containers:
+      - name: {{ .Chart.Name }}
+        image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+        imagePullPolicy: {{ .Values.image.pullPolicy }}
+        volumeMounts:
+        - name: config-volume
+          mountPath: {{ .Values.file.location }}
+          readOnly: true
+        env:
+        - name: K8S_SECRET_NAME
+          value: {{ template "service-broker-proxy.fullname" . }}-regsecret
+        - name: K8S_SECRET_NAMESPACE
+          value: {{ .Release.Namespace }}
+        - name: SM_USER
+          valueFrom:
+            secretKeyRef:
+              name: {{ template "service-broker-proxy.fullname" . }}-regsecret
+              key: username
+        - name: SM_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: {{ template "service-broker-proxy.fullname" . }}-regsecret
+              key: password
+        - name: APP_URL
+          {{- if .Values.config.app.url }}
+          value: {{ .Values.config.app.url }}
+          {{- else}}
+          value: {{ .Values.config.sm.url }}
+          {{- end}}
+        - name: APP_LEGACY_URL
+          {{- if .Values.config.app.legacy_url }}
+          value: {{ .Values.config.app.legacy_url }}
+          {{- else}}
+          value: http://{{ template "service-broker-proxy.fullname" . }}.{{ .Release.Namespace }}:{{ .Values.service.port }}
+          {{- end}}
+        ports:
+        - name: http
+          containerPort: 8081
+          protocol: TCP
+        args:
+          - "--file.location={{ .Values.file.location }}"
+          - "--file.name={{ .Values.file.name }}"
+          - "--file.format={{ .Values.file.format }}"

--- a/resources/service-broker-proxy/templates/rbac.yaml
+++ b/resources/service-broker-proxy/templates/rbac.yaml
@@ -1,0 +1,75 @@
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: {{ template "service-broker-proxy.fullname" . }}
+  labels:
+    app: {{ template "service-broker-proxy.name" . }}
+    chart: {{ template "service-broker-proxy.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+rules:
+- apiGroups: ["servicecatalog.k8s.io"]
+  resources:
+  - clusterservicebrokers
+  verbs:
+  - "*"
+
+---
+
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{ template "service-broker-proxy.fullname" . }}
+  labels:
+    app: {{ template "service-broker-proxy.name" . }}
+    chart: {{ template "service-broker-proxy.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+roleRef:
+  kind: ClusterRole
+  name: {{ template "service-broker-proxy.fullname" . }}
+  apiGroup: rbac.authorization.k8s.io
+subjects:
+- kind: ServiceAccount
+  name: {{ template "service-broker-proxy.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+
+---
+
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  namespace: {{ .Release.Namespace }}
+  name: {{ template "service-broker-proxy.fullname" . }}-regsecretviewer
+  labels:
+    app: {{ template "service-broker-proxy.name" . }}
+    chart: {{ template "service-broker-proxy.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+rules:
+- apiGroups: [""]
+  resources: ["secrets"]
+  resourceNames:
+   - {{ template "service-broker-proxy.fullname" . }}-regsecret
+  verbs: ["get"]
+
+---
+
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{ template "service-broker-proxy.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: {{ template "service-broker-proxy.name" . }}
+    chart: {{ template "service-broker-proxy.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+roleRef:
+  kind: Role
+  name: {{ template "service-broker-proxy.fullname" . }}-regsecretviewer
+  apiGroup: rbac.authorization.k8s.io
+subjects:
+- kind: ServiceAccount
+  name: {{ template "service-broker-proxy.fullname" . }}
+  namespace: {{ .Release.Namespace }}

--- a/resources/service-broker-proxy/templates/rbac.yaml
+++ b/resources/service-broker-proxy/templates/rbac.yaml
@@ -1,3 +1,4 @@
+{{ if .Values.sm.user }}
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
@@ -73,3 +74,5 @@ subjects:
 - kind: ServiceAccount
   name: {{ template "service-broker-proxy.fullname" . }}
   namespace: {{ .Release.Namespace }}
+
+{{ end }}

--- a/resources/service-broker-proxy/templates/service-account.yaml
+++ b/resources/service-broker-proxy/templates/service-account.yaml
@@ -1,3 +1,4 @@
+{{ if .Values.sm.user }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -7,3 +8,5 @@ metadata:
     chart: {{ template "service-broker-proxy.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
+
+{{ end }}

--- a/resources/service-broker-proxy/templates/service-account.yaml
+++ b/resources/service-broker-proxy/templates/service-account.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ template "service-broker-proxy.fullname" . }}
+  labels:
+    app: {{ template "service-broker-proxy.name" . }}
+    chart: {{ template "service-broker-proxy.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}

--- a/resources/service-broker-proxy/templates/service.yaml
+++ b/resources/service-broker-proxy/templates/service.yaml
@@ -1,3 +1,4 @@
+{{ if .Values.sm.user }}
 apiVersion: v1
 kind: Service
 metadata:
@@ -17,3 +18,5 @@ spec:
   selector:
     app: {{ template "service-broker-proxy.name" . }}
     release: {{ .Release.Name }}
+
+{{ end }}

--- a/resources/service-broker-proxy/templates/service.yaml
+++ b/resources/service-broker-proxy/templates/service.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "service-broker-proxy.fullname" . }}
+  labels:
+    app: {{ template "service-broker-proxy.name" . }}
+    chart: {{ template "service-broker-proxy.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: 8081
+      protocol: TCP
+      name: http
+  selector:
+    app: {{ template "service-broker-proxy.name" . }}
+    release: {{ .Release.Name }}

--- a/resources/service-broker-proxy/templates/smsecret.yaml
+++ b/resources/service-broker-proxy/templates/smsecret.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ template "service-broker-proxy.fullname" . }}-regsecret
+  labels:
+    app: {{ template "service-broker-proxy.name" . }}
+    chart: {{ template "service-broker-proxy.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+data:
+  username: {{ .Values.sm.user | b64enc }}
+  password: {{ .Values.sm.password | b64enc }}

--- a/resources/service-broker-proxy/templates/smsecret.yaml
+++ b/resources/service-broker-proxy/templates/smsecret.yaml
@@ -1,3 +1,4 @@
+{{ if .Values.sm.user }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -10,3 +11,5 @@ metadata:
 data:
   username: {{ .Values.sm.user | b64enc }}
   password: {{ .Values.sm.password | b64enc }}
+
+{{ end }}

--- a/resources/service-broker-proxy/values.yaml
+++ b/resources/service-broker-proxy/values.yaml
@@ -20,8 +20,8 @@ file:
   format: yml
 
 sm:
-  user: admin
-  password: admin
+  user: Yb5W1rCQUm5nCVTsHd2A8bJ3JrCxgNeZqbYNcfalng8=
+  password: k1bKtV9beduQ1Yr9HwJU+vIEyMBSHTeIR+aRTDiQExY=
 
 ##
 # Security context
@@ -39,7 +39,7 @@ config:
     level: info
     format: text
   sm:
-    url: http://service-manager.dev.cfdev.sh
+    url: https://service-manager.cfapps.stagingaws.hanavlab.ondemand.com
     osb_api_path: /v1/osb
     request_timeout: 6000ms
     skip_ssl_validation: false

--- a/resources/service-broker-proxy/values.yaml
+++ b/resources/service-broker-proxy/values.yaml
@@ -1,0 +1,50 @@
+# Default values for service-broker-proxy.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+replicaCount: 1
+
+image:
+  repository: quay.io/service-manager/sb-proxy-k8s
+  tag: master
+  pullPolicy: IfNotPresent
+  pullsecret:
+
+service:
+  type: ClusterIP
+  port: 80
+
+file:
+  name: application
+  location: /etc/config
+  format: yml
+
+sm:
+  user: admin
+  password: admin
+
+##
+# Security context
+securityContext: {}
+
+config:
+  app:
+    legacy_url:
+    url:
+  server:
+    port: 8081
+    request_timeout: 6000ms
+    shutdown_timeout: 6000ms
+  log:
+    level: info
+    format: text
+  sm:
+    url: http://service-manager.dev.cfdev.sh
+    osb_api_path: /v1/osb
+    request_timeout: 6000ms
+    skip_ssl_validation: false
+  producer:
+    resync_period: 1h
+  k8s:
+    client:
+      timeout: 30000ms


### PR DESCRIPTION
This PR adds new Kyma component: `service-broker-proxy` which allows communication with Service Manager.

Before provision the Service Broker Proxy credential to Service Manager should be updated.
Credential are located in `values.yaml` under two fields `sm.user` and `sm.password` and used by `smsecret.yaml` file.

The URL to the Service Manager can be overridden. Default URL is located in `values.yaml` under the `config.sm.url key`.