### PR TITLE
knative-serving: Disable scale-to-zero feature

### DIFF
--- a/resources/knative-serving/README.md
+++ b/resources/knative-serving/README.md
@@ -12,6 +12,7 @@ Kyma-specific changes:
  * The `knative-serving` Namespace is no longer created. This happens during the installation process.
  * The image versions are changed to use the release tag.
  * The `knative-ingress-gateway` is now a copy of `kyma-gateway`.
+ * Disable scale-to-zero feature.
  * Changed CPU for minikube
  * Include [istio-knative-extras.yaml](https://github.com/knative/serving/blob/1cb31d16/third_party/istio-1.3.5/istio-knative-extras.yaml) which enables support for Knative Serving's `cluster-local` Gateway. This is required to create [private cluster-local Services](https://knative.dev/docs/serving/cluster-local-route/).
    * Comment all RBAC objects related to `istio-multi` and `istio-reader` ServiceAccounts, which are already part of the `istio` Chart.

--- a/resources/knative-serving/templates/serving.yaml
+++ b/resources/knative-serving/templates/serving.yaml
@@ -664,6 +664,8 @@ spec:
 ---
 apiVersion: v1
 data:
+  enable-scale-to-zero: 'false'
+
   _example: |
     ################################
     #                              #


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Disable Knative Serving's scale-to-zero feature

Side effect: forces _every_ `Revision` to have at least one replica running. `Revisions` multiply over time, leaving running Pods around.

```console
$ kubectl -n kyma-integration get revision
NAME               CONFIG NAME   K8S SERVICE NAME   GENERATION   READY
stuff-h49dg        stuff         stuff-h49dg        6            True
stuff-j69tt        stuff         stuff-j69tt        4            True
stuff-kvx5b        stuff         stuff-kvx5b        7            True
stuff-tpv6n        stuff         stuff-tpv6n        5            True
```

```console
$ kubectl -n kyma-integration get pod -l  serving.knative.dev/service=stuff
NAME                                      READY   STATUS    RESTARTS   AGE
stuff-h49dg-deployment-fd66946f9-p27qz    3/3     Running   0          15m
stuff-j69tt-deployment-5bdfd76b8c-4qzzr   3/3     Running   0          24m
stuff-kvx5b-deployment-66569865c7-vlztn   3/3     Running   0          15m
stuff-tpv6n-deployment-84979b8ddc-qvwqq   3/3     Running   0          15m
```

**Related issue(s)**

#5352
#6619