### PR TITLE
Apply default serving.knative.dev/visibility label on Knative Service, not on Function CR

### DIFF
--- a/components/function-controller/pkg/apis/serverless/v1alpha1/function_types.go
+++ b/components/function-controller/pkg/apis/serverless/v1alpha1/function_types.go
@@ -45,16 +45,6 @@ type FunctionSpec struct {
 	Env []v1.EnvVar `json:"env,omitempty"`
 }
 
-// FunctionVisibility defines the visibility of function.
-type FunctionVisibility string
-
-const (
-	// FunctionVisibilityClusterLocal is used to denote that the Function
-	// should be only be exposed locally to the cluster.
-	// This is the default value for FunctionVisibility.
-	FunctionVisibilityClusterLocal FunctionVisibility = "cluster-local"
-)
-
 // FunctionCondition defines condition of function.
 type FunctionCondition string
 

--- a/components/function-controller/pkg/controllers/function/function_controller.go
+++ b/components/function-controller/pkg/controllers/function/function_controller.go
@@ -23,6 +23,8 @@ import (
 	"reflect"
 	"strings"
 
+	"knative.dev/serving/pkg/reconciler/route/config"
+
 	tektonv1alpha1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1alpha1"
 
 	"crypto/sha256"
@@ -55,10 +57,6 @@ var knativeServingAnnotations = []string{
 	servingapis.GroupName + knapis.CreatorAnnotationSuffix,
 	servingapis.GroupName + knapis.UpdaterAnnotationSuffix,
 }
-
-const (
-	kNativeServingVisibilityLabel = "serving.knative.dev/visibility"
-)
 
 // Add creates a new Function Controller and adds it to the Manager with default RBAC. The Manager will set fields on the Controller
 // and Start it when the Manager is Started.
@@ -515,7 +513,7 @@ func (r *ReconcileFunction) applyClusterLocalVisibleLabel(fnLabels map[string]st
 		labels[key] = value
 	}
 
-	labels[kNativeServingVisibilityLabel] = string(serverlessv1alpha1.FunctionVisibilityClusterLocal)
+	labels[config.VisibilityLabelKey] = config.VisibilityClusterLocal
 	return labels
 }
 

