### PR TITLE
Make the Ports configurable based on cloud provider

### DIFF
--- a/resources/monitoring/templates/exporters/core-dns/service.yaml
+++ b/resources/monitoring/templates/exporters/core-dns/service.yaml
@@ -1,6 +1,4 @@
 {{- if .Values.coreDns.enabled }}
-  {{- if .Values.configuration.provider -}}
-  {{- $provider := .Values.configuration.provider -}}
 apiVersion: v1
 kind: Service
 metadata:
@@ -14,11 +12,11 @@ spec:
   clusterIP: None
   ports:
     - name: http-metrics
-      {{- if eq $provider "azure" }}
+      {{- if eq .Values.global.provider "azure" }}
       port: {{ .Values.coreDns.service.azPort }}
       protocol: TCP
       targetPort: {{ .Values.coreDns.service.azTargetPort }}
-      {{- else if eq $provider "gcp" }}
+      {{- else if eq .Values.global.provider "gcp" }}
       port: {{ .Values.coreDns.service.gcpPort }}
       protocol: TCP
       targetPort: {{ .Values.coreDns.service.gcpTargetPort }}
@@ -29,5 +27,4 @@ spec:
     {{- else}}
     k8s-app: kube-dns
     {{- end}}
-  {{- end}}
 {{- end }}

--- a/resources/monitoring/templates/exporters/core-dns/service.yaml
+++ b/resources/monitoring/templates/exporters/core-dns/service.yaml
@@ -13,14 +13,16 @@ spec:
   ports:
     - name: http-metrics
       {{- if eq .Values.global.provider "azure" }}
-      port: {{ .Values.coreDns.service.azPort }}
-      protocol: TCP
-      targetPort: {{ .Values.coreDns.service.azTargetPort }}
+      port: {{ .Values.coreDns.service.defaultPort }}
+      targetPort: {{ .Values.coreDns.service.defaultTargetPort }}
       {{- else if eq .Values.global.provider "gcp" }}
       port: {{ .Values.coreDns.service.gcpPort }}
-      protocol: TCP
       targetPort: {{ .Values.coreDns.service.gcpTargetPort }}
+      {{- else }}
+      port: {{ .Values.coreDns.service.defaultPort }}
+      targetPort: {{ .Values.coreDns.service.defaultTargetPort }}
       {{- end}}
+      protocol: TCP
   selector:
     {{- if .Values.coreDns.service.selector }}
 {{ toYaml .Values.coreDns.service.selector | indent 4 }}

--- a/resources/monitoring/templates/exporters/core-dns/service.yaml
+++ b/resources/monitoring/templates/exporters/core-dns/service.yaml
@@ -1,4 +1,6 @@
 {{- if .Values.coreDns.enabled }}
+  {{- if .Values.configuration.provider -}}
+  {{- $provider := .Values.configuration.provider -}}
 apiVersion: v1
 kind: Service
 metadata:
@@ -12,13 +14,20 @@ spec:
   clusterIP: None
   ports:
     - name: http-metrics
-      port: {{ .Values.coreDns.service.port }}
+      {{- if eq $provider "azure" }}
+      port: {{ .Values.coreDns.service.azPort }}
       protocol: TCP
-      targetPort: {{ .Values.coreDns.service.targetPort }}
+      targetPort: {{ .Values.coreDns.service.azTargetPort }}
+      {{- else if eq $provider "gcp" }}
+      port: {{ .Values.coreDns.service.gcpPort }}
+      protocol: TCP
+      targetPort: {{ .Values.coreDns.service.gcpTargetPort }}
+      {{- end}}
   selector:
     {{- if .Values.coreDns.service.selector }}
 {{ toYaml .Values.coreDns.service.selector | indent 4 }}
     {{- else}}
     k8s-app: kube-dns
     {{- end}}
+  {{- end}}
 {{- end }}

--- a/resources/monitoring/values.yaml
+++ b/resources/monitoring/values.yaml
@@ -1,4 +1,5 @@
 global:
+  provider: ""
   isLocalEnv: false
   containerRegistry:
     path: eu.gcr.io/kyma-project

--- a/resources/monitoring/values.yaml
+++ b/resources/monitoring/values.yaml
@@ -691,8 +691,8 @@ coreDns:
     # Changed from the default value of 9153 to 10054 to make it work on GKE.
     gcpPort: 10054
     gcpTargetPort: 10054
-    azPort: 9153
-    azTargetPort: 9153
+    defaultPort: 9153
+    defaultTargetPort: 9153
     # selector:
     #  k8s-app: kube-dns
   serviceMonitor:

--- a/resources/monitoring/values.yaml
+++ b/resources/monitoring/values.yaml
@@ -688,8 +688,10 @@ coreDns:
   enabled: true
   service:
     # Changed from the default value of 9153 to 10054 to make it work on GKE.
-    port: 10054
-    targetPort: 10054
+    gcpPort: 10054
+    gcpTargetPort: 10054
+    azPort: 9153
+    azTargetPort: 9153
     # selector:
     #  k8s-app: kube-dns
   serviceMonitor:


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/master/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**
Make the core DNS service port configurable based on cloud provider as the metrics are exposed on different ports on Azure and on GKE.

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
