### PR TITLE
Remove leftover selector from Knative Serving's cluster-local ingress Service

### DIFF
--- a/resources/knative-serving/templates/istio-knative-extras.yaml
+++ b/resources/knative-serving/templates/istio-knative-extras.yaml
@@ -24,7 +24,6 @@ metadata:
 spec:
   type: ClusterIP
   selector:
-    release: RELEASE-NAME
     app: cluster-local-gateway
     istio: cluster-local-gateway
   ports:


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Remove leftover selector from Knative Serving's cluster-local ingress Service

**Related issue(s)**

#6505