### PR TITLE
Set application-name label on HTTP source Channel

### DIFF
--- a/components/event-sources/Gopkg.lock
+++ b/components/event-sources/Gopkg.lock
@@ -1401,6 +1401,7 @@
     "k8s.io/code-generator/cmd/informer-gen",
     "k8s.io/code-generator/cmd/lister-gen",
     "knative.dev/eventing/pkg/adapter",
+    "knative.dev/eventing/pkg/apis/messaging",
     "knative.dev/eventing/pkg/apis/messaging/v1alpha1",
     "knative.dev/eventing/pkg/client/clientset/versioned/fake",
     "knative.dev/eventing/pkg/client/clientset/versioned/typed/messaging/v1alpha1",

--- a/components/event-sources/apis/sources/v1alpha1/http_lifecycle.go
+++ b/components/event-sources/apis/sources/v1alpha1/http_lifecycle.go
@@ -55,8 +55,8 @@ func (s *HTTPSource) ToKey() string {
 }
 
 const (
-	HTTPSourceReasonSinkNotFound    = "NotFound"
-	HTTPSourceReasonSinkEmpty       = "EmptyURI"
+	HTTPSourceReasonSinkNotFound    = "SinkNotFound"
+	HTTPSourceReasonSinkEmpty       = "EmptySinkURI"
 	HTTPSourceReasonServiceNotReady = "ServiceNotReady"
 )
 

--- a/components/event-sources/reconciler/httpsource/controller.go
+++ b/components/event-sources/reconciler/httpsource/controller.go
@@ -90,6 +90,11 @@ func NewController(ctx context.Context, cmw configmap.Watcher) *controller.Impl 
 		Handler:    controller.HandleAll(impl.EnqueueControllerOf),
 	})
 
+	chInformer.Informer().AddEventHandler(cache.FilteringResourceEventHandler{
+		FilterFunc: controller.Filter(sourcesv1alpha1.HTTPSourceGVK()),
+		Handler:    controller.HandleAll(impl.EnqueueControllerOf),
+	})
+
 	// watch for changes to metrics/logging configs
 
 	cmw.Watch(metrics.ConfigMapName(), r.updateAdapterMetricsConfig)

