### PR TITLE
KafkaChannelAcceptanceTest: Send CE to kafka channel 

### DIFF
--- a/tests/contract/knative-channel-kafka/Gopkg.lock
+++ b/tests/contract/knative-channel-kafka/Gopkg.lock
@@ -607,6 +607,7 @@
   input-imports = [
     "github.com/avast/retry-go",
     "github.com/cloudevents/sdk-go",
+    "github.com/cloudevents/sdk-go/pkg/cloudevents/client",
     "github.com/kyma-incubator/knative-kafka/components/controller/pkg/apis/knativekafka/v1alpha1",
     "github.com/kyma-incubator/knative-kafka/components/controller/pkg/client/clientset/versioned/typed/knativekafka/v1alpha1",
     "k8s.io/apimachinery/pkg/api/errors",
@@ -614,6 +615,7 @@
     "k8s.io/client-go/plugin/pkg/client/auth/gcp",
     "k8s.io/client-go/rest",
     "k8s.io/client-go/tools/clientcmd",
+    "knative.dev/pkg/apis",
   ]
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/tests/contract/knative-channel-kafka/Gopkg.lock
+++ b/tests/contract/knative-channel-kafka/Gopkg.lock
@@ -10,12 +10,41 @@
   version = "v0.52.0"
 
 [[projects]]
+  digest = "1:9f3b30d9f8e0d7040f729b82dcbc8f0dead820a133b3147ce355fc451f32d761"
+  name = "github.com/BurntSushi/toml"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "3012a1dbe2e4bd1391d42b32f0577cb7bbc7f005"
+  version = "v0.3.1"
+
+[[projects]]
   digest = "1:6062abf6317d3d6963496e01e22264a2e8a7e3b35e2917aa00ed3d182f569be6"
   name = "github.com/avast/retry-go"
   packages = ["."]
   pruneopts = "UT"
   revision = "f9a5f3752008752cd4f31f9c0c4dc60dec4583e5"
   version = "v2.4.3"
+
+[[projects]]
+  digest = "1:ebe7ae214ffe3d2a4160849d733703557e10761c54b94d5ee2501ce4077bc59e"
+  name = "github.com/cloudevents/sdk-go"
+  packages = [
+    ".",
+    "pkg/cloudevents",
+    "pkg/cloudevents/client",
+    "pkg/cloudevents/context",
+    "pkg/cloudevents/datacodec",
+    "pkg/cloudevents/datacodec/json",
+    "pkg/cloudevents/datacodec/text",
+    "pkg/cloudevents/datacodec/xml",
+    "pkg/cloudevents/observability",
+    "pkg/cloudevents/transport",
+    "pkg/cloudevents/transport/http",
+    "pkg/cloudevents/types",
+  ]
+  pruneopts = "UT"
+  revision = "d289f68c35e89dd9b6a32b1d41faf60a0d9d090a"
+  version = "v0.11.0"
 
 [[projects]]
   digest = "1:ffe9824d294da03b391f44e1ae8281281b4afc1bdaa9588c9097785e3af10cec"
@@ -45,6 +74,14 @@
   version = "v1.3.1"
 
 [[projects]]
+  branch = "master"
+  digest = "1:b7cb6054d3dff43b38ad2e92492f220f57ae6087ee797dca298139776749ace8"
+  name = "github.com/golang/groupcache"
+  packages = ["lru"]
+  pruneopts = "UT"
+  revision = "8c9f03a8e57eb486e42badaed3fb287da51807ba"
+
+[[projects]]
   digest = "1:573ca21d3669500ff845bdebee890eb7fc7f0f50c59f2132f2a0c6b03d85086a"
   name = "github.com/golang/protobuf"
   packages = ["proto"]
@@ -72,6 +109,14 @@
   pruneopts = "UT"
   revision = "db92cf7ae75e4a7a28abc005addab2b394362888"
   version = "v1.1.0"
+
+[[projects]]
+  digest = "1:582b704bebaa06b48c29b0cec224a6058a09c86883aaddabde889cd1a5f73e1b"
+  name = "github.com/google/uuid"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "0cd6bf5da1e1c83f8b45653022c74f71af0538a4"
+  version = "v1.1.1"
 
 [[projects]]
   digest = "1:e631368e174090a276fc00b48283f92ac4ccfbbb1945bcfcee083f5f9210dc00"
