### PR TITLE
Add Event Mesh Latencies dashboard

### DIFF
--- a/resources/knative-eventing/charts/event-mesh-dashboard/templates/event-mesh-latency-dashboard.yaml
+++ b/resources/knative-eventing/charts/event-mesh-dashboard/templates/event-mesh-latency-dashboard.yaml
@@ -82,7 +82,7 @@ data:
           "steppedLine": false,
           "targets": [
             {
-              "expr": "histogram_quantile(0.99, sum(rate(istio_request_duration_seconds_bucket{source_workload_namespace=\"kyma-integration\",source_workload=~\"[A-Za-z0-9]+-connectivity-validator\",destination_workload_namespace=\"knative-serving\",destination_workload=\"activator\"}[5m])) by (le,source_workload_namespace,source_workload,destination_workload_namespace,destination_workload))",
+              "expr": "histogram_quantile(0.99, sum(rate(istio_request_duration_seconds_bucket{source_workload_namespace=\"kyma-integration\",source_workload=~\"[a-z0-9]+-connectivity-validator\",destination_workload_namespace=\"knative-serving\",destination_workload=\"activator\"}[5m])) by (le,source_workload_namespace,source_workload,destination_workload_namespace,destination_workload))",
               "legendFormat": "{{`{{source_workload_namespace}}/{{source_workload}} -> {{destination_workload_namespace}}/{{destination_workload}} (p99)`}}",
               "refId": "A"
             }
@@ -169,7 +169,7 @@ data:
           "steppedLine": false,
           "targets": [
             {
-              "expr": "histogram_quantile(0.99, sum(rate(istio_request_duration_seconds_bucket{source_workload_namespace=\"knative-serving\",source_workload=\"activator\",destination_workload_namespace=\"kyma-integration\",destination_workload=~\"([A-Za-z0-9]+-){2}deployment\"}[5m])) by (le,source_workload_namespace,source_workload,destination_workload_namespace,destination_workload))",
+              "expr": "histogram_quantile(0.99, sum(rate(istio_request_duration_seconds_bucket{source_workload_namespace=\"knative-serving\",source_workload=\"activator\",destination_workload_namespace=\"kyma-integration\",destination_workload=~\"([a-z0-9]+-){2}deployment\"}[5m])) by (le,source_workload_namespace,source_workload,destination_workload_namespace,destination_workload))",
               "legendFormat": "{{`{{source_workload_namespace}}/{{source_workload}} -> {{destination_workload_namespace}}/{{destination_workload}} (p99)`}}",
               "refId": "A"
             }
@@ -257,7 +257,7 @@ data:
           "steppedLine": false,
           "targets": [
             {
-              "expr": "histogram_quantile(0.99, sum(rate(istio_request_duration_seconds_bucket{source_workload_namespace=\"kyma-integration\",source_workload=~\"([A-Za-z0-9]+-){2}deployment\",destination_workload_namespace=\"knative-eventing\",destination_workload=~\"[A-Za-z]+-ch-dispatcher\"}[5m])) by (le,source_workload_namespace,source_workload,destination_workload_namespace,destination_workload))",
+              "expr": "histogram_quantile(0.99, sum(rate(istio_request_duration_seconds_bucket{source_workload_namespace=\"kyma-integration\",source_workload=~\"([a-z0-9]+-){2}deployment\",destination_workload_namespace=\"knative-eventing\",destination_workload=~\"[a-z0-9-]+-dispatcher|knative-kafka-channel\"}[5m])) by (le,source_workload_namespace,source_workload,destination_workload_namespace,destination_workload))",
               "hide": false,
               "legendFormat": "{{`{{source_workload_namespace}}/{{source_workload}} -> {{destination_workload_namespace}}/{{destination_workload}} (p99)`}}",
               "refId": "A"
@@ -345,7 +345,7 @@ data:
           "steppedLine": false,
           "targets": [
             {
-              "expr": "histogram_quantile(0.99, sum(rate(istio_request_duration_seconds_bucket{source_workload=~\"[A-Za-z]+-ch-dispatcher\",destination_workload=\"default-broker-ingress\"}[5m])) by (le,source_workload_namespace,source_workload,destination_workload_namespace,destination_workload))",
+              "expr": "histogram_quantile(0.99, sum(rate(istio_request_duration_seconds_bucket{source_workload=~\"[a-z0-9-]+-dispatcher\",destination_workload=\"default-broker-ingress\"}[5m])) by (le,source_workload_namespace,source_workload,destination_workload_namespace,destination_workload))",
               "hide": false,
               "legendFormat": "{{`{{source_workload_namespace}}/{{source_workload}} -> {{destination_workload_namespace}}/{{destination_workload}} (p99)`}}",
               "refId": "A"
@@ -433,7 +433,7 @@ data:
           "steppedLine": false,
           "targets": [
             {
-              "expr": "histogram_quantile(0.99, sum(rate(istio_request_duration_seconds_bucket{source_workload_namespace!=\"kyma-integration\",destination_workload=~\"[A-Za-z]+-ch-dispatcher\"}[5m])) by (le,source_workload_namespace,source_workload,destination_workload_namespace,destination_workload))",
+              "expr": "histogram_quantile(0.99, sum(rate(istio_request_duration_seconds_bucket{source_workload_namespace!=\"kyma-integration\",destination_workload=~\"[a-z0-9-]+-dispatcher|knative-kafka-channel\"}[5m])) by (le,source_workload_namespace,source_workload,destination_workload_namespace,destination_workload))",
               "legendFormat": "{{`{{source_workload_namespace}}/{{source_workload}} -> {{destination_workload_namespace}}/{{destination_workload}} (p99)`}}",
               "refId": "A"
             }
@@ -520,7 +520,7 @@ data:
           "steppedLine": false,
           "targets": [
             {
-              "expr": "histogram_quantile(0.99, sum(rate(istio_request_duration_seconds_bucket{source_workload=~\"[A-Za-z]+-ch-dispatcher\",destination_workload=\"default-broker-filter\"}[5m])) by (le,source_workload_namespace,source_workload,destination_workload_namespace,destination_workload))",
+              "expr": "histogram_quantile(0.99, sum(rate(istio_request_duration_seconds_bucket{source_workload=~\"[a-z0-9-]+-dispatcher\",destination_workload=\"default-broker-filter\"}[5m])) by (le,source_workload_namespace,source_workload,destination_workload_namespace,destination_workload))",
               "legendFormat": "{{`{{source_workload_namespace}}/{{source_workload}} -> {{destination_workload_namespace}}/{{destination_workload}} (p99)`}}",
               "refId": "A"
             }
@@ -607,7 +607,7 @@ data:
           "steppedLine": false,
           "targets": [
             {
-              "expr": "histogram_quantile(0.99, sum(rate(istio_request_duration_seconds_bucket{source_workload=\"default-broker-filter\",destination_workload!~\"istio-.+|dex|unknown|[A-Za-z]+-ch-dispatcher\"}[5m])) by (le,source_workload_namespace,source_workload,destination_workload_namespace,destination_workload))",
+              "expr": "histogram_quantile(0.99, sum(rate(istio_request_duration_seconds_bucket{source_workload=\"default-broker-filter\",destination_workload!~\"istio-.+|dex|unknown|[a-z0-9-]+-dispatcher\"}[5m])) by (le,source_workload_namespace,source_workload,destination_workload_namespace,destination_workload))",
               "hide": false,
               "legendFormat": "{{`{{source_workload_namespace}}/{{source_workload}} -> {{destination_workload_namespace}}/{{destination_workload}} (p99)`}}",
               "refId": "A"

--- a/resources/knative-eventing/charts/event-mesh-dashboard/templates/event-mesh-latency-dashboard.yaml
+++ b/resources/knative-eventing/charts/event-mesh-dashboard/templates/event-mesh-latency-dashboard.yaml
@@ -597,7 +597,7 @@ data:
         ]
       },
       "timezone": "",
-      "title": "Kyma / Event Mesh / Latency",
+      "title": "Event Mesh / Latency",
       "uid": "ycULeS8Zz",
       "version": 1
     }

--- a/resources/knative-eventing/charts/event-mesh-dashboard/templates/event-mesh-latency-dashboard.yaml
+++ b/resources/knative-eventing/charts/event-mesh-dashboard/templates/event-mesh-latency-dashboard.yaml
@@ -84,7 +84,7 @@ data:
           "targets": [
             {
               "expr": "histogram_quantile(0.99, sum(rate(istio_request_duration_seconds_bucket{source_workload_namespace=\"kyma-integration\",source_workload=~\"[A-Za-z0-9]+-connectivity-validator\",destination_workload_namespace=\"kyma-integration\",destination_workload!~\"istio-.+|unknown\"}[5m])) by (le,source_workload_namespace,source_workload,destination_workload_namespace,destination_workload))",
-              "legendFormat": "{{source_workload_namespace}}/{{source_workload}} -> {{destination_workload_namespace}}/{{destination_workload}} (p99)",
+              "legendFormat": "{{`{{source_workload_namespace}}`}}/{{`{{source_workload}}`}} -> {{`{{destination_workload_namespace}}`}}/{{`{{destination_workload}}`}} (p99)",
               "refId": "A"
             }
           ],
@@ -173,7 +173,7 @@ data:
             {
               "expr": "histogram_quantile(0.99, sum(rate(istio_request_duration_seconds_bucket{source_workload_namespace=\"kyma-integration\",destination_workload_namespace=\"knative-eventing\",destination_workload=~\"[A-Za-z]+-ch-dispatcher\"}[5m])) by (le,source_workload_namespace,source_workload,destination_workload_namespace,destination_workload))",
               "hide": false,
-              "legendFormat": "{{source_workload_namespace}}/{{source_workload}} -> {{destination_workload_namespace}}/{{destination_workload}} (p99)",
+              "legendFormat": "{{`{{source_workload_namespace}}`}}/{{`{{source_workload}}`}} -> {{`{{destination_workload_namespace}}`}}/{{`{{destination_workload}}`}} (p99)",
               "refId": "A"
             }
           ],
@@ -261,7 +261,7 @@ data:
             {
               "expr": "histogram_quantile(0.99, sum(rate(istio_request_duration_seconds_bucket{source_workload=~\"[A-Za-z]+-ch-dispatcher\",destination_workload=\"default-broker-ingress\"}[5m])) by (le,source_workload_namespace,source_workload,destination_workload_namespace,destination_workload))",
               "hide": false,
-              "legendFormat": "{{source_workload_namespace}}/{{source_workload}} -> {{destination_workload_namespace}}/{{destination_workload}} (p99)",
+              "legendFormat": "{{`{{source_workload_namespace}}`}}/{{`{{source_workload}}`}} -> {{`{{destination_workload_namespace}}`}}/{{`{{destination_workload}}`}} (p99)",
               "refId": "A"
             }
           ],
@@ -348,7 +348,7 @@ data:
           "targets": [
             {
               "expr": "histogram_quantile(0.99, sum(rate(istio_request_duration_seconds_bucket{source_workload_namespace!=\"kyma-integration\",destination_workload=~\"[A-Za-z]+-ch-dispatcher\"}[5m])) by (le,source_workload_namespace,source_workload,destination_workload_namespace,destination_workload))",
-              "legendFormat": "{{source_workload_namespace}}/{{source_workload}} -> {{destination_workload_namespace}}/{{destination_workload}} (p99)",
+              "legendFormat": "{{`{{source_workload_namespace}}`}}/{{`{{source_workload}}`}} -> {{`{{destination_workload_namespace}}`}}/{{`{{destination_workload}}`}} (p99)",
               "refId": "A"
             }
           ],
@@ -435,7 +435,7 @@ data:
           "targets": [
             {
               "expr": "histogram_quantile(0.99, sum(rate(istio_request_duration_seconds_bucket{source_workload=~\"[A-Za-z]+-ch-dispatcher\",destination_workload=\"default-broker-filter\"}[5m])) by (le,source_workload_namespace,source_workload,destination_workload_namespace,destination_workload))",
-              "legendFormat": "{{source_workload_namespace}}/{{source_workload}} -> {{destination_workload_namespace}}/{{destination_workload}} (p99)",
+              "legendFormat": "{{`{{source_workload_namespace}}`}}/{{`{{source_workload}}`}} -> {{`{{destination_workload_namespace}}`}}/{{`{{destination_workload}}`}} (p99)",
               "refId": "A"
             }
           ],
@@ -523,7 +523,7 @@ data:
             {
               "expr": "histogram_quantile(0.99, sum(rate(istio_request_duration_seconds_bucket{source_workload=\"default-broker-filter\",destination_workload!~\"istio-.+|dex|unknown|[A-Za-z]+-ch-dispatcher\"}[5m])) by (le,source_workload_namespace,source_workload,destination_workload_namespace,destination_workload))",
               "hide": false,
-              "legendFormat": "{{source_workload_namespace}}/{{source_workload}} -> {{destination_workload_namespace}}/{{destination_workload}} (p99)",
+              "legendFormat": "{{`{{source_workload_namespace}}`}}/{{`{{source_workload}}`}} -> {{`{{destination_workload_namespace}}`}}/{{`{{destination_workload}}`}} (p99)",
               "refId": "A"
             }
           ],

--- a/resources/knative-eventing/charts/event-mesh-dashboard/templates/event-mesh-latency-dashboard.yaml
+++ b/resources/knative-eventing/charts/event-mesh-dashboard/templates/event-mesh-latency-dashboard.yaml
@@ -1,10 +1,11 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: event-mesh-latency-dashboard
+  name: {{ template "event-mesh-dashboard.fullname" . }}-latency
+  namespace: kyma-system
   labels:
     grafana_dashboard: "1"
-    app: monitoring-grafana
+{{ include "event-mesh-dashboard.labels.standard" . | indent 4 }}
 data:
   event-mesh-latency-dashboard.json: |-
     {

--- a/resources/knative-eventing/charts/event-mesh-dashboard/templates/event-mesh-latency-dashboard.yaml
+++ b/resources/knative-eventing/charts/event-mesh-dashboard/templates/event-mesh-latency-dashboard.yaml
@@ -25,7 +25,6 @@ data:
       "editable": false,
       "gnetId": null,
       "graphTooltip": 0,
-      "id": 52,
       "links": [],
       "panels": [
         {
@@ -83,8 +82,8 @@ data:
           "steppedLine": false,
           "targets": [
             {
-              "expr": "histogram_quantile(0.99, sum(rate(istio_request_duration_seconds_bucket{source_workload_namespace=\"kyma-integration\",source_workload=~\"[A-Za-z0-9]+-connectivity-validator\",destination_workload_namespace=\"kyma-integration\",destination_workload!~\"istio-.+|unknown\"}[5m])) by (le,source_workload_namespace,source_workload,destination_workload_namespace,destination_workload))",
-              "legendFormat": "{{`{{source_workload_namespace}}`}}/{{`{{source_workload}}`}} -> {{`{{destination_workload_namespace}}`}}/{{`{{destination_workload}}`}} (p99)",
+              "expr": "histogram_quantile(0.99, sum(rate(istio_request_duration_seconds_bucket{source_workload_namespace=\"kyma-integration\",source_workload=~\"[A-Za-z0-9]+-connectivity-validator\",destination_workload_namespace=\"knative-serving\",destination_workload=\"activator\"}[5m])) by (le,source_workload_namespace,source_workload,destination_workload_namespace,destination_workload))",
+              "legendFormat": "{{`{{source_workload_namespace}}/{{source_workload}} -> {{destination_workload_namespace}}/{{destination_workload}} (p99)`}}",
               "refId": "A"
             }
           ],
@@ -92,7 +91,7 @@ data:
           "timeFrom": null,
           "timeRegions": [],
           "timeShift": null,
-          "title": "Connectivity Validator -> HTTP Event Source",
+          "title": "Connectivity Validator -> Knative Service Activator",
           "tooltip": {
             "shared": true,
             "sort": 0,
@@ -144,6 +143,93 @@ data:
             "y": 1
           },
           "hiddenSeries": false,
+          "id": 16,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "nullPointMode": "null",
+          "options": {
+            "dataLinks": []
+          },
+          "percentage": false,
+          "pointradius": 2,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "histogram_quantile(0.99, sum(rate(istio_request_duration_seconds_bucket{source_workload_namespace=\"knative-serving\",source_workload=\"activator\",destination_workload_namespace=\"kyma-integration\",destination_workload!~\"istio-.+|unknown\"}[5m])) by (le,source_workload_namespace,source_workload,destination_workload_namespace,destination_workload))",
+              "legendFormat": "{{`{{source_workload_namespace}}/{{source_workload}} -> {{destination_workload_namespace}}/{{destination_workload}} (p99)`}}",
+              "refId": "A"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeRegions": [],
+          "timeShift": null,
+          "title": "Knative Service Activator -> HTTP Event Source",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "s",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": false
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": null,
+          "fill": 1,
+          "fillGradient": 0,
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 9
+          },
+          "hiddenSeries": false,
           "id": 4,
           "legend": {
             "alignAsTable": false,
@@ -173,7 +259,7 @@ data:
             {
               "expr": "histogram_quantile(0.99, sum(rate(istio_request_duration_seconds_bucket{source_workload_namespace=\"kyma-integration\",destination_workload_namespace=\"knative-eventing\",destination_workload=~\"[A-Za-z]+-ch-dispatcher\"}[5m])) by (le,source_workload_namespace,source_workload,destination_workload_namespace,destination_workload))",
               "hide": false,
-              "legendFormat": "{{`{{source_workload_namespace}}`}}/{{`{{source_workload}}`}} -> {{`{{destination_workload_namespace}}`}}/{{`{{destination_workload}}`}} (p99)",
+              "legendFormat": "{{`{{source_workload_namespace}}/{{source_workload}} -> {{destination_workload_namespace}}/{{destination_workload}} (p99)`}}",
               "refId": "A"
             }
           ],
@@ -229,7 +315,7 @@ data:
           "gridPos": {
             "h": 8,
             "w": 12,
-            "x": 0,
+            "x": 12,
             "y": 9
           },
           "hiddenSeries": false,
@@ -261,7 +347,7 @@ data:
             {
               "expr": "histogram_quantile(0.99, sum(rate(istio_request_duration_seconds_bucket{source_workload=~\"[A-Za-z]+-ch-dispatcher\",destination_workload=\"default-broker-ingress\"}[5m])) by (le,source_workload_namespace,source_workload,destination_workload_namespace,destination_workload))",
               "hide": false,
-              "legendFormat": "{{`{{source_workload_namespace}}`}}/{{`{{source_workload}}`}} -> {{`{{destination_workload_namespace}}`}}/{{`{{destination_workload}}`}} (p99)",
+              "legendFormat": "{{`{{source_workload_namespace}}/{{source_workload}} -> {{destination_workload_namespace}}/{{destination_workload}} (p99)`}}",
               "refId": "A"
             }
           ],
@@ -317,8 +403,8 @@ data:
           "gridPos": {
             "h": 8,
             "w": 12,
-            "x": 12,
-            "y": 9
+            "x": 0,
+            "y": 17
           },
           "hiddenSeries": false,
           "id": 10,
@@ -348,7 +434,7 @@ data:
           "targets": [
             {
               "expr": "histogram_quantile(0.99, sum(rate(istio_request_duration_seconds_bucket{source_workload_namespace!=\"kyma-integration\",destination_workload=~\"[A-Za-z]+-ch-dispatcher\"}[5m])) by (le,source_workload_namespace,source_workload,destination_workload_namespace,destination_workload))",
-              "legendFormat": "{{`{{source_workload_namespace}}`}}/{{`{{source_workload}}`}} -> {{`{{destination_workload_namespace}}`}}/{{`{{destination_workload}}`}} (p99)",
+              "legendFormat": "{{`{{source_workload_namespace}}/{{source_workload}} -> {{destination_workload_namespace}}/{{destination_workload}} (p99)`}}",
               "refId": "A"
             }
           ],
@@ -404,7 +490,7 @@ data:
           "gridPos": {
             "h": 8,
             "w": 12,
-            "x": 0,
+            "x": 12,
             "y": 17
           },
           "hiddenSeries": false,
@@ -435,7 +521,7 @@ data:
           "targets": [
             {
               "expr": "histogram_quantile(0.99, sum(rate(istio_request_duration_seconds_bucket{source_workload=~\"[A-Za-z]+-ch-dispatcher\",destination_workload=\"default-broker-filter\"}[5m])) by (le,source_workload_namespace,source_workload,destination_workload_namespace,destination_workload))",
-              "legendFormat": "{{`{{source_workload_namespace}}`}}/{{`{{source_workload}}`}} -> {{`{{destination_workload_namespace}}`}}/{{`{{destination_workload}}`}} (p99)",
+              "legendFormat": "{{`{{source_workload_namespace}}/{{source_workload}} -> {{destination_workload_namespace}}/{{destination_workload}} (p99)`}}",
               "refId": "A"
             }
           ],
@@ -491,8 +577,8 @@ data:
           "gridPos": {
             "h": 8,
             "w": 12,
-            "x": 12,
-            "y": 17
+            "x": 0,
+            "y": 25
           },
           "hiddenSeries": false,
           "id": 12,
@@ -523,7 +609,7 @@ data:
             {
               "expr": "histogram_quantile(0.99, sum(rate(istio_request_duration_seconds_bucket{source_workload=\"default-broker-filter\",destination_workload!~\"istio-.+|dex|unknown|[A-Za-z]+-ch-dispatcher\"}[5m])) by (le,source_workload_namespace,source_workload,destination_workload_namespace,destination_workload))",
               "hide": false,
-              "legendFormat": "{{`{{source_workload_namespace}}`}}/{{`{{source_workload}}`}} -> {{`{{destination_workload_namespace}}`}}/{{`{{destination_workload}}`}} (p99)",
+              "legendFormat": "{{`{{source_workload_namespace}}/{{source_workload}} -> {{destination_workload_namespace}}/{{destination_workload}} (p99)`}}",
               "refId": "A"
             }
           ],

--- a/resources/knative-eventing/charts/event-mesh-dashboard/templates/event-mesh-latency-dashboard.yaml
+++ b/resources/knative-eventing/charts/event-mesh-dashboard/templates/event-mesh-latency-dashboard.yaml
@@ -169,7 +169,7 @@ data:
           "steppedLine": false,
           "targets": [
             {
-              "expr": "histogram_quantile(0.99, sum(rate(istio_request_duration_seconds_bucket{source_workload_namespace=\"knative-serving\",source_workload=\"activator\",destination_workload_namespace=\"kyma-integration\",destination_workload!~\"istio-.+|unknown\"}[5m])) by (le,source_workload_namespace,source_workload,destination_workload_namespace,destination_workload))",
+              "expr": "histogram_quantile(0.99, sum(rate(istio_request_duration_seconds_bucket{source_workload_namespace=\"knative-serving\",source_workload=\"activator\",destination_workload_namespace=\"kyma-integration\",destination_workload=~\"([A-Za-z0-9]+-){2}deployment\"}[5m])) by (le,source_workload_namespace,source_workload,destination_workload_namespace,destination_workload))",
               "legendFormat": "{{`{{source_workload_namespace}}/{{source_workload}} -> {{destination_workload_namespace}}/{{destination_workload}} (p99)`}}",
               "refId": "A"
             }
@@ -257,7 +257,7 @@ data:
           "steppedLine": false,
           "targets": [
             {
-              "expr": "histogram_quantile(0.99, sum(rate(istio_request_duration_seconds_bucket{source_workload_namespace=\"kyma-integration\",destination_workload_namespace=\"knative-eventing\",destination_workload=~\"[A-Za-z]+-ch-dispatcher\"}[5m])) by (le,source_workload_namespace,source_workload,destination_workload_namespace,destination_workload))",
+              "expr": "histogram_quantile(0.99, sum(rate(istio_request_duration_seconds_bucket{source_workload_namespace=\"kyma-integration\",source_workload=~\"([A-Za-z0-9]+-){2}deployment\",destination_workload_namespace=\"knative-eventing\",destination_workload=~\"[A-Za-z]+-ch-dispatcher\"}[5m])) by (le,source_workload_namespace,source_workload,destination_workload_namespace,destination_workload))",
               "hide": false,
               "legendFormat": "{{`{{source_workload_namespace}}/{{source_workload}} -> {{destination_workload_namespace}}/{{destination_workload}} (p99)`}}",
               "refId": "A"

--- a/resources/knative-eventing/charts/event-mesh-dashboard/templates/event-mesh-pods-dashboard.yaml
+++ b/resources/knative-eventing/charts/event-mesh-dashboard/templates/event-mesh-pods-dashboard.yaml
@@ -1,551 +1,551 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-    name: {{ template "event-mesh-dashboard.fullname" . }}-pods
-    namespace: kyma-system
-    labels:
-        grafana_dashboard: "1"
-{{ include "event-mesh-dashboard.labels.standard" . | indent 8 }}
+  name: {{ template "event-mesh-dashboard.fullname" . }}-pods
+  namespace: kyma-system
+  labels:
+    grafana_dashboard: "1"
+{{ include "event-mesh-dashboard.labels.standard" . | indent 4 }}
 data:
-    event-mesh-pods-dashboard.json: |-
-        {
-        "annotations": {
-            "list": [
-            {
-                "builtIn": 1,
-                "datasource": "Prometheus",
-                "enable": true,
-                "expr": "time() == BOOL timestamp(rate(kube_pod_container_status_restarts_total{job=\"kube-state-metrics\", cluster=\"$cluster\", namespace=\"$namespace\", pod=\"$pod\"}[2m]) > 0)",
-                "hide": false,
-                "iconColor": "rgba(215, 44, 44, 1)",
-                "name": "Restarts",
-                "showIn": 0,
-                "tags": [
-                    "restart"
-                ],
-                "type": "rows"
-            }
-            ]
-        },
-        "editable": true,
-        "gnetId": null,
-        "graphTooltip": 0,
-        "id": 56,
-        "iteration": 1579214423464,
-        "links": [],
-        "panels": [
-        {
-            "aliasColors": {},
-            "bars": false,
-            "dashLength": 10,
-            "dashes": false,
+  event-mesh-pods-dashboard.json: |-
+    {
+      "annotations": {
+        "list": [
+          {
+            "builtIn": 1,
             "datasource": "Prometheus",
-            "fill": 1,
-            "fillGradient": 0,
-            "gridPos": {
-                "h": 7,
-                "w": 24,
-                "x": 0,
-                "y": 0
-            },
-            "hiddenSeries": false,
-            "id": 2,
-            "legend": {
-                "alignAsTable": true,
-                "avg": true,
-                "current": true,
-                "max": false,
-                "min": false,
-                "rightSide": true,
-                "show": true,
-                "total": false,
-                "values": false
-            },
-            "lines": true,
-            "linewidth": 1,
-            "links": [],
-            "nullPointMode": "null",
-            "options": {
-                "dataLinks": []
-            },
-            "percentage": false,
-            "pointradius": 5,
-            "points": false,
-            "renderer": "flot",
-            "repeat": null,
-            "seriesOverrides": [],
-            "spaceLength": 10,
-            "stack": false,
-            "steppedLine": false,
-            "targets": [
-            {
-                "expr": "sum by(container, pod) (container_memory_usage_bytes{job=\"kubelet\", container!=\"POD\", container !=\"\"}) * on(pod) group_left() kube_pod_labels{label_kyma_project_io_dashboard=\"event-mesh\", label_app=~\"$app.*\", namespace=\"$namespace\"} or sum by(container, pod) (container_memory_usage_bytes{job=\"kubelet\", container!=\"POD\", container !=\"\"}) * on(pod) group_left() kube_pod_labels{label_eventing_knative_dev_broker=\"default\", namespace=\"$namespace\"}",
-                "format": "time_series",
-                "intervalFactor": 2,
-                "legendFormat": "Current: {{`{{ pod }}`}}({{`{{ container }}`}})",
-                "refId": "A"
-            },
-            {
-                "expr": "sum by(container, pod) (kube_pod_container_resource_requests{job=\"kube-state-metrics\", resource=\"memory\"}) * on(pod) group_left() kube_pod_labels{label_kyma_project_io_dashboard=\"event-mesh\", label_app=~\"$app.*\", namespace=\"$namespace\"} or sum by(container, pod) (kube_pod_container_resource_requests{job=\"kube-state-metrics\", resource=\"memory\"}) * on(pod) group_left() kube_pod_labels{label_eventing_knative_dev_broker=\"default\", namespace=\"$namespace\"}",
-                "format": "time_series",
-                "intervalFactor": 2,
-                "legendFormat": "Requested: {{`{{ pod }}`}}({{`{{ container }}`}})",
-                "refId": "B"
-            },
-            {
-                "expr": "sum by(container, pod) (kube_pod_container_resource_limits{job=\"kube-state-metrics\", resource=\"memory\"}) * on(pod) group_left() kube_pod_labels{label_kyma_project_io_dashboard=\"event-mesh\", label_app=~\"$app.*\", namespace=\"$namespace\"} or sum by(container, pod) (kube_pod_container_resource_limits{job=\"kube-state-metrics\", resource=\"memory\"}) * on(pod) group_left() kube_pod_labels{label_eventing_knative_dev_broker=\"default\", namespace=\"$namespace\"}",
-                "format": "time_series",
-                "intervalFactor": 2,
-                "legendFormat": "Limit: {{`{{ pod }}`}}({{`{{ container }}`}})",
-                "refId": "C"
-            },
-            {
-                "expr": "sum by(container, pod) (container_memory_cache{job=\"kubelet\", container!=\"POD\", container!=\"\"}) * on(pod) group_left() kube_pod_labels{label_kyma_project_io_dashboard=\"event-mesh\", label_app=~\"$app.*\", namespace=\"$namespace\"} or sum by(container, pod) (container_memory_cache{job=\"kubelet\", container!=\"POD\", container!=\"\"}) * on(pod) group_left() kube_pod_labels{label_eventing_knative_dev_broker=\"default\", namespace=\"$namespace\"}",
-                "format": "time_series",
-                "intervalFactor": 2,
-                "legendFormat": "Cache: {{`{{ pod }}`}}({{`{{ container }}`}})",
-                "refId": "D"
-            }
+            "enable": true,
+            "expr": "time() == BOOL timestamp(rate(kube_pod_container_status_restarts_total{job=\"kube-state-metrics\", cluster=\"$cluster\", namespace=\"$namespace\", pod=\"$pod\"}[2m]) > 0)",
+            "hide": false,
+            "iconColor": "rgba(215, 44, 44, 1)",
+            "name": "Restarts",
+            "showIn": 0,
+            "tags": [
+              "restart"
             ],
-            "thresholds": [],
-            "timeFrom": null,
-            "timeRegions": [],
-            "timeShift": null,
-            "title": "Memory Usage",
-            "tooltip": {
-                "shared": false,
-                "sort": 0,
-                "value_type": "individual"
-            },
-            "type": "graph",
-            "xaxis": {
-                "buckets": null,
-                "mode": "time",
-                "name": null,
-                "show": true,
-                "values": []
-            },
-            "yaxes": [
-            {
-                "format": "bytes",
-                "label": null,
-                "logBase": 1,
-                "max": null,
-                "min": 0,
-                "show": true
-            },
-            {
-                "format": "bytes",
-                "label": null,
-                "logBase": 1,
-                "max": null,
-                "min": 0,
-                "show": true
-            }
-            ],
-            "yaxis": {
-                "align": false,
-                "alignLevel": null
-            }
-        },
+            "type": "rows"
+          }
+        ]
+      },
+      "editable": true,
+      "gnetId": null,
+      "graphTooltip": 0,
+      "id": 56,
+      "iteration": 1579214423464,
+      "links": [],
+      "panels": [
         {
-            "aliasColors": {},
-            "bars": false,
-            "dashLength": 10,
-            "dashes": false,
-            "datasource": "Prometheus",
-            "fill": 1,
-            "fillGradient": 0,
-            "gridPos": {
-                "h": 7,
-                "w": 24,
-                "x": 0,
-                "y": 7
-            },
-            "hiddenSeries": false,
-            "id": 3,
-            "interval": "",
-            "legend": {
-                "alignAsTable": true,
-                "avg": true,
-                "current": true,
-                "max": false,
-                "min": false,
-                "rightSide": true,
-                "show": true,
-                "total": false,
-                "values": false
-            },
-            "lines": true,
-            "linewidth": 1,
-            "links": [],
-            "nullPointMode": "null",
-            "options": {
-                "dataLinks": []
-            },
-            "percentage": false,
-            "pointradius": 5,
-            "points": false,
-            "renderer": "flot",
-            "repeat": null,
-            "seriesOverrides": [],
-            "spaceLength": 10,
-            "stack": false,
-            "steppedLine": false,
-            "targets": [
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "Prometheus",
+          "fill": 1,
+          "fillGradient": 0,
+          "gridPos": {
+            "h": 7,
+            "w": 24,
+            "x": 0,
+            "y": 0
+          },
+          "hiddenSeries": false,
+          "id": 2,
+          "legend": {
+            "alignAsTable": true,
+            "avg": true,
+            "current": true,
+            "max": false,
+            "min": false,
+            "rightSide": true,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "nullPointMode": "null",
+          "options": {
+            "dataLinks": []
+          },
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "repeat": null,
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
             {
-                "expr": "sum by (container, pod_name) (irate(container_cpu_usage_seconds_total{job=\"kubelet\", image!=\"\", container!=\"POD\"}[4m])) * on(pod_name) group_left()\nlabel_replace(max(kube_pod_labels{label_kyma_project_io_dashboard=\"event-mesh\", label_app=~\"$app.*\", namespace=\"$namespace\"}) by (pod), \"pod_name\", \"$1\", \"pod\", \"(.*)\") or sum by (container, pod_name) (irate(container_cpu_usage_seconds_total{job=\"kubelet\", image!=\"\", container!=\"POD\"}[4m])) * on(pod_name) group_left()\nlabel_replace(max(kube_pod_labels{label_eventing_knative_dev_broker=\"default\", namespace=\"$namespace\"}) by (pod), \"pod_name\", \"$1\", \"pod\", \"(.*)\")",
-                "format": "time_series",
-                "intervalFactor": 2,
-                "legendFormat": "Current: {{`{{ pod_name }}`}}({{`{{ container }}`}})",
-                "refId": "A"
-            },
-            {
-                "expr": "sum by (container, pod) (irate(kube_pod_container_resource_requests{job=\"kube-state-metrics\", resource=\"cpu\"}[4m])) * on(pod) group_left() kube_pod_labels{label_kyma_project_io_dashboard=\"event-mesh\", label_app=~\"$app.*\", namespace=\"$namespace\"} or sum by (container, pod) (irate(kube_pod_container_resource_requests{job=\"kube-state-metrics\", resource=\"cpu\"}[4m])) * on(pod) group_left() kube_pod_labels{label_eventing_knative_dev_broker=\"default\", namespace=\"$namespace\"}",
-                "format": "time_series",
-                "intervalFactor": 2,
-                "legendFormat": "Requested: {{`{{ pod }}`}}({{`{{ container }}`}})",
-                "refId": "B"
+              "expr": "sum by(container, pod) (container_memory_usage_bytes{job=\"kubelet\", container!=\"POD\", container !=\"\"}) * on(pod) group_left() kube_pod_labels{label_kyma_project_io_dashboard=\"event-mesh\", label_app=~\"$app.*\", namespace=\"$namespace\"} or sum by(container, pod) (container_memory_usage_bytes{job=\"kubelet\", container!=\"POD\", container !=\"\"}) * on(pod) group_left() kube_pod_labels{label_eventing_knative_dev_broker=\"default\", namespace=\"$namespace\"}",
+              "format": "time_series",
+              "intervalFactor": 2,
+              "legendFormat": "Current: {{`{{ pod }}`}}({{`{{ container }}`}})",
+              "refId": "A"
             },
             {
-                "expr": "sum by (container, pod) (kube_pod_container_resource_limits{job=\"kube-state-metrics\", resource=\"cpu\"}) * on(pod) group_left() kube_pod_labels{label_kyma_project_io_dashboard=\"event-mesh\", label_app=~\"$app.*\", namespace=\"$namespace\"} or sum by (container, pod) (kube_pod_container_resource_limits{job=\"kube-state-metrics\", resource=\"cpu\"}) * on(pod) group_left() kube_pod_labels{label_eventing_knative_dev_broker=\"default\", namespace=\"$namespace\"}",
-                "format": "time_series",
-                "intervalFactor": 2,
-                "legendFormat": "Limit: {{`{{ pod }}`}}({{`{{ container }}`}})",
-                "refId": "C"
+              "expr": "sum by(container, pod) (kube_pod_container_resource_requests{job=\"kube-state-metrics\", resource=\"memory\"}) * on(pod) group_left() kube_pod_labels{label_kyma_project_io_dashboard=\"event-mesh\", label_app=~\"$app.*\", namespace=\"$namespace\"} or sum by(container, pod) (kube_pod_container_resource_requests{job=\"kube-state-metrics\", resource=\"memory\"}) * on(pod) group_left() kube_pod_labels{label_eventing_knative_dev_broker=\"default\", namespace=\"$namespace\"}",
+              "format": "time_series",
+              "intervalFactor": 2,
+              "legendFormat": "Requested: {{`{{ pod }}`}}({{`{{ container }}`}})",
+              "refId": "B"
+            },
+            {
+              "expr": "sum by(container, pod) (kube_pod_container_resource_limits{job=\"kube-state-metrics\", resource=\"memory\"}) * on(pod) group_left() kube_pod_labels{label_kyma_project_io_dashboard=\"event-mesh\", label_app=~\"$app.*\", namespace=\"$namespace\"} or sum by(container, pod) (kube_pod_container_resource_limits{job=\"kube-state-metrics\", resource=\"memory\"}) * on(pod) group_left() kube_pod_labels{label_eventing_knative_dev_broker=\"default\", namespace=\"$namespace\"}",
+              "format": "time_series",
+              "intervalFactor": 2,
+              "legendFormat": "Limit: {{`{{ pod }}`}}({{`{{ container }}`}})",
+              "refId": "C"
+            },
+            {
+              "expr": "sum by(container, pod) (container_memory_cache{job=\"kubelet\", container!=\"POD\", container!=\"\"}) * on(pod) group_left() kube_pod_labels{label_kyma_project_io_dashboard=\"event-mesh\", label_app=~\"$app.*\", namespace=\"$namespace\"} or sum by(container, pod) (container_memory_cache{job=\"kubelet\", container!=\"POD\", container!=\"\"}) * on(pod) group_left() kube_pod_labels{label_eventing_knative_dev_broker=\"default\", namespace=\"$namespace\"}",
+              "format": "time_series",
+              "intervalFactor": 2,
+              "legendFormat": "Cache: {{`{{ pod }}`}}({{`{{ container }}`}})",
+              "refId": "D"
             }
-            ],
-            "thresholds": [],
-            "timeFrom": null,
-            "timeRegions": [],
-            "timeShift": null,
-            "title": "CPU Usage",
-            "tooltip": {
-                "shared": false,
-                "sort": 0,
-                "value_type": "individual"
-            },
-            "type": "graph",
-            "xaxis": {
-                "buckets": null,
-                "mode": "time",
-                "name": null,
-                "show": true,
-                "values": []
-            },
-            "yaxes": [
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeRegions": [],
+          "timeShift": null,
+          "title": "Memory Usage",
+          "tooltip": {
+            "shared": false,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
             {
-                "format": "short",
-                "label": null,
-                "logBase": 1,
-                "max": null,
-                "min": 0,
-                "show": true
+              "format": "bytes",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": 0,
+              "show": true
             },
             {
-                "format": "short",
-                "label": null,
-                "logBase": 1,
-                "max": null,
-                "min": 0,
-                "show": true
+              "format": "bytes",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": 0,
+              "show": true
             }
-            ],
-            "yaxis": {
-                "align": false,
-                "alignLevel": null
-            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
         },
         {
-            "aliasColors": {},
-            "bars": false,
-            "dashLength": 10,
-            "dashes": false,
-            "datasource": "Prometheus",
-            "fill": 1,
-            "fillGradient": 0,
-            "gridPos": {
-                "h": 7,
-                "w": 24,
-                "x": 0,
-                "y": 14
-            },
-            "hiddenSeries": false,
-            "id": 4,
-            "legend": {
-                "alignAsTable": true,
-                "avg": true,
-                "current": true,
-                "max": false,
-                "min": false,
-                "rightSide": true,
-                "show": true,
-                "total": false,
-                "values": false
-            },
-            "lines": true,
-            "linewidth": 1,
-            "links": [],
-            "nullPointMode": "null",
-            "options": {
-                "dataLinks": []
-            },
-            "percentage": false,
-            "pointradius": 5,
-            "points": false,
-            "renderer": "flot",
-            "repeat": null,
-            "seriesOverrides": [],
-            "spaceLength": 10,
-            "stack": false,
-            "steppedLine": false,
-            "targets": [
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "Prometheus",
+          "fill": 1,
+          "fillGradient": 0,
+          "gridPos": {
+            "h": 7,
+            "w": 24,
+            "x": 0,
+            "y": 7
+          },
+          "hiddenSeries": false,
+          "id": 3,
+          "interval": "",
+          "legend": {
+            "alignAsTable": true,
+            "avg": true,
+            "current": true,
+            "max": false,
+            "min": false,
+            "rightSide": true,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "nullPointMode": "null",
+          "options": {
+            "dataLinks": []
+          },
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "repeat": null,
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
             {
-                "expr": "sort_desc(sum by (pod) (irate(container_network_receive_bytes_total{job=\"kubelet\"}[4m])))\n* on(pod)\nkube_pod_labels{label_kyma_project_io_dashboard=\"event-mesh\", label_app=~\"$app.*\", namespace=\"$namespace\"} or sort_desc(sum by (pod) (irate(container_network_receive_bytes_total{job=\"kubelet\"}[4m])))\n* on(pod)\nkube_pod_labels{label_eventing_knative_dev_broker=\"default\", namespace=\"$namespace\"}",
-                "format": "time_series",
-                "intervalFactor": 2,
-                "legendFormat": "RX: {{`{{ pod }}`}}",
-                "refId": "A"
+              "expr": "sum by (container, pod_name) (irate(container_cpu_usage_seconds_total{job=\"kubelet\", image!=\"\", container!=\"POD\"}[4m])) * on(pod_name) group_left()\nlabel_replace(max(kube_pod_labels{label_kyma_project_io_dashboard=\"event-mesh\", label_app=~\"$app.*\", namespace=\"$namespace\"}) by (pod), \"pod_name\", \"$1\", \"pod\", \"(.*)\") or sum by (container, pod_name) (irate(container_cpu_usage_seconds_total{job=\"kubelet\", image!=\"\", container!=\"POD\"}[4m])) * on(pod_name) group_left()\nlabel_replace(max(kube_pod_labels{label_eventing_knative_dev_broker=\"default\", namespace=\"$namespace\"}) by (pod), \"pod_name\", \"$1\", \"pod\", \"(.*)\")",
+              "format": "time_series",
+              "intervalFactor": 2,
+              "legendFormat": "Current: {{`{{ pod_name }}`}}({{`{{ container }}`}})",
+              "refId": "A"
             },
             {
-                "expr": "sort_desc(sum by (pod) (irate(container_network_transmit_bytes_total{job=\"kubelet\"}[4m])))\n* on(pod)\nkube_pod_labels{label_kyma_project_io_dashboard=\"event-mesh\", label_app=~\"$app.*\", namespace=\"$namespace\"} or sort_desc(sum by (pod) (irate(container_network_transmit_bytes_total{job=\"kubelet\"}[4m])))\n* on(pod)\nkube_pod_labels{label_eventing_knative_dev_broker=\"default\", namespace=\"$namespace\"}",
-                "format": "time_series",
-                "intervalFactor": 2,
-                "legendFormat": "TX: {{`{{ pod }}`}}",
-                "refId": "B"
+              "expr": "sum by (container, pod) (irate(kube_pod_container_resource_requests{job=\"kube-state-metrics\", resource=\"cpu\"}[4m])) * on(pod) group_left() kube_pod_labels{label_kyma_project_io_dashboard=\"event-mesh\", label_app=~\"$app.*\", namespace=\"$namespace\"} or sum by (container, pod) (irate(kube_pod_container_resource_requests{job=\"kube-state-metrics\", resource=\"cpu\"}[4m])) * on(pod) group_left() kube_pod_labels{label_eventing_knative_dev_broker=\"default\", namespace=\"$namespace\"}",
+              "format": "time_series",
+              "intervalFactor": 2,
+              "legendFormat": "Requested: {{`{{ pod }}`}}({{`{{ container }}`}})",
+              "refId": "B"
+            },
+            {
+              "expr": "sum by (container, pod) (kube_pod_container_resource_limits{job=\"kube-state-metrics\", resource=\"cpu\"}) * on(pod) group_left() kube_pod_labels{label_kyma_project_io_dashboard=\"event-mesh\", label_app=~\"$app.*\", namespace=\"$namespace\"} or sum by (container, pod) (kube_pod_container_resource_limits{job=\"kube-state-metrics\", resource=\"cpu\"}) * on(pod) group_left() kube_pod_labels{label_eventing_knative_dev_broker=\"default\", namespace=\"$namespace\"}",
+              "format": "time_series",
+              "intervalFactor": 2,
+              "legendFormat": "Limit: {{`{{ pod }}`}}({{`{{ container }}`}})",
+              "refId": "C"
             }
-            ],
-            "thresholds": [],
-            "timeFrom": null,
-            "timeRegions": [],
-            "timeShift": null,
-            "title": "Network I/O",
-            "tooltip": {
-                "shared": false,
-                "sort": 0,
-                "value_type": "individual"
-            },
-            "type": "graph",
-            "xaxis": {
-                "buckets": null,
-                "mode": "time",
-                "name": null,
-                "show": true,
-                "values": []
-            },
-            "yaxes": [
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeRegions": [],
+          "timeShift": null,
+          "title": "CPU Usage",
+          "tooltip": {
+            "shared": false,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
             {
-                "format": "bytes",
-                "label": null,
-                "logBase": 1,
-                "max": null,
-                "min": 0,
-                "show": true
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": 0,
+              "show": true
             },
             {
-                "format": "bytes",
-                "label": null,
-                "logBase": 1,
-                "max": null,
-                "min": 0,
-                "show": true
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": 0,
+              "show": true
             }
-            ],
-            "yaxis": {
-                "align": false,
-                "alignLevel": null
-            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
         },
         {
-            "aliasColors": {},
-            "bars": false,
-            "dashLength": 10,
-            "dashes": false,
-            "datasource": "Prometheus",
-            "fill": 1,
-            "fillGradient": 0,
-            "gridPos": {
-                "h": 7,
-                "w": 24,
-                "x": 0,
-                "y": 21
-            },
-            "hiddenSeries": false,
-            "id": 5,
-            "legend": {
-                "alignAsTable": true,
-                "avg": true,
-                "current": true,
-                "max": false,
-                "min": false,
-                "rightSide": true,
-                "show": true,
-                "total": false,
-                "values": false
-            },
-            "lines": true,
-            "linewidth": 1,
-            "links": [],
-            "nullPointMode": "null",
-            "options": {
-                "dataLinks": []
-            },
-            "percentage": false,
-            "pointradius": 5,
-            "points": false,
-            "renderer": "flot",
-            "repeat": null,
-            "seriesOverrides": [],
-            "spaceLength": 10,
-            "stack": false,
-            "steppedLine": false,
-            "targets": [
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "Prometheus",
+          "fill": 1,
+          "fillGradient": 0,
+          "gridPos": {
+            "h": 7,
+            "w": 24,
+            "x": 0,
+            "y": 14
+          },
+          "hiddenSeries": false,
+          "id": 4,
+          "legend": {
+            "alignAsTable": true,
+            "avg": true,
+            "current": true,
+            "max": false,
+            "min": false,
+            "rightSide": true,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "nullPointMode": "null",
+          "options": {
+            "dataLinks": []
+          },
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "repeat": null,
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
             {
-                "expr": "max by (container, pod) (kube_pod_container_status_restarts_total{job=\"kube-state-metrics\"}) * on(pod) group_left() kube_pod_labels{label_kyma_project_io_dashboard=\"event-mesh\", label_app=~\"$app.*\", namespace=\"$namespace\"} or max by (container, pod) (kube_pod_container_status_restarts_total{job=\"kube-state-metrics\"}) * on(pod) group_left() kube_pod_labels{label_eventing_knative_dev_broker=\"default\", namespace=\"$namespace\"}",
-                "format": "time_series",
-                "intervalFactor": 2,
-                "legendFormat": "Restarts: {{`{{ pod }}`}}({{`{{ container }}`}})",
-                "refId": "A"
-            }
-            ],
-            "thresholds": [],
-            "timeFrom": null,
-            "timeRegions": [],
-            "timeShift": null,
-            "title": "Total Restarts Per Container",
-            "tooltip": {
-                "shared": false,
-                "sort": 0,
-                "value_type": "individual"
-            },
-            "type": "graph",
-            "xaxis": {
-                "buckets": null,
-                "mode": "time",
-                "name": null,
-                "show": true,
-                "values": []
-            },
-            "yaxes": [
-            {
-                "format": "short",
-                "label": null,
-                "logBase": 1,
-                "max": null,
-                "min": 0,
-                "show": true
+              "expr": "sort_desc(sum by (pod) (irate(container_network_receive_bytes_total{job=\"kubelet\"}[4m])))\n* on(pod)\nkube_pod_labels{label_kyma_project_io_dashboard=\"event-mesh\", label_app=~\"$app.*\", namespace=\"$namespace\"} or sort_desc(sum by (pod) (irate(container_network_receive_bytes_total{job=\"kubelet\"}[4m])))\n* on(pod)\nkube_pod_labels{label_eventing_knative_dev_broker=\"default\", namespace=\"$namespace\"}",
+              "format": "time_series",
+              "intervalFactor": 2,
+              "legendFormat": "RX: {{`{{ pod }}`}}",
+              "refId": "A"
             },
             {
-                "format": "short",
-                "label": null,
-                "logBase": 1,
-                "max": null,
-                "min": 0,
-                "show": true
+              "expr": "sort_desc(sum by (pod) (irate(container_network_transmit_bytes_total{job=\"kubelet\"}[4m])))\n* on(pod)\nkube_pod_labels{label_kyma_project_io_dashboard=\"event-mesh\", label_app=~\"$app.*\", namespace=\"$namespace\"} or sort_desc(sum by (pod) (irate(container_network_transmit_bytes_total{job=\"kubelet\"}[4m])))\n* on(pod)\nkube_pod_labels{label_eventing_knative_dev_broker=\"default\", namespace=\"$namespace\"}",
+              "format": "time_series",
+              "intervalFactor": 2,
+              "legendFormat": "TX: {{`{{ pod }}`}}",
+              "refId": "B"
             }
-            ],
-            "yaxis": {
-                "align": false,
-                "alignLevel": null
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeRegions": [],
+          "timeShift": null,
+          "title": "Network I/O",
+          "tooltip": {
+            "shared": false,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "bytes",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": 0,
+              "show": true
+            },
+            {
+              "format": "bytes",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": 0,
+              "show": true
             }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "Prometheus",
+          "fill": 1,
+          "fillGradient": 0,
+          "gridPos": {
+            "h": 7,
+            "w": 24,
+            "x": 0,
+            "y": 21
+          },
+          "hiddenSeries": false,
+          "id": 5,
+          "legend": {
+            "alignAsTable": true,
+            "avg": true,
+            "current": true,
+            "max": false,
+            "min": false,
+            "rightSide": true,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "nullPointMode": "null",
+          "options": {
+            "dataLinks": []
+          },
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "repeat": null,
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "max by (container, pod) (kube_pod_container_status_restarts_total{job=\"kube-state-metrics\"}) * on(pod) group_left() kube_pod_labels{label_kyma_project_io_dashboard=\"event-mesh\", label_app=~\"$app.*\", namespace=\"$namespace\"} or max by (container, pod) (kube_pod_container_status_restarts_total{job=\"kube-state-metrics\"}) * on(pod) group_left() kube_pod_labels{label_eventing_knative_dev_broker=\"default\", namespace=\"$namespace\"}",
+              "format": "time_series",
+              "intervalFactor": 2,
+              "legendFormat": "Restarts: {{`{{ pod }}`}}({{`{{ container }}`}})",
+              "refId": "A"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeRegions": [],
+          "timeShift": null,
+          "title": "Total Restarts Per Container",
+          "tooltip": {
+            "shared": false,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": 0,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": 0,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
         }
-        ],
-        "refresh": "",
-        "schemaVersion": 21,
-        "style": "dark",
-        "tags": [
-            "kyma",
-            "eventing"
-        ],
-        "templating": {
-            "list": [
-            {
-                "allValue": null,
-                "current": {
-                    "isNone": true,
-                    "selected": true,
-                    "text": "None",
-                    "value": ""
-                },
-                "datasource": "Prometheus",
-                "definition": "query_result(kube_pod_info{pod=~\"default-broker-ingress.*\"} or kube_pod_info{pod=~\"application-broker.*\"} or kube_pod_info{pod=~\"eventing-controller.*\"} or kube_pod_info{pod=~\"autoscaler.*\"} or kube_pod_info{pod=~\"application-connector.*\"})",
-                "hide": 0,
-                "includeAll": false,
-                "label": "Namespace",
-                "multi": false,
-                "name": "namespace",
-                "options": [],
-                "query": "query_result(kube_pod_info{pod=~\"default-broker-ingress.*\"} or kube_pod_info{pod=~\"application-broker.*\"} or kube_pod_info{pod=~\"eventing-controller.*\"} or kube_pod_info{pod=~\"autoscaler.*\"} or kube_pod_info{pod=~\"application-connector.*\"})",
-                "refresh": 2,
-                "regex": "/namespace=\"([a-zA-Z0-9-\\.]+)\"/",
-                "skipUrlSync": false,
-                "sort": 0,
-                "tagValuesQuery": "",
-                "tags": [],
-                "tagsQuery": "",
-                "type": "query",
-                "useTags": false
+      ],
+      "refresh": "",
+      "schemaVersion": 21,
+      "style": "dark",
+      "tags": [
+        "kyma",
+        "eventing"
+      ],
+      "templating": {
+        "list": [
+          {
+            "allValue": null,
+            "current": {
+              "isNone": true,
+              "selected": true,
+              "text": "None",
+              "value": ""
             },
-            {
-                "allValue": null,
-                "current": {
-                    "isNone": true,
-                    "selected": true,
-                    "text": "None",
-                    "value": ""
-                },
-                "datasource": "Prometheus",
-                "definition": "label_values(kube_pod_labels{label_app=~\".*connectivity-validator\", namespace=~\"$namespace\"}, label_release)",
-                "hide": 0,
-                "includeAll": false,
-                "label": "Application",
-                "multi": false,
-                "name": "app",
-                "options": [],
-                "query": "label_values(kube_pod_labels{label_app=~\".*connectivity-validator\", namespace=~\"$namespace\"}, label_release)",
-                "refresh": 2,
-                "regex": "",
-                "skipUrlSync": false,
-                "sort": 1,
-                "tagValuesQuery": "",
-                "tags": [],
-                "tagsQuery": "",
-                "type": "query",
-                "useTags": false
-            }
-            ]
-        },
-        "time": {
-            "from": "now-5m",
-            "to": "now"
-        },
-        "timepicker": {
-            "refresh_intervals": [
-                "5s",
-                "10s",
-                "30s",
-                "1m",
-                "5m",
-                "15m",
-                "30m",
-                "1h",
-                "2h",
-                "1d"
-            ],
-            "time_options": [
-                "5m",
-                "15m",
-                "1h",
-                "6h",
-                "12h",
-                "24h",
-                "2d",
-                "7d",
-                "30d"
-            ]
-        },
-        "timezone": "",
-        "title": "Event Mesh / Pods",
-        "uid": "ab4f13a9892a76a4d21ce8c2444bf4e8",
-        "version": 3
-        }
+            "datasource": "Prometheus",
+            "definition": "query_result(kube_pod_info{pod=~\"default-broker-ingress.*\"} or kube_pod_info{pod=~\"application-broker.*\"} or kube_pod_info{pod=~\"eventing-controller.*\"} or kube_pod_info{pod=~\"autoscaler.*\"} or kube_pod_info{pod=~\"application-connector.*\"})",
+            "hide": 0,
+            "includeAll": false,
+            "label": "Namespace",
+            "multi": false,
+            "name": "namespace",
+            "options": [],
+            "query": "query_result(kube_pod_info{pod=~\"default-broker-ingress.*\"} or kube_pod_info{pod=~\"application-broker.*\"} or kube_pod_info{pod=~\"eventing-controller.*\"} or kube_pod_info{pod=~\"autoscaler.*\"} or kube_pod_info{pod=~\"application-connector.*\"})",
+            "refresh": 2,
+            "regex": "/namespace=\"([a-zA-Z0-9-\\.]+)\"/",
+            "skipUrlSync": false,
+            "sort": 0,
+            "tagValuesQuery": "",
+            "tags": [],
+            "tagsQuery": "",
+            "type": "query",
+            "useTags": false
+          },
+          {
+            "allValue": null,
+            "current": {
+              "isNone": true,
+              "selected": true,
+              "text": "None",
+              "value": ""
+            },
+            "datasource": "Prometheus",
+            "definition": "label_values(kube_pod_labels{label_app=~\".*connectivity-validator\", namespace=~\"$namespace\"}, label_release)",
+            "hide": 0,
+            "includeAll": false,
+            "label": "Application",
+            "multi": false,
+            "name": "app",
+            "options": [],
+            "query": "label_values(kube_pod_labels{label_app=~\".*connectivity-validator\", namespace=~\"$namespace\"}, label_release)",
+            "refresh": 2,
+            "regex": "",
+            "skipUrlSync": false,
+            "sort": 1,
+            "tagValuesQuery": "",
+            "tags": [],
+            "tagsQuery": "",
+            "type": "query",
+            "useTags": false
+          }
+        ]
+      },
+      "time": {
+        "from": "now-5m",
+        "to": "now"
+      },
+      "timepicker": {
+        "refresh_intervals": [
+          "5s",
+          "10s",
+          "30s",
+          "1m",
+          "5m",
+          "15m",
+          "30m",
+          "1h",
+          "2h",
+          "1d"
+        ],
+        "time_options": [
+          "5m",
+          "15m",
+          "1h",
+          "6h",
+          "12h",
+          "24h",
+          "2d",
+          "7d",
+          "30d"
+        ]
+      },
+      "timezone": "",
+      "title": "Event Mesh / Pods",
+      "uid": "ab4f13a9892a76a4d21ce8c2444bf4e8",
+      "version": 3
+    }

--- a/resources/monitoring/templates/grafana/kyma-dashboards/event-mesh-latency.yaml
+++ b/resources/monitoring/templates/grafana/kyma-dashboards/event-mesh-latency.yaml
@@ -1,0 +1,602 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: event-mesh-latency-dashboard
+  labels:
+    grafana_dashboard: "1"
+    app: monitoring-grafana
+data:
+  event-mesh-latency-dashboard.json: |-
+    {
+      "annotations": {
+        "list": [
+          {
+            "builtIn": 1,
+            "datasource": "-- Grafana --",
+            "enable": true,
+            "hide": true,
+            "iconColor": "rgba(0, 211, 255, 1)",
+            "name": "Annotations & Alerts",
+            "type": "dashboard"
+          }
+        ]
+      },
+      "editable": false,
+      "gnetId": null,
+      "graphTooltip": 0,
+      "id": 52,
+      "links": [],
+      "panels": [
+        {
+          "collapsed": false,
+          "datasource": null,
+          "gridPos": {
+            "h": 1,
+            "w": 24,
+            "x": 0,
+            "y": 0
+          },
+          "id": 14,
+          "panels": [],
+          "title": "Network latency",
+          "type": "row"
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": null,
+          "fill": 1,
+          "fillGradient": 0,
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 1
+          },
+          "hiddenSeries": false,
+          "id": 2,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "nullPointMode": "null",
+          "options": {
+            "dataLinks": []
+          },
+          "percentage": false,
+          "pointradius": 2,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "histogram_quantile(0.99, sum(rate(istio_request_duration_seconds_bucket{source_workload_namespace=\"kyma-integration\",source_workload=~\"[A-Za-z0-9]+-connectivity-validator\",destination_workload_namespace=\"kyma-integration\",destination_workload!~\"istio-.+|unknown\"}[5m])) by (le,source_workload_namespace,source_workload,destination_workload_namespace,destination_workload))",
+              "legendFormat": "{{source_workload_namespace}}/{{source_workload}} -> {{destination_workload_namespace}}/{{destination_workload}} (p99)",
+              "refId": "A"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeRegions": [],
+          "timeShift": null,
+          "title": "Connectivity Validator -> HTTP Event Source",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "s",
+              "label": "",
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": false
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": null,
+          "fill": 1,
+          "fillGradient": 0,
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 1
+          },
+          "hiddenSeries": false,
+          "id": 4,
+          "legend": {
+            "alignAsTable": false,
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "nullPointMode": "null",
+          "options": {
+            "dataLinks": []
+          },
+          "percentage": false,
+          "pointradius": 2,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "histogram_quantile(0.99, sum(rate(istio_request_duration_seconds_bucket{source_workload_namespace=\"kyma-integration\",destination_workload_namespace=\"knative-eventing\",destination_workload=~\"[A-Za-z]+-ch-dispatcher\"}[5m])) by (le,source_workload_namespace,source_workload,destination_workload_namespace,destination_workload))",
+              "hide": false,
+              "legendFormat": "{{source_workload_namespace}}/{{source_workload}} -> {{destination_workload_namespace}}/{{destination_workload}} (p99)",
+              "refId": "A"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeRegions": [],
+          "timeShift": null,
+          "title": "HTTP Event Source -> Source Channel",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "s",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": false
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": null,
+          "fill": 1,
+          "fillGradient": 0,
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 9
+          },
+          "hiddenSeries": false,
+          "id": 6,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "nullPointMode": "null",
+          "options": {
+            "dataLinks": []
+          },
+          "percentage": false,
+          "pointradius": 2,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "histogram_quantile(0.99, sum(rate(istio_request_duration_seconds_bucket{source_workload=~\"[A-Za-z]+-ch-dispatcher\",destination_workload=\"default-broker-ingress\"}[5m])) by (le,source_workload_namespace,source_workload,destination_workload_namespace,destination_workload))",
+              "hide": false,
+              "legendFormat": "{{source_workload_namespace}}/{{source_workload}} -> {{destination_workload_namespace}}/{{destination_workload}} (p99)",
+              "refId": "A"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeRegions": [],
+          "timeShift": null,
+          "title": "Source Channel -> Event Broker Ingress",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "s",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": false
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": null,
+          "fill": 1,
+          "fillGradient": 0,
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 9
+          },
+          "hiddenSeries": false,
+          "id": 10,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "nullPointMode": "null",
+          "options": {
+            "dataLinks": []
+          },
+          "percentage": false,
+          "pointradius": 2,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "histogram_quantile(0.99, sum(rate(istio_request_duration_seconds_bucket{source_workload_namespace!=\"kyma-integration\",destination_workload=~\"[A-Za-z]+-ch-dispatcher\"}[5m])) by (le,source_workload_namespace,source_workload,destination_workload_namespace,destination_workload))",
+              "legendFormat": "{{source_workload_namespace}}/{{source_workload}} -> {{destination_workload_namespace}}/{{destination_workload}} (p99)",
+              "refId": "A"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeRegions": [],
+          "timeShift": null,
+          "title": "Event Broker Ingress -> Event Broker Channel",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "s",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": false
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": null,
+          "fill": 1,
+          "fillGradient": 0,
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 17
+          },
+          "hiddenSeries": false,
+          "id": 8,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "nullPointMode": "null",
+          "options": {
+            "dataLinks": []
+          },
+          "percentage": false,
+          "pointradius": 2,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "histogram_quantile(0.99, sum(rate(istio_request_duration_seconds_bucket{source_workload=~\"[A-Za-z]+-ch-dispatcher\",destination_workload=\"default-broker-filter\"}[5m])) by (le,source_workload_namespace,source_workload,destination_workload_namespace,destination_workload))",
+              "legendFormat": "{{source_workload_namespace}}/{{source_workload}} -> {{destination_workload_namespace}}/{{destination_workload}} (p99)",
+              "refId": "A"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeRegions": [],
+          "timeShift": null,
+          "title": "Event Broker Channel -> Event Broker Filter",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "s",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": false
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": null,
+          "fill": 1,
+          "fillGradient": 0,
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 17
+          },
+          "hiddenSeries": false,
+          "id": 12,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "nullPointMode": "null",
+          "options": {
+            "dataLinks": []
+          },
+          "percentage": false,
+          "pointradius": 2,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "histogram_quantile(0.99, sum(rate(istio_request_duration_seconds_bucket{source_workload=\"default-broker-filter\",destination_workload!~\"istio-.+|dex|unknown|[A-Za-z]+-ch-dispatcher\"}[5m])) by (le,source_workload_namespace,source_workload,destination_workload_namespace,destination_workload))",
+              "hide": false,
+              "legendFormat": "{{source_workload_namespace}}/{{source_workload}} -> {{destination_workload_namespace}}/{{destination_workload}} (p99)",
+              "refId": "A"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeRegions": [],
+          "timeShift": null,
+          "title": "Event Broker Filter -> Lambda",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "s",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": false
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
+        }
+      ],
+      "refresh": "10s",
+      "schemaVersion": 21,
+      "style": "dark",
+      "tags": [
+        "kyma"
+      ],
+      "templating": {
+        "list": []
+      },
+      "time": {
+        "from": "now-1h",
+        "to": "now"
+      },
+      "timepicker": {
+        "refresh_intervals": [
+          "5s",
+          "10s",
+          "30s",
+          "1m",
+          "5m",
+          "15m",
+          "30m",
+          "1h",
+          "2h",
+          "1d"
+        ]
+      },
+      "timezone": "",
+      "title": "Kyma / Event Mesh / Latency",
+      "uid": "ycULeS8Zz",
+      "version": 1
+    }

--- a/resources/monitoring/templates/grafana/kyma-dashboards/event-mesh-latency.yaml
+++ b/resources/monitoring/templates/grafana/kyma-dashboards/event-mesh-latency.yaml
@@ -355,7 +355,7 @@ data:
           "timeFrom": null,
           "timeRegions": [],
           "timeShift": null,
-          "title": "Event Broker Ingress -> Event Broker Channel",
+          "title": "Event Broker Ingress -> Event Broker Filter Channel",
           "tooltip": {
             "shared": true,
             "sort": 0,
@@ -442,7 +442,7 @@ data:
           "timeFrom": null,
           "timeRegions": [],
           "timeShift": null,
-          "title": "Event Broker Channel -> Event Broker Filter",
+          "title": "Event Broker Filter Channel -> Event Broker Filter",
           "tooltip": {
             "shared": true,
             "sort": 0,


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Add a Grafana dashboard that shows the latencies between event mesh components.

I took the liberty to
* show only **1 percentile** per app, otherwise the graphs get completely bloated and become unreadable (5 * the number of apps per graph)
* measure the **99th** percentile instead of your suggested values (see Gil Tene's talk about ["how not to measure latency"](https://www.youtube.com/watch?v=lJ8ydIuPFeU))

**Related issue(s)**

#6788
#6656