### PR TITLE
Add curl to connector-service-tests

### DIFF
--- a/tests/connector-service-tests/Dockerfile
+++ b/tests/connector-service-tests/Dockerfile
@@ -11,7 +11,7 @@ FROM alpine:3.10
 
 LABEL source=git@github.com:kyma-project/kyma.git
 
-RUN apk --no-cache add ca-certificates
+RUN apk --no-cache add ca-certificates && apk --no-cache add curl
 
 COPY --from=builder /go/src/github.com/kyma-project/kyma/tests/connector-service-tests/scripts/entrypoint.sh .
 COPY --from=builder /go/src/github.com/kyma-project/kyma/tests/connector-service-tests/apitests.test .


### PR DESCRIPTION
**Description**
Add `curl` binary to connector-service-tests Docker image
This is necessary in order to run our tests in Azure environment - See #4719 

Changes proposed in this pull request:
- Add `curl` binary to connector-service-tests Docker image


**Related issue(s)**
See also #4719