### PR TITLE
Set Prometheus port for event-sources' HTTP adapter metrics

### DIFF
--- a/components/event-sources/reconciler/httpsource/adapter_config.go
+++ b/components/event-sources/reconciler/httpsource/adapter_config.go
@@ -36,13 +36,17 @@ type httpAdapterEnvConfig struct {
 	Port int32 `default:"8080"`
 }
 
+// Ports 9090-9091 are reserved for the Serving queue proxy (knative.dev/serving/pkg/apis/networking)
+const adapterMetricsPort = 9092
+
 // updateAdapterMetricsConfig serializes the metrics config from a ConfigMap to
 // JSON and updates the existing config stored in the Reconciler.
 func (r *Reconciler) updateAdapterMetricsConfig(cfg *corev1.ConfigMap) {
 	metricsCfg := &metrics.ExporterOptions{
-		Domain:    metrics.Domain(),
-		Component: component,
-		ConfigMap: cfg.Data,
+		Domain:         metrics.Domain(),
+		Component:      component,
+		PrometheusPort: adapterMetricsPort,
+		ConfigMap:      cfg.Data,
 	}
 
 	metricsCfgJSON, err := metrics.MetricsOptionsToJson(metricsCfg)

--- a/components/event-sources/reconciler/httpsource/reconcile_test.go
+++ b/components/event-sources/reconciler/httpsource/reconcile_test.go
@@ -18,6 +18,7 @@ package httpsource
 
 import (
 	"context"
+	"strconv"
 	"testing"
 
 	corev1 "k8s.io/api/core/v1"
@@ -72,7 +73,8 @@ var tEnvVars = []corev1.EnvVar{
 		Name: metricsConfigEnvVar,
 		Value: `{"Domain":"` + tMetricsDomain + `",` +
 			`"Component":"` + component + `",` +
-			`"PrometheusPort":0,` +
+			`"PrometheusPort":` + strconv.Itoa(adapterMetricsPort) + `,` +
+
 			`"ConfigMap":{"metrics.backend":"prometheus"}}`,
 	}, {
 		Name:  loggingConfigEnvVar,


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Set Prometheus port to 9092 for adapter metrics. The default port 9090 is reserved ([Godoc](https://godoc.org/knative.dev/serving/pkg/apis/networking#pkg-constants)).

**Related issue(s)**

#6282