### PR TITLE
Use fixed version of busybox image

### DIFF
--- a/resources/ory/charts/hydra/templates/tests/test-connection.yaml
+++ b/resources/ory/charts/hydra/templates/tests/test-connection.yaml
@@ -12,7 +12,7 @@ metadata:
 spec:
   containers:
     - name: healthcheck-ready
-      image: busybox
+      image: busybox:1.13.1
       command: ['wget']
       args:  ['{{ include "hydra.fullname" . }}-admin:{{ .Values.service.admin.port }}/health/ready']
   restartPolicy: Never

--- a/resources/ory/charts/oathkeeper/templates/deployment-with-sidecar.yaml
+++ b/resources/ory/charts/oathkeeper/templates/deployment-with-sidecar.yaml
@@ -45,7 +45,7 @@ spec:
             secretName: {{ include "oathkeeper.fullname" . }}
       initContainers:
         - name: init
-          image: busybox:1.13.1
+          image: busybox:1
           volumeMounts:
             - name: {{ include "oathkeeper.name" . }}-rules-volume
               mountPath: /etc/rules

--- a/resources/ory/charts/oathkeeper/templates/deployment-with-sidecar.yaml
+++ b/resources/ory/charts/oathkeeper/templates/deployment-with-sidecar.yaml
@@ -45,7 +45,7 @@ spec:
             secretName: {{ include "oathkeeper.fullname" . }}
       initContainers:
         - name: init
-          image: busybox:1
+          image: busybox:1.13.1
           volumeMounts:
             - name: {{ include "oathkeeper.name" . }}-rules-volume
               mountPath: /etc/rules

--- a/resources/ory/charts/oathkeeper/templates/tests/test-connection.yaml
+++ b/resources/ory/charts/oathkeeper/templates/tests/test-connection.yaml
@@ -12,11 +12,11 @@ metadata:
 spec:
   containers:
     - name: liveness-probe
-      image: busybox
+      image: busybox:1.13.1
       command: ['wget']
       args:  ['http://{{ include "oathkeeper.fullname" . }}-api:{{ .Values.service.api.port }}/health/alive']
     - name: readiness-probe
-      image: busybox
+      image: busybox:1.13.1
       command: ['wget']
       args:  ['http://{{ include "oathkeeper.fullname" . }}-api:{{ .Values.service.api.port }}/health/ready']
   restartPolicy: Never


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/master/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- Use `busybox` version `1.31.1` instead of `latest`

I noticed that `latest` tag is used that is not allowed in Kyma. Also, the new upgrade pipeline based on kind (switch is planned for the 2nd week of January) is failing because of that, for example, https://status.build.kyma-project.io/view/gcs/kyma-prow-logs/pr-logs/pull/kyma-project_kyma/6730/pre-master-kyma-kind-upgrade/1209043540156354560