### PR TITLE
explicit "default" namespace for installation resource

### DIFF
--- a/components/kyma-operator/README.md
+++ b/components/kyma-operator/README.md
@@ -79,14 +79,14 @@ Connect to the cluster that hosts your Kyma installation. Prepare the URL to the
 
 Change the `url` property in **spec** to `{URL_TO KYMA_TAR_GZ}`. Trigger the update by overriding the **action** label in CR:
   ```
-  kubectl label installation/{CR_NAME} action=install --overwrite
+  kubectl -n default label installation/{CR_NAME} action=install --overwrite
   ```
 
 ## Uninstall Kyma
 
 Run this command to uninstall Kyma:
   ```
-  kubectl label installation/kyma-installation action=uninstall
+  kubectl -n default label installation/kyma-installation action=uninstall
   ```
 
 >**NOTE:** Uninstallation is an experimental feature that invokes the `helm delete --purge` command for each release specified in the CR. It is Helm's policy to prevent some types of resources, such as CRDs or Namespaces, from being deleted. Delete them manually before you attempt to install Kyma again on a cluster from which it was uninstalled.  

--- a/docs/backup/10-01-restore-troubleshooting.md
+++ b/docs/backup/10-01-restore-troubleshooting.md
@@ -16,7 +16,7 @@ kubectl delete $(kubectl get pod -l app=service-catalog-addons-service-binding-u
 The [restore](/components/backup/#tutorial-restore-a-kyma-cluster) tutorial assumes that the DNS and the public IP values for the new cluster are the same as for the backed up cluster. If they change, check the relevant fields in the Secrets and ConfigMaps overrides in the `kyma-installer` Namespace and update them with new values. Then run the installer again to propagate them to all the components:
 
 ```bash
-kubectl label installation/kyma-installation action=install
+kubectl -n default label installation/kyma-installation action=install
 ```
 
 ## Eventing does not work

--- a/docs/kyma/04-11-update.md
+++ b/docs/kyma/04-11-update.md
@@ -39,7 +39,7 @@ In case of dependency conflicts or major changes between components versions, so
 - If you add a new component to your Kyma deployment, add a top-level Helm chart for that component. Additionally, run this command to edit the Installation custom resource and add the new component to the installed components list:
 
    ```bash
-   kubectl edit installation kyma-installation
+   kubectl -n default edit installation kyma-installation
    ```
 
    > **NOTE:** Read [this](#custom-resource-installation) document to learn more about the Installation custom resource.
@@ -100,5 +100,5 @@ Read about each update step in the following sections.
 Execute the following command to trigger the update process:
 
 ```bash
-kubectl label installation/kyma-installation action=install
+kubectl -n default label installation/kyma-installation action=install
 ```

--- a/docs/kyma/05-02-custom-component-installation.md
+++ b/docs/kyma/05-02-custom-component-installation.md
@@ -71,7 +71,7 @@ To add a component that was not installed with Kyma by default, modify the Insta
 3. Trigger the installation:
 
    ```
-   kubectl label installation/kyma-installation action=install
+   kubectl -n default label installation/kyma-installation action=install
    ```
 
 ### Verify the installation

--- a/docs/kyma/05-02-custom-component-installation.md
+++ b/docs/kyma/05-02-custom-component-installation.md
@@ -61,7 +61,7 @@ To add a component that was not installed with Kyma by default, modify the Insta
 
 1. Edit the resource:
     ```
-    kubectl edit installation kyma-installation
+    kubectl -n default edit installation kyma-installation
     ```
 2. Add the new component to the list of components or remove the hash character (#) preceding these lines:
     ```

--- a/docs/kyma/05-03-overrides.md
+++ b/docs/kyma/05-03-overrides.md
@@ -89,7 +89,7 @@ For overrides that the system should keep in Secrets, just define a Secret objec
 If you add the overrides in the runtime, trigger the update process using this command:
 
 ```
-kubectl label installation/kyma-installation action=install
+kubectl -n default label installation/kyma-installation action=install
 ```
 
 ### Sub-chart overrides

--- a/docs/kyma/06-01-installation.md
+++ b/docs/kyma/06-01-installation.md
@@ -21,6 +21,7 @@ apiVersion: "installer.kyma-project.io/v1alpha1"
 kind: Installation
 metadata:
   name: kyma-installation
+  namespace: default
   labels:
     action: install
   finalizers:

--- a/docs/monitoring/08-05-send-notifications.md
+++ b/docs/monitoring/08-05-send-notifications.md
@@ -59,7 +59,7 @@ Follow these steps to configure notifications for Slack every time Alertmanager 
 
    >**NOTE**: If you add the overrides in the runtime, trigger the update process using this command:
    >```bash
-   >kubectl label installation/kyma-installation action=install
+   >kubectl -n default label installation/kyma-installation action=install
    >```
    >**NOTE**: If the rule you created is removed during the update, re-apply it following the [**Define alerting rules**](#tutorials-define-alerting-rules) tutorial.
 

--- a/docs/rafter/08-02-set-minio-to-gateway-mode.md
+++ b/docs/rafter/08-02-set-minio-to-gateway-mode.md
@@ -403,5 +403,5 @@ EOF
 Trigger Kyma installation or update by labeling the Installation custom resource. Run:
 
 ```bash
-kubectl label installation/kyma-installation action=install
+kubectl -n default label installation/kyma-installation action=install
 ```

--- a/docs/security/08-01-update-tls-certificates.md
+++ b/docs/security/08-01-update-tls-certificates.md
@@ -58,7 +58,7 @@ The TLS certificate is a vital security element. Follow this tutorial to update 
 2. Trigger the update process. Run:
 
   ```
-  kubectl label installation/kyma-installation action=install
+  kubectl -n default label installation/kyma-installation action=install
   ```
 
   To watch the progress of the update, run:

--- a/installation/resources/installer-cr-cluster-compass.yaml.tpl
+++ b/installation/resources/installer-cr-cluster-compass.yaml.tpl
@@ -2,6 +2,7 @@ apiVersion: "installer.kyma-project.io/v1alpha1"
 kind: Installation
 metadata:
   name: kyma-installation
+  namespace: default
   labels:
     action: install
     kyma-project.io/installation: ""

--- a/installation/resources/installer-cr-cluster-runtime.yaml.tpl
+++ b/installation/resources/installer-cr-cluster-runtime.yaml.tpl
@@ -2,6 +2,7 @@ apiVersion: "installer.kyma-project.io/v1alpha1"
 kind: Installation
 metadata:
   name: kyma-installation
+  namespace: default
   labels:
     action: install
     kyma-project.io/installation: ""

--- a/installation/resources/installer-cr-cluster-with-compass.yaml.tpl
+++ b/installation/resources/installer-cr-cluster-with-compass.yaml.tpl
@@ -2,6 +2,7 @@ apiVersion: "installer.kyma-project.io/v1alpha1"
 kind: Installation
 metadata:
   name: kyma-installation
+  namespace: default
   labels:
     action: install
     kyma-project.io/installation: ""

--- a/installation/resources/installer-cr-cluster.yaml.tpl
+++ b/installation/resources/installer-cr-cluster.yaml.tpl
@@ -2,6 +2,7 @@ apiVersion: "installer.kyma-project.io/v1alpha1"
 kind: Installation
 metadata:
   name: kyma-installation
+  namespace: default
   labels:
     action: install
     kyma-project.io/installation: ""

--- a/installation/resources/installer-cr.yaml.tpl
+++ b/installation/resources/installer-cr.yaml.tpl
@@ -2,6 +2,7 @@ apiVersion: "installer.kyma-project.io/v1alpha1"
 kind: Installation
 metadata:
   name: kyma-installation
+  namespace: default
   labels:
     action: install
     kyma-project.io/installation: ""

--- a/installation/scripts/is-installed.sh
+++ b/installation/scripts/is-installed.sh
@@ -78,8 +78,8 @@ fi
 echo "Checking state of kyma installation...hold on"
 while :
 do
-  STATUS="$(kubectl get installation/kyma-installation -o jsonpath='{.status.state}')"
-  DESC="$(kubectl get installation/kyma-installation -o jsonpath='{.status.description}')"
+  STATUS="$(kubectl -n default get installation/kyma-installation -o jsonpath='{.status.state}')"
+  DESC="$(kubectl -n default get installation/kyma-installation -o jsonpath='{.status.description}')"
   if [ "$STATUS" = "Installed" ]
   then
       echo "kyma is installed..."
@@ -93,7 +93,7 @@ do
     if [ "$TIMEOUT_SET" -ne 0 ] && [ "$ITERATIONS_LEFT" -le 0 ]; then
       echo "Installation errors until timeout:"
       echo "----------"
-      kubectl get installation  kyma-installation -o go-template --template='{{- range .status.errorLog }}
+      kubectl -n default get installation kyma-installation -o go-template --template='{{- range .status.errorLog }}
 {{.component}}:
   {{.log}}
 {{- end}}
@@ -106,7 +106,7 @@ do
     echo "Status: ${STATUS}, description: ${DESC}"
     if [ "$TIMEOUT_SET" -ne 0 ] && [ "$ITERATIONS_LEFT" -le 0 ]; then
       echo "----------"
-      kubectl get installation  kyma-installation -o go-template --template='{{- range .status.errorLog }}
+      kubectl -n default get installation kyma-installation -o go-template --template='{{- range .status.errorLog }}
 {{.component}}:
   {{.log}}
 {{- end}}
@@ -117,7 +117,7 @@ do
     fi
   fi
   if [ "${VERBOSE}" -eq 1 ]; then
-    kubectl get installation/kyma-installation -o yaml
+    kubectl -n default get installation/kyma-installation -o yaml
     echo "----------"
     kubectl get po --all-namespaces
   fi


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/master/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**
As a temporary solution, we should set the expected "default" namespace everywhere, in the resources itself but also in the documentation and tools when working with the resource.
I already found places in tools and docu where it is done, so the actual status is very inconsistent and that PR makes it consistent at least. Still a proper solution will be best.

Changes proposed in this pull request:

- Add namespace to all resources of kind "installation"
- Add namespace to all kubectl commands working with installation resources

**Related issue(s)**
https://github.com/kyma-project/kyma/issues/2134