### PR TITLE
Randomize names in api-gateway tests

### DIFF
--- a/resources/api-gateway/values.yaml
+++ b/resources/api-gateway/values.yaml
@@ -71,7 +71,7 @@ tests:
   enabled: true
   image:
     registry: "eu.gcr.io/kyma-project"
-    version: "PR-7266"
+    version: "ca9bc456"
   env:
     testUser: "admin-user"
     timeout: 120

--- a/resources/api-gateway/values.yaml
+++ b/resources/api-gateway/values.yaml
@@ -71,7 +71,7 @@ tests:
   enabled: true
   image:
     registry: "eu.gcr.io/kyma-project"
-    version: "ca9bc456"
+    version: "PR-7266"
   env:
     testUser: "admin-user"
     timeout: 120

--- a/tests/integration/api-gateway/gateway-tests/main_test.go
+++ b/tests/integration/api-gateway/gateway-tests/main_test.go
@@ -73,8 +73,9 @@ func TestApiGatewayIntegration(t *testing.T) {
 
 	oauthClientID := generateRandomString(OauthClientIDLength)
 	oauthClientSecret := generateRandomString(OauthClientSecretLength)
-	oauthSecretName := generateRandomString(OauthSecretNameLength)
-	oauthClientName := generateRandomString(OauthSecretNameLength)
+	randomSuffix6 := generateRandomString(6)
+	oauthSecretName := fmt.Sprintf("api-gateway-tests-secret-%s", randomSuffix6)
+	oauthClientName := fmt.Sprintf("api-gateway-tests-client-%s", randomSuffix6)
 	log.Printf("Using OAuth2Client with name: %s, secretName: %s", oauthClientName, oauthSecretName)
 
 	oauth2Cfg := clientcredentials.Config{

--- a/tests/integration/api-gateway/gateway-tests/main_test.go
+++ b/tests/integration/api-gateway/gateway-tests/main_test.go
@@ -72,10 +72,12 @@ func TestApiGatewayIntegration(t *testing.T) {
 
 	oauthClientID := generateRandomString(OauthClientIDLength)
 	oauthClientSecret := generateRandomString(OauthClientSecretLength)
+	namespace := fmt.Sprintf("api-gateway-test-%s", generateRandomString(6))
 	randomSuffix6 := generateRandomString(6)
 	oauthSecretName := fmt.Sprintf("api-gateway-tests-secret-%s", randomSuffix6)
 	oauthClientName := fmt.Sprintf("api-gateway-tests-client-%s", randomSuffix6)
-	log.Printf("Using OAuth2Client with name: %s, secretName: %s", oauthClientName, oauthSecretName)
+	log.Printf("Using namespace: %s\n", namespace)
+	log.Printf("Using OAuth2Client with name: %s, secretName: %s\n", oauthClientName, oauthSecretName)
 
 	oauth2Cfg := clientcredentials.Config{
 		ClientID:     oauthClientID,
@@ -106,10 +108,12 @@ func TestApiGatewayIntegration(t *testing.T) {
 
 	// create common resources for all scenarios
 	globalCommonResources, err := manifestprocessor.ParseFromFileWithTemplate(globalCommonResourcesFile, manifestsDirectory, resourceSeparator, struct {
+		Namespace         string
 		OauthClientSecret string
 		OauthClientID     string
 		OauthSecretName   string
 	}{
+		Namespace:         namespace,
 		OauthClientSecret: base64.StdEncoding.EncodeToString([]byte(oauthClientSecret)),
 		OauthClientID:     base64.StdEncoding.EncodeToString([]byte(oauthClientID)),
 		OauthSecretName:   oauthSecretName,
@@ -129,9 +133,11 @@ func TestApiGatewayIntegration(t *testing.T) {
 	time.Sleep(time.Duration(conf.ReqDelay) * time.Second)
 
 	hydraClientResource, err := manifestprocessor.ParseFromFileWithTemplate(hydraClientFile, manifestsDirectory, resourceSeparator, struct {
+		Namespace       string
 		OauthClientName string
 		OauthSecretName string
 	}{
+		Namespace:       namespace,
 		OauthClientName: oauthClientName,
 		OauthSecretName: oauthSecretName,
 	})
@@ -151,7 +157,13 @@ func TestApiGatewayIntegration(t *testing.T) {
 			testID := generateRandomString(testIDLength)
 
 			// create common resources from files
-			commonResources, err := manifestprocessor.ParseFromFileWithTemplate(testingAppFile, manifestsDirectory, resourceSeparator, struct{ TestID string }{TestID: testID})
+			commonResources, err := manifestprocessor.ParseFromFileWithTemplate(testingAppFile, manifestsDirectory, resourceSeparator, struct {
+				Namespace string
+				TestID    string
+			}{
+				Namespace: namespace,
+				TestID:    testID,
+			})
 			if err != nil {
 				t.Fatalf("failed to process common manifest files for test %s, details %s", t.Name(), err.Error())
 			}
@@ -159,10 +171,11 @@ func TestApiGatewayIntegration(t *testing.T) {
 
 			// create api-rule from file
 			noAccessStrategyApiruleResource, err := manifestprocessor.ParseFromFileWithTemplate(noAccessStrategyApiruleFile, manifestsDirectory, resourceSeparator, struct {
+				Namespace  string
 				NamePrefix string
 				TestID     string
 				Domain     string
-			}{NamePrefix: "unsecured", TestID: testID, Domain: conf.Domain})
+			}{Namespace: namespace, NamePrefix: "unsecured", TestID: testID, Domain: conf.Domain})
 			if err != nil {
 				t.Fatalf("failed to process resource manifest files for test %s, details %s", t.Name(), err.Error())
 			}
@@ -183,7 +196,13 @@ func TestApiGatewayIntegration(t *testing.T) {
 			testID := generateRandomString(testIDLength)
 
 			// create common resources from files
-			commonResources, err := manifestprocessor.ParseFromFileWithTemplate(testingAppFile, manifestsDirectory, resourceSeparator, struct{ TestID string }{TestID: testID})
+			commonResources, err := manifestprocessor.ParseFromFileWithTemplate(testingAppFile, manifestsDirectory, resourceSeparator, struct {
+				Namespace string
+				TestID    string
+			}{
+				Namespace: namespace,
+				TestID:    testID,
+			})
 			if err != nil {
 				t.Fatalf("failed to process common manifest files for test %s, details %s", t.Name(), err.Error())
 			}
@@ -191,10 +210,11 @@ func TestApiGatewayIntegration(t *testing.T) {
 
 			// create api-rule from file
 			resources, err := manifestprocessor.ParseFromFileWithTemplate(oauthStrategyApiruleFile, manifestsDirectory, resourceSeparator, struct {
+				Namespace  string
 				NamePrefix string
 				TestID     string
 				Domain     string
-			}{NamePrefix: "oauth2", TestID: testID, Domain: conf.Domain})
+			}{Namespace: namespace, NamePrefix: "oauth2", TestID: testID, Domain: conf.Domain})
 			if err != nil {
 				t.Fatalf("failed to process resource manifest files for test %s, details %s", t.Name(), err.Error())
 			}
@@ -215,7 +235,13 @@ func TestApiGatewayIntegration(t *testing.T) {
 			testID := generateRandomString(testIDLength)
 
 			// create common resources from files
-			commonResources, err := manifestprocessor.ParseFromFileWithTemplate(testingAppFile, manifestsDirectory, resourceSeparator, struct{ TestID string }{TestID: testID})
+			commonResources, err := manifestprocessor.ParseFromFileWithTemplate(testingAppFile, manifestsDirectory, resourceSeparator, struct {
+				Namespace string
+				TestID    string
+			}{
+				Namespace: namespace,
+				TestID:    testID,
+			})
 			if err != nil {
 				t.Fatalf("failed to process common manifest files for test %s, details %s", t.Name(), err.Error())
 			}
@@ -223,10 +249,11 @@ func TestApiGatewayIntegration(t *testing.T) {
 
 			// create api-rule from file
 			oauthStrategyApiruleResource, err := manifestprocessor.ParseFromFileWithTemplate(jwtAndOauthStrategyApiruleFile, manifestsDirectory, resourceSeparator, struct {
+				Namespace  string
 				NamePrefix string
 				TestID     string
 				Domain     string
-			}{NamePrefix: "jwt-oauth", TestID: testID, Domain: conf.Domain})
+			}{Namespace: namespace, NamePrefix: "jwt-oauth", TestID: testID, Domain: conf.Domain})
 			if err != nil {
 				t.Fatalf("failed to process resource manifest files for test %s, details %s", t.Name(), err.Error())
 			}
@@ -256,7 +283,13 @@ func TestApiGatewayIntegration(t *testing.T) {
 			testID := generateRandomString(testIDLength)
 
 			// create common resources from files
-			commonResources, err := manifestprocessor.ParseFromFileWithTemplate(testingAppFile, manifestsDirectory, resourceSeparator, struct{ TestID string }{TestID: testID})
+			commonResources, err := manifestprocessor.ParseFromFileWithTemplate(testingAppFile, manifestsDirectory, resourceSeparator, struct {
+				Namespace string
+				TestID    string
+			}{
+				Namespace: namespace,
+				TestID:    testID,
+			})
 			if err != nil {
 				t.Fatalf("failed to process common manifest files for test %s, details %s", t.Name(), err.Error())
 			}
@@ -264,10 +297,11 @@ func TestApiGatewayIntegration(t *testing.T) {
 
 			// create api-rule from file
 			oauthStrategyApiruleResource, err := manifestprocessor.ParseFromFileWithTemplate(jwtAndOauthOnePathApiruleFile, manifestsDirectory, resourceSeparator, struct {
+				Namespace  string
 				NamePrefix string
 				TestID     string
 				Domain     string
-			}{NamePrefix: "jwt-oauth-one-path", TestID: testID, Domain: conf.Domain})
+			}{Namespace: namespace, NamePrefix: "jwt-oauth-one-path", TestID: testID, Domain: conf.Domain})
 			if err != nil {
 				t.Fatalf("failed to process resource manifest files for test %s, details %s", t.Name(), err.Error())
 			}
@@ -296,7 +330,13 @@ func TestApiGatewayIntegration(t *testing.T) {
 			testID := generateRandomString(testIDLength)
 
 			// create common resources from files
-			commonResources, err := manifestprocessor.ParseFromFileWithTemplate(testingAppFile, manifestsDirectory, resourceSeparator, struct{ TestID string }{TestID: testID})
+			commonResources, err := manifestprocessor.ParseFromFileWithTemplate(testingAppFile, manifestsDirectory, resourceSeparator, struct {
+				Namespace string
+				TestID    string
+			}{
+				Namespace: namespace,
+				TestID:    testID,
+			})
 			if err != nil {
 				t.Fatalf("failed to process common manifest files for test %s, details %s", t.Name(), err.Error())
 			}
@@ -304,10 +344,11 @@ func TestApiGatewayIntegration(t *testing.T) {
 
 			// create api-rule from file
 			resources, err := manifestprocessor.ParseFromFileWithTemplate(oauthStrategyApiruleFile, manifestsDirectory, resourceSeparator, struct {
+				Namespace  string
 				NamePrefix string
 				TestID     string
 				Domain     string
-			}{NamePrefix: "oauth2", TestID: testID, Domain: conf.Domain})
+			}{Namespace: namespace, NamePrefix: "oauth2", TestID: testID, Domain: conf.Domain})
 			if err != nil {
 				t.Fatalf("failed to process resource manifest files for test %s, details %s", t.Name(), err.Error())
 			}
@@ -322,10 +363,11 @@ func TestApiGatewayIntegration(t *testing.T) {
 			namePrefix := strings.TrimSuffix(resources[0].GetName(), "-"+testID)
 
 			unsecuredApiruleResource, err := manifestprocessor.ParseFromFileWithTemplate(noAccessStrategyApiruleFile, manifestsDirectory, resourceSeparator, struct {
+				Namespace  string
 				NamePrefix string
 				TestID     string
 				Domain     string
-			}{NamePrefix: namePrefix, TestID: testID, Domain: conf.Domain})
+			}{Namespace: namespace, NamePrefix: namePrefix, TestID: testID, Domain: conf.Domain})
 			if err != nil {
 				t.Fatalf("failed to process resource manifest files for test %s, details %s", t.Name(), err.Error())
 			}
@@ -343,7 +385,13 @@ func TestApiGatewayIntegration(t *testing.T) {
 			t.Parallel()
 			testID := generateRandomString(testIDLength)
 			// create common resources from files
-			commonResources, err := manifestprocessor.ParseFromFileWithTemplate(testingAppFile, manifestsDirectory, resourceSeparator, struct{ TestID string }{TestID: testID})
+			commonResources, err := manifestprocessor.ParseFromFileWithTemplate(testingAppFile, manifestsDirectory, resourceSeparator, struct {
+				Namespace string
+				TestID    string
+			}{
+				Namespace: namespace,
+				TestID:    testID,
+			})
 			if err != nil {
 				t.Fatalf("failed to process common manifest files for test %s, details %s", t.Name(), err.Error())
 			}
@@ -351,10 +399,11 @@ func TestApiGatewayIntegration(t *testing.T) {
 
 			// create api-rule from file
 			noAccessStrategyApiruleResource, err := manifestprocessor.ParseFromFileWithTemplate(noAccessStrategyApiruleFile, manifestsDirectory, resourceSeparator, struct {
+				Namespace  string
 				NamePrefix string
 				TestID     string
 				Domain     string
-			}{NamePrefix: "unsecured", TestID: testID, Domain: conf.Domain})
+			}{Namespace: namespace, NamePrefix: "unsecured", TestID: testID, Domain: conf.Domain})
 			if err != nil {
 				t.Fatalf("failed to process resource manifest files for test %s, details %s", t.Name(), err.Error())
 			}
@@ -367,10 +416,11 @@ func TestApiGatewayIntegration(t *testing.T) {
 			namePrefix := strings.TrimSuffix(noAccessStrategyApiruleResource[0].GetName(), "-"+testID)
 
 			securedApiruleResource, err := manifestprocessor.ParseFromFileWithTemplate(oauthStrategyApiruleFile, manifestsDirectory, resourceSeparator, struct {
+				Namespace  string
 				NamePrefix string
 				TestID     string
 				Domain     string
-			}{NamePrefix: namePrefix, TestID: testID, Domain: conf.Domain})
+			}{Namespace: namespace, NamePrefix: namePrefix, TestID: testID, Domain: conf.Domain})
 			if err != nil {
 				t.Fatalf("failed to process resource manifest files for test %s, details %s", t.Name(), err.Error())
 			}
@@ -389,7 +439,13 @@ func TestApiGatewayIntegration(t *testing.T) {
 			t.Parallel()
 			testID := generateRandomString(testIDLength)
 			// create common resources from files
-			commonResources, err := manifestprocessor.ParseFromFileWithTemplate(testingAppFile, manifestsDirectory, resourceSeparator, struct{ TestID string }{TestID: testID})
+			commonResources, err := manifestprocessor.ParseFromFileWithTemplate(testingAppFile, manifestsDirectory, resourceSeparator, struct {
+				Namespace string
+				TestID    string
+			}{
+				Namespace: namespace,
+				TestID:    testID,
+			})
 			if err != nil {
 				t.Fatalf("failed to process common manifest files for test %s, details %s", t.Name(), err.Error())
 			}
@@ -397,10 +453,11 @@ func TestApiGatewayIntegration(t *testing.T) {
 
 			// create api-rule from file
 			noAccessStrategyApiruleResource, err := manifestprocessor.ParseFromFileWithTemplate(noAccessStrategyApiruleFile, manifestsDirectory, resourceSeparator, struct {
+				Namespace  string
 				NamePrefix string
 				TestID     string
 				Domain     string
-			}{NamePrefix: "unsecured", TestID: testID, Domain: conf.Domain})
+			}{Namespace: namespace, NamePrefix: "unsecured", TestID: testID, Domain: conf.Domain})
 			if err != nil {
 				t.Fatalf("failed to process resource manifest files for test %s, details %s", t.Name(), err.Error())
 			}
@@ -413,10 +470,11 @@ func TestApiGatewayIntegration(t *testing.T) {
 			namePrefix := strings.TrimSuffix(noAccessStrategyApiruleResource[0].GetName(), "-"+testID)
 
 			securedApiruleResource, err := manifestprocessor.ParseFromFileWithTemplate(jwtAndOauthStrategyApiruleFile, manifestsDirectory, resourceSeparator, struct {
+				Namespace  string
 				NamePrefix string
 				TestID     string
 				Domain     string
-			}{NamePrefix: namePrefix, TestID: testID, Domain: conf.Domain})
+			}{Namespace: namespace, NamePrefix: namePrefix, TestID: testID, Domain: conf.Domain})
 			if err != nil {
 				t.Fatalf("failed to process resource manifest files for test %s, details %s", t.Name(), err.Error())
 			}

--- a/tests/integration/api-gateway/gateway-tests/main_test.go
+++ b/tests/integration/api-gateway/gateway-tests/main_test.go
@@ -34,7 +34,6 @@ import (
 const testIDLength = 8
 const OauthClientSecretLength = 8
 const OauthClientIDLength = 8
-const OauthSecretNameLength = 8
 const manifestsDirectory = "manifests/"
 const testingAppFile = "testing-app.yaml"
 const globalCommonResourcesFile = "global-commons.yaml"

--- a/tests/integration/api-gateway/gateway-tests/manifests/global-commons.yaml
+++ b/tests/integration/api-gateway/gateway-tests/manifests/global-commons.yaml
@@ -9,6 +9,6 @@ data:
   client_secret: "{{.OauthClientSecret}}"
 kind: Secret
 metadata:
-  name: api-gateway-tests-secret
+  name: {{.OauthSecretName}}
   namespace: api-gateway-tests
 type: Opaque

--- a/tests/integration/api-gateway/gateway-tests/manifests/global-commons.yaml
+++ b/tests/integration/api-gateway/gateway-tests/manifests/global-commons.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Namespace
 metadata:
-  name: api-gateway-tests
+  name: "{{.Namespace}}"
 ---
 apiVersion: v1
 data:
@@ -9,6 +9,6 @@ data:
   client_secret: "{{.OauthClientSecret}}"
 kind: Secret
 metadata:
-  name: {{.OauthSecretName}}
-  namespace: api-gateway-tests
+  name: "{{.OauthSecretName}}"
+  namespace: "{{.Namespace}}"
 type: Opaque

--- a/tests/integration/api-gateway/gateway-tests/manifests/hydra-client.yaml
+++ b/tests/integration/api-gateway/gateway-tests/manifests/hydra-client.yaml
@@ -2,10 +2,10 @@
 apiVersion: hydra.ory.sh/v1alpha1
 kind: OAuth2Client
 metadata:
-  name: api-gateway-tests-client
+  name: {{.OauthClientName}}
   namespace: api-gateway-tests
 spec:
   grantTypes:
   - "client_credentials"
   scope: "read write"
-  secretName: api-gateway-tests-secret
+  secretName: {{.OauthSecretName}}

--- a/tests/integration/api-gateway/gateway-tests/manifests/hydra-client.yaml
+++ b/tests/integration/api-gateway/gateway-tests/manifests/hydra-client.yaml
@@ -2,10 +2,10 @@
 apiVersion: hydra.ory.sh/v1alpha1
 kind: OAuth2Client
 metadata:
-  name: {{.OauthClientName}}
-  namespace: api-gateway-tests
+  name: "{{.OauthClientName}}"
+  namespace: "{{.Namespace}}"
 spec:
   grantTypes:
   - "client_credentials"
   scope: "read write"
-  secretName: {{.OauthSecretName}}
+  secretName: "{{.OauthSecretName}}"

--- a/tests/integration/api-gateway/gateway-tests/manifests/jwt-oauth-one-path-strategy.yaml
+++ b/tests/integration/api-gateway/gateway-tests/manifests/jwt-oauth-one-path-strategy.yaml
@@ -2,7 +2,7 @@ apiVersion: gateway.kyma-project.io/v1alpha1
 kind: APIRule
 metadata:
   name: "{{.NamePrefix}}-{{.TestID}}"
-  namespace: api-gateway-tests
+  namespace: "{{.Namespace}}"
 spec:
   gateway: kyma-gateway.kyma-system.svc.cluster.local
   service:

--- a/tests/integration/api-gateway/gateway-tests/manifests/jwt-oauth-strategy.yaml
+++ b/tests/integration/api-gateway/gateway-tests/manifests/jwt-oauth-strategy.yaml
@@ -2,7 +2,7 @@ apiVersion: gateway.kyma-project.io/v1alpha1
 kind: APIRule
 metadata:
   name: "{{.NamePrefix}}-{{.TestID}}"
-  namespace: api-gateway-tests
+  namespace: "{{.Namespace}}"
 spec:
   gateway: kyma-gateway.kyma-system.svc.cluster.local
   service:

--- a/tests/integration/api-gateway/gateway-tests/manifests/no_access_strategy.yaml
+++ b/tests/integration/api-gateway/gateway-tests/manifests/no_access_strategy.yaml
@@ -2,7 +2,7 @@ apiVersion: gateway.kyma-project.io/v1alpha1
 kind: APIRule
 metadata:
   name: "{{.NamePrefix}}-{{.TestID}}"
-  namespace: api-gateway-tests
+  namespace: "{{.Namespace}}"
 spec:
   service:
     host: "httpbin-{{.TestID}}.{{.Domain}}"

--- a/tests/integration/api-gateway/gateway-tests/manifests/oauth-strategy.yaml
+++ b/tests/integration/api-gateway/gateway-tests/manifests/oauth-strategy.yaml
@@ -2,7 +2,7 @@ apiVersion: gateway.kyma-project.io/v1alpha1
 kind: APIRule
 metadata:
   name: "{{.NamePrefix}}-{{.TestID}}"
-  namespace: api-gateway-tests
+  namespace: "{{.Namespace}}"
 spec:
   gateway: kyma-gateway.kyma-system.svc.cluster.local
   service:

--- a/tests/integration/api-gateway/gateway-tests/manifests/testing-app.yaml
+++ b/tests/integration/api-gateway/gateway-tests/manifests/testing-app.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: httpbin-{{.TestID}}
-  namespace: api-gateway-tests
+  namespace: "{{.Namespace}}"
   labels:
     app: httpbin-{{.TestID}}
 spec:
@@ -17,7 +17,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: httpbin-{{.TestID}}
-  namespace: api-gateway-tests
+  namespace: "{{.Namespace}}"
 spec:
   replicas: 1
   selector:


### PR DESCRIPTION
**Description**

Randomizes k8s object names in order to improve api-gateway test stability
Changes proposed in this pull request:

- Randomize test namespace name used for the test
- Randomize OAuth2Client name used in the test
- Randomize the name of the k8s secret used by OAuth2Client

**Related issue(s)**
See also #7021
