### PR TITLE
Enable test coverage in generic makefile

### DIFF
--- a/common/makefiles/docs/generic-make-go.md
+++ b/common/makefiles/docs/generic-make-go.md
@@ -119,6 +119,6 @@ Then, add {YOUR_RULE} to the **MOUNT_TARGETS** or **COPY_TARGETS** variables.
 
 ### Change artifacts directory
 
-By default test coverage report is saved to `/tmp/artifacts` directory.
-To change this location set the `ARTIFACTS` environment variable.
-It is automatically set when running in [Prow environment](https://github.com/kubernetes/test-infra/blob/master/prow/pod-utilities.md)
+By default, the test coverage report is saved to the `/tmp/artifacts` directory.
+To change this location, set the `ARTIFACTS` environment variable.
+It is automatically set when running in the [Prow environment](https://github.com/kubernetes/test-infra/blob/master/prow/pod-utilities.md).

--- a/common/makefiles/docs/generic-make-go.md
+++ b/common/makefiles/docs/generic-make-go.md
@@ -116,3 +116,9 @@ To add a new rule in the generic Makefile, define a new local rule in the `gener
 {YOUR_RULE}-local:  {COMMANDS}
 ```
 Then, add {YOUR_RULE} to the **MOUNT_TARGETS** or **COPY_TARGETS** variables.
+
+### Change artifacts directory
+
+By default test coverage report is saved to `/tmp/artifacts` directory.
+To change this location set the `ARTIFACTS` environment variable.
+It is automatically set when running in [Prow environment](https://github.com/kubernetes/test-infra/blob/master/prow/pod-utilities.md)


### PR DESCRIPTION
**Description**
Coverage output was disabled when we created common makefile.
This PR brings it back and exports cover.out report to artifacts storage 

Changes proposed in this pull request:

-  added log message with "Total coverage: "
- coverage report copied to artifacts storage

**Related issue(s)**
https://github.com/kyma-project/kyma/issues/5474