### PR TITLE
Change caching policy for GraphQL requests

### DIFF
--- a/resources/core/charts/console/values.yaml
+++ b/resources/core/charts/console/values.yaml
@@ -5,7 +5,7 @@ replicaCount: 1
 console:
   image:
     dir:
-    tag: d232465e
+    tag: 4868792c
     pullPolicy: IfNotPresent
   service:
     name: nginx


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- use `network-only` cache policy for apollo client to fix caching issue for gql subscriptions

