### PR TITLE
Add curl to asset-store-tests

### DIFF
--- a/tests/asset-store/Dockerfile
+++ b/tests/asset-store/Dockerfile
@@ -27,10 +27,10 @@ WORKDIR /app
 ENV TEST_DIR /go/src/github.com/kyma-project/kyma/tests/asset-store
 
 #
-# Install certificates
+# Install certificates and tools
 #
 
-RUN apk update && apk add ca-certificates && rm -rf /var/cache/apk/*
+RUN apk update && apk add ca-certificates && apk add curl && rm -rf /var/cache/apk/*
 
 #
 # Copy binaries


### PR DESCRIPTION
**Description**
Add `curl` binary to asset-store-tests Docker image
This is necessary in order to run our tests in Azure environment - See #4719

Changes proposed in this pull request:
- Add `curl` binary to asset-store-tests Docker image

**Related issue(s)**
See also #4719 
