### PR TITLE
Fetch Dex token after waiting for API Server in Runtime Agent tests

### DIFF
--- a/resources/compass-runtime-agent/values.yaml
+++ b/resources/compass-runtime-agent/values.yaml
@@ -7,7 +7,7 @@ global:
       version: PR-6244
     runtimeAgentTests:
       dir:
-      version: PR-6244
+      version: PR-6333
 
 compassRuntimeAgent:
   image:

--- a/tests/compass-runtime-agent/test/runtimeagent/suite.go
+++ b/tests/compass-runtime-agent/test/runtimeagent/suite.go
@@ -58,8 +58,7 @@ type TestSuite struct {
 
 	mockServiceServer *mock.AppMockServer
 
-	Config        testkit.TestConfig
-	CoreClientset *kubernetes.Clientset
+	Config testkit.TestConfig
 
 	mockServiceName string
 	testPodsLabels  string
@@ -100,11 +99,6 @@ func NewTestSuite(config testkit.TestConfig) (*TestSuite, error) {
 		return nil, err
 	}
 
-	coreClientset, err := kubernetes.NewForConfig(k8sConfig)
-	if err != nil {
-		return nil, err
-	}
-
 	serviceClient := k8sClient.CoreV1().Services(config.IntegrationNamespace)
 	secretsClient := k8sClient.CoreV1().Secrets(config.IntegrationNamespace)
 
@@ -120,7 +114,6 @@ func NewTestSuite(config testkit.TestConfig) (*TestSuite, error) {
 		K8sResourceChecker:  assertions.NewK8sResourceChecker(serviceClient, secretsClient, appClient.Applications(), nameResolver, istioClient, clusterDocsTopicClient, config.IntegrationNamespace),
 		mockServiceServer:   mock.NewAppMockServer(config.MockServicePort),
 		Config:              config,
-		CoreClientset:       coreClientset,
 		mockServiceName:     config.MockServiceName,
 		testPodsLabels:      testPodLabels,
 	}, nil
@@ -292,7 +285,7 @@ func (ts *TestSuite) updatePod(podName string, updateFunc updatePodFunc) error {
 }
 
 func (ts *TestSuite) getDirectorToken() (string, error) {
-	secretInterface := ts.CoreClientset.CoreV1().Secrets(ts.Config.DexSecretNamespace)
+	secretInterface := ts.k8sClient.CoreV1().Secrets(ts.Config.DexSecretNamespace)
 	secretsRepository := secrets.NewRepository(secretInterface)
 	dexSecret, err := secretsRepository.Get(ts.Config.DexSecretName)
 	if err != nil {

--- a/tests/compass-runtime-agent/test/testkit/compass/client.go
+++ b/tests/compass-runtime-agent/test/testkit/compass/client.go
@@ -32,7 +32,7 @@ type Client struct {
 	directorToken string
 }
 
-func NewCompassClient(endpoint, tenant, runtimeId, scenarioLabel, directorToken string, gqlLog bool) *Client {
+func NewCompassClient(endpoint, tenant, runtimeId, scenarioLabel string, gqlLog bool) *Client {
 
 	httpClient := &http.Client{
 		Transport: &http.Transport{
@@ -56,7 +56,6 @@ func NewCompassClient(endpoint, tenant, runtimeId, scenarioLabel, directorToken 
 		tenant:        tenant,
 		scenarioLabel: scenarioLabel,
 		runtimeId:     runtimeId,
-		directorToken: directorToken,
 	}
 }
 
@@ -73,6 +72,12 @@ func (c *Client) GetRuntime(runtimeId string) (Runtime, error) {
 	}
 
 	return runtime, nil
+}
+
+// Setup
+
+func (c *Client) SetDirectorToken(directorToken string) {
+	c.directorToken = directorToken
 }
 
 // Scenario labels


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Fetch Dex token after waiting for API Server in Runtime Agent tests. Not doing so could cause bugs with not ready sidecars and flaky tests failures

**Related issue(s)**

See the issue #6106 
