### PR TITLE
Update event-bus base images to curl 7.68.0

### DIFF
--- a/components/event-bus/cmd/event-publish-service/Dockerfile
+++ b/components/event-bus/cmd/event-publish-service/Dockerfile
@@ -1,4 +1,4 @@
-FROM curlimages/curl:7.66.0
+FROM curlimages/curl:7.68.0
 COPY event-publish-service /
 COPY licenses ./licenses
 ENTRYPOINT ["/event-publish-service"]

--- a/components/event-bus/cmd/subscription-controller/Dockerfile
+++ b/components/event-bus/cmd/subscription-controller/Dockerfile
@@ -1,4 +1,4 @@
-FROM curlimages/curl:7.66.0
+FROM curlimages/curl:7.68.0
 COPY subscription-controller /
 COPY licenses ./licenses
 ENTRYPOINT ["/subscription-controller"]


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Update event-bus base images to curl 7.68.0 to solve CVE-2019-15601

**Related issue(s)**

Closes #7325