### PR TITLE
Disable istio sidecar injection for fluentbit

### DIFF
--- a/installation/resources/installer-cr-cluster-compass.yaml.tpl
+++ b/installation/resources/installer-cr-cluster-compass.yaml.tpl
@@ -32,3 +32,5 @@ spec:
       namespace: "compass-system"
     - name: "monitoring"
       namespace: "kyma-system"
+    - name: "logging"
+      namespace: "kyma-system"

--- a/resources/logging/charts/fluentbit/templates/daemonset.yaml
+++ b/resources/logging/charts/fluentbit/templates/daemonset.yaml
@@ -8,6 +8,7 @@ metadata:
   labels:
     {{- include "fluent-bit.metaLabels" . | trim | nindent 4 }}
   annotations:
+    sidecar.istio.io/inject: "false"
     {{- if .Values.globalAnnotations }}
     {{- toYaml .Values.globalAnnotations | trim | nindent 4 }}
     {{- end }}


### PR DESCRIPTION
Installing fluentbit on a PSP enabled k8s cluster doesn't work because of istio (capabilities missing which are needed for istio).
Options are:

Modify the PSP to add NET_ADMIN (and NET_RAW ?) capabilities when you have Istio installed. The problem with this is the more complex configuration, without any added benefits.
Turn off Istio via an override with kyma-installer. This is not an option as the kyma-installer doesn't support annotations with "/" in them.
Just turn off istio for fluentbit, as there's no sane reason to configure it for this service.