### PR TITLE
Refactored readiness check handler and fixed metrics

### DIFF
--- a/components/event-bus/cmd/event-publish-service/application/application.go
+++ b/components/event-bus/cmd/event-publish-service/application/application.go
@@ -1,6 +1,7 @@
 package application
 
 import (
+	"log"
 	"net/http"
 
 	messagingv1alpha1client "github.com/knative/eventing/pkg/client/clientset/versioned/typed/messaging/v1alpha1"
@@ -57,10 +58,11 @@ func (app *KnativePublishApplication) start() {
 
 	// mark the app as started and register the readiness and the publish handlers
 	app.started = true
-	if app.knativeLib != nil {
-		app.registerReadinessProbe(app.knativeLib.MsgChannelClient())
+	if app.knativeLib == nil {
+		log.Fatalf("Cannot start without knativeLib!")
 	}
 
+	app.registerReadinessProbe(app.knativeLib.MsgChannelClient())
 	app.registerPublishV1Handler()
 	app.registerPublishV2Handler()
 }

--- a/components/event-bus/cmd/event-publish-service/application/application.go
+++ b/components/event-bus/cmd/event-publish-service/application/application.go
@@ -3,7 +3,7 @@ package application
 import (
 	"net/http"
 
-	messagingv1alpha1Client "github.com/knative/eventing/pkg/client/clientset/versioned/typed/messaging/v1alpha1"
+	messagingv1alpha1client "github.com/knative/eventing/pkg/client/clientset/versioned/typed/messaging/v1alpha1"
 	"github.com/kyma-project/kyma/components/event-bus/cmd/event-publish-service/handlers"
 	"github.com/kyma-project/kyma/components/event-bus/cmd/event-publish-service/publisher"
 	constants "github.com/kyma-project/kyma/components/event-bus/cmd/event-publish-service/util"
@@ -70,7 +70,7 @@ func (app *KnativePublishApplication) ServeMux() *http.ServeMux {
 	return app.serveMux
 }
 
-func (app *KnativePublishApplication) registerReadinessProbe(msgClientInf messagingv1alpha1Client.MessagingV1alpha1Interface) {
+func (app *KnativePublishApplication) registerReadinessProbe(msgClientInf messagingv1alpha1client.MessagingV1alpha1Interface) {
 	app.serveMux.HandleFunc("/v1/status/ready", handlers.ReadinessProbeHandler(msgClientInf))
 }
 

--- a/components/event-bus/cmd/event-publish-service/application/application.go
+++ b/components/event-bus/cmd/event-publish-service/application/application.go
@@ -3,7 +3,7 @@ package application
 import (
 	"net/http"
 
-	eventingv1alpha1 "github.com/knative/eventing/pkg/client/clientset/versioned/typed/eventing/v1alpha1"
+	messagingv1alpha1Client "github.com/knative/eventing/pkg/client/clientset/versioned/typed/messaging/v1alpha1"
 	"github.com/kyma-project/kyma/components/event-bus/cmd/event-publish-service/handlers"
 	"github.com/kyma-project/kyma/components/event-bus/cmd/event-publish-service/publisher"
 	constants "github.com/kyma-project/kyma/components/event-bus/cmd/event-publish-service/util"
@@ -58,7 +58,7 @@ func (app *KnativePublishApplication) start() {
 	// mark the app as started and register the readiness and the publish handlers
 	app.started = true
 	if app.knativeLib != nil {
-		app.registerReadinessProbe(app.knativeLib.EvClient())
+		app.registerReadinessProbe(app.knativeLib.MsgChannelClient())
 	}
 
 	app.registerPublishV1Handler()
@@ -70,8 +70,8 @@ func (app *KnativePublishApplication) ServeMux() *http.ServeMux {
 	return app.serveMux
 }
 
-func (app *KnativePublishApplication) registerReadinessProbe(eventingIn eventingv1alpha1.EventingV1alpha1Interface) {
-	app.serveMux.HandleFunc("/v1/status/ready", handlers.ReadinessProbeHandler(eventingIn))
+func (app *KnativePublishApplication) registerReadinessProbe(msgClientInf messagingv1alpha1Client.MessagingV1alpha1Interface) {
+	app.serveMux.HandleFunc("/v1/status/ready", handlers.ReadinessProbeHandler(msgClientInf))
 }
 
 func (app *KnativePublishApplication) registerPublishV1Handler() {

--- a/components/event-bus/cmd/event-publish-service/application/application.go
+++ b/components/event-bus/cmd/event-publish-service/application/application.go
@@ -3,6 +3,7 @@ package application
 import (
 	"net/http"
 
+	eventingv1alpha1 "github.com/knative/eventing/pkg/client/clientset/versioned/typed/eventing/v1alpha1"
 	"github.com/kyma-project/kyma/components/event-bus/cmd/event-publish-service/handlers"
 	"github.com/kyma-project/kyma/components/event-bus/cmd/event-publish-service/publisher"
 	constants "github.com/kyma-project/kyma/components/event-bus/cmd/event-publish-service/util"
@@ -56,7 +57,7 @@ func (app *KnativePublishApplication) start() {
 
 	// mark the app as started and register the readiness and the publish handlers
 	app.started = true
-	app.registerReadinessProbe()
+	app.registerReadinessProbe(app.knativeLib.EvClient())
 	app.registerPublishV1Handler()
 	app.registerPublishV2Handler()
 }
@@ -66,8 +67,8 @@ func (app *KnativePublishApplication) ServeMux() *http.ServeMux {
 	return app.serveMux
 }
 
-func (app *KnativePublishApplication) registerReadinessProbe() {
-	app.serveMux.HandleFunc("/v1/status/ready", handlers.ReadinessProbeHandler())
+func (app *KnativePublishApplication) registerReadinessProbe(eventingIn eventingv1alpha1.EventingV1alpha1Interface) {
+	app.serveMux.HandleFunc("/v1/status/ready", handlers.ReadinessProbeHandler(eventingIn))
 }
 
 func (app *KnativePublishApplication) registerPublishV1Handler() {

--- a/components/event-bus/cmd/event-publish-service/application/application.go
+++ b/components/event-bus/cmd/event-publish-service/application/application.go
@@ -57,7 +57,10 @@ func (app *KnativePublishApplication) start() {
 
 	// mark the app as started and register the readiness and the publish handlers
 	app.started = true
-	app.registerReadinessProbe(app.knativeLib.EvClient())
+	if app.knativeLib != nil {
+		app.registerReadinessProbe(app.knativeLib.EvClient())
+	}
+
 	app.registerPublishV1Handler()
 	app.registerPublishV2Handler()
 }

--- a/components/event-bus/cmd/event-publish-service/application/application_test.go
+++ b/components/event-bus/cmd/event-publish-service/application/application_test.go
@@ -292,6 +292,6 @@ func Test_PublishV1ResponseFields(t *testing.T) {
 	// assert
 	assert.Nil(t, err)
 	assert.Equal(t, testV1.TestEventID, publishResponse.EventID)
-	assert.Equal(t, publisher.PUBLISHED, publishResponse.Status)
+	assert.Equal(t, publisher.Published, publishResponse.Status)
 	assert.Equal(t, "Message successfully published to the channel", publishResponse.Reason)
 }

--- a/components/event-bus/cmd/event-publish-service/handlers/publish.go
+++ b/components/event-bus/cmd/event-publish-service/handlers/publish.go
@@ -250,9 +250,9 @@ func getPublishStatusReason(status *string) string {
 	switch *status {
 	case publisher.PUBLISHED:
 		reason = "Message successfully published to the channel"
-	case publisher.IGNORED_CHANNEL_MISSING:
+	case publisher.IgnoredChannelMissing:
 		reason = "Event was ignored as there are no channels"
-	case publisher.IGNORED_CHANNEL_NOT_READY:
+	case publisher.IgnoredChannelNotReady:
 		reason = "Event was ignored as the channel was not ready"
 	case publisher.FAILED:
 		reason = "Some validation or internal error occurred"

--- a/components/event-bus/cmd/event-publish-service/handlers/publish.go
+++ b/components/event-bus/cmd/event-publish-service/handlers/publish.go
@@ -250,10 +250,10 @@ func getPublishStatusReason(status *string) string {
 	switch *status {
 	case publisher.PUBLISHED:
 		reason = "Message successfully published to the channel"
-	case publisher.IGNORED_NOT_READY_CHANNEL:
-		reason = "Event was ignored as the channel was not ready"
-	case publisher.IGNORED_NO_CHANNEL:
+	case publisher.IGNORED_CHANNEL_MISSING:
 		reason = "Event was ignored as there are no channels"
+	case publisher.IGNORED_CHANNEL_NOT_READY:
+		reason = "Event was ignored as the channel was not ready"
 	case publisher.FAILED:
 		reason = "Some validation or internal error occurred"
 	}

--- a/components/event-bus/cmd/event-publish-service/handlers/publish.go
+++ b/components/event-bus/cmd/event-publish-service/handlers/publish.go
@@ -250,8 +250,10 @@ func getPublishStatusReason(status *string) string {
 	switch *status {
 	case publisher.PUBLISHED:
 		reason = "Message successfully published to the channel"
-	case publisher.IGNORED:
-		reason = "Event was ignored as there are no subscriptions or consumers configured for this event"
+	case publisher.IGNORED_NOT_READY_CHANNEL:
+		reason = "Event was ignored as the channel was not ready"
+	case publisher.IGNORED_NO_CHANNEL:
+		reason = "Event was ignored as there are no channels"
 	case publisher.FAILED:
 		reason = "Some validation or internal error occurred"
 	}

--- a/components/event-bus/cmd/event-publish-service/handlers/publish.go
+++ b/components/event-bus/cmd/event-publish-service/handlers/publish.go
@@ -111,7 +111,7 @@ func handleKnativePublishRequestV1(w http.ResponseWriter, r *http.Request, knati
 	if err != nil {
 		log.Printf("validate request failed: %v", err)
 		_ = sendJSONError(w, err)
-		return nil, nil, nil, err, publisher.FAILED
+		return nil, nil, nil, err, publisher.Failed
 	}
 
 	// set source-id from the headers if missing in the payload
@@ -119,14 +119,14 @@ func handleKnativePublishRequestV1(w http.ResponseWriter, r *http.Request, knati
 		err = api.ErrorResponseMissingFieldSourceID()
 		log.Printf("source-id missing: %v", err)
 		_ = sendJSONError(w, err)
-		return nil, nil, nil, err, publisher.FAILED
+		return nil, nil, nil, err, publisher.Failed
 	}
 
 	// validate the publish request
 	if err = v1.ValidatePublish(publishRequest, opts.EventOptions); err != nil {
 		log.Printf("validate publish failed: %v", err)
 		_ = sendJSONError(w, err)
-		return nil, nil, nil, err, publisher.FAILED
+		return nil, nil, nil, err, publisher.Failed
 	}
 
 	// generate event-id if there is none
@@ -136,7 +136,7 @@ func handleKnativePublishRequestV1(w http.ResponseWriter, r *http.Request, knati
 			err = api.ErrorResponseInternalServer()
 			log.Printf("EventID generation failed: %v", err)
 			_ = sendJSONError(w, err)
-			return nil, nil, nil, err, publisher.FAILED
+			return nil, nil, nil, err, publisher.Failed
 		}
 		publishRequest.EventID = eventID
 	}
@@ -152,7 +152,7 @@ func handleKnativePublishRequestV1(w http.ResponseWriter, r *http.Request, knati
 		log.Printf("marshal message failed: %v", errMarshal.Error())
 		err = api.ErrorResponseInternalServer()
 		_ = sendJSONError(w, err)
-		return nil, nil, nil, err, publisher.FAILED
+		return nil, nil, nil, err, publisher.Failed
 	}
 
 	// publish the message
@@ -160,7 +160,7 @@ func handleKnativePublishRequestV1(w http.ResponseWriter, r *http.Request, knati
 		&messagePayload, publishRequest.SourceID, publishRequest.EventType, publishRequest.EventTypeVersion)
 	if err != nil {
 		_ = sendJSONError(w, err)
-		return nil, nil, nil, err, publisher.FAILED
+		return nil, nil, nil, err, publisher.Failed
 	}
 	// Succeed if the Status is IGNORED | PUBLISHED
 	return message, &channelName, &defaultChannelNamespace, nil, status
@@ -248,13 +248,13 @@ func buildCEMessage(event *publishv2.EventRequestV2, traceContext *api.TraceCont
 func getPublishStatusReason(status *string) string {
 	var reason string
 	switch *status {
-	case publisher.PUBLISHED:
+	case publisher.Published:
 		reason = "Message successfully published to the channel"
 	case publisher.IgnoredChannelMissing:
 		reason = "Event was ignored as there are no channels"
 	case publisher.IgnoredChannelNotReady:
 		reason = "Event was ignored as the channel was not ready"
-	case publisher.FAILED:
+	case publisher.Failed:
 		reason = "Some validation or internal error occurred"
 	}
 	return reason
@@ -279,14 +279,14 @@ func handleKnativePublishRequestV2(w http.ResponseWriter, r *http.Request, knati
 	if err != nil {
 		log.Printf("validate request failed: %v", err)
 		_ = sendJSONError(w, err)
-		return nil, nil, nil, err, publisher.FAILED
+		return nil, nil, nil, err, publisher.Failed
 	}
 
 	// validate the publish request
 	if err = publishv2.ValidatePublish(event, opts.EventOptions); err != nil {
 		log.Printf("validate publish failed: %v", err)
 		_ = sendJSONError(w, err)
-		return nil, nil, nil, err, publisher.FAILED
+		return nil, nil, nil, err, publisher.Failed
 	}
 
 	headers := filterCEHeaders(r)
@@ -300,7 +300,7 @@ func handleKnativePublishRequestV2(w http.ResponseWriter, r *http.Request, knati
 		log.Printf("marshal message failed: %v", errMarshal.Error())
 		err = api.ErrorResponseInternalServer()
 		_ = sendJSONError(w, err)
-		return nil, nil, nil, err, publisher.FAILED
+		return nil, nil, nil, err, publisher.Failed
 	}
 
 	// publish the message
@@ -308,7 +308,7 @@ func handleKnativePublishRequestV2(w http.ResponseWriter, r *http.Request, knati
 		&messagePayload, event.Source, event.Type, event.TypeVersion)
 	if err != nil {
 		_ = sendJSONError(w, err)
-		return nil, nil, nil, err, publisher.FAILED
+		return nil, nil, nil, err, publisher.Failed
 	}
 	// Succeed if the Status is IGNORED | PUBLISHED
 	return message, &channelName, &defaultChannelNamespace, nil, status

--- a/components/event-bus/cmd/event-publish-service/handlers/readiness_check.go
+++ b/components/event-bus/cmd/event-publish-service/handlers/readiness_check.go
@@ -5,12 +5,12 @@ import (
 
 	"log"
 
-	messagingv1alpha1Client "github.com/knative/eventing/pkg/client/clientset/versioned/typed/messaging/v1alpha1"
+	messagingv1alpha1client "github.com/knative/eventing/pkg/client/clientset/versioned/typed/messaging/v1alpha1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 // ReadinessProbeHandler of the Knative PublishApplication
-func ReadinessProbeHandler(msgClientInf messagingv1alpha1Client.MessagingV1alpha1Interface) http.HandlerFunc {
+func ReadinessProbeHandler(msgClientInf messagingv1alpha1client.MessagingV1alpha1Interface) http.HandlerFunc {
 
 	return func(w http.ResponseWriter, r *http.Request) {
 		// Namespace could be anything but hardcoded to default as it is a readiness check call to Kube

--- a/components/event-bus/cmd/event-publish-service/handlers/readiness_check.go
+++ b/components/event-bus/cmd/event-publish-service/handlers/readiness_check.go
@@ -3,13 +3,19 @@ package handlers
 import (
 	"net/http"
 
-	knative "github.com/kyma-project/kyma/components/event-bus/internal/knative/util"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	eventingv1alpha1 "github.com/knative/eventing/pkg/client/clientset/versioned/typed/eventing/v1alpha1"
 )
 
 // ReadinessProbeHandler of the Knative PublishApplication
-func ReadinessProbeHandler() http.HandlerFunc {
+func ReadinessProbeHandler(evClient eventingv1alpha1.EventingV1alpha1Interface) http.HandlerFunc {
+
 	return func(w http.ResponseWriter, r *http.Request) {
-		if _, err := knative.GetKnativeLib(); err != nil {
+		// Namespace could be anything but hardcoded to default as it is a readiness check call to Kube
+		// API server and the output is ignored
+		_, err := evClient.Channels("default").List(v1.ListOptions{})
+		if err != nil {
 			w.WriteHeader(http.StatusBadGateway)
 			return
 		}

--- a/components/event-bus/cmd/event-publish-service/handlers/readiness_check.go
+++ b/components/event-bus/cmd/event-publish-service/handlers/readiness_check.go
@@ -3,19 +3,21 @@ package handlers
 import (
 	"net/http"
 
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"log"
 
-	eventingv1alpha1 "github.com/knative/eventing/pkg/client/clientset/versioned/typed/eventing/v1alpha1"
+	messagingv1alpha1Client "github.com/knative/eventing/pkg/client/clientset/versioned/typed/messaging/v1alpha1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 // ReadinessProbeHandler of the Knative PublishApplication
-func ReadinessProbeHandler(evClient eventingv1alpha1.EventingV1alpha1Interface) http.HandlerFunc {
+func ReadinessProbeHandler(msgClientInf messagingv1alpha1Client.MessagingV1alpha1Interface) http.HandlerFunc {
 
 	return func(w http.ResponseWriter, r *http.Request) {
 		// Namespace could be anything but hardcoded to default as it is a readiness check call to Kube
 		// API server and the output is ignored
-		_, err := evClient.Subscriptions("default").List(v1.ListOptions{})
+		_, err := msgClientInf.Channels("default").List(v1.ListOptions{})
 		if err != nil {
+			log.Printf("Error in ReadinessProbeHandler: %v", err)
 			w.WriteHeader(http.StatusBadGateway)
 			return
 		}

--- a/components/event-bus/cmd/event-publish-service/handlers/readiness_check.go
+++ b/components/event-bus/cmd/event-publish-service/handlers/readiness_check.go
@@ -14,7 +14,7 @@ func ReadinessProbeHandler(evClient eventingv1alpha1.EventingV1alpha1Interface) 
 	return func(w http.ResponseWriter, r *http.Request) {
 		// Namespace could be anything but hardcoded to default as it is a readiness check call to Kube
 		// API server and the output is ignored
-		_, err := evClient.Channels("default").List(v1.ListOptions{})
+		_, err := evClient.Subscriptions("default").List(v1.ListOptions{})
 		if err != nil {
 			w.WriteHeader(http.StatusBadGateway)
 			return

--- a/components/event-bus/cmd/event-publish-service/publisher/publisher.go
+++ b/components/event-bus/cmd/event-publish-service/publisher/publisher.go
@@ -13,13 +13,13 @@ import (
 
 const (
 	// FAILED status label
-	FAILED = "failed"
+	Failed = "failed"
 	// IGNORED_CHANNEL_MISSING status label
-	IGNORED_CHANNEL_MISSING = "ignored_channel_missing"
+	IgnoredChannelMissing = "ignored_channel_missing"
 	// IGNORED_CHANNEL_NOT_READY status label
-	IGNORED_CHANNEL_NOT_READY = "ignored_channel_not_ready"
+	IgnoredChannelNotReady = "ignored_channel_not_ready"
 	// PUBLISHED status label
-	PUBLISHED = "published"
+	Published = "published"
 
 	empty = ""
 
@@ -52,35 +52,35 @@ func (publisher *DefaultKnativePublisher) Publish(knativeLib *knative.KnativeLib
 	// knativelib should not be nil
 	if knativeLib == nil {
 		log.Println("knative-lib is nil")
-		return api.ErrorResponseInternalServer(), FAILED, empty
+		return api.ErrorResponseInternalServer(), Failed, empty
 	}
 
 	// namespace should be present
 	if namespace == nil || len(*namespace) == 0 {
 		log.Println("namespace is missing")
-		return api.ErrorResponseInternalServer(), FAILED, empty
+		return api.ErrorResponseInternalServer(), Failed, empty
 	}
 
 	// headers should be present
 	if headers == nil || len(*headers) == 0 {
 		log.Println("headers are missing")
-		return api.ErrorResponseInternalServer(), FAILED, empty
+		return api.ErrorResponseInternalServer(), Failed, empty
 	}
 
 	// payload should be present
 	if payload == nil || len(*payload) == 0 {
 		log.Println("payload is missing")
-		return api.ErrorResponseInternalServer(), FAILED, empty
+		return api.ErrorResponseInternalServer(), Failed, empty
 	}
 
 	if len(source) == 0 {
 		log.Println("source is missing")
-		return api.ErrorResponseInternalServer(), FAILED, empty
+		return api.ErrorResponseInternalServer(), Failed, empty
 	}
 
 	if len(eventType) == 0 {
 		log.Println("eventType is missing")
-		return api.ErrorResponseInternalServer(), FAILED, empty
+		return api.ErrorResponseInternalServer(), Failed, empty
 	}
 
 	if len(eventTypeVersion) == 0 {
@@ -100,16 +100,16 @@ func (publisher *DefaultKnativePublisher) Publish(knativeLib *knative.KnativeLib
 		log.Printf("failed to get the knative channel for source: '%v', event-type: '%v', event-type-version: '%v' in namespace '%v'\n"+
 			"error: '%v':", source, eventType, eventTypeVersion, *namespace, err)
 		log.Println("incrementing ignored messages counter")
-		updateMetrics(channel, IGNORED_CHANNEL_MISSING, *namespace)
-		return nil, IGNORED_CHANNEL_MISSING, empty
+		updateMetrics(channel, IgnoredChannelMissing, *namespace)
+		return nil, IgnoredChannelMissing, empty
 	}
 
 	// If Knative channel is not ready there is no point in pushing it to dispatcher hence ignored
 	if !channel.Status.IsReady() {
 		log.Printf("knative channel is not ready :: for source: '%v', event-type: '%v', event-type-version: '%v' in namespace '%v' error: '%v':", source, eventType, eventTypeVersion, *namespace, err)
 		log.Println("incrementing ignored messages counter")
-		updateMetrics(channel, IGNORED_CHANNEL_NOT_READY, *namespace)
-		return nil, IGNORED_CHANNEL_NOT_READY, empty
+		updateMetrics(channel, IgnoredChannelNotReady, *namespace)
+		return nil, IgnoredChannelNotReady, empty
 	}
 
 	return publisher.publishOnChannel(knativeLib, channel, namespace, headers, payload)
@@ -123,12 +123,12 @@ func (publisher *DefaultKnativePublisher) publishOnChannel(knativeLib *knative.K
 	err := knativeLib.SendMessage(channel, headers, &messagePayload)
 	if err != nil {
 		log.Printf("failed to send message to the knative channel '%v' in namespace '%v'", channel.Name, *namespace)
-		return api.ErrorResponseInternalServer(), FAILED, channel.Name
+		return api.ErrorResponseInternalServer(), Failed, channel.Name
 	}
-	updateMetrics(channel, PUBLISHED, *namespace)
+	updateMetrics(channel, Published, *namespace)
 
 	// publish to channel succeeded return nil error
-	return nil, PUBLISHED, channel.Name
+	return nil, Published, channel.Name
 }
 
 func updateMetrics(channel *messagingV1Alpha1.Channel, status, ns string) {

--- a/components/event-bus/cmd/event-publish-service/publisher/publisher.go
+++ b/components/event-bus/cmd/event-publish-service/publisher/publisher.go
@@ -14,10 +14,10 @@ import (
 const (
 	// FAILED status label
 	FAILED = "failed"
-	// IGNORED_NO_CHANNEL status label
-	IGNORED_NO_CHANNEL = "ignored_no_channel"
-	// IGNORED_NOT_READY_CHANNEL status label
-	IGNORED_NOT_READY_CHANNEL = "ignored_not_ready_channel"
+	// IGNORED_CHANNEL_MISSING status label
+	IGNORED_CHANNEL_MISSING = "ignored_channel_missing"
+	// IGNORED_CHANNEL_NOT_READY status label
+	IGNORED_CHANNEL_NOT_READY = "ignored_channel_not_ready"
 	// PUBLISHED status label
 	PUBLISHED = "published"
 
@@ -100,16 +100,16 @@ func (publisher *DefaultKnativePublisher) Publish(knativeLib *knative.KnativeLib
 		log.Printf("failed to get the knative channel for source: '%v', event-type: '%v', event-type-version: '%v' in namespace '%v'\n"+
 			"error: '%v':", source, eventType, eventTypeVersion, *namespace, err)
 		log.Println("incrementing ignored messages counter")
-		report(channel, IGNORED_NO_CHANNEL, *namespace)
-		return nil, IGNORED_NO_CHANNEL, empty
+		updateMetrics(channel, IGNORED_CHANNEL_MISSING, *namespace)
+		return nil, IGNORED_CHANNEL_MISSING, empty
 	}
 
 	// If Knative channel is not ready there is no point in pushing it to dispatcher hence ignored
 	if !channel.Status.IsReady() {
 		log.Printf("knative channel is not ready :: for source: '%v', event-type: '%v', event-type-version: '%v' in namespace '%v' error: '%v':", source, eventType, eventTypeVersion, *namespace, err)
 		log.Println("incrementing ignored messages counter")
-		report(channel, IGNORED_NOT_READY_CHANNEL, *namespace)
-		return nil, IGNORED_NOT_READY_CHANNEL, empty
+		updateMetrics(channel, IGNORED_CHANNEL_NOT_READY, *namespace)
+		return nil, IGNORED_CHANNEL_NOT_READY, empty
 	}
 
 	return publisher.publishOnChannel(knativeLib, channel, namespace, headers, payload)
@@ -125,13 +125,13 @@ func (publisher *DefaultKnativePublisher) publishOnChannel(knativeLib *knative.K
 		log.Printf("failed to send message to the knative channel '%v' in namespace '%v'", channel.Name, *namespace)
 		return api.ErrorResponseInternalServer(), FAILED, channel.Name
 	}
-	report(channel, PUBLISHED, *namespace)
+	updateMetrics(channel, PUBLISHED, *namespace)
 
 	// publish to channel succeeded return nil error
 	return nil, PUBLISHED, channel.Name
 }
 
-func report(channel *messagingV1Alpha1.Channel, status, ns string) {
+func updateMetrics(channel *messagingV1Alpha1.Channel, status, ns string) {
 	metrics.TotalPublishedMessages.With(prometheus.Labels{
 		metrics.Namespace:        ns,
 		metrics.Status:           status,

--- a/components/event-bus/cmd/event-publish-service/publisher/publisher.go
+++ b/components/event-bus/cmd/event-publish-service/publisher/publisher.go
@@ -85,7 +85,7 @@ func (publisher *DefaultKnativePublisher) Publish(knativeLib *knative.KnativeLib
 
 	if len(eventTypeVersion) == 0 {
 		log.Println("eventTypeVersion is missing")
-		return api.ErrorResponseInternalServer(), FAILED, empty
+		return api.ErrorResponseInternalServer(), Failed, empty
 	}
 
 	//Adding the event-metadata as channel labels

--- a/components/event-bus/cmd/event-publish-service/publisher/publisher.go
+++ b/components/event-bus/cmd/event-publish-service/publisher/publisher.go
@@ -12,13 +12,13 @@ import (
 )
 
 const (
-	// FAILED status label
+	// Failed status label
 	Failed = "failed"
-	// IGNORED_CHANNEL_MISSING status label
+	// IgnoredChannelMissing status label
 	IgnoredChannelMissing = "ignored_channel_missing"
-	// IGNORED_CHANNEL_NOT_READY status label
+	// IgnoredChannelNotReady status label
 	IgnoredChannelNotReady = "ignored_channel_not_ready"
-	// PUBLISHED status label
+	// Published status label
 	Published = "published"
 
 	empty = ""

--- a/components/event-bus/cmd/event-publish-service/test/fake/publisher.go
+++ b/components/event-bus/cmd/event-publish-service/test/fake/publisher.go
@@ -6,10 +6,6 @@ import (
 	knative "github.com/kyma-project/kyma/components/event-bus/internal/knative/util"
 )
 
-const (
-	channelName = "test-channel"
-)
-
 // MockKnativePublisher to mock the knative publisher for testing purposes.
 type MockKnativePublisher struct{}
 
@@ -23,5 +19,5 @@ func NewMockKnativePublisher() publisher.KnativePublisher {
 func (m *MockKnativePublisher) Publish(knativeLib *knative.KnativeLib, namespace *string,
 	headers *map[string][]string, payload *[]byte, source string, eventType string,
 	eventTypeVersion string) (error *api.Error, status string, channelName string) {
-	return nil, publisher.PUBLISHED, channelName
+	return nil, publisher.Published, channelName
 }

--- a/components/event-bus/internal/knative/subscription/controller/subscription/reconcile_test.go
+++ b/components/event-bus/internal/knative/subscription/controller/subscription/reconcile_test.go
@@ -7,8 +7,8 @@ import (
 	"testing"
 	"time"
 
+	messagingv1alpha1Client "github.com/knative/eventing/pkg/client/clientset/versioned/typed/messaging/v1alpha1"
 	"knative.dev/pkg/apis"
-
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
@@ -424,7 +424,7 @@ func (k *MockKnativeLib) SendMessage(channel *messagingV1Alpha1.Channel, headers
 	return nil
 }
 
-func (k *MockKnativeLib) EvClient() eventingV1Alpha1Client.EventingV1alpha1Interface {
+func (k *MockKnativeLib) MsgChannelClient() messagingv1alpha1Client.MessagingV1alpha1Interface {
 	return nil
 }
 

--- a/components/event-bus/internal/knative/subscription/controller/subscription/reconcile_test.go
+++ b/components/event-bus/internal/knative/subscription/controller/subscription/reconcile_test.go
@@ -21,7 +21,7 @@ import (
 	duckv1beta1 "knative.dev/pkg/apis/duck/v1beta1"
 
 	messagingV1Alpha1 "github.com/knative/eventing/pkg/apis/messaging/v1alpha1"
-	eventingV1Alpha1 "github.com/knative/eventing/pkg/client/clientset/versioned/typed/eventing/v1alpha1"
+	eventingV1Alpha1Client "github.com/knative/eventing/pkg/client/clientset/versioned/typed/eventing/v1alpha1"
 
 	messagingv1alpha1 "github.com/knative/eventing/pkg/client/clientset/versioned/typed/messaging/v1alpha1"
 	eventingv1alpha1 "github.com/kyma-project/kyma/components/event-bus/api/push/eventing.kyma-project.io/v1alpha1"
@@ -424,8 +424,12 @@ func (k *MockKnativeLib) SendMessage(channel *messagingV1Alpha1.Channel, headers
 	return nil
 }
 
+func (k *MockKnativeLib) EvClient() eventingV1Alpha1Client.EventingV1alpha1Interface {
+	return nil
+}
+
 // InjectClient injects a client, useful for running tests.
-func (k *MockKnativeLib) InjectClient(evClient eventingV1Alpha1.EventingV1alpha1Interface, msgClient messagingv1alpha1.MessagingV1alpha1Interface) error {
+func (k *MockKnativeLib) InjectClient(evClient eventingV1Alpha1Client.EventingV1alpha1Interface, msgClient messagingv1alpha1.MessagingV1alpha1Interface) error {
 	return nil
 }
 

--- a/components/event-bus/internal/knative/util/kn-eventing.go
+++ b/components/event-bus/internal/knative/util/kn-eventing.go
@@ -123,10 +123,10 @@ func NewKnativeLib() (*KnativeLib, error) {
 
 // KnativeLib represents the knative lib.
 type KnativeLib struct {
-	evClient         eventingv1alpha1.EventingV1alpha1Interface
-	httpClient       http.Client
-	chLister         evlistersv1alpha1.ChannelLister
-	messagingChannel messagingv1alpha1Client.MessagingV1alpha1Interface
+	evClient   eventingv1alpha1.EventingV1alpha1Interface
+	httpClient http.Client
+	chLister   evlistersv1alpha1.ChannelLister
+	msgClient  messagingv1alpha1Client.MessagingV1alpha1Interface
 }
 
 // Verify the struct KnativeLib implements KnativeLibIntf
@@ -148,9 +148,9 @@ func GetKnativeLib() (*KnativeLib, error) {
 	factory := evinformers.NewSharedInformerFactory(evClient, 0)
 
 	k := &KnativeLib{
-		evClient:         evClient.EventingV1alpha1(),
-		chLister:         factory.Messaging().V1alpha1().Channels().Lister(),
-		messagingChannel: evClient.MessagingV1alpha1(),
+		evClient:  evClient.EventingV1alpha1(),
+		chLister:  factory.Messaging().V1alpha1().Channels().Lister(),
+		msgClient: evClient.MessagingV1alpha1(),
 	}
 	once.Do(func() {
 		k.httpClient = http.Client{
@@ -206,7 +206,7 @@ func hasSynced(ctx context.Context, fn waitForCacheSyncFunc) error {
 
 // MsgChannelClient returns a clientset interface for messaging v1alpha1 API
 func (k *KnativeLib) MsgChannelClient() messagingv1alpha1Client.MessagingV1alpha1Interface {
-	return k.messagingChannel
+	return k.msgClient
 }
 
 // GetChannelByLabels return a knative channel fetched via label selectors
@@ -242,7 +242,7 @@ func (k *KnativeLib) CreateChannel(prefix, namespace string, labels map[string]s
 	readyFn ...ChannelReadyFunc) (*messagingV1Alpha1.Channel, error) {
 
 	c := makeChannel(prefix, namespace, labels)
-	channel, err := k.messagingChannel.Channels(namespace).Create(c)
+	channel, err := k.msgClient.Channels(namespace).Create(c)
 	if err != nil && !k8serrors.IsAlreadyExists(err) {
 		log.Printf("ERROR: CreateChannel(): creating channel: %v", err)
 		return nil, err
@@ -259,7 +259,7 @@ func (k *KnativeLib) CreateChannel(prefix, namespace string, labels map[string]s
 
 // DeleteChannel deletes a Knative/Eventing channel
 func (k *KnativeLib) DeleteChannel(name string, namespace string) error {
-	if err := k.messagingChannel.Channels(namespace).Delete(name, &metav1.DeleteOptions{}); err != nil {
+	if err := k.msgClient.Channels(namespace).Delete(name, &metav1.DeleteOptions{}); err != nil {
 		log.Printf("ERROR: DeleteChannel(): deleting channel: %v", err)
 		return err
 	}
@@ -346,7 +346,7 @@ func (k *KnativeLib) SendMessage(channel *messagingV1Alpha1.Channel, headers *ma
 // InjectClient injects a client, useful for running tests.
 func (k *KnativeLib) InjectClient(evClient eventingv1alpha1.EventingV1alpha1Interface, msgClient messagingv1alpha1Client.MessagingV1alpha1Interface) error {
 	k.evClient = evClient
-	k.messagingChannel = msgClient
+	k.msgClient = msgClient
 	return nil
 }
 

--- a/components/event-bus/internal/knative/util/kn-eventing.go
+++ b/components/event-bus/internal/knative/util/kn-eventing.go
@@ -82,7 +82,7 @@ type KnativeAccessLib interface {
 	UpdateSubscription(sub *evapisv1alpha1.Subscription) (*evapisv1alpha1.Subscription, error)
 	SendMessage(channel *messagingV1Alpha1.Channel, headers *map[string][]string, message *string) error
 	InjectClient(evClient eventingv1alpha1.EventingV1alpha1Interface, msgClient messagingv1alpha1Client.MessagingV1alpha1Interface) error
-	EvClient() eventingv1alpha1.EventingV1alpha1Interface
+	MsgChannelClient() messagingv1alpha1Client.MessagingV1alpha1Interface
 }
 
 // ChannelReadyFunc is a function used to ensure that a Channel has become Ready.
@@ -204,9 +204,9 @@ func hasSynced(ctx context.Context, fn waitForCacheSyncFunc) error {
 	return nil
 }
 
-// EvClient returns a clientset interface for eventing v1alpha1 API
-func (k *KnativeLib) EvClient() eventingv1alpha1.EventingV1alpha1Interface {
-	return k.evClient
+// MsgChannelClient returns a clientset interface for messaging v1alpha1 API
+func (k *KnativeLib) MsgChannelClient() messagingv1alpha1Client.MessagingV1alpha1Interface {
+	return k.messagingChannel
 }
 
 // GetChannelByLabels return a knative channel fetched via label selectors

--- a/components/event-bus/internal/knative/util/kn-eventing.go
+++ b/components/event-bus/internal/knative/util/kn-eventing.go
@@ -82,6 +82,7 @@ type KnativeAccessLib interface {
 	UpdateSubscription(sub *evapisv1alpha1.Subscription) (*evapisv1alpha1.Subscription, error)
 	SendMessage(channel *messagingV1Alpha1.Channel, headers *map[string][]string, message *string) error
 	InjectClient(evClient eventingv1alpha1.EventingV1alpha1Interface, msgClient messagingv1alpha1Client.MessagingV1alpha1Interface) error
+	EvClient() eventingv1alpha1.EventingV1alpha1Interface
 }
 
 // ChannelReadyFunc is a function used to ensure that a Channel has become Ready.
@@ -203,6 +204,10 @@ func hasSynced(ctx context.Context, fn waitForCacheSyncFunc) error {
 	return nil
 }
 
+func (k *KnativeLib) EvClient() eventingv1alpha1.EventingV1alpha1Interface {
+	return k.evClient
+}
+
 // GetChannelByLabels return a knative channel fetched via label selectors
 // so based on the labels, we assume that the list of channels should have only one item in it
 // Hence, we'd be returning the item at 0th index.
@@ -319,6 +324,7 @@ func (k *KnativeLib) SendMessage(channel *messagingV1Alpha1.Channel, headers *ma
 		return err
 	}
 	defer func() {
+		_ = req.Body.Close()
 		_ = res.Body.Close()
 	}()
 

--- a/components/event-bus/internal/knative/util/kn-eventing.go
+++ b/components/event-bus/internal/knative/util/kn-eventing.go
@@ -204,6 +204,7 @@ func hasSynced(ctx context.Context, fn waitForCacheSyncFunc) error {
 	return nil
 }
 
+// EvClient returns a clientset interface for eventing v1alpha1 API
 func (k *KnativeLib) EvClient() eventingv1alpha1.EventingV1alpha1Interface {
 	return k.evClient
 }

--- a/components/event-bus/internal/knative/util/kn-eventing_test.go
+++ b/components/event-bus/internal/knative/util/kn-eventing_test.go
@@ -139,8 +139,8 @@ func Test_CreateChannelWithError(t *testing.T) {
 	   and https://github.com/kubernetes/kubernetes/pull/73601
 	*/
 	setErrorWaitForChannelFunc := ChannelReadyFunc(func(name string, l evlistersv1alpha1.ChannelNamespaceLister) error {
-		getFunc := k.messagingChannel.Channels(testNS).Get
-		updFunc := k.messagingChannel.Channels(testNS).Update
+		getFunc := k.msgClient.Channels(testNS).Get
+		updFunc := k.msgClient.Channels(testNS).Update
 		ch, _ := getFunc(name, metav1.GetOptions{})
 		ch.Labels["l1"] = "not-matching"
 		_, err := updFunc(ch)
@@ -335,9 +335,9 @@ func newKnativeLib(client evclientset.Interface, t *testing.T) (*KnativeLib, cha
 
 	factory.Messaging().V1alpha1().Channels().Informer()
 	kl := &KnativeLib{
-		evClient:         client.EventingV1alpha1(),
-		messagingChannel: client.MessagingV1alpha1(),
-		chLister:         factory.Messaging().V1alpha1().Channels().Lister(),
+		evClient:  client.EventingV1alpha1(),
+		msgClient: client.MessagingV1alpha1(),
+		chLister:  factory.Messaging().V1alpha1().Channels().Lister(),
 	}
 
 	stopCh := make(chan struct{})


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/master/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- KnativeLib creates informers for Channel and readiness probe was using it. So for each readiness- check it was creating informers which were not used later. As a result, memory usage kept growing. Hence, removed the usage of KnativeLib from ReadinessProbe handler.
- Fixed the metrics for the published messages.

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
See #6299