### PR TITLE
Initialize apollo only when idToken available

### DIFF
--- a/resources/core/charts/console/values.yaml
+++ b/resources/core/charts/console/values.yaml
@@ -5,7 +5,7 @@ replicaCount: 1
 console:
   image:
     dir:
-    tag: fe129ccc
+    tag: 678a1592
     pullPolicy: IfNotPresent
   service:
     name: nginx

--- a/resources/core/charts/kubeless/charts/lambdas-ui/values.yaml
+++ b/resources/core/charts/kubeless/charts/lambdas-ui/values.yaml
@@ -5,7 +5,7 @@ replicaCount: 1
 image:
   dir:
   name: lambda
-  tag: d3e1d74f
+  tag: f76a6e6c
   pullPolicy: IfNotPresent
 service:
   name: nginx


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Initialize apollo client only once idToken is available

**Related issue(s)**
Fixes https://github.com/kyma-project/console/issues/1425
