### PR TITLE
Update testing charts for cbs and kubeless

### DIFF
--- a/installation/scripts/testing.sh
+++ b/installation/scripts/testing.sh
@@ -88,16 +88,6 @@ if [[ -n "${TEST_NAME}" && -n "${TEST_NAMESPACE}" ]]; then
 "
 fi
 
-# creates a ClusterAddonsConfiguration which provides the testing addons
-injectTestingAddons
-if [[ $? -eq 1 ]]; then
-  exit 1
-fi
-
-if [[ ${CLEANUP} = "true" ]]; then
-  trap removeTestingAddons EXIT
-fi
-
 cat <<EOF | ${kc} apply -f -
 apiVersion: testing.kyma-project.io/v1alpha1
 kind: ClusterTestSuite

--- a/resources/core/charts/console-backend-service/templates/tests/rbac.yaml
+++ b/resources/core/charts/console-backend-service/templates/tests/rbac.yaml
@@ -65,6 +65,9 @@ rules:
   - apiGroups: ["addons.kyma-project.io"]
     resources: ["clusteraddonsconfigurations", "addonsconfigurations"]
     verbs: ["get"]
+  - apiGroups: ["addons.kyma-project.io"]
+    resources: ["clusteraddonsconfigurations"]
+    verbs: ["create", "delete"]
 
 ---
 kind: ClusterRoleBinding

--- a/resources/core/charts/console-backend-service/templates/tests/test.yaml
+++ b/resources/core/charts/console-backend-service/templates/tests/test.yaml
@@ -9,7 +9,6 @@ metadata:
     app.kubernetes.io/managed-by: {{ .Release.Service }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
-    testing.kyma-project.io/require-testing-addon: "true"
 spec:
   disableConcurrency: true
   template:
@@ -65,6 +64,8 @@ spec:
                   secretKeyRef:
                       name: test-no-rights-user
                       key: password
+            - name: TEST_TESTING_ADDONS_URL
+              value: "https://github.com/kyma-project/addons/releases/download/0.8.0/index-testing.yaml"
           resources:
             limits:
               memory: 128Mi

--- a/resources/core/charts/kubeless/templates/tests/e2e-rbac.yaml
+++ b/resources/core/charts/kubeless/templates/tests/e2e-rbac.yaml
@@ -55,6 +55,9 @@ rules:
 - apiGroups: ["autoscaling"]
   resources: ["horizontalpodautoscalers"]
   verbs: ["get", "list"]
+- apiGroups: ["addons.kyma-project.io"]
+  resources: ["addonsconfigurations"]
+  verbs: ["get", "create", "delete"]
 ---
 apiVersion: v1
 kind: ServiceAccount

--- a/resources/core/charts/kubeless/templates/tests/e2e-test.yaml
+++ b/resources/core/charts/kubeless/templates/tests/e2e-test.yaml
@@ -51,6 +51,8 @@ spec:
           value: {{ template "fullname" . }}-config
         - name: DOMAIN_NAME
           value: {{ .Values.global.ingress.domainName }}
+        - name: TESTING_ADDONS_URL
+          value: "https://github.com/kyma-project/addons/releases/download/0.8.0/index-testing.yaml"
       volumes:
         - name: k8syaml
           configMap:

--- a/resources/core/charts/kubeless/templates/tests/test.yaml
+++ b/resources/core/charts/kubeless/templates/tests/test.yaml
@@ -9,7 +9,6 @@ metadata:
     app.kubernetes.io/managed-by: {{ .Release.Service }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
-    testing.kyma-project.io/require-testing-addon: "true"
 spec:
   disableConcurrency: false
   template:

--- a/resources/core/values.yaml
+++ b/resources/core/values.yaml
@@ -45,7 +45,7 @@ global:
     version: 8a10f0ed
   kubeless_integration_tests:
     dir: develop/tests/
-    version: 1f9dbb20
+    version: e6722333
   kubeless_tests:
     dir: develop/
     version: acd1bd1c
@@ -59,7 +59,7 @@ global:
     version: 1509e382
   console_backend_service_test:
     dir:
-    version: e80dea63
+    version: 2cf5063d
   cluster_users_integration_tests:
     dir:
     version: 3cf2773d

--- a/tests/end-to-end/upgrade/chart/upgrade/templates/pod.yaml
+++ b/tests/end-to-end/upgrade/chart/upgrade/templates/pod.yaml
@@ -40,3 +40,5 @@ spec:
       value: "{{ .Values.dex.namespace }}"
     - name: APP_DEX_USER_SECRET
       value: "{{ .Values.dex.userSecret }}"
+    - name: APP_TESTING_ADDONS_URL
+      value: "https://github.com/kyma-project/addons/releases/download/0.8.0/index-testing.yaml"

--- a/tests/end-to-end/upgrade/chart/upgrade/templates/rbac.yaml
+++ b/tests/end-to-end/upgrade/chart/upgrade/templates/rbac.yaml
@@ -58,6 +58,9 @@ rules:
 - apiGroups: [""]
   resources: ["services", "services/proxy"]
   verbs: ["create", "delete", "get", "list"]
+- apiGroups: ["addons.kyma-project.io"]
+  resources: ["addonsconfigurations"]
+  verbs: ["get", "create", "delete"]
 
 # Kubeless
 - apiGroups: ["kubeless.io"]

--- a/tests/end-to-end/upgrade/chart/upgrade/templates/test/test-upgrade.yaml
+++ b/tests/end-to-end/upgrade/chart/upgrade/templates/test/test-upgrade.yaml
@@ -34,4 +34,6 @@ spec:
           value: "{{ .Values.dex.namespace }}"
         - name: APP_DEX_USER_SECRET
           value: "{{ .Values.dex.userSecret }}"
+        - name: APP_TESTING_ADDONS_URL
+          value: "https://github.com/kyma-project/addons/releases/download/0.8.0/index-testing.yaml"
 {{- end }}

--- a/tests/end-to-end/upgrade/chart/upgrade/values.yaml
+++ b/tests/end-to-end/upgrade/chart/upgrade/values.yaml
@@ -3,7 +3,7 @@ containerRegistry:
 
 image:
   dir:
-  version: "PR-6200"
+  version: "PR-6536"
   pullPolicy: "IfNotPresent"
 
 dex:


### PR DESCRIPTION
**Description**

We want to get rid of injecting the testing AddonsConfiguration from testing.sh script. To do it we need to move the injection testing addons directly into given tests.

Changes proposed in this pull request:

- Update charts to reflect changes introduced in those PRs: https://github.com/kyma-project/kyma/pull/6484, https://github.com/kyma-project/kyma/pull/6489


**Related issue(s)**

- #6253
