### PR TITLE
Don't remove old crds in rafter-migration-post-terminator

### DIFF
--- a/resources/rafter/templates/_helper_migration_terminator.txt
+++ b/resources/rafter/templates/_helper_migration_terminator.txt
@@ -78,25 +78,11 @@ removeHelmRelease() {
     --tls-key "${CERTS_DIR}/key.pem"
 }
 
-removeHeadlessCMSCRDs() {
-  removeResource "crd" "docstopics.cms.kyma-project.io"
-  removeResource "crd" "clusterdocstopics.cms.kyma-project.io"
-}
-
 removeHeadlessCMS() {
   removeResources "docstopics.cms.kyma-project.io"
   removeResources "clusterdocstopics.cms.kyma-project.io"
 
   removeHelmRelease "cms"
-
-  removeHeadlessCMSCRDs
-}
-
-removeAssetStoreCRDs() {
-  removeResource "crd" "assets.assetstore.kyma-project.io"
-  removeResource "crd" "buckets.assetstore.kyma-project.io"
-  removeResource "crd" "clusterassets.assetstore.kyma-project.io"
-  removeResource "crd" "clusterbuckets.assetstore.kyma-project.io"
 }
 
 removeAssetStore() {
@@ -107,8 +93,6 @@ removeAssetStore() {
 
   removeHelmRelease "assetstore"
 
-  removeAssetStoreCRDs
-
   # remove custom ConfigMap created by assetstore-upload-service, which is not related with assetstore release
   removeResource "cm" "asset-upload-service" "kyma-system"
 }
@@ -116,8 +100,6 @@ removeAssetStore() {
 main() {
   local -r isAssetStoreInstalled="$(kubectl get cm -n kube-system -l NAME=assetstore,OWNER=TILLER)"
   if [ -z "${isAssetStoreInstalled}" ]; then
-    removeAssetStoreCRDs
-    removeHeadlessCMSCRDs
     exit 0
   fi
 


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/master/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:
- Don't remove old crds (from `assetstore` and `cms` in `rafter-migration-post-terminator` job) - sometimes Helm restore old `ClusterDocsTopics` after migration from 1.8 version, so we decide to leave on next release crds, and remove after new release.

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
