### PR TITLE
Adding Przemyslaw Golicz(koala7659) as a codeowner of Kyma components

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -50,31 +50,31 @@
 /resources/rafter/ @michal-hudy @m00g3n @aerfio @magicmatatjahu
 
 # The `application-connector` chart
-/resources/application-connector/ @akgalwas @janmedrek @Szymongib @franpog859 @Maladie @crabtree
+/resources/application-connector/ @akgalwas @janmedrek @Szymongib @franpog859 @Maladie @crabtree @koala7659
 
 # The `values.yaml` file for `application-connector` chart
 /resources/application-connector/values.yaml @kyma-project/developers
 
 # The `connector-service` subchart
-/resources/application-connector/charts/connector-service/ @akgalwas @janmedrek @Szymongib @franpog859 @Maladie @crabtree
+/resources/application-connector/charts/connector-service/ @akgalwas @janmedrek @Szymongib @franpog859 @Maladie @crabtree @koala7659
 
 # The `connection-token-handler` subchart
-/resources/application-connector/charts/connection-token-handler/ @akgalwas @janmedrek @Szymongib @franpog859 @Maladie @crabtree
+/resources/application-connector/charts/connection-token-handler/ @akgalwas @janmedrek @Szymongib @franpog859 @Maladie @crabtree @koala7659
 
 # The `connectivity-certs-controller` subchart
-/resources/application-connector/charts/connectivity-certs-controller/ @akgalwas @janmedrek @Szymongib @franpog859 @Maladie @crabtree
+/resources/application-connector/charts/connectivity-certs-controller/ @akgalwas @janmedrek @Szymongib @franpog859 @Maladie @crabtree @koala7659
 
 # The `application-registry` subchart
-/resources/application-connector/charts/application-registry/ @akgalwas @janmedrek @Szymongib @franpog859 @Maladie @crabtree
+/resources/application-connector/charts/application-registry/ @akgalwas @janmedrek @Szymongib @franpog859 @Maladie @crabtree @koala7659
 
 # The `application-operator` subchart
-/resources/application-connector/charts/application-operator/ @akgalwas @janmedrek @Szymongib @franpog859 @Maladie @crabtree
+/resources/application-connector/charts/application-operator/ @akgalwas @janmedrek @Szymongib @franpog859 @Maladie @crabtree @koala7659
 
 # The `application-connector-helper` chart
-/resources/application-connector-helper/ @piotrmsc @kubadz @strekm @jakkab @Tomasz-Smelcerz-SAP @Demonsthere @akgalwas @janmedrek @Szymongib @franpog859 @Maladie @crabtree
+/resources/application-connector-helper/ @piotrmsc @kubadz @strekm @jakkab @Tomasz-Smelcerz-SAP @Demonsthere @akgalwas @janmedrek @Szymongib @franpog859 @Maladie @crabtree @koala7659
 
 # The `application-connector-ingress` chart
-/resources/application-connector-ingress/ @akgalwas @janmedrek @Szymongib @franpog859 @Maladie @crabtree
+/resources/application-connector-ingress/ @akgalwas @janmedrek @Szymongib @franpog859 @Maladie @crabtree @koala7659
 
 # The `console` subchart
 /resources/core/charts/console/ @dariadomagala @y-kkamil @parostatkiem @akucharska @Wawrzyn321 @kwiatekus @sjanota
@@ -188,14 +188,14 @@
 /resources/api-gateway/templates/api-rules-microfrontend.yaml @dariadomagala @parostatkiem @akucharska @Wawrzyn321 @kwiatekus @sjanota
 
 # The `compass` chart
