### PR TITLE
Unify backend and frontend naming in docs

### DIFF
--- a/docs/console/06-02-clustermicrofrontend.md
+++ b/docs/console/06-02-clustermicrofrontend.md
@@ -49,14 +49,14 @@ This table lists all the possible parameters of a given resource together with t
 | Field   |      Required      |  Description |
 |----------|:-------------:|------|
 | **metadata.name** | Yes | Specifies the name of the CR. |
-| **spec.version** | No | Specifies the version of the cluster micro front-end. |
-| **spec.category** | No | Defines the category name under which the cluster micro front-end appears in the navigation. |
-| **spec.viewBaseUrl** | Yes | Specifies the address of the cluster micro front-end. The address has to begin with `https://`.  |
-| **spec.placement** | No |  Specifies if the cluster micro front-end should be visible in the Namespace navigation or settings navigation. The placement value has to be either `namespace` or `cluster`. |
-| **spec.navigationNodes** | Yes | The list of navigation nodes specified for the cluster micro front-end. |
-| **spec.navigationNodes.label** | Yes | Specifies the name used to display the cluster micro front-end's node in the Console UI. |
+| **spec.version** | No | Specifies the version of the cluster micro frontend. |
+| **spec.category** | No | Defines the category name under which the cluster micro frontend appears in the navigation. |
+| **spec.viewBaseUrl** | Yes | Specifies the address of the cluster micro frontend. The address has to begin with `https://`.  |
+| **spec.placement** | No |  Specifies if the cluster micro frontend should be visible in the Namespace navigation or settings navigation. The placement value has to be either `namespace` or `cluster`. |
+| **spec.navigationNodes** | Yes | The list of navigation nodes specified for the cluster micro frontend. |
+| **spec.navigationNodes.label** | Yes | Specifies the name used to display the cluster micro frontend's node in the Console UI. |
 | **spec.navigationNodes.navigationPath** | No | Specifies the path that is used for routing within the Console. |
-| **spec.navigationNodes.viewUrl** | No | Specifies the URL used to display the content of the cluster micro-front end. |
-| **spec.navigationNodes.externalLink** | No | Specifies the URL used to display the content of the cluster micro front-end in a new browser tab. |
-| **spec.navigationNodes.showInNavigation** | No | The Boolean that specifies if the cluster micro front-end's node is visible in the navigation or not. |
+| **spec.navigationNodes.viewUrl** | No | Specifies the URL used to display the content of the cluster micro frontend. |
+| **spec.navigationNodes.externalLink** | No | Specifies the URL used to display the content of the cluster micro frontend in a new browser tab. |
+| **spec.navigationNodes.showInNavigation** | No | The Boolean that specifies if the cluster micro frontend's node is visible in the navigation or not. |
 | **spec.navigationNodes.requiredPermissions** | No | Specifies the list of permissions (RBAC rules) that determine if the navigation node should be shown for the current user.  |

--- a/docs/event-bus/03-01-concepts.md
+++ b/docs/event-bus/03-01-concepts.md
@@ -9,7 +9,7 @@ The following resources are involved in Event transfer and validation in Kyma:
 
 * **NATS Streaming** is an open source, log-based streaming system that serves as a database allowing the Event Bus to store and transfer the Events on a large scale.
 
-* **Persistence** is a back-end storage volume for NATS Streaming that stores Events. When the Event flow fails, the Event Bus can resume the process using the Events saved in Persistence.
+* **Persistence** is a backend storage volume for NATS Streaming that stores Events. When the Event flow fails, the Event Bus can resume the process using the Events saved in Persistence.
 
 * **Publish** is an internal Event Bus service that transfers the enriched Event from a given external solution to NATS Streaming.
 

--- a/docs/tracing/03-01-distributed-tracing.md
+++ b/docs/tracing/03-01-distributed-tracing.md
@@ -4,9 +4,9 @@ type: Details
 ---
 
 
-Observability tools should clearly show the big picture, no matter if they help you monitor just a couple or multiple components. In a cloud-native microservice architecture, a user request often flows through dozens of different microservices. Tools such as logging or monitoring help to track the way, however, they treat each component or microservice in isolation. This individual treatment results in operational issues. 
+Observability tools should clearly show the big picture, no matter if they help you monitor just a couple or multiple components. In a cloud-native microservice architecture, a user request often flows through dozens of different microservices. Tools such as logging or monitoring help to track the way, however, they treat each component or microservice in isolation. This individual treatment results in operational issues.
 
-Distributed tracing charts out the transactions in cloud-native systems, helping you to understand the application behavior and relations between the front end actions and back end implementation. 
+Distributed tracing charts out the transactions in cloud-native systems, helping you to understand the application behavior and relations between the frontend actions and backend implementation.
 
 The diagram shows how the distributed tracing helps to track the request path.
 

--- a/docs/tracing/03-02-jaeger.md
+++ b/docs/tracing/03-02-jaeger.md
@@ -14,7 +14,7 @@ type: Details
 
 ## Usage
 
-The Envoy sidecar uses Jaeger to trace the request flow in the Istio Service Mesh. Jaeger is compatible with the Zipkin protocol, which Istio and Envoy use to communicate with the tracing back end. This allows you to use the Zipkin protocol and clients in Istio, Envoy, and Kyma services.
+The Envoy sidecar uses Jaeger to trace the request flow in the Istio Service Mesh. Jaeger is compatible with the Zipkin protocol, which Istio and Envoy use to communicate with the tracing backend. This allows you to use the Zipkin protocol and clients in Istio, Envoy, and Kyma services.
 
 For details, see [Istio's Distributed Tracing](https://istio.io/docs/tasks/observability/distributed-tracing/).
 

--- a/resources/jaeger/README.md
+++ b/resources/jaeger/README.md
@@ -4,9 +4,8 @@
 [Jaeger](http://jaeger.readthedocs.io/en/latest/) is a monitoring and tracing tool for microservice-based distributed systems.
 
 ## Details
-The Envoy sidecar uses Jaeger to trace the request flow in the Istio service mesh. Istio and Envoy use the Zipkin protocol to communicate with the tracing back-end. Jaeger provides compatibility with the Zipkin protocol. This allows you to use Zipkin protocol and clients in Istio, Envoy, and the Kyma services.
+The Envoy sidecar uses Jaeger to trace the request flow in the Istio service mesh. Istio and Envoy use the Zipkin protocol to communicate with the tracing backend. Jaeger provides compatibility with the Zipkin protocol. This allows you to use Zipkin protocol and clients in Istio, Envoy, and the Kyma services.
 
 
 ## Installation
-While Jager installs automatically during cluster installation, local Jaeger installation is optional. To run Jaeger locally, install it on a Kyma instance and run using Helm.
-
+While Jaeger installs automatically during cluster installation, local Jaeger installation is optional. To run Jaeger locally, install it on a Kyma instance and run using Helm.


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Unified backend and frontend naming in all `md` files in the repository

**Related issue(s)**
See also #2225 
