### PR TITLE
Add missing verb to application-connector ClusterRole

### DIFF
--- a/resources/application-connector/charts/application-broker/templates/cluster-role.yaml
+++ b/resources/application-connector/charts/application-broker/templates/cluster-role.yaml
@@ -38,6 +38,7 @@ rules:
 - apiGroups: ["messaging.knative.dev"]
   resources: ["channels"]
   verbs: ["list"]
+# Istio policies for authorization and authentication
 - apiGroups: ["authentication.istio.io"]
   resources: ["policies"]
-  verbs: ["create"]
+  verbs: ["create","update"]


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Add missing "update" verb to application-connector ClusterRole

This was omitted during the last PR (#7013)

**Related issue(s)**

#7013