@@ -153,12 +198,84 @@
   version = "v1.0.5"
 
 [[projects]]
+  digest = "1:466793fb60a8af60da5780a33ef3e24352eca3f8c8b51cdadb596b86cf8abbea"
+  name = "go.opencensus.io"
+  packages = [
+    ".",
+    "internal",
+    "internal/tagencoding",
+    "metric/metricdata",
+    "metric/metricproducer",
+    "resource",
+    "stats",
+    "stats/internal",
+    "stats/view",
+    "tag",
+    "trace",
+    "trace/internal",
+    "trace/tracestate",
+  ]
+  pruneopts = "UT"
+  revision = "aad2c527c5defcf89b5afab7f37274304195a6b2"
+  version = "v0.22.2"
+
+[[projects]]
+  digest = "1:c708d00d1097e62bf4f3a72f239efa7dafc257581421b0b7d3789e1ff5299f30"
+  name = "go.uber.org/atomic"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "40ae6a40a970ef4cdbffa7b24b280e316db8accc"
+  version = "v1.5.1"
+
+[[projects]]
+  digest = "1:e6d88834deb4e35eb998c74f4d042db6ccecaaf62c0f6d57905852800994af00"
+  name = "go.uber.org/multierr"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "824d08f79702fe5f54aca8400aa0d754318786e7"
+  version = "v1.4.0"
+
+[[projects]]
+  branch = "master"
+  digest = "1:3032e90a153750ea149f68bf081f97ca738f041fba45c41c80737f572ffdf2f4"
+  name = "go.uber.org/tools"
+  packages = ["update-license"]
+  pruneopts = "UT"
+  revision = "2cfd321de3ee5d5f8a5fda2521d1703478334d98"
+
+[[projects]]
+  digest = "1:260048b6193e304ee294452a9e3410c474e3ce187248c7e2e4a2631207386f74"
+  name = "go.uber.org/zap"
+  packages = [
+    ".",
+    "buffer",
+    "internal/bufferpool",
+    "internal/color",
+    "internal/exit",
+    "zapcore",
+  ]
+  pruneopts = "UT"
+  revision = "33e58d4d0120aa28d4df84cd244838c490846c9d"
+  version = "v1.13.0"
+
+[[projects]]
   branch = "master"
   digest = "1:c8b0363634b7f813bd07d829fa98af420d99c68d9e88077a7c86fad8e6e31e27"
   name = "golang.org/x/crypto"
   packages = ["ssh/terminal"]
   pruneopts = "UT"
   revision = "530e935923ad688be97c15eeb8e5ee42ebf2b54a"
+
+[[projects]]
+  branch = "master"
+  digest = "1:334b27eac455cb6567ea28cd424230b07b1a64334a2f861a8075ac26ce10af43"
+  name = "golang.org/x/lint"
+  packages = [
+    ".",
+    "golint",
+  ]
+  pruneopts = "UT"
+  revision = "fdd1cda4f05fd1fd86124f0ef9ce31a0b72c8448"
 
 [[projects]]
   branch = "master"
@@ -234,6 +351,27 @@
   revision = "555d28b269f0569763d25dbe1a237ae74c6bcc82"
 
 [[projects]]
