### PR TITLE
Fix the Knative Serving acceptance test

### DIFF
--- a/tests/knative-serving/Gopkg.lock
+++ b/tests/knative-serving/Gopkg.lock
@@ -639,7 +639,6 @@
     "github.com/kyma-project/kyma/common",
     "github.com/kyma-project/kyma/common/ingressgateway",
     "k8s.io/api/core/v1",
-    "k8s.io/apimachinery/pkg/api/errors",
     "k8s.io/apimachinery/pkg/apis/meta/v1",
     "k8s.io/client-go/plugin/pkg/client/auth/gcp",
     "k8s.io/client-go/rest",

--- a/tests/knative-serving/Gopkg.lock
+++ b/tests/knative-serving/Gopkg.lock
@@ -639,6 +639,7 @@
     "github.com/kyma-project/kyma/common",
     "github.com/kyma-project/kyma/common/ingressgateway",
     "k8s.io/api/core/v1",
+    "k8s.io/apimachinery/pkg/api/errors",
     "k8s.io/apimachinery/pkg/apis/meta/v1",
     "k8s.io/client-go/plugin/pkg/client/auth/gcp",
     "k8s.io/client-go/rest",

--- a/tests/knative-serving/knative_serving_test.go
+++ b/tests/knative-serving/knative_serving_test.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/avast/retry-go"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
 	meta "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
@@ -77,7 +78,12 @@ func TestKnativeServingAcceptance(t *testing.T) {
 		},
 	}
 
