### PR TITLE
Bump Oathkeeper image to support alternative token location

### DIFF
--- a/resources/compass/values.yaml
+++ b/resources/compass/values.yaml
@@ -123,19 +123,19 @@ global:
           api:
             url: http://compass-director.compass-system.svc.cluster.local:3000/tenant-mapping
             retry:
-              number: 3
-              delayInMilliseconds: 2000
+              number_of_retries: 3
+              delay_in_milliseconds: 2000
       certificateResolverService:
         config:
           api:
             url: http://compass-connector.compass-system.svc.cluster.local:8080/v1/certificate/data/resolve
             retry:
-              number: 3
-              delayInMilliseconds: 2000
+              number_of_retries: 3
+              delay_in_milliseconds: 2000
       tokenResolverService:
         config:
           api:
             url: http://compass-connector.compass-system.svc.cluster.local:8080/v1/tokens/resolve
             retry:
-              number: 3
-              delayInMilliseconds: 2000
+              number_of_retries: 3
+              delay_in_milliseconds: 2000

--- a/resources/ory/charts/oathkeeper/templates/deployment.yaml
+++ b/resources/ory/charts/oathkeeper/templates/deployment.yaml
@@ -49,7 +49,7 @@ spec:
           command: [ "oathkeeper", "serve", "--config", "/etc/config/config.yaml" ]
           env:
             {{- if .Values.oathkeeper.mutatorIdTokenJWKs }}
-            - name: MUTATORS_ID_TOKEN_JWKS_URL
+            - name: MUTATORS_ID_TOKEN_CONFIG_JWKS_URL
               value: "file:///etc/secrets/mutator.id_token.jwks.json"
             {{- end }}
           volumeMounts:

--- a/resources/ory/charts/oathkeeper/values.yaml
+++ b/resources/ory/charts/oathkeeper/values.yaml
@@ -5,7 +5,7 @@ image:
   # ORY Oathkeeper image
   repository: oryd/oathkeeper
   # ORY Oathkeeper version
-  tag: v0.18.0
+  tag: v0.32.1
   # Image pull policy
   pullPolicy: IfNotPresent
 

--- a/resources/ory/values.yaml
+++ b/resources/ory/values.yaml
@@ -153,7 +153,7 @@ oathkeeper:
           enabled: true
           config:
             api:
-              url: https://example.com
+              url: http://compass-director.compass-system.svc.cluster.local:3000/tenant-mapping
       serve:
         proxy:
           port: 4455

--- a/resources/ory/values.yaml
+++ b/resources/ory/values.yaml
@@ -85,34 +85,39 @@ oathkeeper:
           enabled: true
         anonymous:
           enabled: true
-          subject: anonymous
+          config:
+            subject: anonymous
         cookie_session:
           enabled: false
-          # REQUIRED IF ENABLED - The session store to forward request method/path/headers to for validation
-          check_session_url: https://session-store-host
-          # Optionally set a list of cookie names to look for in incoming requests.
-          # If unset, all requests are forwarded.
-          # If set, only requests that have at least one of the set cookies will be forwarded, others will be passed to the next authenticator
-          only:
-              - sessionid
+          config:
+            # REQUIRED IF ENABLED - The session store to forward request method/path/headers to for validation
+            check_session_url: https://session-store-host
+            # Optionally set a list of cookie names to look for in incoming requests.
+            # If unset, all requests are forwarded.
+            # If set, only requests that have at least one of the set cookies will be forwarded, others will be passed to the next authenticator
+            only:
+            - sessionid
         oauth2_client_credentials:
           enabled: true
-          # REQUIRED IF ENABLED - The OAuth 2.0 Token Endpoint that will be used to validate the client credentials.
-          token_url: http://ory-hydra-public.kyma-system.svc.cluster.local:4444/oauth2/token
+          config:
+            # REQUIRED IF ENABLED - The OAuth 2.0 Token Endpoint that will be used to validate the client credentials.
+            token_url: http://ory-hydra-public.kyma-system.svc.cluster.local:4444/oauth2/token
         oauth2_introspection:
           # Set enabled to true if the authenticator should be enabled and false to disable the authenticator. Defaults to false.
           enabled: true
