### PR TITLE
compass e2e tests image bump

### DIFF
--- a/resources/compass/values.yaml
+++ b/resources/compass/values.yaml
@@ -31,7 +31,7 @@ global:
     tests:
       e2e:
         dir:
-        version: "09ca1b73"
+        version: "1c25ea88"
       connector:
         dir:
         version: "32b69555"


### PR DESCRIPTION
**Description**
compass-e2e-tests Docker image bump after curl binary is added to the image.

**Changes proposed in this pull request:**
- event-bus-tests Docker image bump

Related issue(s)
#See also #4719 https://github.com/kyma-incubator/compass/pull/525