### PR TITLE
Upgrade istio installer image

### DIFF
--- a/components/istio-installer/Dockerfile
+++ b/components/istio-installer/Dockerfile
@@ -1,4 +1,4 @@
-FROM eu.gcr.io/kyma-project/test-infra/alpine-kubectl:v20190325-ff66a3a
+FROM eu.gcr.io/kyma-project/test-infra/alpine-kubectl:v20200121-4f3202bd
 
 LABEL source=git@github.com:kyma-project/kyma.git
 


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/master/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**
Upgrade istio installer image

Changes proposed in this pull request:

- Upgrade istio installer image to use latest alpine-kubectl with updated base image, kubectl and helm versions.

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
See also: https://github.com/kyma-project/test-infra/pull/1939
See also: kyma-project/kyma#5530