### PR TITLE
connector-service-tests image bump

### DIFF
--- a/resources/application-connector/values.yaml
+++ b/resources/application-connector/values.yaml
@@ -27,7 +27,7 @@ global:
     version: fbf1000b
   connector_service_tests:
     dir:
-    version: fbf1000b
+    version: 27eff119
   connection_token_handler:
     dir:
     version: fbf1000b


### PR DESCRIPTION
**Description**
connector-service-tests Docker image bump after `curl` binary is added to the image.

Changes proposed in this pull request:
- connector-service-tests Docker image bump

**Related issue(s)**
See also: #4719 #6401 