### PR TITLE
event-bus-tests image bump

### DIFF
--- a/resources/event-bus/templates/tests/test.yaml
+++ b/resources/event-bus/templates/tests/test.yaml
@@ -35,7 +35,7 @@ spec:
             - bin/sh
             - -c
             - |
-                SERVICE="/root/e2e-tester"
+                SERVICE="/test/e2e-tester"
                 while true; do
                   if pgrep -x "${SERVICE}"; then
                     echo "---> ${SERVICE} is running."

--- a/resources/event-bus/values.yaml
+++ b/resources/event-bus/values.yaml
@@ -12,7 +12,7 @@ global:
     subscriptionControllerImage: subscription-controller
   event_bus_tests:
     dir: develop/
-    version: bd7b9d23
+    version: 4579b411
   natsStreaming:
     url: "nats-streaming.natss:4222"
     clusterID: "kyma-nats-streaming"

--- a/resources/event-bus/values.yaml
+++ b/resources/event-bus/values.yaml
@@ -12,7 +12,7 @@ global:
     subscriptionControllerImage: subscription-controller
   event_bus_tests:
     dir: develop/
-    version: 4579b411
+    version: e5dd7c15
   natsStreaming:
     url: "nats-streaming.natss:4222"
     clusterID: "kyma-nats-streaming"


### PR DESCRIPTION
**Description**
event-bus-tests Docker image bump after curl binary is added to the image.

Changes proposed in this pull request:
- event-bus-tests Docker image bump


**Related issue(s)**
#See also #4719 #6432 #6446 