### PR TITLE
Emphasize in docs that Rafter is only for storing public data

### DIFF
--- a/docs/rafter/01-01-rafter.md
+++ b/docs/rafter/01-01-rafter.md
@@ -3,7 +3,7 @@ title: Overview
 type: Overview
 ---
 
-Rafter is a solution for storing and managing different types of assets, such as documents, files, images, API specifications, and client-side applications. It uses an external solution, [MinIO](https://min.io/), for storing assets. The whole concept relies on [Kubernetes custom resources (CRs)](https://kubernetes.io/docs/concepts/extend-kubernetes/api-extension/custom-resources/) managed by the Asset, Bucket, and AssetGroup controllers (and their cluster-wide counterparts) grouped under the [Rafter Controller Manager](https://github.com/kyma-project/rafter/blob/master/cmd/manager/README.md). These CRs include:
+Rafter is a solution for storing and managing different types of public assets, such as documents, files, images, API specifications, and client-side applications. It uses an external solution, [MinIO](https://min.io/), for storing assets. The whole concept relies on [Kubernetes custom resources (CRs)](https://kubernetes.io/docs/concepts/extend-kubernetes/api-extension/custom-resources/) managed by the Asset, Bucket, and AssetGroup controllers (and their cluster-wide counterparts) grouped under the [Rafter Controller Manager](https://github.com/kyma-project/rafter/blob/master/cmd/manager/README.md). These CRs include:
 
 - Asset CR which manages a single asset or a package of assets
 - Bucket CR which manages buckets in which these assets are stored
@@ -21,11 +21,12 @@ Rafter comes with the following set of services and extensions compatible with R
 - [AsyncAPI Service](#details-asyncapi-service) (extension)
 - [Front Matter Service](#details-front-matter-service) (extension)
 
+>**CAUTION:** Rafter does not enforce any access control. To protect the confidentiality of your information, use Rafter only to store public data. Do not use it to process and store any kind of confidential information, including personal data.
 
 ## What Rafter is not
 
-* Rafter is not a [Content Management System](https://en.wikipedia.org/wiki/Content_management_system) (Wordpress-like),
-* Rafter is not a solution for [Enterprise Content Management](https://en.wikipedia.org/wiki/Enterprise_content_management),
+* Rafter is not a [Content Management System](https://en.wikipedia.org/wiki/Content_management_system), such as Wordpress-like.
+* Rafter is not a solution for [Enterprise Content Management](https://en.wikipedia.org/wiki/Enterprise_content_management).
 * Rafter doesn't come with any out-of-the-box UI that allows you to modify or consume files managed by Rafter.
 
 ## What Rafter can be used for

--- a/docs/rafter/01-01-rafter.md
+++ b/docs/rafter/01-01-rafter.md
@@ -25,7 +25,7 @@ Rafter comes with the following set of services and extensions compatible with R
 
 ## What Rafter is not
 
-* Rafter is not a [Content Management System](https://en.wikipedia.org/wiki/Content_management_system), such as Wordpress-like.
+* Rafter is not a Wordpress-like [Content Management System](https://en.wikipedia.org/wiki/Content_management_system).
 * Rafter is not a solution for [Enterprise Content Management](https://en.wikipedia.org/wiki/Enterprise_content_management).
 * Rafter doesn't come with any out-of-the-box UI that allows you to modify or consume files managed by Rafter.
 

--- a/docs/rafter/03-04-minio-gateway.md
+++ b/docs/rafter/03-04-minio-gateway.md
@@ -30,7 +30,7 @@ For the production purposes, Rafter uses MinIO Gateway which:
 
 ![](./assets/minio-gateway.svg)
 
->**TIP:** Every cloud provider offers a different payment policy for storing buckets. To avoid unexpected costs, verify the payment policy with the given provider before you start using Gateway mode. To reduce the costs in general, always try to limit the number of buckets and create them for groups and domains rather than separate assets.
+>**TIP:** Using Gateway mode may generate additional costs for storing buckets, assets, or traffic in general. To avoid them, verify the payment policy with the given provider before you switch to Gateway mode. 
 
 See [this tutorial](#tutorials-set-minio-to-gateway-mode) to learn how to set MinIO to Google Cloud Storage Gateway mode.
 

--- a/docs/rafter/03-04-minio-gateway.md
+++ b/docs/rafter/03-04-minio-gateway.md
@@ -30,6 +30,8 @@ For the production purposes, Rafter uses MinIO Gateway which:
 
 ![](./assets/minio-gateway.svg)
 
+>**TIP:** Every cloud provider offers a different payment policy for storing buckets. To avoid unexpected costs, verify the payment policy with the given provider before you start using Gateway mode. To reduce the costs in general, always try to limit the number of buckets and create them for groups and domains rather than separate assets.
+
 See [this tutorial](#tutorials-set-minio-to-gateway-mode) to learn how to set MinIO to Google Cloud Storage Gateway mode.
 
 ## Access MinIO credentials

--- a/docs/rafter/03-04-minio-gateway.md
+++ b/docs/rafter/03-04-minio-gateway.md
@@ -30,7 +30,7 @@ For the production purposes, Rafter uses MinIO Gateway which:
 
 ![](./assets/minio-gateway.svg)
 
->**TIP:** Using Gateway mode may generate additional costs for storing buckets, assets, or traffic in general. To avoid them, verify the payment policy with the given provider before you switch to Gateway mode. 
+>**TIP:** Using Gateway mode may generate additional costs for storing buckets, assets, or traffic in general. To avoid them, verify the payment policy with the given cloud provider before you switch to Gateway mode. 
 
 See [this tutorial](#tutorials-set-minio-to-gateway-mode) to learn how to set MinIO to Google Cloud Storage Gateway mode.
 

--- a/docs/rafter/03-06-upload-service.md
+++ b/docs/rafter/03-06-upload-service.md
@@ -3,14 +3,14 @@ title: Upload Service
 type: Details
 ---
 
-The Upload Service is an HTTP server that exposes the file upload functionality for MinIO. It contains a simple HTTP endpoint which accepts `multipart/form-data` forms. It can upload files to the private and public system buckets.
+The Upload Service is an HTTP server that exposes the file upload functionality for MinIO. It contains a simple HTTP endpoint which accepts `multipart/form-data` forms. It uploads files to public system buckets.
 
 The main purpose of the service is to provide a solution for hosting static files for components that use Rafter, such as the [Application Connector](/components/application-connector/#overview-overview).
 You can also use the Upload Service for development purposes to host files for Rafter, without the need to rely on external providers.
 
 ## System buckets
 
-The Upload Service creates two system buckets, `system-private-{generated-suffix}` and `system-public-{generated-suffix}`, where `{generated-suffix}` is a Unix nano timestamp in the 32-base number system. The public bucket has a read-only policy specified.
+The Upload Service creates a `system-public-{generated-suffix}` system bucket, where `{generated-suffix}` is a Unix nano timestamp in the 32-base number system. The public bucket has a read-only policy specified.
 
 To enable the service scaling and to maintain the bucket configuration data between the application restarts, the Upload Service stores its configuration in the `rafter-upload-service` ConfigMap.
 
@@ -34,14 +34,13 @@ You can access the service on port `3000`.
 
 To upload files, send the multipart form **POST** request to the `/v1/upload` endpoint. The endpoint recognizes the following field names:
 
-- `private` that is an array of files to upload to a private system bucket.
 - `public` that is an array of files to upload to a public system bucket.
 - `directory` that is an optional directory for storing the uploaded files. If you do not specify it, the service creates a directory with a random name. If the directory and files already exist, the service overwrites them.
 
 To do the multipart request using `curl`, run the following command:
 
 ```bash
-curl -v -F directory='example' -F private=@sample.md -F private=@text-file.md -F public=@archive.zip http://localhost:3000/v1/upload
+curl -v -F directory='example' -F public=@sample.md -F public=@text-file.md -F public=@archive.zip http://localhost:3000/v1/upload
 ```
 
 The result is as follows:
@@ -51,8 +50,8 @@ The result is as follows:
    "uploadedFiles": [
       {
          "fileName": "text-file.md",
-         "remotePath": "{STORAGE_ADDRESS}/private-1b0sjap35m9o0/example/text-file.md",
-         "bucket": "private-1b0sjap35m9o0",
+         "remotePath": "{STORAGE_ADDRESS}/public-1b0sjap35m9o0/example/text-file.md",
+         "bucket": "public-1b0sjap35m9o0",
          "size": 212
       },
       {
@@ -63,8 +62,8 @@ The result is as follows:
       },
       {
          "fileName": "sample.md",
-         "remotePath": "{STORAGE_ADDRESS}/private-1b0sjap35m9o0/example/sample.md",
-         "bucket": "private-1b0sjap35m9o0",
+         "remotePath": "{STORAGE_ADDRESS}/public-1b0sjap35m9o0/example/sample.md",
+         "bucket": "public-1b0sjap35m9o0",
          "size": 4414
       }
    ]

--- a/docs/rafter/08-02-set-minio-to-gateway-mode.md
+++ b/docs/rafter/08-02-set-minio-to-gateway-mode.md
@@ -5,7 +5,7 @@ type: Tutorials
 
 By default, you install Kyma with Rafter in MinIO stand-alone mode. This tutorial shows how to set MinIO to Gateway mode on different cloud providers using an [override](/root/kyma/#configuration-helm-overrides-for-kyma-installation).
 
->**TIP:** Every cloud provider offers a different payment policy for storing buckets. To avoid unexpected costs, verify the payment policy with the given provider before you start using Gateway mode. To reduce the costs in general, always try to limit the number of buckets and create them for groups and domains rather than separate assets.
+>**CAUTION:** The authentication and authorization measures required to edit the assets in the public cloud storage may differ from those used in Rafter. That's why, we recommend using separate subscriptions for Minio Gateway to ensure that you only have access to data created by Rafter, and to avoid compromising other public data.
 
 ## Prerequisites
 

--- a/docs/rafter/08-02-set-minio-to-gateway-mode.md
+++ b/docs/rafter/08-02-set-minio-to-gateway-mode.md
@@ -5,7 +5,7 @@ type: Tutorials
 
 By default, you install Kyma with Rafter in MinIO stand-alone mode. This tutorial shows how to set MinIO to Gateway mode on different cloud providers using an [override](/root/kyma/#configuration-helm-overrides-for-kyma-installation).
 
->**CAUTION:** The authentication and authorization measures required to edit the assets in the public cloud storage may differ from those used in Rafter. That's why, we recommend using separate subscriptions for Minio Gateway to ensure that you only have access to data created by Rafter, and to avoid compromising other public data.
+>**CAUTION:** The authentication and authorization measures required to edit the assets in the public cloud storage may differ from those used in Rafter. That's why we recommend using separate subscriptions for Minio Gateway to ensure that you only have access to data created by Rafter, and to avoid compromising other public data.
 
 ## Prerequisites
 


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Removed any private bucket references from Rafter docs
- Added clear notes that Rafter is only for storing public data
- Emphasized that you should use separate subscriptions in Gateway mode.

**Related issue(s)**
See also #https://github.com/kyma-project/rafter/issues/51
