### PR TITLE
Require rules field in APIRule CRD

### DIFF
--- a/resources/api-gateway/files/crd-apirules.yaml
+++ b/resources/api-gateway/files/crd-apirules.yaml
@@ -392,7 +392,7 @@ spec:
               pattern: ^(?:[_a-z0-9](?:[_a-z0-9-]+[a-z0-9])?\.)+(?:[a-z](?:[a-z0-9-]+[a-z0-9])?)?$
               type: string
             rules:
-              description: Paths represents collection of Path to secure
+              description: Rules represents collection of Rule to apply
               items:
                 properties:
                   accessStrategies:
@@ -471,6 +471,7 @@ spec:
           required:
             - service
             - gateway
+            - rules
           type: object
         status:
           properties:


### PR DESCRIPTION
**Description**

Documentation already states that `spec.rules` field is required.

Changes proposed in this pull request:

- Add `rules` to required section

**Related issue(s)**
#6337