### PR TITLE
add curl binary to compass-runtime-agent tests image bump

### DIFF
--- a/resources/compass-runtime-agent/values.yaml
+++ b/resources/compass-runtime-agent/values.yaml
@@ -7,7 +7,7 @@ global:
       version: "3ef28a8e"
     runtimeAgentTests:
       dir:
-      version: "3ef28a8e"
+      version: "99f20810"
 
 compassRuntimeAgent:
   image:


### PR DESCRIPTION
**Description**
compass-runtime-agent Docker image bump after curl binary is added to the image.

Changes proposed in this pull request:
- compass-runtime-agent Docker image bump


**Related issue(s)**
#See also #4719 #6495