### PR TITLE
Fix bug with Specification URL in Application Registry

### DIFF
--- a/components/application-registry/internal/apperrors/apperrors.go
+++ b/components/application-registry/internal/apperrors/apperrors.go
@@ -69,7 +69,7 @@ func hideBasicCredentials(str string) (output string) {
 		output = fmt.Sprintf("%s%s ", output, reg.ReplaceAllString(strPart, "$1://***:***@$4"))
 	}
 	if length := len(output); length > 0 {
-		output = output[:length - 1]
+		output = output[:length-1]
 	}
 	return output
 }

--- a/components/application-registry/internal/apperrors/apperrors.go
+++ b/components/application-registry/internal/apperrors/apperrors.go
@@ -12,6 +12,12 @@ const (
 	CodeAlreadyExists            = 3
 	CodeWrongInput               = 4
 	CodeUpstreamServerCallFailed = 5
+
+	urlWithBasicAuthRegexpReplaceString = "$1://***:***@$4"
+)
+
+var (
+	urlWithBasicAuthRegexp = regexp.MustCompile("(.+)://(.+):(.+)@(.+)")
 )
 
 type AppError interface {
@@ -64,9 +70,12 @@ func (ae appError) Error() string {
 
 func hideBasicCredentials(str string) (output string) {
 	strSplitted := strings.Split(str, " ")
-	reg := regexp.MustCompile("(.+)://(.+):(.+)@(.+)")
 	for _, strPart := range strSplitted {
-		output = fmt.Sprintf("%s%s ", output, reg.ReplaceAllString(strPart, "$1://***:***@$4"))
+		output = fmt.Sprintf(
+			"%s%s ",
+			output,
+			urlWithBasicAuthRegexp.ReplaceAllString(strPart, urlWithBasicAuthRegexpReplaceString),
+		)
 	}
 	if length := len(output); length > 0 {
 		output = output[:length-1]

--- a/components/application-registry/internal/apperrors/apperrors_test.go
+++ b/components/application-registry/internal/apperrors/apperrors_test.go
@@ -77,4 +77,18 @@ func TestAppError(t *testing.T) {
 		assert.Equal(t, "Some additional message: error, Some WrongInput apperror, Some pkg err", appendedWrongInputErr.Error())
 		assert.Equal(t, "Some additional message: error, Some UpstreamServerCallFailed apperror, Some pkg err", appendedUpstreamServerCallFailedErr.Error())
 	})
+
+	t.Run("should hide basic credentials from message", func(t *testing.T) {
+		// given
+		simpleError := UpstreamServerCallFailed("error: https://user:password@dummy.com")
+		formattedError := UpstreamServerCallFailed("code: %d, error: %s", 1, "https://user:password@dummy.com")
+		appendedError := UpstreamServerCallFailed("error1: https://user:password@dummy.com").Append("error2: https://user:password@dummy.com")
+		appendedFormatedError := UpstreamServerCallFailed("error1: https://user:password@dummy.com").Append("code: %d, error2: %s", 1, "https://user:password@dummy.com")
+
+		// then
+		assert.Equal(t, "error: https://***:***@dummy.com", simpleError.Error())
+		assert.Equal(t, "code: 1, error: https://***:***@dummy.com", formattedError.Error())
+		assert.Equal(t, "error2: https://***:***@dummy.com, error1: https://***:***@dummy.com", appendedError.Error())
+		assert.Equal(t, "code: 1, error2: https://***:***@dummy.com, error1: https://***:***@dummy.com", appendedFormatedError.Error())
+	})
 }

--- a/resources/application-connector/values.yaml
+++ b/resources/application-connector/values.yaml
@@ -54,7 +54,7 @@ global:
     version: c608dbf3
   application_registry:
     dir:
-    version: PR-6798
+    version: PR-6828
   application_registry_tests:
     dir:
     version: c608dbf3


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Fix misleading URL formatting from error logs
- Hide basic auth credentials from URLs in error logs 
  - for example change `https://user1:password!@service.com` to `https://***:***@service.com`

**Related issue(s)**

See the issue #6518 