-/resources/compass/ @PK85 @aszecowka @crabtree @pkosiec @kfurgol @tgorgol @dbadura @kjaksik @akgalwas @janmedrek @Szymongib @franpog859 @Maladie
-/resources/compass/values.yaml @PK85 @aszecowka @crabtree @pkosiec @kfurgol @tgorgol @dbadura @kjaksik @akgalwas @janmedrek @Szymongib @franpog859 @Maladie @mszostok @piotrmiskiewicz @polskikiel @ksputo @jasiu001
+/resources/compass/ @PK85 @aszecowka @crabtree @pkosiec @kfurgol @tgorgol @dbadura @kjaksik @akgalwas @janmedrek @Szymongib @franpog859 @Maladie @koala7659
+/resources/compass/values.yaml @PK85 @aszecowka @crabtree @pkosiec @kfurgol @tgorgol @dbadura @kjaksik @akgalwas @janmedrek @Szymongib @franpog859 @Maladie @mszostok @piotrmiskiewicz @polskikiel @ksputo @jasiu001 @koala7659
 
 # The `compass-cockpit` chart
 /resources/compass/charts/cockpit @dariadomagala @y-kkamil @parostatkiem @akucharska @Wawrzyn321 @kwiatekus @sjanota
 
 # The `compass-runtime-agent` chart
-/resources/compass-runtime-agent/ @PK85 @aszecowka @crabtree @pkosiec @kfurgol @tgorgol @dbadura @kjaksik @akgalwas @janmedrek @Szymongib @franpog859 @Maladie
+/resources/compass-runtime-agent/ @PK85 @aszecowka @crabtree @pkosiec @kfurgol @tgorgol @dbadura @kjaksik @akgalwas @janmedrek @Szymongib @franpog859 @Maladie @koala7659
 
 # The `kyma-environment-broker` chart
 /resources/compass/charts/kyma-environment-broker @PK85 @mszostok @piotrmiskiewicz @polskikiel @ksputo @jasiu001
@@ -251,28 +251,28 @@ components/etcd-tls-setup-job/ @aszecowka @PK85 @mszostok @piotrmiskiewicz @pols
 /components/idppreset/ @dariadomagala @y-kkamil @parostatkiem @akucharska @Wawrzyn321 @kwiatekus @sjanota
 
 # Connector Service Component
-/components/connector-service/ @akgalwas @janmedrek @Szymongib @franpog859 @Maladie @crabtree
+/components/connector-service/ @akgalwas @janmedrek @Szymongib @franpog859 @Maladie @crabtree @koala7659
 
 # Connection Token Handler Component
-/components/connection-token-handler/ @akgalwas @janmedrek @Szymongib @franpog859 @Maladie @crabtree
+/components/connection-token-handler/ @akgalwas @janmedrek @Szymongib @franpog859 @Maladie @crabtree @koala7659
 
 # Connectivity Certs Controller Component
-/components/connectivity-certs-controller/ @akgalwas @janmedrek @Szymongib @franpog859 @Maladie @crabtree
+/components/connectivity-certs-controller/ @akgalwas @janmedrek @Szymongib @franpog859 @Maladie @crabtree @koala7659
 
 # Application Registry Component
-/components/application-registry/ @akgalwas @janmedrek @Szymongib @franpog859 @Maladie @crabtree
+/components/application-registry/ @akgalwas @janmedrek @Szymongib @franpog859 @Maladie @crabtree @koala7659
 
 # Application Operator Component
-/components/application-operator/ @akgalwas @janmedrek @Szymongib @franpog859 @Maladie @crabtree
+/components/application-operator/ @akgalwas @janmedrek @Szymongib @franpog859 @Maladie @crabtree @koala7659
 
 # Application Gateway Component
-/components/application-gateway/ @akgalwas @janmedrek @Szymongib @franpog859 @Maladie @crabtree
+/components/application-gateway/ @akgalwas @janmedrek @Szymongib @franpog859 @Maladie @crabtree @koala7659
 
 # Application Connectivity Validator Component
-/components/application-connectivity-validator/ @akgalwas @janmedrek @Szymongib @franpog859 @Maladie @crabtree
+/components/application-connectivity-validator/ @akgalwas @janmedrek @Szymongib @franpog859 @Maladie @crabtree @koala7659
 
 # Application Connectivity Certs Setup Job Component
