### PR TITLE
Fix a dead link to chart template debugging

### DIFF
--- a/docs/helm-broker/03-01-create-addons.md
+++ b/docs/helm-broker/03-01-create-addons.md
@@ -125,4 +125,4 @@ As a prerequisite, you must install [Helm](https://github.com/kubernetes/helm) o
  helm install --dry-run {path-to-chart} --debug
 ```
 
-For more details, read the Helm [official documentation](https://helm.sh/docs/topics/chart_template_guide/debugging/).
+For more details, read the Helm [official documentation](https://helm.sh/docs/chart_template_guide/debugging/).


### PR DESCRIPTION

**Description**

Changes proposed in this pull request:

- Correct a dead link to docs on helm template debugging
