### PR TITLE
Change IPRanges in istio to *

### DIFF
--- a/resources/core/charts/kubeless/templates/tests/e2e-test.yaml
+++ b/resources/core/charts/kubeless/templates/tests/e2e-test.yaml
@@ -38,6 +38,11 @@ spec:
       - name: e2e-{{ .Chart.Name }}-tests
         image: {{ .Values.global.containerRegistry.path }}/{{ .Values.global.kubeless_integration_tests.dir }}kubeless-integration:{{ .Values.global.kubeless_integration_tests.version }}
         command: ["/bin/sh"]
+        resources:
+          limits:
+            memory: 128Mi
+          requests:
+            memory: 100Mi
         args: ["-c", "sleep 20; /test-kubeless; exit_code=$?; curl -XPOST http://127.0.0.1:15020/quitquitquit; sleep 4; exit $exit_code;"]
         volumeMounts:
         - name: k8syaml

--- a/resources/istio/values.yaml
+++ b/resources/istio/values.yaml
@@ -340,7 +340,7 @@ global:
     # example: includeIPRanges: "172.30.0.0/16,172.20.0.0/16"
     # would only capture egress traffic on those two IP Ranges, all other outbound traffic would
     # be allowed by the sidecar
-    includeIPRanges: "10.0.0.1/8"
+    includeIPRanges: "*"
     excludeIPRanges: ""
     excludeOutboundPorts: ""
 


### PR DESCRIPTION
**Description**

Due to Gardener addressing we need to change the includeIPRanges field to allow pods to communicate with each other.
Also, during testing the changes it turned out that e2e-kubeless tests require more resources than it's specified as default in the kyma-system namespace.

Changes proposed in this pull request:

- Change includeIPRanges value to *
- Add resources limits and requests to e2e-kubeless-tests TestDefinition

**Related issue(s)**
#6330