### PR TITLE
[WIP] Remove port 80 from Kyma and Compass gateways

### DIFF
--- a/resources/compass/charts/gateway/templates/gateway.yaml
+++ b/resources/compass/charts/gateway/templates/gateway.yaml
@@ -37,12 +37,4 @@ spec:
         credentialName: {{ .Values.global.istio.gateway.name }}-certs
       hosts:
         - "*.{{ .Values.global.ingress.domainName }}"
-    - port:
-        number: 80
-        name: http
-        protocol: HTTP
-      tls:
-        httpsRedirect: true # automatic 301 redirect from http to https
-      hosts:
-        - "*.{{.Values.global.ingress.domainName}}"
 {{- end -}}

--- a/resources/core/charts/gateway/templates/gateway.yaml
+++ b/resources/core/charts/gateway/templates/gateway.yaml
@@ -16,11 +16,3 @@ spec:
       credentialName: {{ .Values.global.istio.gateway.name }}-certs
     hosts:
       - "*.{{ .Values.global.ingress.domainName }}"
-  - port:
-      number: 80
-      name: http
-      protocol: HTTP
-    tls:
-      httpsRedirect: true # automatic 301 redirect from http to https
-    hosts:
-      - "*.{{ .Values.global.ingress.domainName }}"


### PR DESCRIPTION
**Description**

From security point of view allowing unencrypted traffic on port 80 is not a good idea.
Because of the gateway configuration (port 80 is enabled) when we install Kyma on some cloud providers (for instance GKE) it automatically creates exception in the firewall configuration.

Changes proposed in this pull request:

- port 80 is removed from Kyma and Compass gateways
