### PR TITLE
Parametrize Compass Connector RBAC rule

### DIFF
--- a/resources/compass/charts/connector/templates/service-role-binding.yaml
+++ b/resources/compass/charts/connector/templates/service-role-binding.yaml
@@ -6,7 +6,7 @@ metadata:
   namespace: {{ .Release.Namespace }}
 spec:
   rules:
-    - services: ["{{ template "fullname" . }}-internal.compass-system.svc.cluster.local"]
+    - services: ["{{ template "fullname" . }}-internal.{{ .Release.Namespace }}.svc.cluster.local"]
       paths: ["*"]
       methods: ["*"]
 ---

--- a/resources/compass/charts/connector/values.yaml
+++ b/resources/compass/charts/connector/values.yaml
@@ -29,6 +29,6 @@ istio:
     enabled: true
     connectorInternalApi:
       subjects:
-        - user: cluster.local/ns/compass-system/sa/compass-director
-        - user: cluster.local/ns/compass-system/sa/compass-connector-tests
-        - user: cluster.local/ns/compass-system/sa/compass-agent-configuration
+        - user: cluster.local/ns/{{ .Release.Namespace }}/sa/compass-director
+        - user: cluster.local/ns/{{ .Release.Namespace }}/sa/compass-connector-tests
+        - user: cluster.local/ns/{{ .Release.Namespace }}/sa/compass-agent-configuration


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Parametrize Compass Connector RBAC rule. It shouldn't be hardcoded because the Compass Connector service could be installed in different namespace!

**Related issue(s)**

See the issue #6341 
