### PR TITLE
Increasing limit because of prometheus container memory demand.

### DIFF
--- a/resources/cluster-essentials/templates/limit-range.yaml
+++ b/resources/cluster-essentials/templates/limit-range.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   limits:
   - max:
-      memory: 2Gi # Maximum memory that a container can request
+      memory: 6Gi # Maximum memory that a container can request
     default:
       # If a container does not specify memory limit, this default value will be applied.
       # If a container tries to allocate more memory, container will be OOM killed.


### PR DESCRIPTION
**Description**
After deploying stackdriver collector and defining additional grafana charts, prometheus container was suffering OOMKiler. We need incraese max container limit in limitrange to 6Gi as prometheus presented demand for at least 5Gi.
Changes proposed in this pull request:

Increasing max memory in kyma-default limitrange to 6Gi.

**Related issue(s)**
See also test infra issue #1623
