### PR TITLE
Add curl to console-backend-service-tests

### DIFF
--- a/tests/console-backend-service/Dockerfile
+++ b/tests/console-backend-service/Dockerfile
@@ -35,7 +35,7 @@ ENV TEST_SERVICE_CATALOG_DIR /app/tests/servicecatalog
 # Install certificates
 #
 
-RUN apk update && apk add ca-certificates && rm -rf /var/cache/apk/*
+RUN apk update && apk add ca-certificates && apk add curl && rm -rf /var/cache/apk/*
 
 #
 # Copy test run script


### PR DESCRIPTION
**Description**
Add `curl` binary to console-backend-service-tests Docker image
This is necessary in order to run our tests in Azure environment - See #4719

Changes proposed in this pull request:
- Add `curl` binary to console-backend-service-tests Docker image

**Related issue(s)**
See also: #4719 
