### PR TITLE
new retention and memory defaults for monitoring setup

### DIFF
--- a/resources/monitoring/values.yaml
+++ b/resources/monitoring/values.yaml
@@ -1565,11 +1565,11 @@ prometheus:
 
     ## How long to retain metrics
     ##
-    retention: 2h
+    retention: 2d
 
     ## Maximum size of metrics
     ##
-    retentionSize: 8GB
+    retentionSize: 7GB
 
     ## Enable compression of the write-ahead log using Snappy.
     ##
@@ -1663,7 +1663,7 @@ prometheus:
          accessModes: ["ReadWriteOnce"]
          resources:
            requests:
-             storage: 15Gi
+             storage: 10Gi
     #   selector: {}
 
     ## AdditionalScrapeConfigs allows specifying additional Prometheus scrape configurations. Scrape configurations


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/master/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- new default retention time of 2 days (for debugging good enough, for long term analysis 1w is too small as well)
- new default retention size of 7GB (1 day of basic setup requires 1GB roughly, so fine enough)
- new default disk size of 10GB (3GB for WAL and everything else seemed fine)
- new default memory limit of 4GB (weekly analysis showed that 4GB is fine without big load)

**Related issue(s)**
https://github.com/kyma-project/kyma/issues/6124
