### PR TITLE
Add curl to service catalog tests Dockerfile

### DIFF
--- a/tests/service-catalog/Dockerfile
+++ b/tests/service-catalog/Dockerfile
@@ -12,6 +12,8 @@ RUN CGO_ENABLED=0 go test -tags=acceptance -c ./test -o /servicecatalog.test
 
 FROM alpine:3.10
 
+RUN apk add --no-cache curl
+
 COPY --from=builder env-tester.bin /go/bin/env-tester.bin
 COPY --from=builder ./servicecatalog.test .
 COPY ./licenses/ /app/licenses


### PR DESCRIPTION
**Description**
We can resolve the problem described in #4719 with newly added Istio endpoint `/quitquitquit`. We need to add curl to our Dockerfile to be able to call it.

Changes proposed in this pull request:

- Install curl in Dockerfile

**Related issue(s)**
#4719