### PR TITLE
Removed default namespace from CRD

### DIFF
--- a/docs/serverless-v2/06-01-function-cr.md
+++ b/docs/serverless-v2/06-01-function-cr.md
@@ -18,7 +18,6 @@ apiVersion: serverless.kyma-project.io/v1alpha1
 kind: Function
 metadata:
   name: my-test-lambda
-  namespace: default
 spec:
   functionContentType: plaintext
   runtime: nodejs8


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Removed the `default` namespace from the example 
