### PR TITLE
Set max number of revisions kept in tiller history

### DIFF
--- a/installation/resources/tiller.yaml
+++ b/installation/resources/tiller.yaml
@@ -66,6 +66,8 @@ spec:
           value: "1"
         - name: TILLER_TLS_CERTS
           value: /etc/certs
+        - name: TILLER_HISTORY_MAX
+          value: "10"
         ports:
         - containerPort: 44134
           name: tiller


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/master/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Resolves a problem with helm mentioned in issue #6585:

```
Helm error: rpc error: code = ResourceExhausted desc = trying to send message larger than max
```

that occurs when helm creates too much configmaps with revisions data. After this PR is merged Helm will keep last 10 revisions of each release. 

Changes proposed in this pull request:

- Set max number of revisions kept in tiller history

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
See also #6585