### PR TITLE
Change test location to a non-privileged one

### DIFF
--- a/tests/event-bus/e2e-tester/Dockerfile
+++ b/tests/event-bus/e2e-tester/Dockerfile
@@ -15,9 +15,9 @@ LABEL source=git@github.com:kyma-project/kyma.git
 ARG version
 ENV APP_VERSION $version
 
-WORKDIR /root/
+WORKDIR /test/
 
 COPY --from=builder /go/src/github.com/kyma-project/kyma/tests/event-bus/e2e-tester/e2e-tester .
 COPY --from=builder /go/src/github.com/kyma-project/kyma/tests/event-bus/licenses/ ./licenses
 
-ENTRYPOINT ["/root/e2e-tester"]
+ENTRYPOINT ["/test/e2e-tester"]


### PR DESCRIPTION
**Description**
After changing the base image to an alpine-derived one, the `/root` folder is not accessible and binaries placed there can't be executed - `permission denied`.
Choice of `/root` folder wasn't the best - after all, this directory is by convention reserved to root user only, and the container should run as non-root anyway.
The `/test` directory is a better choice.

Changes proposed in this pull request:

- Change the location of test binary from `/root` to `/test`


**Related issue(s)**
See also #4719 #6432 