### PR TITLE
Adjust group name for runtime namespace admins

### DIFF
--- a/components/permission-controller/Makefile
+++ b/components/permission-controller/Makefile
@@ -45,7 +45,7 @@ path-to-referenced-charts:
 ###############
 
 EXCLUDED_NAMESPACES ?= "kyma-system, istio-system, default, knative-eventing, knative-serving, kube-node-lease, kube-public, kube-system, kyma-installer, kyma-integration, natss, tekton-pipelines"
-SUBJECT_GROUPS ?= "namespace-admins"
+SUBJECT_GROUPS ?= "runtimeNamespaceAdmin"
 STATIC_CONNECTOR ?= true
 
 .PHONY: run

--- a/components/permission-controller/controllers/namespace_controller_test.go
+++ b/components/permission-controller/controllers/namespace_controller_test.go
@@ -27,7 +27,7 @@ import (
 const (
 	timeout         = 5 * time.Second
 	systemNamespace = "test-system"
-	adminGroup      = "namespace-admins"
+	adminGroup      = "runtimeNamespaceAdmin"
 )
 
 type testSetup struct {

--- a/docs/security/03-08-permission-controller.md
+++ b/docs/security/03-08-permission-controller.md
@@ -7,7 +7,7 @@ The Permission Controller is a Kubernetes controller which listens for new Names
 
 When the Controller is deployed in a cluster, it checks all existing Namespaces and assigns the roles accordingly.
 
-By default, the controller binds users of the **namespace-admins** group to the **kyma-admin** role in the Namespaces they create. Additionally, the controller creates a RoleBinding for the static `namespace.admin@kyma.cx` user to the **kyma-admin** role in every Namespace that is not blacklisted.
+By default, the controller binds users of the **runtimeNamespaceAdmin** group to the **kyma-admin** role in the Namespaces they create. Additionally, the controller creates a RoleBinding for the static `namespace.admin@kyma.cx` user to the **kyma-admin** role in every Namespace that is not blacklisted.
 
 You can adjust the default settings of the Permission Controller by applying these overrides to the cluster either before installation, or at runtime: 
 

--- a/docs/security/05-05-permission-controller.md
+++ b/docs/security/05-05-permission-controller.md
@@ -15,6 +15,6 @@ The following table lists the configurable parameters of the permission-controll
 
 | Parameter | Description | Default value |
 | --------- | ----------- | ------------- |
-| `global.kymaRuntime.namespaceAdminGroup` | Determines the user group for which a RoleBinding to the **kyma-admin** role is created in all Namespaces except those specified in the `config.namespaceBlacklist` parameter. | `namespace-admins` |
+| `global.kymaRuntime.namespaceAdminGroup` | Determines the user group for which a RoleBinding to the **kyma-admin** role is created in all Namespaces except those specified in the `config.namespaceBlacklist` parameter. | `runtimeNamespaceAdmin` |
 | `config.namespaceBlacklist` | Comma-separated list of Namespaces in which a RoleBinding to the **kyma-admin** role is not created for the members of the group specified in the `global.kymaRuntime.namespaceAdminGroup` parameter.|`kyma-system, istio-system, default, knative-eventing, knative-serving, kube-node-lease, kube-public, kube-system, kyma-installer, kyma-integration, natss, tekton-pipelines` |
 | `config.enableStaticUser`| Determines if a RoleBinding to the **kyma-admin** role for the static `namespace.admin@kyma.cx` user is created for every Namespace that is not blacklisted. | `true` |

--- a/resources/core/charts/cluster-users/values.yaml
+++ b/resources/core/charts/cluster-users/values.yaml
@@ -67,7 +67,7 @@ global:
   kymaRuntime:
     adminGroup: runtimeAdmin
     developerGroup: runtimeDeveloper
-    namespaceAdminGroup: namespace-admins
+    namespaceAdminGroup: runtimeNamespaceAdmin
 
 users:
   adminGroup:

--- a/resources/core/charts/console/values.yaml
+++ b/resources/core/charts/console/values.yaml
@@ -50,7 +50,7 @@ cluster:
   disabledNavigationNodes: ""
   # Provide a list of Namespaces that should be considered as system Namespaces. The Console UI gives you the possibility to toggle the visibility of system Namespaces.
   systemNamespaces: "istio-system knative-eventing knative-serving kube-public kube-system kyma-backup kyma-installer kyma-integration kyma-system natss compass-system kube-node-lease kubernetes-dashboard tekton-pipelines"
-  adminsGroupName: "namespace-admins"
+  adminsGroupName: "runtimeNamespaceAdmin"
 
 test:
   acceptance:

--- a/resources/permission-controller/values.yaml
+++ b/resources/permission-controller/values.yaml
@@ -18,7 +18,7 @@ deployment:
 
 global:
   kymaRuntime:
-    namespaceAdminGroup: "namespace-admins"
+    namespaceAdminGroup: "runtimeNamespaceAdmin"
 
 config:
   enableStaticUser: "true"

--- a/resources/permission-controller/values.yaml
+++ b/resources/permission-controller/values.yaml
@@ -1,6 +1,6 @@
 image:
   repository: eu.gcr.io/kyma-project/permission-controller
-  tag: 21c32ff8
+  tag: PR-7319
   pullPolicy: IfNotPresent
 
 deployment:

--- a/resources/uaa-activator/templates/secret.yaml
+++ b/resources/uaa-activator/templates/secret.yaml
@@ -17,15 +17,15 @@ stringData:
       },
       {
         "name": "$XSAPPNAME.{{ .Values.global.kymaRuntime.adminGroup }}",
-        "description": "Admin access to all kyma standard resources"
+        "description": "Global admin access on all Kyma resources"
       },
       {
         "name": "$XSAPPNAME.{{ .Values.global.kymaRuntime.developerGroup }}",
-        "description": "Developer access to all kyma standard resources"
+        "description": "Runtime developer access to all managed resources"
       },
       {
         "name": "$XSAPPNAME.{{ .Values.global.kymaRuntime.namespaceAdminGroup }}",
-        "description": "Customer admin access"
+        "description": "Runtime admin access to all managed resources"
       }
       ],
       "authorities": [
@@ -34,21 +34,21 @@ stringData:
       "role-templates": [
       {
         "name": "KymaAdmin",
-        "description": "Admin access on all standard resources",
+        "description": "Global admin access on all Kyma resources",
         "scope-references": [
           "$XSAPPNAME.{{ .Values.global.kymaRuntime.adminGroup }}"
         ]
       },
       {
-        "name": "KymaDeveloper",
-        "description": "Developer access to all standard resources",
+        "name": "KymaRuntimeDeveloper",
+        "description": "Runtime developer access to all managed resources",
         "scope-references": [
           "$XSAPPNAME.{{ .Values.global.kymaRuntime.developerGroup }}"
         ]
       },
       {
-        "name": "KymaCustomerAdmin",
-        "description": "Customer admin access",
+        "name": "KymaRuntimeAdmin",
+        "description": "Runtime admin access to all managed resources",
         "scope-references": [
           "$XSAPPNAME.{{ .Values.global.kymaRuntime.namespaceAdminGroup }}"
         ]

--- a/resources/uaa-activator/templates/secret.yaml
+++ b/resources/uaa-activator/templates/secret.yaml
@@ -17,7 +17,7 @@ stringData:
       },
       {
         "name": "$XSAPPNAME.{{ .Values.global.kymaRuntime.adminGroup }}",
-        "description": "Global admin access on all Kyma resources"
+        "description": "Global admin access to all Kyma resources"
       },
       {
         "name": "$XSAPPNAME.{{ .Values.global.kymaRuntime.developerGroup }}",
@@ -34,7 +34,7 @@ stringData:
       "role-templates": [
       {
         "name": "KymaAdmin",
-        "description": "Global admin access on all Kyma resources",
+        "description": "Global admin access to all Kyma resources",
         "scope-references": [
           "$XSAPPNAME.{{ .Values.global.kymaRuntime.adminGroup }}"
         ]

--- a/resources/uaa-activator/values.yaml
+++ b/resources/uaa-activator/values.yaml
@@ -6,7 +6,7 @@ global:
   kymaRuntime:
     adminGroup: runtimeAdmin
     developerGroup: runtimeDeveloper
-    namespaceAdminGroup: namespace-admins
+    namespaceAdminGroup: runtimeNamespaceAdmin
 
 image:
   registryPath: eu.gcr.io/kyma-project


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/master/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- Change group naming from `namespace-admin` to runtimeNamespaceAdmin
- Adjust helm charts for permission controller and uaa-activator
- Adjust Readme for permission controller
- Change makefile & var in test

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
