### PR TITLE
api-gateway jwt and oauth2 on the same path integration test

### DIFF
--- a/tests/integration/api-gateway/gateway-tests/go.mod
+++ b/tests/integration/api-gateway/gateway-tests/go.mod
@@ -8,7 +8,6 @@ require (
 	github.com/pkg/errors v0.8.1
 	github.com/stretchr/testify v1.3.0
 	github.com/vrischmann/envconfig v1.2.0
-	golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2 // indirect
 	golang.org/x/net v0.0.0-20190812203447-cdfb69ac37fc
 	golang.org/x/oauth2 v0.0.0-20190402181905-9f3314589c9a
 	golang.org/x/sys v0.0.0-20191010194322-b09406accb47 // indirect

--- a/tests/integration/api-gateway/gateway-tests/main_test.go
+++ b/tests/integration/api-gateway/gateway-tests/main_test.go
@@ -272,7 +272,7 @@ func TestApiGatewayIntegration(t *testing.T) {
 			assert.NotNil(tokenJWT)
 
 			assert.NoError(tester.TestSecuredEndpoint(fmt.Sprintf("https://httpbin-%s.%s/image", testID, conf.Domain), tokenOAUTH.AccessToken, "oauth2-access-token"))
-			assert.NoError(tester.TestSecuredEndpoint(fmt.Sprintf("https://httpbin-%s.%s/image", testID, conf.Domain), fmt.Sprintf("Bearer %s", tokenOAUTH.AccessToken), defaultHeaderName))
+			assert.NoError(tester.TestSecuredEndpoint(fmt.Sprintf("https://httpbin-%s.%s/image", testID, conf.Domain), fmt.Sprintf("Bearer %s", tokenJWT), defaultHeaderName))
 
 			deleteResources(k8sClient, commonResources...)
 

--- a/tests/integration/api-gateway/gateway-tests/manifests/jwt-oauth-one-path-strategy.yaml
+++ b/tests/integration/api-gateway/gateway-tests/manifests/jwt-oauth-one-path-strategy.yaml
@@ -1,0 +1,24 @@
+apiVersion: gateway.kyma-project.io/v1alpha1
+kind: APIRule
+metadata:
+  name: "{{.NamePrefix}}-{{.TestID}}"
+  namespace: api-gateway-tests
+spec:
+  gateway: kyma-gateway.kyma-system.svc.cluster.local
+  service:
+    name: httpbin-{{.TestID}}
+    port: 8000
+    host: "httpbin-{{.TestID}}.{{.Domain}}"
+  rules:
+    - path: /image
+      methods: ["GET"]
+      mutators: []
+      accessStrategies:
+        - handler: jwt
+          config:
+            trusted_issuers: ["https://dex.{{ .Domain }}"]
+        - handler: oauth2_introspection
+          config:
+            required_scope: ["read"]
+            token_from:
+              header: "oauth2-access-token"

--- a/tests/integration/api-gateway/gateway-tests/pkg/api/apitest.go
+++ b/tests/integration/api-gateway/gateway-tests/pkg/api/apitest.go
@@ -35,7 +35,7 @@ func (h *Tester) TestSecuredEndpoint(url, token string, headerName string) error
 	if err != nil {
 		return err
 	}
-	req.Header.Set(headerName, fmt.Sprintf("Bearer %s", token))
+	req.Header.Set(headerName, token)
 	return h.withRetries(func() (*http.Response, error) {
 		return h.client.Do(req)
 	}, httpOkPredicate)

--- a/tests/integration/api-gateway/gateway-tests/pkg/api/apitest.go
+++ b/tests/integration/api-gateway/gateway-tests/pkg/api/apitest.go
@@ -21,7 +21,7 @@ func NewTester(c *http.Client, opts []retry.Option) *Tester {
 	}
 }
 
-func (h *Tester) TestSecuredEndpoint(url, token string) error {
+func (h *Tester) TestSecuredEndpoint(url, token string, headerName string) error {
 
 	err := h.withRetries(func() (*http.Response, error) {
 		return h.client.Get(url)
@@ -35,7 +35,7 @@ func (h *Tester) TestSecuredEndpoint(url, token string) error {
 	if err != nil {
 		return err
 	}
-	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", token))
+	req.Header.Set(headerName, fmt.Sprintf("Bearer %s", token))
 	return h.withRetries(func() (*http.Response, error) {
 		return h.client.Do(req)
 	}, httpOkPredicate)

--- a/tests/integration/api-gateway/gateway-tests/pkg/api/apitest.go
+++ b/tests/integration/api-gateway/gateway-tests/pkg/api/apitest.go
@@ -1,7 +1,6 @@
 package api
 
 import (
-	"fmt"
 	"io/ioutil"
 	"net/http"
 

--- a/tests/integration/api-gateway/gateway-tests/pkg/api/apitest_test.go
+++ b/tests/integration/api-gateway/gateway-tests/pkg/api/apitest_test.go
@@ -74,7 +74,7 @@ func TestTestSecuredAPI(t *testing.T) {
 		t.Run(fmt.Sprintf("case: call secured API should %s has been included in the request", desc), func(t *testing.T) {
 
 			//when
-			err := tester.TestSecuredEndpoint(securedEndpoint, token)
+			err := tester.TestSecuredEndpoint(securedEndpoint, fmt.Sprintf("Bearer %s", token), "Authorization")
 
 			//then
 			if token == testToken {


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/master/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- api-gateway jwt and oauth2 on the same path integration test

**Related issue(s)**
see #6349