-	if _, err = serviceClient.Create(&svc); err != nil {
+	_, err = serviceClient.Create(&svc)
+
+	switch {
+	case errors.IsAlreadyExists(err):
+		// reuse the existing Knative service
+	case err != nil:
 		t.Fatalf("Cannot create test Service: %v", err)
 	}
 

--- a/tests/knative-serving/knative_serving_test.go
+++ b/tests/knative-serving/knative_serving_test.go
@@ -11,20 +11,19 @@ import (
 	"testing"
 	"time"
 
-	"knative.dev/serving/pkg/apis/serving/v1beta1"
-
-	"github.com/avast/retry-go"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
 	meta "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
-
 	// allow client authentication against GKE clusters
 	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
 
 	serving "knative.dev/serving/pkg/apis/serving/v1alpha1"
+	"knative.dev/serving/pkg/apis/serving/v1beta1"
 	servingtyped "knative.dev/serving/pkg/client/clientset/versioned/typed/serving/v1alpha1"
 
+	"github.com/avast/retry-go"
 	"github.com/kyma-project/kyma/common/ingressgateway"
 )
 
@@ -219,7 +218,11 @@ func deleteService(t *testing.T, servingClient servingtyped.ServiceInterface, na
 	t.Helper()
 
 	err := servingClient.Delete(name, &meta.DeleteOptions{})
-	if err != nil {
+
+	switch {
+	case errors.IsNotFound(err):
+		// The Knative service was already deleted.
+	case err != nil:
 		t.Fatalf("Cannot delete service %v, Error: %v", name, err)
 	}
 }

--- a/tests/knative-serving/knative_serving_test.go
+++ b/tests/knative-serving/knative_serving_test.go
@@ -5,7 +5,9 @@ import (
 	"io/ioutil"
 	"net/http"
 	"os"
+	"os/signal"
 	"strings"
+	"syscall"
 	"testing"
 	"time"
 
@@ -13,7 +15,6 @@ import (
 
 	"github.com/avast/retry-go"
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/errors"
 	meta "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
@@ -31,6 +32,11 @@ const (
 	// Message that should be printed by the sample Hello World service.
 	// https://knative.dev/docs/serving/samples/hello-world/helloworld-go/index.html
 	targetEnvVar = "TARGET"
+)
+
+var (
+	// Interrupt signals to be handled for graceful cleanup.
+	interruptSignals = []os.Signal{syscall.SIGTERM, syscall.SIGINT}
 )
 
 func TestKnativeServingAcceptance(t *testing.T) {
@@ -78,12 +84,17 @@ func TestKnativeServingAcceptance(t *testing.T) {
 		},
 	}
 
-	_, err = serviceClient.Create(&svc)
+	// Cleanup test resources gracefully when an interrupt signal is received.
+	interrupted := cleanupOnInterrupt(t, interruptSignals, func() { deleteService(t, serviceClient, svc.Name) })
+	defer close(interrupted)
 
-	switch {
-	case errors.IsAlreadyExists(err):
-		// reuse the existing Knative service
-	case err != nil:
+	// If the Knative service already exists, delete it to make sure
+	// the new object to be created has the correct structure and data.
+	if _, err = serviceClient.Get(svcName, meta.GetOptions{}); err == nil {
+		deleteService(t, serviceClient, svc.Name)
+	}
+
+	if _, err = serviceClient.Create(&svc); err != nil {
 		t.Fatalf("Cannot create test Service: %v", err)
 	}
 
@@ -91,21 +102,26 @@ func TestKnativeServingAcceptance(t *testing.T) {
 	var testServiceURL string
 
 	err = retry.Do(func() error {
-		ksvc, err := serviceClient.Get(svcName, meta.GetOptions{})
-		if err != nil {
-			return err
-		}
-		if ksvc.Status.URL.String() == "" {
-			return fmt.Errorf("url not set yet")
-		}
-		svcurl := ksvc.Status.URL
+		select {
+		case <-interrupted:
+			t.Fatal("Cannot continue, test was interrupted")
+			return nil
+		default:
+			ksvc, err := serviceClient.Get(svcName, meta.GetOptions{})
+			if err != nil {
+				return err
+			}
+			if ksvc.Status.URL.String() == "" {
+				return fmt.Errorf("url not set yet")
+			}
+			svcurl := ksvc.Status.URL
 
-		//TODO(k15r): ksvc returns a URL with scheme http, but this fails as the client then tries to
-		//  open an unencrypted connection on a secure port (443, as probably configured by the ingressgateway.client() )
-		svcurl.Scheme = "https"
-		testServiceURL = svcurl.String()
-		return nil
-
+			//TODO(k15r): ksvc returns a URL with scheme http, but this fails as the client then tries to
+			//  open an unencrypted connection on a secure port (443, as probably configured by the ingressgateway.client() )
+			svcurl.Scheme = "https"
+			testServiceURL = svcurl.String()
+			return nil
+		}
 	}, retry.DelayType(retry.FixedDelay), retry.Delay(5*time.Second), retry.Attempts(10))
 
 	if err != nil {
@@ -113,31 +129,37 @@ func TestKnativeServingAcceptance(t *testing.T) {
 	}
 
 	err = retry.Do(func() error {
-		t.Logf("Calling: %s", testServiceURL)
+		select {
+		case <-interrupted:
+			t.Fatal("Cannot continue, test was interrupted")
+			return nil
+		default:
+			t.Logf("Calling: %s", testServiceURL)
 
-		resp, err := ingressClient.Get(testServiceURL)
-		if err != nil {
-			return err
+			resp, err := ingressClient.Get(testServiceURL)
+			if err != nil {
+				return err
+			}
+
+			body, err := ioutil.ReadAll(resp.Body)
+			if err != nil {
+				return err
+			}
+
+			msg := strings.TrimSpace(string(body))
+			expectedMsg := fmt.Sprintf("Hello %s!", target)
+
+			t.Logf("Received %d: %q", resp.StatusCode, msg)
+
+			if resp.StatusCode != http.StatusOK {
+				return fmt.Errorf("expected status code %d, got %d", http.StatusOK, resp.StatusCode)
+			}
+			if msg != expectedMsg {
+				return fmt.Errorf("expected response to be %q, got %q", expectedMsg, msg)
+			}
+
+			return nil
 		}
-
-		body, err := ioutil.ReadAll(resp.Body)
-		if err != nil {
-			return err
-		}
-
-		msg := strings.TrimSpace(string(body))
-		expectedMsg := fmt.Sprintf("Hello %s!", target)
-
-		t.Logf("Received %d: %q", resp.StatusCode, msg)
-
-		if resp.StatusCode != http.StatusOK {
-			return fmt.Errorf("expected status code %d, got %d", http.StatusOK, resp.StatusCode)
-		}
-		if msg != expectedMsg {
-			return fmt.Errorf("expected response to be %q, got %q", expectedMsg, msg)
-		}
-
-		return nil
 	}, retry.OnRetry(func(n uint, err error) {
 		t.Logf("[%v] try failed: %s", n, err)
 	}), retry.Attempts(20),
@@ -186,4 +208,28 @@ func deleteService(t *testing.T, servingClient servingtyped.ServiceInterface, na
 	if err != nil {
 		t.Fatalf("Cannot delete service %v, Error: %v", name, err)
 	}
+}
+
+// cleanupOnInterrupt will execute the cleanup function in a goroutine if any of the interrupt signals was received.
+func cleanupOnInterrupt(t *testing.T, interruptSignals []os.Signal, cleanup func()) chan bool {
+	t.Helper()
+
+	// To notify the callers if an interrupt signal was received.
+	interrupted := make(chan bool, 1)
+
+	ch := make(chan os.Signal, 1)
+	signal.Notify(ch, interruptSignals...)
+
+	go func() {
+		defer close(ch)
+		<-ch
+
+		t.Log("Interrupt signal received, cleanup started")
+		cleanup()
+		t.Log("Cleanup finished")
+
+		interrupted <- true
+	}()
+
+	return interrupted
 }


### PR DESCRIPTION
**Description**

The Knative Serving acceptance test is failing as it tries to create a new ksvc when there is an already existing one with the same name.

**Fix**

The introduced fix consists of the following steps:
* Before creating a new Knative service, check if there is an already exiting one, if yes delete it and recreate a new one, this will guarantee that the new one will have the desired structure and data, and will also mitigate the error occurs from having a Knative service exited before.
* Introduced a graceful cleanup mechanism for the Knative service if the test was suddenly terminated before completion, to not leave any resources behind.