### PR TITLE
fix for missing lambda logs in the lambda UI

### DIFF
--- a/resources/logging/charts/fluentbit/values.yaml
+++ b/resources/logging/charts/fluentbit/values.yaml
@@ -129,6 +129,7 @@ conf:
             labels:
               app: app
               release: release
+              function: function
             host: node
             container_name: container
             pod_name: instance


### PR DESCRIPTION
Lambda logs are not available in the console lambda UI

#7111 
