### PR TITLE
Add a note about README.md files from external charts

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,9 +10,9 @@ These are the main types of documents used in the project:
 
 * `README.md` - This document type contains information about other files in the directory. Each main directory in this repository, such as `cluster` or `resources`, requires a `README.md` document. Additionally, each chart and sub-chart needs such a document. Add a `README.md` document when you create a new directory or chart. Use the [template](https://github.com/kyma-project/community//blob/master/guidelines/templates/resources/chart_README.md) to create `README.md` documents.
 
-> **NOTE:** `README.md` documents imported to Kyma with external charts don't have to follow the template.
+    > **NOTE:** `README.md` documents imported to Kyma with external charts don't have to follow the template.
 
-Do not change the names or the order of the main sections in the `README.md` documents. However, you can create subsections to adjust each `README.md` document to the project's or chart's specific requirements. See the example of a [README.md](resources/core/README.md) document.
+    Do not change the names or the order of the main sections in the `README.md` documents. However, you can create subsections to adjust each `README.md` document to the project's or chart's specific requirements. See the example of a [README.md](resources/core/README.md) document.
 
 ## Contribution rules
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,6 +10,8 @@ These are the main types of documents used in the project:
 
 * `README.md` - This document type contains information about other files in the directory. Each main directory in this repository, such as `cluster` or `resources`, requires a `README.md` document. Additionally, each chart and sub-chart needs such a document. Add a `README.md` document when you create a new directory or chart. Use the [template](https://github.com/kyma-project/community//blob/master/guidelines/templates/resources/chart_README.md) to create `README.md` documents.
 
+> **NOTE:** `README.md` documents imported to Kyma with external charts don't have to follow the template.
+
 Do not change the names or the order of the main sections in the `README.md` documents. However, you can create subsections to adjust each `README.md` document to the project's or chart's specific requirements. See the example of a [README.md](resources/core/README.md) document.
 
 ## Contribution rules


### PR DESCRIPTION

**Description**

Changes proposed in this pull request:

- Add a NOTE to the `CONTRIBUTING.md` doc informing that external `README.md` docs do not have to follow the internal template.

**Related issue(s)**
See also #5140 
