### PR TITLE
Update backup docs with the troubleshooting section for Rafter

### DIFF
--- a/docs/backup/08-02-restore-backup.md
+++ b/docs/backup/08-02-restore-backup.md
@@ -70,31 +70,7 @@ Follow these steps to restore resources:
     velero restore create --from-backup <BACKUP_NAME> --include-resources customresourcedefinitions.apiextensions.k8s.io,services,endpoints --wait
     ```
 
-4. Patch Velero deployment:
-
-    ```bash
-    kubectl patch deployment -n velero velero -p '
-        {  
-          "spec": {
-            "template": {
-              "spec": {
-                "containers": [
-                  {
-                    "args": [
-                      "server",
-                      "--restore-resource-priorities=namespaces,persistentvolumes,persistentvolumeclaims,secrets,configmaps,serviceaccounts,limitranges,pods,clusterbuckets.rafter.kyma-project.io,buckets.rafter.kyma-project.io,  clusterassets.rafter.kyma-project.io,assets.rafter.kyma-project.io"
-                    ],
-                    "name": "velero"
-                  }
-                ]
-              }
-            }
-          }
-        }
-        '
-    ```
-
-5. Restore the rest of Kyma resources:
+4. Restore the rest of Kyma resources:
 
     ```bash
     velero restore create --from-backup <BACKUP_NAME> --exclude-resources customresourcedefinitions.apiextensions.k8s.io,services,endpoints --restore-volumes --wait
@@ -113,7 +89,7 @@ Follow these steps to restore resources:
     > kubectl get virtualservices --all-namespaces
     > ```
 
-6. Once the restore succeeds, remove the `velero` Namespace:
+5. Once the restore succeeds, remove the `velero` Namespace:
 
     ```bash
     kubectl delete ns velero

--- a/docs/backup/10-01-restore-troubleshooting.md
+++ b/docs/backup/10-01-restore-troubleshooting.md
@@ -1,5 +1,5 @@
 ---
-title: Restore troubleshooting 
+title: Restore troubleshooting
 type: Troubleshooting
 ---
 
@@ -33,3 +33,23 @@ If one or more channels report as not ready, delete their corresponding channel 
 kubectl delete service -l messaging.knative.dev/role=natss-channel -n kyma-system
 kubectl annotate natsschannels.messaging.knative.dev -n kyma-system restore=done --all
 ```
+
+## AssetGroup restoration fails due to duplicated default buckets
+
+Velero restores Kyma resources asynchronously, following the alphabetical `kind` object order. This creates issues for Rafter as Velero first restores (Cluster)AssetGroups and then buckets. When the (Cluster)AssetGroup controller notices there are no default buckets available, it automatically tries to create them. If Velero restores the default buckets in the meantime, (Cluster)AssetGroups restoration will fail due to too many buckets with the `rafter.kyma-project.io/access:public` label.
+
+To fix this issue, manually remove all default buckets with the `rafter.kyma-project.io/access:public` label right after restoring Kyma:  
+
+1. Remove the cluster-wide default bucket:
+
+   ```bash
+   kubectl delete clusterbuckets.rafter.kyma-project.io --selector='rafter.kyma-project.io/access=public'
+   ```
+
+2. Remove buckets from the Namespaces where you use them:
+
+   ```bash
+   kubectl delete buckets.rafter.kyma-project.io --selector='rafter.kyma-project.io/access=public' --namespace=default
+   ```
+
+This allows the (Cluster)AssetGroup controller to recreate the default buckets successfully.


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Added a new troubleshooting section to Velero docs that relates to Rafter manual buckets removal

>**NOTE:** This PR can be merged only if there is no change in the Kyma resource restoration order by 1.10.

**Related issue(s)**
See also #6539
