### PR TITLE
add curl binary to compass-runtime-agent tests

### DIFF
--- a/tests/compass-runtime-agent/Dockerfile
+++ b/tests/compass-runtime-agent/Dockerfile
@@ -10,7 +10,9 @@ COPY . $SRC_DIR
 RUN CGO_ENABLED=0 GOOS=linux go test -c ./test/runtimeagent/test
 
 FROM alpine:3.10
+
 LABEL source=git@github.com:kyma-project/kyma.git
+RUN apk add --no-cache curl
 
 COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
 COPY --from=builder /go/src/github.com/kyma-project/kyma/tests/compass-runtime-agent/scripts/entrypoint.sh .


### PR DESCRIPTION
**Description**
Add curl binary to compass-runtime-agent Docker image.
This is necessary in order to run the tests in Azure environment - See #4719 

Changes proposed in this pull request:
- Add curl binary to compass-runtime-agent Docker image

**Related issue(s)**
See also #4719 
