### PR TITLE
Add curl to kubeless tests Dockerfile

### DIFF
--- a/tests/kubeless/Dockerfile
+++ b/tests/kubeless/Dockerfile
@@ -25,6 +25,8 @@ RUN go generate ./... && \
 
 FROM alpine:3.8
 
+RUN apk add --no-cache curl
+
 COPY --from=builder /usr/bin/kubectl /usr/bin/kubectl
 COPY --from=builder /usr/bin/kubeless /usr/bin/kubeless
 


### PR DESCRIPTION
**Description**
We can resolve the problem described in #4719 with newly added Istio endpoint `/quitquitquit`. We need to add curl to our Dockerfile to be able to call it.

Changes proposed in this pull request:

- Install curl in Dockerfile

**Related issue(s)**
#4719