### PR TITLE
kubeless-tests image bump

### DIFF
--- a/resources/core/values.yaml
+++ b/resources/core/values.yaml
@@ -48,7 +48,7 @@ global:
     version: 1f9dbb20
   kubeless_tests:
     dir: develop/
-    version: 716e185b
+    version: acd1bd1c
   apiserver_proxy_integration_tests:
     dir:
     version: bdfddb63


### PR DESCRIPTION
**Description**
kubeless-tests Docker image bump after curl binary is added to the image.

Changes proposed in this pull request:
- kubeless-tests Docker image bump


**Related issue(s)**
See also #4719 , #6405 