-/components/application-connectivity-certs-setup-job/ @akgalwas @janmedrek @Szymongib @franpog859 @Maladie @crabtree
+/components/application-connectivity-certs-setup-job/ @akgalwas @janmedrek @Szymongib @franpog859 @Maladie @crabtree @koala7659
 
 # Event Bus Component
 /components/event-bus/ @Abd4llA @joek @abbi-gaurav @rakesh-garimella @lilitgh @k15r @nachtmaar @anishj0shi @montaro @marcobebway @radufa @sayanh @antoineco
@@ -305,7 +305,7 @@ components/etcd-tls-setup-job/ @aszecowka @PK85 @mszostok @piotrmiskiewicz @pols
 /components/function-controller/ @Abd4llA @rakesh-garimella @lilitgh @k15r @nachtmaar @anishj0shi @montaro @marcobebway @radufa @sayanh @antoineco @michal-hudy @m00g3n @aerfio @magicmatatjahu
 
 # Compass Runtime Agent
-/components/compass-runtime-agent/ @PK85 @aszecowka @crabtree @pkosiec @kfurgol @tgorgol @dbadura @kjaksik @akgalwas @janmedrek @Szymongib @franpog859 @Maladie
+/components/compass-runtime-agent/ @PK85 @aszecowka @crabtree @pkosiec @kfurgol @tgorgol @dbadura @kjaksik @akgalwas @janmedrek @Szymongib @franpog859 @Maladie @koala7659
 
 # Tests
 # Service Catalog acceptance tests
@@ -339,25 +339,25 @@ components/etcd-tls-setup-job/ @aszecowka @PK85 @mszostok @piotrmiskiewicz @pols
 /tests/rafter/ @michal-hudy @m00g3n @aerfio @magicmatatjahu
 
 # Connector Service Tests
-/tests/connector-service-tests/ @akgalwas @janmedrek @Szymongib @franpog859 @Maladie @crabtree
+/tests/connector-service-tests/ @akgalwas @janmedrek @Szymongib @franpog859 @Maladie @crabtree @koala7659
 
 # Application Registry Tests
-/tests/application-registry-tests/ @akgalwas @janmedrek @Szymongib @franpog859 @Maladie @crabtree
+/tests/application-registry-tests/ @akgalwas @janmedrek @Szymongib @franpog859 @Maladie @crabtree @koala7659
 
 # Application Gateway Tests
-/tests/application-gateway-tests/ @akgalwas @janmedrek @Szymongib @franpog859 @Maladie @crabtree
+/tests/application-gateway-tests/ @akgalwas @janmedrek @Szymongib @franpog859 @Maladie @crabtree @koala7659
 
 # Application Operator Tests
-/tests/application-operator-tests/ @akgalwas @janmedrek @Szymongib @franpog859 @Maladie @crabtree
+/tests/application-operator-tests/ @akgalwas @janmedrek @Szymongib @franpog859 @Maladie @crabtree @koala7659
 
 # Application Connector Tests
-/tests/application-connector-tests/ @akgalwas @janmedrek @Szymongib @franpog859 @Maladie @crabtree
+/tests/application-connector-tests/ @akgalwas @janmedrek @Szymongib @franpog859 @Maladie @crabtree @koala7659
 
 # Connection Token Handler Tests
-/tests/connection-token-handler-tests/ @akgalwas @janmedrek @Szymongib @franpog859 @Maladie @crabtree
+/tests/connection-token-handler-tests/ @akgalwas @janmedrek @Szymongib @franpog859 @Maladie @crabtree @koala7659
 
 # Compass Runtime Agent Tests
-/tests/compass-runtime-agent/ @PK85 @aszecowka @crabtree @pkosiec @kfurgol @tgorgol @dbadura @kjaksik @akgalwas @janmedrek @Szymongib @franpog859 @Maladie
+/tests/compass-runtime-agent/ @PK85 @aszecowka @crabtree @pkosiec @kfurgol @tgorgol @dbadura @kjaksik @akgalwas @janmedrek @Szymongib @franpog859 @Maladie @koala7659
 
 # Knative Build Tests
 tests/knative-build @rakesh-garimella @lilitgh @k15r @nachtmaar @montaro @marcobebway @radufa @sayanh @antoineco @anishj0shi @Abd4llA

