### PR TITLE
Add migration guide for 1.8

### DIFF
--- a/docs/migration-guides/1.7-1.8.md
+++ b/docs/migration-guides/1.7-1.8.md
@@ -5,7 +5,7 @@
 
 ## Monitoring
 
-In Kyma 1.8, we increased the size of Persistent Volume Claims (PVC) for Prometheus to 10GB to prevent Prometheus from running out of disk space. Unfortunately, the standard upgrade procedure does not auto resize the volumes as the volume expansion through StatefulSets is not supported.
+We have increased the size of Persistent Volume Claims (PVC) for Prometheus to 10GB to prevent it from running out of disk space. Unfortunately, the standard upgrade procedure does not auto resize the volumes as the volume expansion through StatefulSets is not supported.
 To make sure the PVC size is 10GB, perform the following steps:
 
 1. Increase the PVC size:
@@ -18,4 +18,4 @@ kubectl patch pvc prometheus-monitoring-db-prometheus-monitoring-0 -n kyma-syste
 ```
 kubectl delete pod prometheus-monitoring-0 -n kyma-system
 ```
-The Pod will recreate with an increased PVC size.
+The Pod will recreate with the PVC size already increased.

--- a/docs/migration-guides/1.7-1.8.md
+++ b/docs/migration-guides/1.7-1.8.md
@@ -13,6 +13,9 @@ Follow these steps:
 ```
 kubectl patch pvc prometheus-monitoring-db-prometheus-monitoring-0 -n kyma-system -p '{"spec":{"resources":{"requests":{"storage":"10Gi"}}}}'
 ```
+
+Once you run the command, wait a bit before proceeding to the next step to make sure the changes were applied. 
+
 2. Delete the Pod:  
 
 ```

--- a/docs/migration-guides/1.7-1.8.md
+++ b/docs/migration-guides/1.7-1.8.md
@@ -5,10 +5,10 @@
 
 ## Monitoring
 
-We have increased the size of Persistent Volume Claims (PVC) for Prometheus to 10GB to prevent it from running out of disk space. Unfortunately, the standard upgrade procedure does not resize the volumes automatically, as the volume expansion through StatefulSets is not supported.
-To make sure PVC size is 10GB, perform the following steps:
+We have increased the size of Persistent Volume Claims (PVC) for Prometheus to 10GB to prevent it from running out of disk space. The automatic upgrade procedure does not resize the volumes automatically, as the volume expansion through StatefulSets is not supported. As a result, you must trigger the Prometheus PVC size change manually.
+Follow these steps:
 
-1. Increase PVC size:
+1. Increase the PVC size:
 
 ```
 kubectl patch pvc prometheus-monitoring-db-prometheus-monitoring-0 -n kyma-system -p '{"spec":{"resources":{"requests":{"storage":"10Gi"}}}}'
@@ -18,4 +18,4 @@ kubectl patch pvc prometheus-monitoring-db-prometheus-monitoring-0 -n kyma-syste
 ```
 kubectl delete pod prometheus-monitoring-0 -n kyma-system
 ```
-The Pod will recreate with the PVC size already increased.
+The Pod will recreate with the PVC size increased.

--- a/docs/migration-guides/1.7-1.8.md
+++ b/docs/migration-guides/1.7-1.8.md
@@ -13,9 +13,11 @@ Follow these steps:
 ```
 kubectl patch pvc prometheus-monitoring-db-prometheus-monitoring-0 -n kyma-system -p '{"spec":{"resources":{"requests":{"storage":"10Gi"}}}}'
 ```
-2. Delete the `prometheus-monitoring-0` Pod:  
+2. Delete the Pod:  
 
 ```
 kubectl delete pod prometheus-monitoring-0 -n kyma-system
 ```
 The Pod will recreate with the PVC size increased.
+
+>**NOTE:** If you have more than one replica, perform the steps for each of them.

--- a/docs/migration-guides/1.7-1.8.md
+++ b/docs/migration-guides/1.7-1.8.md
@@ -1,0 +1,20 @@
+# Migrate from v1.7 to v1.8
+
+>**TIP:** To learn more about upgrading Kyma, read [this](https://kyma-project.io/docs/master/root/kyma/#installation-upgrade-kyma) document.
+
+
+## Monitoring
+
+In Kyma 1.8, we increased the size of Persistent Volume Claims (PVC) for Prometheus to 10GB to prevent Prometheus from running out of disk space. Unfortunately, the standard upgrade procedure does not auto resize the volumes as the volume expansion through StatefulSets is not supported.
+To make sure the PVC size is 10GB, perform the following steps:
+
+1. Increase the PVC size:
+
+```
+kubectl patch pvc prometheus-monitoring-db-prometheus-monitoring-0 -n kyma-system -p '{"spec":{"resources":{"requests":{"storage":"10Gi"}}}}'
+```
+2. Delete the `prometheus-monitoring-0` Pod, so it can recreate with increased PVC. 
+
+```
+kubectl delete pod prometheus-monitoring-0 -n kyma-system
+```

--- a/docs/migration-guides/1.7-1.8.md
+++ b/docs/migration-guides/1.7-1.8.md
@@ -5,10 +5,10 @@
 
 ## Monitoring
 
-We have increased the size of Persistent Volume Claims (PVC) for Prometheus to 10GB to prevent it from running out of disk space. Unfortunately, the standard upgrade procedure does not auto resize the volumes as the volume expansion through StatefulSets is not supported.
-To make sure the PVC size is 10GB, perform the following steps:
+We have increased the size of Persistent Volume Claims (PVC) for Prometheus to 10GB to prevent it from running out of disk space. Unfortunately, the standard upgrade procedure does not resize the volumes automatically, as the volume expansion through StatefulSets is not supported.
+To make sure PVC size is 10GB, perform the following steps:
 
-1. Increase the PVC size:
+1. Increase PVC size:
 
 ```
 kubectl patch pvc prometheus-monitoring-db-prometheus-monitoring-0 -n kyma-system -p '{"spec":{"resources":{"requests":{"storage":"10Gi"}}}}'

--- a/docs/migration-guides/1.7-1.8.md
+++ b/docs/migration-guides/1.7-1.8.md
@@ -13,8 +13,9 @@ To make sure the PVC size is 10GB, perform the following steps:
 ```
 kubectl patch pvc prometheus-monitoring-db-prometheus-monitoring-0 -n kyma-system -p '{"spec":{"resources":{"requests":{"storage":"10Gi"}}}}'
 ```
-2. Delete the `prometheus-monitoring-0` Pod, so it can recreate with increased PVC. 
+2. Delete the `prometheus-monitoring-0` Pod:  
 
 ```
 kubectl delete pod prometheus-monitoring-0 -n kyma-system
 ```
+The Pod will recreate with an increased PVC size.


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Add a migration guide for Release 1.8

**Related issue(s)**
See also #6506 

**CAUTION:**

as written in a similar PR by Gophers: (https://github.com/kyma-project/kyma/pull/6210)

Do not execute any tests for this release. You changed only the documentation. Executing those tests causing that the artifacts are rebuilt for already pushed release this should not take a place because we can generate the malformed object. You can execute those jobs only for patch release

**This pr should be merged by repo administrator without running any test.**

