### PR TITLE
Bring back missing config URL for ApiServer & Microfrontend converter fix

### DIFF
--- a/resources/core/charts/console/templates/deployment.yaml
+++ b/resources/core/charts/console/templates/deployment.yaml
@@ -29,8 +29,7 @@ spec:
     spec:
       containers:
         - name: console
-          # image: "{{ .Values.global.containerRegistry.path }}{{ .Values.console.image.dir }}/console:{{ .Values.console.image.tag }}"
-          image: "{{ .Values.global.containerRegistry.path }}{{ .Values.console.image.dir }}/pr/console:{{ .Values.console.image.tag }}"
+          image: "{{ .Values.global.containerRegistry.path }}{{ .Values.console.image.dir }}/console:{{ .Values.console.image.tag }}"
           imagePullPolicy: {{ .Values.console.image.pullPolicy }}
           ports:
             - containerPort: {{ .Values.console.service.internalPort }}

--- a/resources/core/charts/console/templates/deployment.yaml
+++ b/resources/core/charts/console/templates/deployment.yaml
@@ -30,7 +30,7 @@ spec:
       containers:
         - name: console
           # image: "{{ .Values.global.containerRegistry.path }}{{ .Values.console.image.dir }}/console:{{ .Values.console.image.tag }}"
-          image: "{{ .Values.global.containerRegistry.path }}{{ .Values.console.image.dir }}pr/console:{{ .Values.console.image.tag }}"
+          image: "{{ .Values.global.containerRegistry.path }}{{ .Values.console.image.dir }}/pr/console:{{ .Values.console.image.tag }}"
           imagePullPolicy: {{ .Values.console.image.pullPolicy }}
           ports:
             - containerPort: {{ .Values.console.service.internalPort }}

--- a/resources/core/charts/console/templates/deployment.yaml
+++ b/resources/core/charts/console/templates/deployment.yaml
@@ -29,7 +29,8 @@ spec:
     spec:
       containers:
         - name: console
-          image: "{{ .Values.global.containerRegistry.path }}{{ .Values.console.image.dir }}/console:{{ .Values.console.image.tag }}"
+          # image: "{{ .Values.global.containerRegistry.path }}{{ .Values.console.image.dir }}/console:{{ .Values.console.image.tag }}"
+          image: "{{ .Values.global.containerRegistry.path }}{{ .Values.console.image.dir }}pr/console:{{ .Values.console.image.tag }}"
           imagePullPolicy: {{ .Values.console.image.pullPolicy }}
           ports:
             - containerPort: {{ .Values.console.service.internalPort }}

--- a/resources/core/charts/console/values.yaml
+++ b/resources/core/charts/console/values.yaml
@@ -5,7 +5,7 @@ replicaCount: 1
 console:
   image:
     dir:
-    tag: 4868792c
+    tag: PR-1398
     pullPolicy: IfNotPresent
   service:
     name: nginx

--- a/resources/core/charts/console/values.yaml
+++ b/resources/core/charts/console/values.yaml
@@ -5,7 +5,7 @@ replicaCount: 1
 console:
   image:
     dir:
-    tag: PR-1398
+    tag: fe129ccc
     pullPolicy: IfNotPresent
   service:
     name: nginx


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/master/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- Bring back missing k8s api url in the config (https://github.com/kyma-project/console/issues/1392)
- change logic behind mf definition --> luigi's navigation conversion (https://github.com/kyma-project/console/issues/1370)
- move gql queries out of main luigi-config file (https://github.com/kyma-project/console/issues/1370)

**Related issue(s)**
See https://github.com/kyma-project/console/issues/1392 & https://github.com/kyma-project/console/issues/1370
