### PR TITLE
application-connector: Add support for Knative Event Mesh

### DIFF
--- a/components/application-connectivity-validator/.gitignore
+++ b/components/application-connectivity-validator/.gitignore
@@ -1,4 +1,12 @@
+# Editors and IDEs
 /.idea
 *.iml
+*~
+*.swp
+*.swo
+
+# Binaries
 /applicationconnectivityvalidator
-licenses
+
+# Software licenses
+/licenses

--- a/components/application-connectivity-validator/cmd/applicationconnectivityvalidator/applicationconnectivityvalidator.go
+++ b/components/application-connectivity-validator/cmd/applicationconnectivityvalidator/applicationconnectivityvalidator.go
@@ -7,13 +7,18 @@ import (
 	"sync"
 	"time"
 
+	"github.com/patrickmn/go-cache"
+	log "github.com/sirupsen/logrus"
+
+	// allow client authentication against GKE clusters
+	//_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
+
+	"sigs.k8s.io/controller-runtime/pkg/client/config"
+
 	"github.com/kyma-project/kyma/components/application-connectivity-validator/internal/apperrors"
 	"github.com/kyma-project/kyma/components/application-connectivity-validator/internal/externalapi"
 	"github.com/kyma-project/kyma/components/application-connectivity-validator/internal/validationproxy"
 	"github.com/kyma-project/kyma/components/application-operator/pkg/client/clientset/versioned"
-	"github.com/patrickmn/go-cache"
-	log "github.com/sirupsen/logrus"
-	"sigs.k8s.io/controller-runtime/pkg/client/config"
 )
 
 func main() {
@@ -44,6 +49,8 @@ func main() {
 		options.eventServicePathPrefixV1,
 		options.eventServicePathPrefixV2,
 		options.eventServiceHost,
+		options.eventMeshPathPrefix,
+		options.eventMeshHost,
 		options.appRegistryPathPrefix,
 		options.appRegistryHost,
 		applicationGetter,

--- a/components/application-connectivity-validator/cmd/applicationconnectivityvalidator/options.go
+++ b/components/application-connectivity-validator/cmd/applicationconnectivityvalidator/options.go
@@ -13,6 +13,8 @@ type options struct {
 	eventServicePathPrefixV1 string
 	eventServicePathPrefixV2 string
 	eventServiceHost         string
+	eventMeshPathPrefix      string
+	eventMeshHost            string
 	appRegistryPathPrefix    string
 	appRegistryHost          string
 	cacheExpirationMinutes   int
@@ -27,6 +29,8 @@ func parseArgs() *options {
 	eventServicePathPrefixV1 := flag.String("eventServicePathPrefixV1", "/v1/events", "Prefix of paths that will be directed to the Event Service V1")
 	eventServicePathPrefixV2 := flag.String("eventServicePathPrefixV2", "/v2/events", "Prefix of paths that will be directed to the Event Service V2")
 	eventServiceHost := flag.String("eventServiceHost", "events-api:8080", "Host (and port) of the Event Service")
+	eventMeshPathPrefix := flag.String("eventMeshPathPrefix", "/events", "Prefix of paths that will be directed to the Event Mesh")
+	eventMeshHost := flag.String("eventMeshHost", "events-adapter:8080", "Host (and port) of the Event Mesh adapter")
 	appRegistryPathPrefix := flag.String("appRegistryPathPrefix", "/v1/metadata", "Prefix of paths that will be directed to the Application Registry")
 	appRegistryHost := flag.String("appRegistryHost", "application-registry-external-api:8081", "Host (and port) of the Application Registry")
 	cacheExpirationMinutes := flag.Int("cacheExpirationMinutes", 1, "Expiration time for client IDs stored in cache expressed in minutes")
@@ -42,6 +46,8 @@ func parseArgs() *options {
 		eventServicePathPrefixV1: *eventServicePathPrefixV1,
 		eventServicePathPrefixV2: *eventServicePathPrefixV2,
 		eventServiceHost:         *eventServiceHost,
+		eventMeshPathPrefix:      *eventMeshPathPrefix,
+		eventMeshHost:            *eventMeshHost,
 		appRegistryPathPrefix:    *appRegistryPathPrefix,
 		appRegistryHost:          *appRegistryHost,
 		cacheExpirationMinutes:   *cacheExpirationMinutes,
@@ -52,10 +58,12 @@ func parseArgs() *options {
 func (o *options) String() string {
 	return fmt.Sprintf("--proxyPort=%d --externalAPIPort=%d --tenant=%s --group=%s "+
 		"--eventServicePathPrefixV1=%s --eventServicePathPrefixV2=%s --eventServiceHost=%s "+
+		"--eventMeshPathPrefix=%s --eventMeshHost=%s "+
 		"--appRegistryPathPrefix=%s --appRegistryHost=%s"+
 		"--cacheExpirationMinutes=%d --cacheCleanupMinutes=%d",
 		o.proxyPort, o.externalAPIPort, o.tenant, o.group,
 		o.eventServicePathPrefixV1, o.eventServicePathPrefixV2, o.eventServiceHost,
+		o.eventMeshPathPrefix, o.eventMeshHost,
 		o.appRegistryPathPrefix, o.appRegistryHost,
 		o.cacheExpirationMinutes, o.cacheCleanupMinutes)
 }

--- a/components/application-connectivity-validator/internal/validationproxy/handler.go
+++ b/components/application-connectivity-validator/internal/validationproxy/handler.go
@@ -9,12 +9,14 @@ import (
 	"time"
 
 	"github.com/gorilla/mux"
+	"github.com/patrickmn/go-cache"
+	log "github.com/sirupsen/logrus"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
 	"github.com/kyma-project/kyma/components/application-connectivity-validator/internal/apperrors"
 	"github.com/kyma-project/kyma/components/application-connectivity-validator/internal/httptools"
 	"github.com/kyma-project/kyma/components/application-operator/pkg/apis/applicationconnector/v1alpha1"
-	"github.com/patrickmn/go-cache"
-	log "github.com/sirupsen/logrus"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 const (
@@ -27,7 +29,7 @@ type ProxyHandler interface {
 
 //go:generate mockery -name=ApplicationGetter
 type ApplicationGetter interface {
-	Get(name string, options v1.GetOptions) (*v1alpha1.Application, error)
+	Get(name string, options metav1.GetOptions) (*v1alpha1.Application, error)
 }
 
 //go:generate mockery -name=Cache
@@ -42,27 +44,45 @@ type proxyHandler struct {
 	eventServicePathPrefixV1 string
 	eventServicePathPrefixV2 string
 	eventServiceHost         string
+	eventMeshPathPrefix      string
+	eventMeshHost            string
 	appRegistryPathPrefix    string
 	appRegistryHost          string
 
 	eventsProxy      *httputil.ReverseProxy
+	eventMeshProxy   *httputil.ReverseProxy
 	appRegistryProxy *httputil.ReverseProxy
 
 	applicationGetter ApplicationGetter
 	cache             Cache
 }
 
-func NewProxyHandler(group, tenant, eventServicePathPrefixV1, eventServicePathPrefixV2, eventServiceHost, appRegistryPathPrefix, appRegistryHost string, applicationGetter ApplicationGetter, cache Cache) *proxyHandler {
+func NewProxyHandler(
+	group string,
+	tenant string,
+	eventServicePathPrefixV1 string,
+	eventServicePathPrefixV2 string,
+	eventServiceHost string,
+	eventMeshPathPrefix string,
+	eventMeshHost string,
+	appRegistryPathPrefix string,
+	appRegistryHost string,
+	applicationGetter ApplicationGetter,
+	cache Cache) *proxyHandler {
+
 	return &proxyHandler{
 		group:                    group,
 		tenant:                   tenant,
 		eventServicePathPrefixV1: eventServicePathPrefixV1,
 		eventServicePathPrefixV2: eventServicePathPrefixV2,
 		eventServiceHost:         eventServiceHost,
+		eventMeshPathPrefix:      eventMeshPathPrefix,
+		eventMeshHost:            eventMeshHost,
 		appRegistryPathPrefix:    appRegistryPathPrefix,
 		appRegistryHost:          appRegistryHost,
 
 		eventsProxy:      createReverseProxy(eventServiceHost),
+		eventMeshProxy:   createReverseProxy(eventMeshHost, withRewriteBaseURL),
 		appRegistryProxy: createReverseProxy(appRegistryHost),
 
 		applicationGetter: applicationGetter,
@@ -130,7 +150,7 @@ func (ph *proxyHandler) getClientIDsFromCache(applicationName string) ([]string,
 }
 
 func (ph *proxyHandler) getClientIDsFromResource(applicationName string) ([]string, apperrors.AppError) {
-	application, err := ph.applicationGetter.Get(applicationName, v1.GetOptions{})
+	application, err := ph.applicationGetter.Get(applicationName, metav1.GetOptions{})
 	if err != nil {
 		return []string{}, apperrors.Internal("failed to get %s application: %s", applicationName, err)
 	}
@@ -142,15 +162,14 @@ func (ph *proxyHandler) getClientIDsFromResource(applicationName string) ([]stri
 }
 
 func (ph *proxyHandler) mapRequestToProxy(path string) (*httputil.ReverseProxy, apperrors.AppError) {
-	if strings.HasPrefix(path, ph.eventServicePathPrefixV1) {
+	switch {
+	case strings.HasPrefix(path, ph.eventServicePathPrefixV1), strings.HasPrefix(path, ph.eventServicePathPrefixV2):
 		return ph.eventsProxy, nil
-	}
 
-	if strings.HasPrefix(path, ph.eventServicePathPrefixV2) {
-		return ph.eventsProxy, nil
-	}
+	case strings.HasPrefix(path, ph.eventMeshPathPrefix):
+		return ph.eventMeshProxy, nil
 
-	if strings.HasPrefix(path, ph.appRegistryPathPrefix) {
+	case strings.HasPrefix(path, ph.appRegistryPathPrefix):
 		return ph.appRegistryProxy, nil
 	}
 
@@ -271,8 +290,8 @@ func extractSubject(subject string) map[string]string {
 	return result
 }
 
-func createReverseProxy(destinationHost string) *httputil.ReverseProxy {
-	return &httputil.ReverseProxy{
+func createReverseProxy(destinationHost string, opts ...reverseProxyOption) *httputil.ReverseProxy {
+	rp := &httputil.ReverseProxy{
 		Director: func(request *http.Request) {
 			request.URL.Scheme = "http"
 			request.URL.Host = destinationHost
@@ -282,5 +301,21 @@ func createReverseProxy(destinationHost string) *httputil.ReverseProxy {
 			log.Infof("Host responded with status: %s", response.Status)
 			return nil
 		},
+	}
+
+	for _, opt := range opts {
+		opt(rp)
+	}
+
+	return rp
+}
+
+type reverseProxyOption func(*httputil.ReverseProxy)
+
+func withRewriteBaseURL(rp *httputil.ReverseProxy) {
+	currentDirectorFn := rp.Director
+	rp.Director = func(req *http.Request) {
+		req.URL.Path = "/"
+		currentDirectorFn(req)
 	}
 }

--- a/components/application-operator/charts/application/templates/httpsource.yaml
+++ b/components/application-operator/charts/application/templates/httpsource.yaml
@@ -1,0 +1,8 @@
+{{ if .Values.knativeEventMesh.enable }}
+apiVersion: sources.kyma-project.io/v1alpha1
+kind: HTTPSource
+metadata:
+  name: {{ .Release.Name }}
+spec:
+  source: {{ .Release.Name }}
+{{ end }}

--- a/components/application-operator/charts/application/templates/validator.yaml
+++ b/components/application-operator/charts/application/templates/validator.yaml
@@ -37,6 +37,8 @@ spec:
             - "--eventServicePathPrefixV1=/{{ .Release.Name }}/v1/events"
             - "--eventServicePathPrefixV2=/{{ .Release.Name }}/v2/events"
             - "--eventServiceHost={{ .Release.Name }}-event-service:{{ .Values.eventService.service.externalapi.port }}"
+            - "--eventMeshPathPrefix=/{{ .Release.Name }}/events"
+            - "--eventMeshHost={{ .Release.Name }}.{{ .Release.Namespace }}"
             - "--appRegistryPathPrefix=/{{ .Release.Name }}/v1/metadata"
             - "--appRegistryHost={{ .Values.applicationConnectivityValidator.args.appRegistryHost }}"
             - "--cacheExpirationMinutes={{ .Values.applicationConnectivityValidator.args.cacheExpirationMinutes }}"

--- a/components/application-operator/charts/application/templates/virtual-service.yaml
+++ b/components/application-operator/charts/application/templates/virtual-service.yaml
@@ -1,7 +1,7 @@
 apiVersion: networking.istio.io/v1alpha3
 kind: VirtualService
 metadata:
-  name: {{ .Release.Name }}
+  name: {{ .Release.Name }}-validator
   namespace: {{ .Values.global.namespace }}
   labels:
     app: {{ .Release.Name }}

--- a/components/application-operator/charts/application/templates/virtual-service.yaml
+++ b/components/application-operator/charts/application/templates/virtual-service.yaml
@@ -20,6 +20,8 @@ spec:
             prefix: /{{ .Release.Name }}/v1/events
         - uri:
             prefix: /{{ .Release.Name }}/v2/events
+        - uri:
+            prefix: /{{ .Release.Name }}/events
       route:
         - destination:
             port:

--- a/components/application-operator/charts/application/values.yaml
+++ b/components/application-operator/charts/application/values.yaml
@@ -50,3 +50,11 @@ eventService:
   service:
     externalapi:
       port: *eventServiceExternalAPIPort
+
+# NOTE(antoineco): the "sources.kyma-project.io" API group is registered by the
+# "event-sources" component, which is currently part of the optional (alpha)
+# Knative Event Mesh. The HTTP event source is therefore puposedly ignored
+# until that component becomes part of the default Kyma installation.
+# Ref. kyma-project/kyma#5927
+knativeEventMesh:
+  enable: false

--- a/resources/application-connector/values.yaml
+++ b/resources/application-connector/values.yaml
@@ -18,10 +18,10 @@ global:
     path: eu.gcr.io/kyma-project
   application_operator:
     dir:
-    version: 06199d9f
+    version: PR-6422
   application_operator_tests:
     dir:
-    version: fbf1000b
+    version: PR-6422
   connector_service:
     dir:
     version: 4e3576cd
@@ -45,7 +45,7 @@ global:
     version: fe0ba6e1
   application_connectivity_validator:
     dir:
-    version: fbf1000b
+    version: PR-6422
   application_gateway:
     dir:
     version: PR-6450
@@ -60,7 +60,7 @@ global:
     version: PR-6450
   application_broker:
     dir:
-    version: "86584816"
+    version: '86584816'
   application_connectivity_certs_setup_job:
     dir:
     version: fbf1000b
@@ -87,5 +87,5 @@ tests:
     skipSslVerify: true
     image:
       dir:
-      version: fbf1000b
+      version: PR-6422
       pullPolicy: IfNotPresent

--- a/tests/application-operator-tests/test/testkit/k8sresources_check.go
+++ b/tests/application-operator-tests/test/testkit/k8sresources_check.go
@@ -10,7 +10,7 @@ import (
 )
 
 const (
-	virtualSvcNameFormat                       = "%s"
+	virtualSvcNameFormat                       = "%s-validator"
 	applicationGatewayDeploymentFormat         = "%s-application-gateway"
 	applicationGatewayRoleFormat               = "%s-application-gateway"
 	applicationGatewayRoleBindingFormat        = "%s-application-gateway"


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

Enable support for the new Knative based event mesh (alpha).

- Provision HTTPSource object upon binding (satisfied by event-sources controller).
- Rename event-service VirtualService from `<app>` to `<app>-validator` to avoid clashing the Knative Serving's VirtualService created for the HTTPSource object above.
- Add reverse proxy for the event mesh (HTTP adapter) to the application-connectivity-validator.

Quick demo:

```console
$ kubectl get applications,applicationmappings

NAME                                                     AGE
application.applicationconnector.kyma-project.io/dummy   3m59s

NAME                                                            AGE
applicationmapping.applicationconnector.kyma-project.io/dummy   2m47s
```
```console
$ kubectl -n kyma-integration get httpsource,ksvc

NAME                                       READY   REASON
httpsource.sources.kyma-project.io/dummy   True

NAME                                URL                                               LATESTCREATED   LATESTREADY   READY   REASON
service.serving.knative.dev/dummy   http://dummy.kyma-integration.svc.cluster.local   dummy-wlwsr     dummy-wlwsr   True
```

```console
$ kubectl -n kyma-integration get pod dummy-connectivity-validator-123xyz-123xyz -o jsonpath='{ .spec.containers[0].args }'

[/applicationconnectivityvalidator --proxyPort=8081 ... --eventMeshPathPrefix=/dummy/events --eventMeshHost=dummy.kyma-integration ...]
```

```console
$ kubectl -n kyma-integration get virtualservices.networking.istio.io

NAME                     GATEWAYS                                                                          HOSTS
connector-service        [kyma-system/kyma-gateway]                                                        [connector-service.35.242.147.25.xip.io]
connector-service-mtls   [kyma-system/kyma-gateway-application-connector]                                  [gateway.35.242.147.25.xip.io]
dummy                    [knative-serving/cluster-local-gateway knative-serving/knative-ingress-gateway]   [dummy.kyma-integration dummy.kyma-integration.svc dummy.kyma-integration.svc.cluster.local 0c0563e5ba4f5b17aa30914b52acbff7.probe.invalid]
dummy-validator          [kyma-gateway-application-connector.kyma-system.svc.cluster.local]                [gateway.35.242.147.25.xip.io]
dummy-mesh               [mesh]                                                                            [dummy.kyma-integration.svc.cluster.local 107e7d872485708d4218540d5a5a2380.probe.invalid]
```

**Related issue(s)**

#6149