### PR TITLE
Provide tutorial on how to create certificate application pairing via Compass

### DIFF
--- a/docs/compass/08-07-establish-secure-connection-with-compass.md
+++ b/docs/compass/08-07-establish-secure-connection-with-compass.md
@@ -1,0 +1,99 @@
+---
+title: Establish a secure connection with Compass
+type: Tutorials
+---
+
+To establish a secure connection with Compass and generate the client certificate, follow this tutorial. 
+
+## Prerequisites
+
+- [OpenSSL toolkit](https://www.openssl.org/docs/man1.0.2/apps/openssl.html) to create a Certificate Signing Request (CSR), keys, and certificates which meet high security standards
+- Compass (version 1.8 or higher)
+- Registered Application
+- Runtime connected to Compass
+
+## Steps
+
+1. Get the Connector URL and the one-time token.
+
+    To get the Connector URL and the one-time token which allow you to fetch the required configuration details, use the Compass Console.
+    
+    Alternatively, make a call to the Director including the `Tenant` header with Tenant ID and `authorization` header with the Dex Bearer token. Use the following mutation: 
+    
+    ```graphql
+    mutation { 
+        result: generateOneTimeTokenForApplication(id: "{APPLICATION_ID}") { 
+            token 
+            connectorURL 
+        }
+    }
+    ```
+   
+   > **NOTE:** The one-time token expires after 5 minutes.
+
+2. Get the CSR information and configuration details from Kyma using the one-time token.
+
+    To get the CSR information and configuration details, send this GraphQL query to the Connector URL.
+    You must include the `connector-token` header containing the one-time token when making the call.
+
+    ```graphql
+    query {
+        result: configuration {
+            token {
+                token
+            }
+            certificateSigningRequestInfo {
+                subject
+                keyAlgorithm
+            }
+            managementPlaneInfo {
+                directorURL
+                certificateSecuredConnectorURL
+            }
+        }
+    }
+    ``` 
+
+    A successful call returns the data requested in the query including a new one-time token.
+
+3. Generate a key and a Certificate Signing Request (CSR).
+
+    Generate a CSR with the following command. `SUBJECT` is the certificate subject data returned with the CSR information as `subject`.   
+    
+    ```bash
+    export KEY_LENGTH=4096
+    openssl genrsa -out compass-app.key $KEY_LENGTH
+    openssl req -new -sha256 -out compass-app.csr -key compass-app.key -subj "{SUBJECT}"
+    ```
+   > **NOTE:** The key length is configurable, however, 4096 is the recommended value.
+
+4. Sign the CSR and get a client certificate. 
+
+    Encode the obtained CSR with base64:
+    ```bash
+    openssl base64 -in compass-app.csr 
+    ```
+
+    To get the CSR signed, use the encoded CSR in this GraphQL mutation:
+    ```graphql
+    mutation {
+        result: signCertificateSigningRequest(csr: "{BASE64_ENCODED_CSR}") {
+            certificateChain
+            caCertificate
+            clientCertificate
+        }
+    }
+    ```
+   
+    Send the modified GraphQL mutation to the Connector URL. You must include the `connector-token` header containing the one-time token fetched with the configuration.
+
+    The response contains a certificate chain, a valid client certificate signed by the Kyma Certificate Authority (CA), and the CA certificate.
+    
+ 5. Decode the certificate chain.
+ 
+    After you receive the certificates, decode the certificate chain with the base64 method and use it in your application: 
+    ```bash
+    base64 -d {CERTIFICATE_CHAIN}
+    ```
+    
+ >**NOTE:** To learn how to renew a client certificate, read [this](#tutorials-maintain-a-secure-connection-with-compass) tutorial.

--- a/docs/compass/08-08-maintain-secure-connection-with-compass.md
+++ b/docs/compass/08-08-maintain-secure-connection-with-compass.md
@@ -1,0 +1,79 @@
+---
+title: Maintain a secure connection with Compass
+type: Tutorials
+---
+
+After you have established a secure connection with Compass, you can fetch the configuration details and renew the client certificate before it expires. To renew the client certificate, follow the steps in this tutorial.
+
+## Prerequisites
+
+- [OpenSSL toolkit](https://www.openssl.org/docs/man1.0.2/apps/openssl.html) to create a Certificate Signing Request (CSR), keys, and certificates which meet high security standards
+- Compass (version 1.8 or higher)
+- Registered Application
+- Runtime connected to Compass
+- [Established secure connection with Compass](#tutorials-establish-a-secure-connection-with-compass)
+
+## Steps
+
+1. Get the CSR information with the configuration details.
+
+    To fetch the configuration, make a call to the Certificate-Secured Connector URL using the client certificate. 
+    The Certificate-Secured Connector URL is the `certificateSecuredConnectorURL` obtained when establishing a secure connection with Compass. 
+    Send this query with the call:
+    
+    ```graphql
+    query {
+        result: configuration {
+            certificateSigningRequestInfo { 
+                subject 
+                keyAlgorithm 
+            }
+            managementPlaneInfo { 
+                directorURL 
+            }
+        }
+    }
+    ``` 
+
+    A successful call returns the requested configuration details.
+
+2. Generate a key and a Certificate Signing Request (CSR).
+
+    Generate a CSR with this command using the certificate subject data obtained with the CSR information: 
+    ```
+    export KEY_LENGTH=4096
+    openssl genrsa -out compass-app.key $KEY_LENGTH
+    openssl req -new -sha256 -out compass-app.csr -key compass-app.key -subj "{SUBJECT}"
+    ```
+   > **NOTE:** The key length is configurable, however, 4096 is the recommended value.
+
+3. Sign the CSR and renew the client certificate. 
+
+    Encode the obtained CSR with base64:
+    ```bash
+    openssl base64 -in compass-app.csr 
+    ```
+
+    Send the following GraphQL mutation with the encoded CSR to the Certificate-Secured Connector URL:
+    ```graphql
+    mutation {
+        result: signCertificateSigningRequest(csr: "{BASE64_ENCODED_CSR}") {
+            certificateChain
+            caCertificate
+            clientCertificate
+        }
+    }
+    ```
+
+    The response contains a renewed client certificate signed by the Kyma Certificate Authority (CA), certificate chain, and the CA certificate. 
+    
+4. Decode the certificate chain.
+
+    The returned certificates and the certificate chain are base64-encoded and need to be decoded before use. 
+    To decode the certificate chain, run:
+    
+    ```bash
+    base64 -d {CERTIFICATE_CHAIN} 
+    ```
+    
+>**NOTE:** To learn how to revoke a client certificate, read [this](#tutorials-revoke-a-client-certificate) tutorial.

--- a/docs/compass/08-09-revoke-client-certificate.md
+++ b/docs/compass/08-09-revoke-client-certificate.md
@@ -1,0 +1,36 @@
+---
+title: Revoke a client certificate
+type: Tutorials
+---
+
+After you have established a secure connection with Compass and generated a client certificate, you may want to revoke this certificate at some point. To revoke a client certificate, follow the steps in this tutorial.
+
+> **NOTE:** A revoked client certificate remains valid until it expires, but it cannot be renewed.
+
+## Prerequisites
+
+- [OpenSSL toolkit](https://www.openssl.org/docs/man1.0.2/apps/openssl.html) to create a Certificate Signing Request (CSR), keys, and certificates which meet high security standards
+- Compass (version 1.8 or higher)
+- Registered Application
+- Runtime connected to Compass
+- [Established secure connection with Compass](#tutorials-establish-a-secure-connection-with-compass)
+
+> **NOTE**: To see how to maintain a secure connection with Compass and renew a client certificate, read [this](#tutorials-maintain-a-secure-connection-with-compass) tutorial.
+
+## Steps
+
+1. Revoke the client certificate
+
+    To revoke a client certificate, make a call to the Certificate-Secured Connector URL using the client certificate. 
+    The Certificate-Secured Connector URL is the `certificateSecuredConnectorURL` obtained when establishing a secure connection with Compass.
+    Send this mutation with the call:
+    
+    ```graphql
+    mutation { result: revokeCertificate }
+    ``` 
+
+    A successful call returns the following response:
+    
+    ```json
+    {"data":{"result":true}}
+    ```


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Provide tutorials for Compass on how to:
  * Establish a secure connection with Compass and generate a client certificate.
  * Maintain a secure connection with Compass and renew a client certificate.
  * Revoke a client certificate.

**Related issue(s)**
See [#493](https://github.com/kyma-incubator/compass/issues/493), [#244](https://github.com/kyma-incubator/compass/issues/244) 