### PR TITLE
use command to specify a command and override a containers entrypoint

### DIFF
--- a/components/application-operator/charts/application/templates/deployment.yaml
+++ b/components/application-operator/charts/application/templates/deployment.yaml
@@ -29,8 +29,8 @@ spec:
       - name: {{ .Release.Name }}-application-gateway
         image: {{ .Values.global.applicationGatewayImage }}
         imagePullPolicy: {{ .Values.deployment.image.pullPolicy }}
+        command: ["/applicationgateway"]
         args:
-          - "/applicationgateway"
           - "--proxyPort={{ .Values.deployment.args.proxyPort }}"
           - "--externalAPIPort={{ .Values.deployment.args.externalAPIPort }}"
           - "--application={{ .Release.Name }}"
@@ -91,8 +91,8 @@ spec:
       - name: {{ .Release.Name }}-event-service
         image: {{ .Values.global.eventServiceImage }}
         imagePullPolicy: {{ .Values.eventService.deployment.image.pullPolicy }}
+        command: ["/eventservice"]
         args:
-        - "/eventservice"
         - "--externalAPIPort={{ .Values.eventService.deployment.args.externalAPIPort }}"
         - "--eventsTargetURLV1={{ .Values.eventService.deployment.args.eventsTargetURLV1 }}"
         - "--eventsTargetURLV2={{ .Values.eventService.deployment.args.eventsTargetURLV2 }}"

--- a/components/application-operator/charts/application/templates/validator.yaml
+++ b/components/application-operator/charts/application/templates/validator.yaml
@@ -28,8 +28,8 @@ spec:
         - name: {{ .Release.Name }}-connectivity-validator
           image: {{ .Values.global.applicationConnectivityValidatorImage }}
           imagePullPolicy: {{ .Values.deployment.image.pullPolicy }}
+          command: ["/applicationconnectivityvalidator"]
           args:
-            - "/applicationconnectivityvalidator"
             - "--proxyPort={{ .Values.applicationConnectivityValidator.args.proxyPort }}"
             - "--externalAPIPort={{ .Values.applicationConnectivityValidator.args.externalAPIPort }}"
             - "--tenant={{ .Values.global.tenant }}"


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/master/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- kubernetes container spec provides two fields: args and command. One should not use args to specify the binary that has to be executed in the container, as this will NOT override a specified entrypoint. Always use command if you want to specify the binary



**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
