### PR TITLE
Add TWs as codeowners of the config file for MILV

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -426,7 +426,7 @@ components/etcd-tls-setup-job/ @aszecowka @PK85 @mszostok @piotrmiskiewicz @pols
 /.kyma-project-io/ @michal-hudy @m00g3n @aerfio @magicmatatjahu
 
 # Config file for MILV - milv.config.yaml
-milv.config.yaml @michal-hudy @m00g3n @aerfio @magicmatatjahu
+milv.config.yaml @michal-hudy @m00g3n @aerfio @magicmatatjahu @kazydek @klaudiagrz @tomekpapiernik @bszwarc @mmitoraj @majakurcius @alexandra-simeonova
 
 # performance tests
 /tests/perf/ @a-thaler @hisarbalik @lilitgh @suleymanakbas91 @clebs @rakesh-garimella


### PR DESCRIPTION
**Description**

Currently the codeowners of the MILV configuration files are the Wookiee team, but it's actually the Technical Writers that write the documentation and verify the correctness of the hyperlinks included, so they should be able to approve changes whitelisting these links in the MILV configuration file.

Changes proposed in this pull request:

- Add Kyma Technical Writers as codeowners of the configuration file for MILV. 