### PR TITLE
Mention the configmap mode in Rafter

### DIFF
--- a/docs/rafter/01-01-rafter.md
+++ b/docs/rafter/01-01-rafter.md
@@ -23,17 +23,17 @@ Rafter comes with the following set of services and extensions compatible with R
 
 >**CAUTION:** Rafter does not enforce any access control. To protect the confidentiality of your information, use Rafter only to store public data. Do not use it to process and store any kind of confidential information, including personal data.
 
-## What Rafter is not
-
-* Rafter is not a Wordpress-like [Content Management System](https://en.wikipedia.org/wiki/Content_management_system).
-* Rafter is not a solution for [Enterprise Content Management](https://en.wikipedia.org/wiki/Enterprise_content_management).
-* Rafter doesn't come with any out-of-the-box UI that allows you to modify or consume files managed by Rafter.
-
 ## What Rafter can be used for
 
 * Rafter is based on [CRs](https://kubernetes.io/docs/concepts/extend-kubernetes/api-extension/custom-resources/). Therefore, it is an extension of Kubernetes API and should be used mainly by developers building their solutions on top of Kubernetes,
 * Rafter is a file store that allows you to programmatically modify, validate the files and/or extract their metadata before they go to storage. Content of those files can be fetched using an API. This is a basic functionality of the [headless CMS](https://en.wikipedia.org/wiki/Headless_content_management_system) concept. If you want to deploy an application to Kubernetes and enrich it with additional documentation or specifications, you can do it using Rafter,
 * Rafter is an S3-like file store also for files written in HTML, CSS, and JS. It means that Rafter can be used as a hosting solution for client-side applications.
+
+## What Rafter is not
+
+* Rafter is not a Wordpress-like [Content Management System](https://en.wikipedia.org/wiki/Content_management_system).
+* Rafter is not a solution for [Enterprise Content Management](https://en.wikipedia.org/wiki/Enterprise_content_management).
+* Rafter doesn't come with any out-of-the-box UI that allows you to modify or consume files managed by Rafter.
 
 ## Benefits
 

--- a/docs/rafter/06-01-asset.md
+++ b/docs/rafter/06-01-asset.md
@@ -103,7 +103,7 @@ This table lists all possible parameters of a given resource together with their
 
 > **NOTE:** The Asset Controller automatically adds all parameters marked as **Not applicable** to the Asset CR.
 
->**TIP:** Rafter has an additional `configmap` mode that allows you to refer to asset sources stored in a ConfigMap. If you use this mode, set the **url** parameter to `{namespace}/(configmap-name)` like `url: default/sample-configmap`. This mode is not enabled in Kyma. If you want to see how it works, see [Rafter tutorials](https://katacoda.com/rafter/) for examples. 
+>**TIP:** Rafter has an additional `configmap` mode that allows you to refer to asset sources stored in a ConfigMap. If you use this mode, set the **url** parameter to `{namespace}/(configmap-name)`, like `url: default/sample-configmap`. This mode is not enabled in Kyma. If you want to see how it works, see [Rafter tutorials](https://katacoda.com/rafter/) for examples. 
 
 ### Status reasons
 

--- a/docs/rafter/06-01-asset.md
+++ b/docs/rafter/06-01-asset.md
@@ -101,8 +101,9 @@ This table lists all possible parameters of a given resource together with their
 | **status.assetRef.assets** | Not applicable | Provides the relative path to the given asset in the storage bucket. |
 | **status.assetRef.baseUrl** | Not applicable | Specifies the absolute path to the location of the assets in the storage bucket. |
 
-
 > **NOTE:** The Asset Controller automatically adds all parameters marked as **Not applicable** to the Asset CR.
+
+>**TIP:** Rafter has an additional `configmap` mode that allows you to refer to asset sources stored in a ConfigMap. If you use this mode, set the **url** parameter to `{namespace}/(configmap-name)` like `url: default/sample-configmap`. This mode is not enabled in Kyma. If you want to see how it works, see [Rafter tutorials](https://katacoda.com/rafter/) for examples. 
 
 ### Status reasons
 

--- a/docs/rafter/06-01-asset.md
+++ b/docs/rafter/06-01-asset.md
@@ -103,7 +103,7 @@ This table lists all possible parameters of a given resource together with their
 
 > **NOTE:** The Asset Controller automatically adds all parameters marked as **Not applicable** to the Asset CR.
 
-> **TIP:** Asset CRs have an additional `configmap` mode that allows you to refer to asset sources stored in ConfigMaps. If you use this mode, set the **url** parameter to `{namespace}/{configmap-name}`, like `url: default/sample-configmap`. This mode is not enabled in Kyma. If you want to see how it works, see [Rafter tutorials](https://katacoda.com/rafter/) for examples.
+> **TIP:** Asset CRs have an additional `configmap` mode that allows you to refer to asset sources stored in ConfigMaps. If you use this mode, set the **url** parameter to `{namespace}/{configMap-name}`, like `url: default/sample-configmap`. This mode is not enabled in Kyma. If you want to see how it works, see [Rafter tutorials](https://katacoda.com/rafter/) for examples.
 
 ### Status reasons
 

--- a/docs/rafter/06-01-asset.md
+++ b/docs/rafter/06-01-asset.md
@@ -103,7 +103,7 @@ This table lists all possible parameters of a given resource together with their
 
 > **NOTE:** The Asset Controller automatically adds all parameters marked as **Not applicable** to the Asset CR.
 
->**TIP:** Asset CRs have an additional `configmap` mode that allows you to refer to asset sources stored in ConfigMaps. If you use this mode, set the **url** parameter to `{namespace}/(configmap-name)`, like `url: default/sample-configmap`. This mode is not enabled in Kyma. If you want to see how it works, see [Rafter tutorials](https://katacoda.com/rafter/) for examples. 
+> **TIP:** Asset CRs have an additional `configmap` mode that allows you to refer to asset sources stored in ConfigMaps. If you use this mode, set the **url** parameter to `{namespace}/{configmap-name}`, like `url: default/sample-configmap`. This mode is not enabled in Kyma. If you want to see how it works, see [Rafter tutorials](https://katacoda.com/rafter/) for examples.
 
 ### Status reasons
 

--- a/docs/rafter/06-01-asset.md
+++ b/docs/rafter/06-01-asset.md
@@ -103,7 +103,7 @@ This table lists all possible parameters of a given resource together with their
 
 > **NOTE:** The Asset Controller automatically adds all parameters marked as **Not applicable** to the Asset CR.
 
->**TIP:** Rafter has an additional `configmap` mode that allows you to refer to asset sources stored in a ConfigMap. If you use this mode, set the **url** parameter to `{namespace}/(configmap-name)`, like `url: default/sample-configmap`. This mode is not enabled in Kyma. If you want to see how it works, see [Rafter tutorials](https://katacoda.com/rafter/) for examples. 
+>**TIP:** Asset CRs have an additional `configmap` mode that allows you to refer to asset sources stored in ConfigMaps. If you use this mode, set the **url** parameter to `{namespace}/(configmap-name)`, like `url: default/sample-configmap`. This mode is not enabled in Kyma. If you want to see how it works, see [Rafter tutorials](https://katacoda.com/rafter/) for examples. 
 
 ### Status reasons
 

--- a/docs/rafter/06-01-asset.md
+++ b/docs/rafter/06-01-asset.md
@@ -103,7 +103,7 @@ This table lists all possible parameters of a given resource together with their
 
 > **NOTE:** The Asset Controller automatically adds all parameters marked as **Not applicable** to the Asset CR.
 
-> **TIP:** Asset CRs have an additional `configmap` mode that allows you to refer to asset sources stored in ConfigMaps. If you use this mode, set the **url** parameter to `{namespace}/{configMap-name}`, like `url: default/sample-configmap`. This mode is not enabled in Kyma. If you want to see how it works, see [Rafter tutorials](https://katacoda.com/rafter/) for examples.
+> **TIP:** Asset CRs have an additional `configmap` mode that allows you to refer to asset sources stored in ConfigMaps. If you use this mode, set the **url** parameter to `{namespace}/{configMap-name}`, like `url: default/sample-configmap`. This mode is not enabled in Kyma. To check how it works, see [Rafter tutorials](https://katacoda.com/rafter/) for examples.
 
 ### Status reasons
 

--- a/docs/rafter/06-02-assetgroup.md
+++ b/docs/rafter/06-02-assetgroup.md
@@ -75,7 +75,7 @@ This table lists all possible parameters of a given resource together with their
 
 >**NOTE:** The AssetGroup Controller automatically adds all parameters marked as **Not applicable** to the AssetGroup CR.
 
->**TIP:** Rafter has an additional `configmap` mode that allows you to refer to asset sources stored in a ConfigMap. If you use this mode, set the **url** parameter to `{namespace}/(configmap-name)` like `url: default/sample-configmap`. This mode is not enabled in Kyma. If you want to see how it works, see [Rafter tutorials](https://katacoda.com/rafter/) for examples. 
+>**TIP:** Rafter has an additional `configmap` mode that allows you to refer to asset sources stored in a ConfigMap. If you use this mode, set the **url** parameter to `{namespace}/(configmap-name)`, like `url: default/sample-configmap`. This mode is not enabled in Kyma. If you want to see how it works, see [Rafter tutorials](https://katacoda.com/rafter/) for examples. 
 
 ### Status reasons
 

--- a/docs/rafter/06-02-assetgroup.md
+++ b/docs/rafter/06-02-assetgroup.md
@@ -75,7 +75,7 @@ This table lists all possible parameters of a given resource together with their
 
 > **NOTE:** The AssetGroup Controller automatically adds all parameters marked as **Not applicable** to the AssetGroup CR.
 
-> **TIP:** ClusterAsset CRs have an additional `configmap` mode that allows you to refer to asset sources stored in ConfigMaps. If you use this mode, set the **url** parameter to `{namespace}/{configmap-name}`, like `url: default/sample-configmap`. This mode is not enabled in Kyma. If you want to see how it works, see [Rafter tutorials](https://katacoda.com/rafter/) for examples.
+> **TIP:** ClusterAsset CRs have an additional `configmap` mode that allows you to refer to asset sources stored in ConfigMaps. If you use this mode, set the **url** parameter to `{namespace}/{configMap-name}`, like `url: default/sample-configmap`. This mode is not enabled in Kyma. If you want to see how it works, see [Rafter tutorials](https://katacoda.com/rafter/) for examples.
 
 ### Status reasons
 

--- a/docs/rafter/06-02-assetgroup.md
+++ b/docs/rafter/06-02-assetgroup.md
@@ -75,6 +75,8 @@ This table lists all possible parameters of a given resource together with their
 
 >**NOTE:** The AssetGroup Controller automatically adds all parameters marked as **Not applicable** to the AssetGroup CR.
 
+>**TIP:** Rafter has an additional `configmap` mode that allows you to refer to asset sources stored in a ConfigMap. If you use this mode, set the **url** parameter to `{namespace}/(configmap-name)` like `url: default/sample-configmap`. This mode is not enabled in Kyma. If you want to see how it works, see [Rafter tutorials](https://katacoda.com/rafter/) for examples. 
+
 ### Status reasons
 
 Processing of an AssetGroup CR can succeed, continue, or fail for one of these reasons:

--- a/docs/rafter/06-02-assetgroup.md
+++ b/docs/rafter/06-02-assetgroup.md
@@ -73,9 +73,9 @@ This table lists all possible parameters of a given resource together with their
 | **status.phase** | Not applicable | The AssetGroup Controller adds it to the AssetGroup CR. It describes the status of processing the AssetGroup CR by the AssetGroup Controller. It can be `Ready`, `Pending`, or `Failed`. |
 | **status.reason** | Not applicable | Provides the reason why the AssetGroup CR processing succeeded, is pending, or failed. See the [**Reasons**](#status-reasons) section for the full list of possible status reasons and their descriptions. |
 
->**NOTE:** The AssetGroup Controller automatically adds all parameters marked as **Not applicable** to the AssetGroup CR.
+> **NOTE:** The AssetGroup Controller automatically adds all parameters marked as **Not applicable** to the AssetGroup CR.
 
->**TIP:** ClusterAsset CRs have an additional `configmap` mode that allows you to refer to asset sources stored in ConfigMaps. If you use this mode, set the **url** parameter to `{namespace}/(configmap-name)`, like `url: default/sample-configmap`. This mode is not enabled in Kyma. If you want to see how it works, see [Rafter tutorials](https://katacoda.com/rafter/) for examples.
+> **TIP:** ClusterAsset CRs have an additional `configmap` mode that allows you to refer to asset sources stored in ConfigMaps. If you use this mode, set the **url** parameter to `{namespace}/{configmap-name}`, like `url: default/sample-configmap`. This mode is not enabled in Kyma. If you want to see how it works, see [Rafter tutorials](https://katacoda.com/rafter/) for examples.
 
 ### Status reasons
 

--- a/docs/rafter/06-02-assetgroup.md
+++ b/docs/rafter/06-02-assetgroup.md
@@ -75,7 +75,7 @@ This table lists all possible parameters of a given resource together with their
 
 > **NOTE:** The AssetGroup Controller automatically adds all parameters marked as **Not applicable** to the AssetGroup CR.
 
-> **TIP:** ClusterAsset CRs have an additional `configmap` mode that allows you to refer to asset sources stored in ConfigMaps. If you use this mode, set the **url** parameter to `{namespace}/{configMap-name}`, like `url: default/sample-configmap`. This mode is not enabled in Kyma. If you want to see how it works, see [Rafter tutorials](https://katacoda.com/rafter/) for examples.
+> **TIP:** ClusterAsset CRs have an additional `configmap` mode that allows you to refer to asset sources stored in ConfigMaps. If you use this mode, set the **url** parameter to `{namespace}/{configMap-name}`, like `url: default/sample-configmap`. This mode is not enabled in Kyma. To check how it works, see [Rafter tutorials](https://katacoda.com/rafter/) for examples.
 
 ### Status reasons
 

--- a/docs/rafter/06-02-assetgroup.md
+++ b/docs/rafter/06-02-assetgroup.md
@@ -75,7 +75,7 @@ This table lists all possible parameters of a given resource together with their
 
 >**NOTE:** The AssetGroup Controller automatically adds all parameters marked as **Not applicable** to the AssetGroup CR.
 
->**TIP:** Rafter has an additional `configmap` mode that allows you to refer to asset sources stored in a ConfigMap. If you use this mode, set the **url** parameter to `{namespace}/(configmap-name)`, like `url: default/sample-configmap`. This mode is not enabled in Kyma. If you want to see how it works, see [Rafter tutorials](https://katacoda.com/rafter/) for examples. 
+>**TIP:** ClusterAsset CRs have an additional `configmap` mode that allows you to refer to asset sources stored in ConfigMaps. If you use this mode, set the **url** parameter to `{namespace}/(configmap-name)`, like `url: default/sample-configmap`. This mode is not enabled in Kyma. If you want to see how it works, see [Rafter tutorials](https://katacoda.com/rafter/) for examples.
 
 ### Status reasons
 


### PR DESCRIPTION

**Description**

Changes proposed in this pull request:

- Add TIPs in docs for Asset and ClusterAsset CRDs with info that there is an additional `configmap` mode in Rafter, that is not enabled in Kyma

**Related issue(s)**
See also #https://github.com/kyma-project/rafter/issues/61
