### PR TITLE
Add curl to Dockerfile

### DIFF
--- a/tests/integration/dex/Dockerfile
+++ b/tests/integration/dex/Dockerfile
@@ -24,10 +24,10 @@ LABEL source = git@github.com:kyma-project/kyma.git
 WORKDIR /tests
 
 #
-# Install certificates
+# Install certificates and curl
 #
 
-RUN apk update && apk add ca-certificates && rm -rf /var/cache/apk/*
+RUN apk update && apk add ca-certificates && apk add curl && rm -rf /var/cache/apk/*
 
 #
 # Copy binary


### PR DESCRIPTION
**Description**
We can resolve the problem described in #4719 with newly added Istio endpoint `/quitquitquit`. We need to add curl to our Dockerfile to be able to call it.

Changes proposed in this pull request:

- Install curl in Dockerfile

**Related issue(s)**
#4719