--- a/components/event-sources/reconciler/httpsource/reconcile.go
+++ b/components/event-sources/reconciler/httpsource/reconcile.go
@@ -83,6 +83,8 @@ const (
 
 const adapterHealthEndpoint = "/healthz"
 
+const applicationNameLabelKey = "application-name"
+
 // Reconcile compares the actual state of a HTTPSource object referenced by key
 // with its desired state, and attempts to converge the two.
 func (r *Reconciler) Reconcile(ctx context.Context, key string) error {
@@ -220,6 +222,7 @@ func (r *Reconciler) makeKnService(src *sourcesv1alpha1.HTTPSource,
 func (r *Reconciler) makeChannel(src *sourcesv1alpha1.HTTPSource) *messagingv1alpha1.Channel {
 	return objects.NewChannel(src.Namespace, src.Name,
 		objects.WithChannelControllerRef(src.ToOwner()),
+		objects.WithChannelLabel(applicationNameLabelKey, src.Name),
 	)
 }
 

--- a/components/event-sources/reconciler/httpsource/reconcile_test.go
+++ b/components/event-sources/reconciler/httpsource/reconcile_test.go
@@ -182,6 +182,26 @@ func TestReconcile(t *testing.T) {
 				rt.Eventf(corev1.EventTypeNormal, string(createReason), "Created Channel %q", tName),
 			},
 		},
+		{
+			Name: "Channel spec does not match expectation",
+			Key:  tNs + "/" + tName,
+			Objects: []runtime.Object{
+				newSourceDeployedWithSink(),
+				newServiceReady(),
+				NewChannel(tNs, tName,
+					WithChannelLabels(labels.Set{"not": "expected"}),
+					WithChannelSinkURI(tSinkURI),
+				),
+			},
+			WantCreates: nil,
+			WantUpdates: []k8stesting.UpdateActionImpl{{
+				Object: newChannelReady(),
+			}},
+			WantStatusUpdates: nil,
+			WantEvents: []string{
+				rt.Eventf(corev1.EventTypeNormal, string(updateReason), "Updated Channel %q", tName),
+			},
+		},
 
 		/* Status updates */
 

--- a/components/event-sources/reconciler/objects/channel.go
+++ b/components/event-sources/reconciler/objects/channel.go
@@ -47,3 +47,13 @@ func WithChannelControllerRef(or *metav1.OwnerReference) ChannelOption {
 		s.OwnerReferences = []metav1.OwnerReference{*or}
 	}
 }
+
+// WithChannelLabel sets a label on a Channel object.
+func WithChannelLabel(key, val string) ChannelOption {
+	return func(s *messagingv1alpha1.Channel) {
+		if s.Labels == nil {
+			s.Labels = make(map[string]string, 1)
+		}
+		s.Labels[key] = val
+	}
+}

--- a/components/event-sources/reconciler/objects/channel_test.go
+++ b/components/event-sources/reconciler/objects/channel_test.go
@@ -32,6 +32,9 @@ func TestNewChannel(t *testing.T) {
 	const (
 		ns   = "testns"
 		name = "test"
+
+		key   = "some-key"
+		value = "some-value"
 	)
 
 	testHTTPSrc := &sourcesv1alpha1.HTTPSource{ObjectMeta: metav1.ObjectMeta{
@@ -47,11 +50,17 @@ func TestNewChannel(t *testing.T) {
 			OwnerReferences: []metav1.OwnerReference{
 				*testHTTPSrc.ToOwner(),
 			},
+			Labels: map[string]string{
+				key + "1": value + "1",
+				key + "2": value + "2",
+			},
 		},
 	}
 
 	ch := NewChannel(ns, name,
 		WithChannelControllerRef(testHTTPSrc.ToOwner()),
+		WithChannelLabel(key+"1", value+"1"),
+		WithChannelLabel(key+"2", value+"2"),
 	)
 
 	if d := cmp.Diff(expectCh, ch); d != "" {

--- a/components/event-sources/reconciler/objects/equality.go
+++ b/components/event-sources/reconciler/objects/equality.go
@@ -22,14 +22,35 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/conversion"
 
+	messagingv1alpha1 "knative.dev/eventing/pkg/apis/messaging/v1alpha1"
 	servingv1alpha1 "knative.dev/serving/pkg/apis/serving/v1alpha1"
 )
 
 // Semantic can do semantic deep equality checks for API objects. Fields which
 // are not relevant for the reconciliation logic are intentionally omitted.
 var Semantic = conversion.EqualitiesOrDie(
+	channelEqual,
 	ksvcEqual,
 )
+
+// channelEqual asserts the equality of two Channel objects.
+func channelEqual(c1, c2 *messagingv1alpha1.Channel) bool {
+	if c1 == c2 {
+		return true
+	}
+	if c1 == nil || c2 == nil {
+		return false
+	}
+
+	if !reflect.DeepEqual(c1.Labels, c2.Labels) {
+		return false
+	}
+	if !reflect.DeepEqual(c1.Annotations, c2.Annotations) {
+		return false
+	}
+
+	return true
+}
 
 // ksvcEqual asserts the equality of two Knative Service objects.
 func ksvcEqual(s1, s2 *servingv1alpha1.Service) bool {

--- a/components/event-sources/reconciler/testing/channel.go
+++ b/components/event-sources/reconciler/testing/channel.go
@@ -65,6 +65,13 @@ func WithChannelController(srcName string) ChannelOption {
 	}
 }
 
+// WithChannelLabels sets the labels of a Channel.
+func WithChannelLabels(labels map[string]string) ChannelOption {
+	return func(ch *messagingv1alpha1.Channel) {
+		ch.Labels = labels
+	}
+}
+
 // WithChannelSinkURI sets the sink URI of a Channel.
 func WithChannelSinkURI(uri string) ChannelOption {
 	return func(ch *messagingv1alpha1.Channel) {

--- a/components/event-sources/reconciler/testing/httpsource.go
+++ b/components/event-sources/reconciler/testing/httpsource.go
@@ -53,24 +53,29 @@ func NewHTTPSource(ns, name string, opts ...HTTPSourceOption) *sourcesv1alpha1.H
 
 type HTTPSourceOption func(s *sourcesv1alpha1.HTTPSource)
 
+// WithInitConditions initializes all conditions to Unknown.
 func WithInitConditions(s *sourcesv1alpha1.HTTPSource) {
 	s.Status.InitializeConditions()
 }
 
+// WithDeployed sets the Deployed condition to True.
 func WithDeployed(s *sourcesv1alpha1.HTTPSource) {
 	s.Status.PropagateServiceReady(NewService("", "", WithServiceReady))
 }
 
+// WithNotDeployed sets the Deployed condition to False.
 func WithNotDeployed(s *sourcesv1alpha1.HTTPSource) {
 	s.Status.PropagateServiceReady(NewService("", ""))
 }
 
+// WithSink sets the SinkProvided condition to True.
 func WithSink(uri string) HTTPSourceOption {
 	return func(s *sourcesv1alpha1.HTTPSource) {
 		s.Status.MarkSink(uri)
 	}
 }
 
+// WithNoSink sets the SinkProvided condition to False.
 func WithNoSink(s *sourcesv1alpha1.HTTPSource) {
 	s.Status.MarkNoSink()
 }

--- a/components/event-sources/test/fixtures/channel.json
+++ b/components/event-sources/test/fixtures/channel.json
@@ -1,0 +1,36 @@
+{
+    "apiVersion": "messaging.knative.dev/v1alpha1",
+    "kind": "Channel",
+    "metadata": {
+        "annotations": {
+            "messaging.knative.dev/creator": "system:serviceaccount:kyma-system:event-sources-controller-manager",
+            "messaging.knative.dev/lastModifier": "system:serviceaccount:kyma-system:event-sources-controller-manager"
+        },
+        "creationTimestamp": "2019-11-22T17:35:43Z",
+        "generation": 1,
+        "labels": {
+            "application-name": "dummy"
+        },
+        "name": "dummy",
+        "namespace": "default",
+        "ownerReferences": [
+            {
+                "apiVersion": "sources.kyma-project.io/v1alpha1",
+                "blockOwnerDeletion": true,
+                "controller": true,
+                "kind": "HTTPSource",
+                "name": "dummy",
+                "uid": "4a698914-c040-4881-bdc5-d0ef1756edc0"
+            }
+        ],
+        "resourceVersion": "911269",
+        "selfLink": "/apis/messaging.knative.dev/v1alpha1/namespaces/default/channels/dummy",
+        "uid": "8bb8d080-0d7b-4d2a-b72a-156af9260e3e"
+    },
+    "spec": {
+        "channelTemplate": {
+            "apiVersion": "messaging.knative.dev/v1alpha1",
+            "kind": "InMemoryChannel"
+        }
+    }
+}


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Set `application-name` label on HTTP source Channel. Required by application broker.
- Add Channel reconciliation logic to ensure the label remains up-to-date

**Related issue(s)**

marcobebway/kyma#2028