### PR TITLE
Disable the pod-not-running rule

### DIFF
--- a/resources/monitoring/charts/alert-rules/templates/kyma-rules.yaml
+++ b/resources/monitoring/charts/alert-rules/templates/kyma-rules.yaml
@@ -11,16 +11,16 @@ metadata:
     app: kyma.rules
 spec:
   groups:
-  #- name: pod-not-running-rule
-  #  rules:
-    #- alert: SystemPodNotRunning
-    #  expr: sum(kube_pod_container_status_running { namespace=~"kyma-.*|kube-.*|istio-.*|natss", pod!~"(test.*)|((dummy|sample)-.*)|(.*(docs|backup|test)-.*)|((oct-tp-testsuite-all)-.*)|(.*-(tests|dummy))" } == 0 )by (pod,namespace) * on(pod, namespace) (kube_pod_status_phase{phase="Succeeded"} != 1)
-    #  for: 60s
-    #  labels:
-    #    severity: critical
-    #  annotations:
-    #    description: "{{`{{ $labels.namespace }}`}}/{{`{{ $labels.pod }}`}} is not running"
-    #    summary: "{{`{{ $labels.pod }}`}} is not running"
+  - name: pod-not-running-rule
+    rules:
+    - alert: SystemPodNotRunning
+      expr: sum(kube_pod_container_status_running { namespace=~"kyma-.*|kube-.*|istio-.*|natss", pod!~"(test.*)|((dummy|sample)-.*)|(.*(docs|backup|test)-.*)|((oct-tp-testsuite-all)-.*)|(.*-(tests|dummy))" } == 0 )by (pod,namespace) * on(pod, namespace) (kube_pod_status_phase{phase="Succeeded"} != 1)
+      for: 60s
+      labels:
+      #  severity: critical
+      annotations:
+        description: "{{`{{ $labels.namespace }}`}}/{{`{{ $labels.pod }}`}} is not running"
+        summary: "{{`{{ $labels.pod }}`}} is not running"
   - name: cpu-90-percent-usage-rule
     rules:
     - alert: CPU90PercentUsage

--- a/resources/monitoring/charts/alert-rules/templates/kyma-rules.yaml
+++ b/resources/monitoring/charts/alert-rules/templates/kyma-rules.yaml
@@ -11,16 +11,16 @@ metadata:
     app: kyma.rules
 spec:
   groups:
-  - name: pod-not-running-rule
-    rules:
-    - alert: SystemPodNotRunning
-      expr: sum(kube_pod_container_status_running { namespace=~"kyma-.*|kube-.*|istio-.*|natss", pod!~"(test.*)|((dummy|sample)-.*)|(.*(docs|backup|test)-.*)|((oct-tp-testsuite-all)-.*)|(.*-(tests|dummy))" } == 0 )by (pod,namespace) * on(pod, namespace) (kube_pod_status_phase{phase="Succeeded"} != 1)
-      for: 60s
-      labels:
-        severity: critical
-      annotations:
-        description: "{{`{{ $labels.namespace }}`}}/{{`{{ $labels.pod }}`}} is not running"
-        summary: "{{`{{ $labels.pod }}`}} is not running"
+  #- name: pod-not-running-rule
+  #  rules:
+    #- alert: SystemPodNotRunning
+    #  expr: sum(kube_pod_container_status_running { namespace=~"kyma-.*|kube-.*|istio-.*|natss", pod!~"(test.*)|((dummy|sample)-.*)|(.*(docs|backup|test)-.*)|((oct-tp-testsuite-all)-.*)|(.*-(tests|dummy))" } == 0 )by (pod,namespace) * on(pod, namespace) (kube_pod_status_phase{phase="Succeeded"} != 1)
+    #  for: 60s
+    #  labels:
+    #    severity: critical
+    #  annotations:
+    #    description: "{{`{{ $labels.namespace }}`}}/{{`{{ $labels.pod }}`}} is not running"
+    #    summary: "{{`{{ $labels.pod }}`}} is not running"
   - name: cpu-90-percent-usage-rule
     rules:
     - alert: CPU90PercentUsage

--- a/resources/monitoring/charts/alert-rules/templates/kyma-rules.yaml
+++ b/resources/monitoring/charts/alert-rules/templates/kyma-rules.yaml
@@ -16,7 +16,7 @@ spec:
     - alert: SystemPodNotRunning
       expr: sum(kube_pod_container_status_running { namespace=~"kyma-.*|kube-.*|istio-.*|natss", pod!~"(test.*)|((dummy|sample)-.*)|(.*(docs|backup|test)-.*)|((oct-tp-testsuite-all)-.*)|(.*-(tests|dummy))" } == 0 )by (pod,namespace) * on(pod, namespace) (kube_pod_status_phase{phase="Succeeded"} != 1)
       for: 60s
-      labels:
+      #labels:
       #  severity: critical
       annotations:
         description: "{{`{{ $labels.namespace }}`}}/{{`{{ $labels.pod }}`}} is not running"


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Disable the `pod-not-running` Prometheus rule until the problem with the unstable k8s API on infra clusters is fixed, as currently it results in an excessive number of alerts being sent. 

**Related issue(s)**
See also #6036 