--- a/components/application-connectivity-certs-setup-job/OWNERS
+++ b/components/application-connectivity-certs-setup-job/OWNERS
@@ -5,5 +5,6 @@ approvers:
   - franpog859 
   - Maladie
   - crabtree
+  - koala7659
 labels:
   - area/application-connector

--- a/components/application-connectivity-validator/OWNERS
+++ b/components/application-connectivity-validator/OWNERS
@@ -5,5 +5,6 @@ approvers:
   - franpog859 
   - Maladie
   - crabtree
+  - koala7659
 labels:
   - area/application-connector

--- a/components/application-gateway/OWNERS
+++ b/components/application-gateway/OWNERS
@@ -5,5 +5,6 @@ approvers:
   - franpog859 
   - Maladie
   - crabtree
+  - koala7659
 labels:
   - area/application-connector

--- a/components/application-operator/OWNERS
+++ b/components/application-operator/OWNERS
@@ -5,5 +5,6 @@ approvers:
   - franpog859 
   - Maladie
   - crabtree
+  - koala7659
 labels:
   - area/application-connector

--- a/components/application-registry/OWNERS
+++ b/components/application-registry/OWNERS
@@ -5,5 +5,6 @@ approvers:
   - franpog859 
   - Maladie
   - crabtree
+  - koala7659
 labels:
   - area/application-connector

--- a/components/compass-runtime-agent/OWNERS
+++ b/components/compass-runtime-agent/OWNERS
@@ -5,6 +5,7 @@ approvers:
   - franpog859 
   - Maladie
   - crabtree
+  - koala7659
 
 reviewers:
   - PK85

--- a/components/connection-token-handler/OWNERS
+++ b/components/connection-token-handler/OWNERS
@@ -5,5 +5,6 @@ approvers:
   - franpog859 
   - Maladie
   - crabtree
+  - koala7659
 labels:
   - area/application-connector

--- a/components/connectivity-certs-controller/OWNERS
+++ b/components/connectivity-certs-controller/OWNERS
@@ -5,5 +5,6 @@ approvers:
   - franpog859 
   - Maladie
   - crabtree
+  - koala7659
 labels:
   - area/application-connector

--- a/components/connector-service/OWNERS
+++ b/components/connector-service/OWNERS
@@ -5,5 +5,6 @@ approvers:
   - franpog859 
   - Maladie
   - crabtree
+  - koala7659
 labels:
   - area/application-connector

--- a/resources/application-connector-helper/OWNERS
+++ b/resources/application-connector-helper/OWNERS
@@ -5,6 +5,7 @@ approvers:
   - franpog859 
   - Maladie
   - crabtree
+  - koala7659
 
 reviewers:
   - piotrmsc

--- a/resources/application-connector-ingress/OWNERS
+++ b/resources/application-connector-ingress/OWNERS
@@ -5,5 +5,6 @@ approvers:
   - franpog859 
   - Maladie
   - crabtree
+  - koala7659
 labels:
   - area/application-connector

--- a/resources/application-connector/OWNERS
+++ b/resources/application-connector/OWNERS
@@ -5,3 +5,4 @@ approvers:
   - franpog859 
   - Maladie
   - crabtree
+  - koala7659

--- a/resources/application-connector/charts/application-operator/OWNERS
+++ b/resources/application-connector/charts/application-operator/OWNERS
@@ -5,5 +5,6 @@ approvers:
   - franpog859 
   - Maladie
   - crabtree
+  - koala7659
 labels:
   - area/application-connector

--- a/resources/application-connector/charts/application-registry/OWNERS
+++ b/resources/application-connector/charts/application-registry/OWNERS
@@ -5,5 +5,6 @@ approvers:
   - franpog859 
   - Maladie
   - crabtree
