### PR TITLE
Add label that injecting testing addons is required

### DIFF
--- a/resources/core/charts/console-backend-service/templates/tests/test.yaml
+++ b/resources/core/charts/console-backend-service/templates/tests/test.yaml
@@ -9,6 +9,7 @@ metadata:
     app.kubernetes.io/managed-by: {{ .Release.Service }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    testing.kyma-project.io/require-testing-addon: "true"
 spec:
   disableConcurrency: true
   template:

--- a/resources/core/charts/kubeless/templates/tests/test.yaml
+++ b/resources/core/charts/kubeless/templates/tests/test.yaml
@@ -9,6 +9,7 @@ metadata:
     app.kubernetes.io/managed-by: {{ .Release.Service }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    testing.kyma-project.io/require-testing-addon: "true"
 spec:
   disableConcurrency: false
   template:


### PR DESCRIPTION
**Description**

Currently, we need to have transition phase. In test-infra we will check if the injecting addon is still necessary (see [PR](https://github.com/kyma-project/test-infra/pull/1802)) if some TD will be discovered then it will be injected if not then it will be skipped. Labels will be removed on [this](https://github.com/kyma-project/kyma/pull/6485/files) pull-request where addon injection is done directly in a given test.

Changes proposed in this pull request:

- Add label that injecting testing addons is required

**Related issue(s)**

- #6253