### PR TITLE
add curl binary to compass test images bump

### DIFF
--- a/resources/compass/values.yaml
+++ b/resources/compass/values.yaml
@@ -34,10 +34,10 @@ global:
         version: "1c25ea88"
       connector:
         dir:
-        version: "32b69555"
+        version: "1551b14a"
       provisioner:
         dir:
-        version: "f5e3e596"
+        version: "1551b14a"
 
   isLocalEnv: false
 


### PR DESCRIPTION
**Description**
compass test Docker images bump after curl binary is added to the image.

Changes proposed in this pull request:
- compass tests Docker images bump


**Related issue(s)**
#See also #4719 https://github.com/kyma-incubator/compass/pull/526