### PR TITLE
Change helm broker metrics port

### DIFF
--- a/resources/helm-broker/templates/deploy.yaml
+++ b/resources/helm-broker/templates/deploy.yaml
@@ -42,6 +42,8 @@ spec:
             value: "{{ .Values.service.internalPort }}"
           - name: APP_STATUS_PORT
             value: "{{ .Values.service.statusPort }}"
+          - name: APP_METRICS_PORT
+            value: "{{ .Values.service.metricsPort }}"
           - name: APP_CONFIG_FILE_NAME
             value: /etc/config/helm-broker/config.yaml
           - name: APP_HELM_TILLER_HOST

--- a/resources/helm-broker/templates/metrics.yaml
+++ b/resources/helm-broker/templates/metrics.yaml
@@ -34,7 +34,7 @@ metadata:
 spec:
   ports:
     - name: http-metrics
-      port: {{ .Values.service.internalPort }}
+      port: {{ .Values.service.metricsPort }}
   selector:
     app: {{ template "fullname" . }}
 ---

--- a/resources/helm-broker/values.yaml
+++ b/resources/helm-broker/values.yaml
@@ -52,7 +52,7 @@ global:
     path: eu.gcr.io/kyma-project
   helm_broker:
     dir: develop/
-    version: baa788d0
+    version: 6536f9b6
   alpine_net:
     dir: develop/
     version: 149967d0

--- a/resources/helm-broker/values.yaml
+++ b/resources/helm-broker/values.yaml
@@ -7,6 +7,7 @@ service:
   externalPort: 80
   internalPort: 8070
   statusPort: 8071
+  metricsPort: 8072
 
 ctrl:
   tmpDirSizeLimit: 1Gi


### PR DESCRIPTION
Related to [#6579](https://github.com/kyma-project/kyma/issues/6579)

Due to a related issue, `helm-broker` metric service didn't work properly (service was not available for a long time since start). 
First, all services, service metrics, endpoints were checked, all was set up properly.
All metrics endpoints inside `helm-broker` container worked properly right after starting. From other Pods service with `helm-broker` metrics was unavailable.
The issue occurs often, one of three resets of Pod causes problems.

After removing sidecar from Pod the issue stoped.
Istio Pilot in logs shows an error:
```
2019-12-24T10:50:19.980942Z	info	ads	RDS: PUSH for node:helm-broker-79b846d46d-wlrfx.kyma-system routes:65
            "helm-broker-79b846d46d-wlrfx.kyma-system": {
                "proxy": "helm-broker-79b846d46d-wlrfx.kyma-system",
                "message": "Conflicting inbound listener:10.0.1.72:8070. existing: helm-broker.kyma-system.svc.cluster.local, incoming: helm-broker-metrics.kyma-system.svc.cluster.local"
2019-12-24T10:50:26.648534Z	info	Handling event update for pod helm-broker-79b846d46d-hxhkd in namespace kyma-system -> 10.0.2.41
```
`Helm-broker` has two services, one for application one for metrics, both have the same `targetPort`.

First I tried attached metrics under application Service, but ServiceMetric couldn't handle it. (maybe changing Service type from PR [#6608](https://github.com/kyma-project/kyma/pull/6608) can solve the problem)
The final solution is to [move metrics](https://github.com/kyma-project/helm-broker/pull/78) to a separate server and different own port.

(!!!) merge after [PR](https://github.com/kyma-project/helm-broker/pull/78) and swapping the instance image