+  - koala7659
 labels:
   - area/application-connector

--- a/resources/application-connector/charts/connection-token-handler/OWNERS
+++ b/resources/application-connector/charts/connection-token-handler/OWNERS
@@ -5,5 +5,6 @@ approvers:
   - franpog859 
   - Maladie
   - crabtree
+  - koala7659
 labels:
   - area/application-connector

--- a/resources/application-connector/charts/connectivity-certs-controller/OWNERS
+++ b/resources/application-connector/charts/connectivity-certs-controller/OWNERS
@@ -5,5 +5,6 @@ approvers:
   - franpog859 
   - Maladie
   - crabtree
+  - koala7659
 labels:
   - area/application-connector

--- a/resources/application-connector/charts/connector-service/OWNERS
+++ b/resources/application-connector/charts/connector-service/OWNERS
@@ -5,5 +5,6 @@ approvers:
   - franpog859 
   - Maladie
   - crabtree
+  - koala7659
 labels:
   - area/application-connector

--- a/resources/compass-runtime-agent/OWNERS
+++ b/resources/compass-runtime-agent/OWNERS
@@ -5,6 +5,7 @@ approvers:
   - franpog859 
   - Maladie
   - crabtree
+  - koala7659
 
 reviewers:
   - PK85

--- a/resources/compass/OWNERS
+++ b/resources/compass/OWNERS
@@ -11,3 +11,4 @@ approvers:
   - franpog859 
   - Maladie
   - dbadura
+  - koala7659

--- a/tests/application-connector-tests/OWNERS
+++ b/tests/application-connector-tests/OWNERS
@@ -5,5 +5,6 @@ approvers:
   - franpog859 
   - Maladie
   - crabtree
+  - koala7659
 labels:
   - area/application-connector

--- a/tests/application-gateway-tests/OWNERS
+++ b/tests/application-gateway-tests/OWNERS
@@ -5,5 +5,6 @@ approvers:
   - franpog859 
   - Maladie
   - crabtree
+  - koala7659
 labels:
   - area/application-connector

--- a/tests/application-operator-tests/OWNERS
+++ b/tests/application-operator-tests/OWNERS
@@ -5,5 +5,6 @@ approvers:
   - franpog859 
   - Maladie
   - crabtree
+  - koala7659
 labels:
   - area/application-connector

--- a/tests/application-registry-tests/OWNERS
+++ b/tests/application-registry-tests/OWNERS
@@ -5,5 +5,6 @@ approvers:
   - franpog859 
   - Maladie
   - crabtree
+  - koala7659
 labels:
   - area/application-connector

--- a/tests/compass-runtime-agent/OWNERS
+++ b/tests/compass-runtime-agent/OWNERS
@@ -5,6 +5,7 @@ approvers:
   - franpog859 
   - Maladie
   - crabtree
+  - koala7659
 
 reviewers:
   - PK85

--- a/tests/connection-token-handler-tests/OWNERS
+++ b/tests/connection-token-handler-tests/OWNERS
@@ -5,5 +5,6 @@ approvers:
   - franpog859 
   - Maladie
   - crabtree
+  - koala7659
 labels:
   - area/application-connector

--- a/tests/connector-service-tests/OWNERS
+++ b/tests/connector-service-tests/OWNERS
@@ -5,5 +5,6 @@ approvers:
   - franpog859 
   - Maladie
   - crabtree
+  - koala7659
 labels:
   - area/application-connector


### PR DESCRIPTION
**Description**

Adding Przemyslaw Golicz(koala7659) as a code owner for multiple Kyma modules:

- components/connectivity-certs-controller
- components/connection-token-handler
- components/compass-runtime-agent
- components/application-registry
- components/application-operator
- components/application-gateway
- components/connector-service
- components/application-connector-ingress
- components/application-connector-helper
- components/application-connectivity-validator
- components/application-certs-setup-job

The updates are also made for respective resources and helm charts.
