### PR TITLE
Add curl to event-bus-tests Docker image

### DIFF
--- a/tests/event-bus/e2e-tester/Dockerfile
+++ b/tests/event-bus/e2e-tester/Dockerfile
@@ -9,7 +9,7 @@ COPY e2e-tester.go .
 RUN ls ./
 RUN CGO_ENABLED=0 GOOS=linux go build -v -a -installsuffix cgo -o e2e-tester .
 
-FROM scratch
+FROM curlimages/curl:7.66.0
 LABEL source=git@github.com:kyma-project/kyma.git
 
 ARG version


### PR DESCRIPTION
**Description**
Add curl binary to event-bus-tests Docker image.
This is necessary in order to run the tests in Azure environment - See #4719 
In addition, the shell is also required, so that we can call curl after the test process is finished.
Example invocation that ensures proper termination:
```
sleep 20; ./test.sh; exit_code=$?; curl -XPOST http://127.0.0.1:15020/quitquitquit; sleep 4; exit $exit_code;
```

Changes proposed in this pull request:
- Add curl binary to event-bus-tests Docker image

**Related issue(s)**
See also #4719 