+  branch = "master"
+  digest = "1:0e80040cca926feb0fa165c81ea6d34f49d4071da41176487ac82ca36b124fa4"
+  name = "golang.org/x/tools"
+  packages = [
+    "go/analysis",
+    "go/analysis/passes/inspect",
+    "go/ast/astutil",
+    "go/ast/inspector",
+    "go/buildutil",
+    "go/gcexportdata",
+    "go/internal/gcimporter",
+    "go/internal/packagesdriver",
+    "go/packages",
+    "go/types/objectpath",
+    "go/types/typeutil",
+    "internal/packagesinternal",
+  ]
+  pruneopts = "UT"
+  revision = "2f3ba24bd6e75104fb11be4edf062de340ffd1ab"
+
+[[projects]]
   digest = "1:3c03b58f57452764a4499c55c582346c0ee78c8a5033affe5bdfd9efd3da5bd1"
   name = "google.golang.org/appengine"
   packages = [
@@ -267,6 +405,40 @@
   pruneopts = "UT"
   revision = "53403b58ad1b561927d19068c655246f2db79d48"
   version = "v2.2.8"
+
+[[projects]]
+  digest = "1:131158a88aad1f94854d0aa21a64af2802d0a470fb0f01cb33c04fafd2047111"
+  name = "honnef.co/go/tools"
+  packages = [
+    "arg",
+    "cmd/staticcheck",
+    "config",
+    "deprecated",
+    "facts",
+    "functions",
+    "go/types/typeutil",
+    "internal/cache",
+    "internal/passes/buildssa",
+    "internal/renameio",
+    "internal/sharedcheck",
+    "lint",
+    "lint/lintdsl",
+    "lint/lintutil",
+    "lint/lintutil/format",
+    "loader",
+    "printf",
+    "simple",
+    "ssa",
+    "ssautil",
+    "staticcheck",
+    "staticcheck/vrp",
+    "stylecheck",
+    "unused",
+    "version",
+  ]
+  pruneopts = "UT"
+  revision = "afd67930eec2a9ed3e9b19f684d17a062285f16a"
+  version = "2019.2.3"
 
 [[projects]]
   digest = "1:1a3338a7b2e81f301fe258965a9b4451f2dcb204d895e98bb5ca2e3f0f070797"
@@ -434,6 +606,7 @@
   analyzer-version = 1
   input-imports = [
     "github.com/avast/retry-go",
+    "github.com/cloudevents/sdk-go",
     "github.com/kyma-incubator/knative-kafka/components/controller/pkg/apis/knativekafka/v1alpha1",
     "github.com/kyma-incubator/knative-kafka/components/controller/pkg/client/clientset/versioned/typed/knativekafka/v1alpha1",
     "k8s.io/apimachinery/pkg/api/errors",

--- a/tests/contract/knative-channel-kafka/kafka_channel_test.go
+++ b/tests/contract/knative-channel-kafka/kafka_channel_test.go
@@ -50,7 +50,7 @@ var (
 // * sends a CE to the channel and asserts status code is 2xx
 // NOTE: log library is used here instead of using testing.T for logging, because log flushes more often
 // and enables live logs on the test.
-func TestKnativeEventingKafkaChannelAcceptance(t *testing.T) {
+func TestKnativeEventingKafkaChannel(t *testing.T) {
 
 	// load cluster config
 	config := loadConfigOrDie(t)

--- a/tests/contract/knative-channel-kafka/kafka_channel_test.go
+++ b/tests/contract/knative-channel-kafka/kafka_channel_test.go
@@ -11,8 +11,6 @@ import (
 	"testing"
 	"time"
 
-	cloudevents "github.com/cloudevents/sdk-go"
-	"github.com/cloudevents/sdk-go/pkg/cloudevents/client"
 	"knative.dev/pkg/apis"
 
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -23,6 +21,8 @@ import (
 	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
 
 	"github.com/avast/retry-go"
+	cloudevents "github.com/cloudevents/sdk-go"
+	"github.com/cloudevents/sdk-go/pkg/cloudevents/client"
 	kafkav1alpha1 "github.com/kyma-incubator/knative-kafka/components/controller/pkg/apis/knativekafka/v1alpha1"
 	kafkaclientset "github.com/kyma-incubator/knative-kafka/components/controller/pkg/client/clientset/versioned/typed/knativekafka/v1alpha1"
 )
@@ -32,9 +32,12 @@ var (
 	interruptSignals = []os.Signal{syscall.SIGTERM, syscall.SIGINT}
 )
 
-// TestKnativeEventingKafkaChannelAcceptance creates a test Kafka channel and asserts its status to be ready.
+// TestKnativeEventingKafkaChannelAcceptance performs the following steps:
+// * creates a test Kafka channel
+// * asserts its status to be ready
+// * sends a CE to the channel
 // NOTE: log library is used here instead of using testing.T for logging, because log flushes more often
-// and enables live logs on the test
+// and enables live logs on the test.
 func TestKnativeEventingKafkaChannelAcceptance(t *testing.T) {
 	// test meta for the Kafka channel
 	name := "test-kafka-channel"
@@ -84,7 +87,7 @@ func TestKnativeEventingKafkaChannelAcceptance(t *testing.T) {
 	log.Printf("test finished successfully")
 }
 
-// send a given CE to the target and retry until the event was successfully received (2xx status code)
+// sendEventUntilReceived sends a given CE to the target and retry until the event was successfully received (2xx status code).
 func sendEventUntilReceived(t *testing.T, interrupted chan bool, event cloudevents.Event, target *apis.URL, ceClient client.Client) {
 	err := retry.Do(func() error {
 		select {
@@ -116,12 +119,12 @@ func sendEventUntilReceived(t *testing.T, interrupted chan bool, event cloudeven
 	}
 }
 
-// is2XXStatusCode checks whether status code is a 2XX status code
+// is2XXStatusCode checks whether status code is a 2XX status code.
 func is2XXStatusCode(statusCode int) bool {
 	return statusCode >= http.StatusOK && statusCode < http.StatusMultipleChoices
 }
 
-// create a simple CE
+// createCloudEvent creates a simple CE.
 func createCloudEvent(t *testing.T) cloudevents.Event {
 	event := cloudevents.NewEvent()
 	data := "hello kafka"
@@ -135,7 +138,7 @@ func createCloudEvent(t *testing.T) cloudevents.Event {
 	return event
 }
 
-// create a CE client configured to send to given target
+// createCloudEventsClient creates a CE client configured to send to given target.
 func createCloudEventsClient(t *testing.T, target *apis.URL) client.Client {
 	transport, err := cloudevents.NewHTTPTransport(
 		cloudevents.WithTarget(target.String()),

--- a/tests/contract/knative-channel-kafka/kafka_channel_test.go
+++ b/tests/contract/knative-channel-kafka/kafka_channel_test.go
@@ -35,7 +35,7 @@ var (
 // TestKnativeEventingKafkaChannelAcceptance performs the following steps:
 // * creates a test Kafka channel
 // * asserts its status to be ready
-// * sends a CE to the channel
+// * sends a CE to the channel and asserts status code is 2xx
 // NOTE: log library is used here instead of using testing.T for logging, because log flushes more often
 // and enables live logs on the test.
 func TestKnativeEventingKafkaChannelAcceptance(t *testing.T) {

--- a/tests/contract/knative-channel-kafka/kafka_channel_test.go
+++ b/tests/contract/knative-channel-kafka/kafka_channel_test.go
@@ -93,8 +93,7 @@ func sendEventUntilReceived(t *testing.T, interrupted chan bool, event cloudeven
 		select {
 		case <-interrupted:
 			log.Printf("cannot continue, test was interrupted")
-			t.FailNow()
-			return nil
+			return retry.Unrecoverable(fmt.Errorf("cannot continue, test was interrupted"))
 		default:
 			// send an CE event to Kafka channel
 			log.Printf("sending cloudevent to Kafka channel: %q", target)
@@ -201,8 +200,7 @@ func deleteChannelIfExistsAndWaitUntilDeleted(t *testing.T, interrupted chan boo
 			select {
 			case <-interrupted:
 				log.Printf("cannot continue, test was interrupted")
-				t.FailNow()
-				return nil
+				return retry.Unrecoverable(fmt.Errorf("cannot continue, test was interrupted"))
 			default:
 				if _, err := kafkaClient.Get(name, v1.GetOptions{}); err == nil {
 					return fmt.Errorf("the old Kafka channel is not deleted yet")
@@ -232,8 +230,7 @@ func checkChannelReadyWithRetry(t *testing.T, interrupted chan bool,
 		select {
 		case <-interrupted:
 			log.Printf("cannot continue, test was interrupted")
-			t.FailNow()
-			return nil
+			return retry.Unrecoverable(fmt.Errorf("cannot continue, test was interrupted"))
 		default:
 			kafkaChannel, err = kafkaClient.Get(name, v1.GetOptions{})
 			if err != nil {

--- a/tests/contract/knative-channel-kafka/kafka_channel_test.go
+++ b/tests/contract/knative-channel-kafka/kafka_channel_test.go
@@ -14,9 +14,10 @@ import (
 	"knative.dev/pkg/apis"
 
 	"k8s.io/apimachinery/pkg/api/errors"
-	"k8s.io/apimachinery/pkg/apis/meta/v1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
+
 	// allow client authentication against GKE clusters
 	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
 
@@ -31,11 +32,10 @@ const (
 	// cloudevent test data and metadata
 	ceData        = "hello kafka"
 	ceEventType   = "com.example.testing"
-	ceEventID     = "A234-1234-1234"
 	ceEventSource = "kafka channel test"
 
 	// test meta for the Kafka channel
-	kafkaName = "test-kafka-channel"
+	kafkaName      = "test-kafka-channel"
 	kafkaNamespace = "knative-eventing"
 )
 
@@ -141,7 +141,6 @@ func createCloudEvent(t *testing.T) cloudevents.Event {
 		t.FailNow()
 	}
 	event.SetType(ceEventType)
-	event.SetID(ceEventID)
 	event.SetSource(ceEventSource)
 	return event
 }
@@ -155,7 +154,9 @@ func createCloudEventsClient(t *testing.T, target *apis.URL) client.Client {
 		log.Printf("could not create cloudevents http transport: %v", err)
 		t.FailNow()
 	}
-	ceClient, err := cloudevents.NewClient(transport)
+	ceClient, err := cloudevents.NewClient(transport,
+		cloudevents.WithUUIDs(),
+	)
 	if err != nil {
 		log.Printf("could not create cloudevents client: %v", err)
 		t.FailNow()

--- a/tests/contract/knative-channel-kafka/kafka_channel_test.go
+++ b/tests/contract/knative-channel-kafka/kafka_channel_test.go
@@ -33,6 +33,8 @@ var (
 )
 
 // TestKnativeEventingKafkaChannelAcceptance creates a test Kafka channel and asserts its status to be ready.
+// NOTE: log library is used here instead of using testing.T for logging, because log flushes more often
+// and enables live logs on the test
 func TestKnativeEventingKafkaChannelAcceptance(t *testing.T) {
 	// test meta for the Kafka channel
 	name := "test-kafka-channel"
@@ -275,9 +277,9 @@ func cleanupOnInterrupt(t *testing.T, interruptSignals []os.Signal, cleanup func
 		<-ch
 		interrupted <- true
 
-		t.Log("interrupt signal received, cleanup started")
+		log.Println("interrupt signal received, cleanup started")
 		cleanup()
-		t.Log("cleanup finished")
+		log.Println("cleanup finished")
 	}()
 
 	return interrupted

--- a/tests/contract/knative-channel-kafka/kafka_channel_test.go
+++ b/tests/contract/knative-channel-kafka/kafka_channel_test.go
@@ -87,7 +87,9 @@ func TestKnativeEventingKafkaChannelAcceptance(t *testing.T) {
 			return fmt.Errorf("received non 2xx status code: %d", rtctx.StatusCode)
 		}
 		return nil
-	})
+	}, retry.Attempts(24), retry.Delay(time.Second*5), // 120=24*5 seconds
+		retry.OnRetry(func(n uint, err error) { log.Printf("[%v] try failed: %s", n, err) }),
+	)
 
 	if err != nil {
 		t.Fatalf("could not send cloudevent %+v to %q: %v", event, target, err)


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/master/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- Send CE to the Kafka channel
- Before it was only checked that the channel is ready

**NOTE**

- an `Istio ServiceEntry` is required in order to allow communication between kafka channel and azure:

```yaml
apiVersion: networking.istio.io/v1alpha3
kind: ServiceEntry
metadata:
  name: azure-eventhubs
  namespace: kyma-system
spec:
  hosts:
  - '*.servicebus.windows.net'
  location: MESH_EXTERNAL
  ports:
  - name: kafka
    number: 9093
    protocol: HTTPS
  - name: https
    number: 443
    protocol: HTTPS
```

 I will further investigate why this is required and update the Kyma documentation accordingly.

Without the ServiceEntry, the following error can be seen in the Kafka channel pod:

```shell
$  k logs -n knative-eventing test-kafka-channel-knative-eventing-channel-785d44f659-h6dr8 test-kafka-channel-knative-eventing-channel
{"level":"warn","ts":"2020-02-04T07:30:17.195Z","caller":"channel/channel.go:147","msg":"Kafka error","error":"sasl_ssl://nachtmaar-test-2.servicebus.windows.net:9093/bootstrap: SSL handshake failed: SSL transport error: Connection reset by peer (after 121ms in state CONNECT)"}
```

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
