### PR TITLE
Exclude testsuite pods from KubePodNotReady alerts

### DIFF
--- a/resources/monitoring/templates/prometheus/rules-1.14/kubernetes-apps.yaml
+++ b/resources/monitoring/templates/prometheus/rules-1.14/kubernetes-apps.yaml
@@ -1,3 +1,6 @@
+{{- /*
+  Customization: KubePodNotReady alert is modified to exclude testsuite pods.
+*/ -}}
 # Generated from 'kubernetes-apps' group from https://raw.githubusercontent.com/coreos/kube-prometheus/master/manifests/prometheus-rules.yaml
 # Do not change in-place! In order to change this file first read following link:
 # https://github.com/helm/charts/tree/master/stable/prometheus-operator/hack
@@ -33,7 +36,7 @@ spec:
       annotations:
         message: Pod {{`{{ $labels.namespace }}`}}/{{`{{ $labels.pod }}`}} has been in a non-ready state for longer than 15 minutes.
         runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubepodnotready
-      expr: sum by (namespace, pod) (kube_pod_status_phase{job="kube-state-metrics", phase=~"Failed|Pending|Unknown"} * on(namespace, pod) group_left(owner_kind) kube_pod_owner{owner_kind!="Job"}) > 0
+      expr: sum by (namespace, pod) (kube_pod_status_phase{pod!~".*testsuite.*",job="kube-state-metrics", phase=~"Failed|Pending|Unknown"} * on(namespace, pod) group_left(owner_kind) kube_pod_owner{owner_kind!="Job"}) > 0
       for: 15m
       labels:
         severity: critical

--- a/resources/monitoring/templates/prometheus/rules/kubernetes-apps.yaml
+++ b/resources/monitoring/templates/prometheus/rules/kubernetes-apps.yaml
@@ -1,3 +1,6 @@
+{{- /*
+  Customization: KubePodNotReady alert is modified to exclude testsuite pods.
+*/ -}}
 # Generated from 'kubernetes-apps' group from https://raw.githubusercontent.com/coreos/kube-prometheus/release-0.1/manifests/prometheus-rules.yaml
 # Do not change in-place! In order to change this file first read following link:
 # https://github.com/helm/charts/tree/master/stable/prometheus-operator/hack
@@ -33,7 +36,7 @@ spec:
       annotations:
         message: Pod {{`{{ $labels.namespace }}`}}/{{`{{ $labels.pod }}`}} has been in a non-ready state for longer than an hour.
         runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubepodnotready
-      expr: sum by (namespace, pod) (kube_pod_status_phase{job="kube-state-metrics", phase=~"Pending|Unknown"}) > 0
+      expr: sum by (namespace, pod) (kube_pod_status_phase{pod!~".*testsuite.*", job="kube-state-metrics", phase=~"Pending|Unknown"}) > 0
       for: 1h
       labels:
         severity: critical


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/master/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- Exclude testsuite pods from KubePodNotReady alerts
