### PR TITLE
Disable Kubeless tests

### DIFF
--- a/resources/core/charts/kubeless/values.yaml
+++ b/resources/core/charts/kubeless/values.yaml
@@ -15,4 +15,4 @@ config:
     secret: ""
 
 tests:
-  enabled: true
+  enabled: false


### PR DESCRIPTION
Disable Kubelss tests to mitigate the failing test **LambdaFunctionUpgradeTest**. 

The tests should be fixed and reactivated again as part of https://github.com/kyma-project/kyma/issues/6315.