### PR TITLE
asset-store-tests image bump

### DIFF
--- a/resources/assetstore/values.yaml
+++ b/resources/assetstore/values.yaml
@@ -14,8 +14,8 @@ global:
     dir: develop/
     version: 'e53f5768'
   asset_store_test:
-    dir: pr/
-    version: 'PR-6058'
+    dir: develop/
+    version: '8d1d9f1d'
   minio_client:
     image: 'minio/mc'
     tag: 'RELEASE.2019-04-03T17-59-57Z'
@@ -34,20 +34,20 @@ minio:
 
   DeploymentUpdate:
     type: Recreate
-  
+
   podAnnotations:
     sidecar.istio.io/inject: "false"
 
   service:
     annotations:
       auth.istio.io/9000: NONE
-  
+
   environment:
     MINIO_BROWSER: "off"
-  
+
   defaultBucket:
     enabled: false
-  
+
   resources:
     requests:
       memory: 32Mi


### PR DESCRIPTION
**Description**
asset-store-tests Docker image bump after `curl` binary is added to the image.

Changes proposed in this pull request:
- asset-store-tests Docker image bump


**Related issue(s)**
See also: #4719 , #6406 