--- a/components/function-controller/pkg/controllers/function/function_controller_test.go
+++ b/components/function-controller/pkg/controllers/function/function_controller_test.go
@@ -22,6 +22,8 @@ import (
 	"testing"
 	"time"
 
+	"knative.dev/serving/pkg/reconciler/route/config"
+
 	serverlessv1alpha1 "github.com/kyma-project/kyma/components/function-controller/pkg/apis/serverless/v1alpha1"
 
 	"golang.org/x/net/context"
@@ -154,8 +156,8 @@ func TestReconcile(t *testing.T) {
 		To(gm.Equal(1))
 
 	// ensure only serving.knative.dev/visibility label is applied
-	g.Expect(ksvc.ObjectMeta.Labels[kNativeServingVisibilityLabel]).
-		To(gm.Equal(string(serverlessv1alpha1.FunctionVisibilityClusterLocal)))
+	g.Expect(ksvc.ObjectMeta.Labels[config.VisibilityLabelKey]).
+		To(gm.Equal(config.VisibilityClusterLocal))
 
 	// ensure container environment variables are correct
 	g.Expect(ksvc.Spec.ConfigurationSpec.Template.Spec.PodSpec.Containers[0].Env).To(gm.Equal(expectedEnv))

--- a/components/function-controller/pkg/controllers/function/function_controller_test.go
+++ b/components/function-controller/pkg/controllers/function/function_controller_test.go
@@ -154,8 +154,8 @@ func TestReconcile(t *testing.T) {
 		To(gm.Equal(1))
 
 	// ensure only serving.knative.dev/visibility label is applied
-	g.Expect(len(ksvc.ObjectMeta.Labels[kNativeServingVisibilityLabel])).
-		To(gm.Equal(serverlessv1alpha1.FunctionVisibilityClusterLocal))
+	g.Expect(ksvc.ObjectMeta.Labels[kNativeServingVisibilityLabel]).
+		To(gm.Equal(string(serverlessv1alpha1.FunctionVisibilityClusterLocal)))
 
 	// ensure container environment variables are correct
 	g.Expect(ksvc.Spec.ConfigurationSpec.Template.Spec.PodSpec.Containers[0].Env).To(gm.Equal(expectedEnv))

--- a/components/function-controller/pkg/controllers/function/function_controller_test.go
+++ b/components/function-controller/pkg/controllers/function/function_controller_test.go
@@ -19,9 +19,10 @@ package function
 import (
 	"crypto/sha256"
 	"fmt"
-	serverlessv1alpha1 "github.com/kyma-project/kyma/components/function-controller/pkg/apis/serverless/v1alpha1"
 	"testing"
 	"time"
+
+	serverlessv1alpha1 "github.com/kyma-project/kyma/components/function-controller/pkg/apis/serverless/v1alpha1"
 
 	"golang.org/x/net/context"
 
@@ -151,6 +152,10 @@ func TestReconcile(t *testing.T) {
 	// ensure only one container is defined
 	g.Expect(len(ksvc.Spec.ConfigurationSpec.Template.Spec.PodSpec.Containers)).
 		To(gm.Equal(1))
+
+	// ensure only serving.knative.dev/visibility label is applied
+	g.Expect(len(ksvc.ObjectMeta.Labels[kNativeServingVisibilityLabel])).
+		To(gm.Equal(serverlessv1alpha1.FunctionVisibilityClusterLocal))
 
 	// ensure container environment variables are correct
 	g.Expect(ksvc.Spec.ConfigurationSpec.Template.Spec.PodSpec.Containers[0].Env).To(gm.Equal(expectedEnv))

--- a/components/function-controller/pkg/utils/build_utils.go
+++ b/components/function-controller/pkg/utils/build_utils.go
@@ -18,9 +18,10 @@ package utils
 
 import (
 	"fmt"
-	tektonv1alpha1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1alpha1"
 	"os"
 	"time"
+
+	tektonv1alpha1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1alpha1"
 
 	"github.com/gogo/protobuf/proto"
 	serverlessv1alpha1 "github.com/kyma-project/kyma/components/function-controller/pkg/apis/serverless/v1alpha1"

--- a/components/function-controller/pkg/utils/equality_test.go
+++ b/components/function-controller/pkg/utils/equality_test.go
@@ -20,11 +20,12 @@ import (
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
-	servingv1 "knative.dev/serving/pkg/apis/serving/v1"
 	stdlog "log"
 	"os"
 	"reflect"
 	"testing"
+
+	servingv1 "knative.dev/serving/pkg/apis/serving/v1"
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"

--- a/components/function-controller/pkg/webhook/validation_mutation_test.go
+++ b/components/function-controller/pkg/webhook/validation_mutation_test.go
@@ -28,7 +28,7 @@ func TestMutation(t *testing.T) {
 	g := gomega.NewGomegaWithT(t)
 	rnInfo := runtimeConfig(t)
 
-	functionWithoutVisibilityLabel := &serverlessv1alpha1.Function{
+	function := &serverlessv1alpha1.Function{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "example-123",
 			Namespace: "ns",
@@ -40,49 +40,14 @@ func TestMutation(t *testing.T) {
 	}
 
 	// mutate function
-	functionCreateHandler.mutatingFunction(functionWithoutVisibilityLabel, rnInfo)
+	functionCreateHandler.mutatingFunction(function, rnInfo)
 
 	// ensure defaults are set
-	g.Expect(functionWithoutVisibilityLabel.ObjectMeta).To(gstruct.MatchFields(gstruct.IgnoreExtras, gstruct.Fields{
+	g.Expect(function.ObjectMeta).To(gstruct.MatchFields(gstruct.IgnoreExtras, gstruct.Fields{
 		"Name":      gomega.BeEquivalentTo("example-123"),
 		"Namespace": gomega.BeEquivalentTo("ns"),
-		"Labels": gomega.BeEquivalentTo(map[string]string{
-			"serving.knative.dev/visibility": string(serverlessv1alpha1.FunctionVisibilityClusterLocal),
-		}),
 	}))
-	g.Expect(functionWithoutVisibilityLabel.Spec).To(gstruct.MatchFields(gstruct.IgnoreExtras, gstruct.Fields{
-		"Size":                gomega.BeEquivalentTo("S"),
-		"Timeout":             gomega.BeEquivalentTo(180),
-		"Runtime":             gomega.BeEquivalentTo("nodejs8"),
-		"FunctionContentType": gomega.BeEquivalentTo("plaintext"),
-	}))
-
-	functionWithVisibilityLabel := &serverlessv1alpha1.Function{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "example-123",
-			Namespace: "ns",
-			Labels: map[string]string{
-				"serving.knative.dev/visibility": "foo-bar",
-			},
-		},
-		Spec: serverlessv1alpha1.FunctionSpec{
-			FunctionContentType: "plaintext",
-			Function:            "foo",
-		},
-	}
-
-	// mutate function
-	functionCreateHandler.mutatingFunction(functionWithVisibilityLabel, rnInfo)
-
-	// ensure defaults are set
-	g.Expect(functionWithVisibilityLabel.ObjectMeta).To(gstruct.MatchFields(gstruct.IgnoreExtras, gstruct.Fields{
-		"Name":      gomega.BeEquivalentTo("example-123"),
-		"Namespace": gomega.BeEquivalentTo("ns"),
-		"Labels": gomega.BeEquivalentTo(map[string]string{
-			"serving.knative.dev/visibility": string(serverlessv1alpha1.FunctionVisibilityClusterLocal),
-		}),
-	}))
-	g.Expect(functionWithVisibilityLabel.Spec).To(gstruct.MatchFields(gstruct.IgnoreExtras, gstruct.Fields{
+	g.Expect(function.Spec).To(gstruct.MatchFields(gstruct.IgnoreExtras, gstruct.Fields{
 		"Size":                gomega.BeEquivalentTo("S"),
 		"Timeout":             gomega.BeEquivalentTo(180),
 		"Runtime":             gomega.BeEquivalentTo("nodejs8"),

--- a/components/function-controller/pkg/webhook/webhook.go
+++ b/components/function-controller/pkg/webhook/webhook.go
@@ -28,8 +28,7 @@ var (
 )
 
 const (
-	kNativeServingVisibilityLabel = "serving.knative.dev/visibility"
-	webhookEndpoint               = "mutating-create-function"
+	webhookEndpoint = "mutating-create-function"
 )
 
 // +kubebuilder:webhook:path=/mutating-create-function,mutating=true,failurePolicy=fail,groups=serverless.kyma-project.io,resources=functions,verbs=create;update,versions=v1alpha1,name=mfunction.kb.io
@@ -62,16 +61,6 @@ func (h *FunctionCreateHandler) mutatingFunction(obj *serverlessv1alpha1.Functio
 	if obj.Spec.FunctionContentType == "" {
 		obj.Spec.FunctionContentType = rnInfo.Defaults.FuncContentType
 	}
-	h.applyVisibility(obj)
-}
-
-func (h *FunctionCreateHandler) applyVisibility(obj *serverlessv1alpha1.Function) {
-	if len(obj.Labels) == 0 {
-		obj.Labels = make(map[string]string)
-	}
-
-	// At the moment function-controller only supports `cluster-local` visibility
-	obj.Labels[kNativeServingVisibilityLabel] = string(serverlessv1alpha1.FunctionVisibilityClusterLocal)
 }
 
 // Validate function values and return an error if the function is not valid


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/master/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:
- Apply default `serving.knative.dev/visibility` label on Knative Service, not on Function CR:
  - apply suggestion described here: https://github.com/kyma-project/kyma/issues/5582#issuecomment-589958427

**Related issue(s)**
https://github.com/kyma-project/kyma/issues/5582
