### PR TITLE
Rename container_name log label after loki migration

### DIFF
--- a/resources/core/charts/kubeless/charts/lambdas-ui/values.yaml
+++ b/resources/core/charts/kubeless/charts/lambdas-ui/values.yaml
@@ -5,7 +5,7 @@ replicaCount: 1
 image:
   dir:
   name: lambda
-  tag: 6da14014
+  tag: e10aff5f
   pullPolicy: IfNotPresent
 service:
   name: nginx

--- a/resources/logging/values.yaml
+++ b/resources/logging/values.yaml
@@ -174,7 +174,7 @@ logui:
   replicaCount: 1
   image:
     name: log-ui
-    tag: 17f3b3c2
+    tag: e10aff5f
     dir:
     pullPolicy: Always
   service:


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- `container_name` log label renamed to `container` in log ui after logging services migration

**Related issue(s)**
https://github.com/kyma-project/kyma/issues/7111