### PR TITLE
Add explicit value for max-pods option in AKS provisioning

### DIFF
--- a/docs/kyma/04-04-cluster-installation.md
+++ b/docs/kyma/04-04-cluster-installation.md
@@ -124,7 +124,8 @@ This installation guide explains how you can quickly deploy Kyma on a cluster wi
       --node-vm-size "Standard_D4_v3" \
       --kubernetes-version 1.14.6 \
       --enable-addons "monitoring,http_application_routing" \
-      --generate-ssh-keys
+      --generate-ssh-keys \
+      --max-pods 110
     ```
 
 4. To configure kubectl to use your new cluster, run:

--- a/docs/kyma/04-05-use-your-own-domain.md
+++ b/docs/kyma/04-05-use-your-own-domain.md
@@ -377,6 +377,7 @@ Get the TLS certificate:
       --kubernetes-version 1.14.6 \
       --enable-addons "monitoring,http_application_routing" \
       --generate-ssh-keys
+      --max-pods 110
     ```
 
 4. To configure kubectl to use your new cluster, run:

--- a/docs/kyma/04-05-use-your-own-domain.md
+++ b/docs/kyma/04-05-use-your-own-domain.md
@@ -376,7 +376,7 @@ Get the TLS certificate:
       --node-vm-size "Standard_D4_v3" \
       --kubernetes-version 1.14.6 \
       --enable-addons "monitoring,http_application_routing" \
-      --generate-ssh-keys
+      --generate-ssh-keys \
       --max-pods 110
     ```
 


### PR DESCRIPTION
**Description**

The default value varies depending on network plugin, therefore it is better to provide it explicitly.

**Related issue(s)**
#6933 