### PR TITLE
Bump images for CBS, cluster-user tests and api-gateway tests

### DIFF
--- a/resources/api-gateway/values.yaml
+++ b/resources/api-gateway/values.yaml
@@ -71,7 +71,7 @@ tests:
   enabled: true
   image:
     registry: "eu.gcr.io/kyma-project"
-    version: "4333158a"
+    version: "ca9bc456"
   env:
     testUser: "admin-user"
     timeout: 120

--- a/resources/core/values.yaml
+++ b/resources/core/values.yaml
@@ -47,7 +47,7 @@ global:
     dir:
     version: 0e4a64c1
   kubeless_tests:
-    dir: 
+    dir:
     version: b2aa1331
   apiserver_proxy_integration_tests:
     dir:
@@ -56,13 +56,13 @@ global:
     dir: develop/
     version: 6b4c356f
   console_backend_service:
-    version: PR-7010
+    version: d2e5eb49
   console_backend_service_test:
     dir:
     version: 238a64de
   cluster_users_integration_tests:
     dir:
-    version: PR-6892
+    version: 49794ee7
   xip_patch:
     dir:
     version: 4664d0f6
@@ -72,10 +72,10 @@ global:
   kubeless_images:
     runtime:
       node6:
-        dir: 
+        dir:
         version: b2aa1331
       node8:
-        dir: 
+        dir:
         version: b2aa1331
     installation:
       node6:


### PR DESCRIPTION
**Description**

Bump images for console-backend-service and cluster-user tests, both changes are related.
Bump image for api-gateway integration tests to keep the image in-sync with current sources. Not related to the other two changes.

Changes proposed in this pull request:

- bump image for console-backend-service - see #7010 
- bump image for cluster-user tests - see #6892 
- bump image for api-gateway tests - see #6895

**Related issue(s)**
See also #6784 