-          # REQUIRED IF ENABLED - The OAuth 2.0 Token Introspection endpoint.
-          introspection_url: http://ory-hydra-admin.kyma-system.svc.cluster.local:4445/oauth2/introspect
-          # Sets the strategy to be used to validate/match the token scope. Supports "hierarchic", "exact", "wildcard", "none". Defaults
-          # to "none".
-          scope_strategy: exact
+          config:
+            # REQUIRED IF ENABLED - The OAuth 2.0 Token Introspection endpoint.
+            introspection_url: http://ory-hydra-admin.kyma-system.svc.cluster.local:4445/oauth2/introspect
+            # Sets the strategy to be used to validate/match the token scope. Supports "hierarchic", "exact", "wildcard", "none". Defaults
+            # to "none".
+            scope_strategy: exact
         # Enable the "jwt" section to allow for jwt authenticator configured for local Dex Id Tokens.
         jwt:
           enabled: true
-          jwks_urls:
+          config:
+            jwks_urls:
             - http://dex-service.kyma-system.svc.cluster.local:5556/keys
-          scope_strategy: wildcard
+            scope_strategy: wildcard
       authorizers:
         allow:
           enabled: true
@@ -123,21 +128,32 @@ oathkeeper:
           enabled: true
         id_token:
           enabled: true
-          # REQUIRED IF ENABLED - Sets the "iss" value of the ID Token.
-          issuer_url: https://oathkeeper.{{ .Values.global.ingress.domainName }}/
-          # REQUIRED IF ENABLED - Sets the URL where keys should be fetched from. Supports remote locations (http, https) as
-          # well as local filesystem paths.
-          # jwks_url: https://fetch-keys/from/this/location.json
-          # jwks_url: file:///from/this/absolute/location.json
-          # jwks_url: file://../from/this/relative/location.json
-          # Sets the time-to-live of the ID token. Defaults to one minute. Valid time units are: s (second), m (minute), h (hour).
-          ttl: 60s
+          config:
+            # REQUIRED IF ENABLED - Sets the "iss" value of the ID Token.
+            issuer_url: https://oathkeeper.{{ .Values.global.ingress.domainName }}/
+            # REQUIRED IF ENABLED - Sets the URL where keys should be fetched from. Supports remote locations (http, https) as
+            # well as local filesystem paths.
+            jwks_url: "file:///etc/secrets/mutator.id_token.jwks.json"
+            # jwks_url: https://fetch-keys/from/this/location.json
+            # jwks_url: file:///from/this/absolute/location.json
+            # jwks_url: file://../from/this/relative/location.json
+            # Sets the time-to-live of the ID token. Defaults to one minute. Valid time units are: s (second), m (minute), h (hour).
+            ttl: 60s
         header:
           enabled: true
+          config:
+            headers:
+              X-Server: oathkeeper
         cookie:
           enabled: true
+          config:
+            cookies:
+              processedWith: oathkeeper
         hydrator:
           enabled: true
+          config:
+            api:
+              url: https://example.com
       serve:
         proxy:
           port: 4455
@@ -152,7 +168,7 @@ oathkeeper:
         cpu: 50m
         memory: 64Mi
   image:
-    tag: v0.18.0-beta.1
+    tag: v0.32.1
   oathkeeper-maester:
     deployment:
       annotations:


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/master/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- update oathkeeper config in ory chart values due to the recent changes in access rules configuration (https://github.com/ory/oathkeeper/pull/258)
- change oathkeeper image to the recent Oathkeeper version
- update hydrator settings in compass charts due to the recent [breaking change](https://github.com/ory/oathkeeper/blob/master/UPGRADE.md#hydrator-mutator) in configuration

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
See also https://github.com/ory/oathkeeper/issues/257
