### PR TITLE
Fix indention in pairing-adapter configuration

### DIFF
--- a/resources/compass/charts/pairing-adapter/templates/deployment.yaml
+++ b/resources/compass/charts/pairing-adapter/templates/deployment.yaml
@@ -53,5 +53,5 @@ spec:
                 protocol: TCP
                     {{- with .Values.deployment.securityContext }}
               securityContext:
-                {{ toYaml . | indent 16 }}
+{{ toYaml . | indent 16 }}
         {{- end }}


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/master/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

the previous indention cause rendering template in the following way:
```
              securityContext:
                                allowPrivilegeEscalation: false
                runAsUser: 2000
```
**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
