### PR TITLE
Enable api-controller tests in e2e backup tests

### DIFF
--- a/resources/core/charts/api-controller/templates/deployment.yaml
+++ b/resources/core/charts/api-controller/templates/deployment.yaml
@@ -21,7 +21,7 @@ spec:
     spec:
       serviceAccountName: api-controller-account
       containers:
-      - image: eu.gcr.io/kyma-project/incubator/pr/api-gateway-controller:PR-94
+      - image: {{ .Values.global.containerRegistry.path }}/{{ .Values.global.api_controller.dir }}api-controller:{{ .Values.global.api_controller.version }}
         name: api-controller
         env:
         - name: DOMAIN_NAME

--- a/resources/core/charts/api-controller/templates/deployment.yaml
+++ b/resources/core/charts/api-controller/templates/deployment.yaml
@@ -21,7 +21,7 @@ spec:
     spec:
       serviceAccountName: api-controller-account
       containers:
-      - image: {{ .Values.global.containerRegistry.path }}/{{ .Values.global.api_controller.dir }}api-controller:{{ .Values.global.api_controller.version }}
+      - image: eu.gcr.io/kyma-project/incubator/pr/api-gateway-controller:PR-94
         name: api-controller
         env:
         - name: DOMAIN_NAME

--- a/tests/end-to-end/backup/pkg/common/common.go
+++ b/tests/end-to-end/backup/pkg/common/common.go
@@ -99,7 +99,7 @@ func RunTest(t *testing.T, mode TestMode) {
 		{enabled: true, backupTest: helmBrokerTest},
 		{enabled: true, backupTest: myEventBusTest},
 		{enabled: true, backupTest: myOryScenarioTest},
-		{enabled: true, backupTest: myApiGatewayScenarioTest}, //disabled due to bug: https://github.com/kyma-project/kyma/issues/7038
+		{enabled: true, backupTest: myApiGatewayScenarioTest},
 		{enabled: true, backupTest: myEventMeshTest},
 		// Rafter is not enabled yet in Kyma
 		// rafterTest,

--- a/tests/end-to-end/backup/pkg/common/common.go
+++ b/tests/end-to-end/backup/pkg/common/common.go
@@ -99,7 +99,7 @@ func RunTest(t *testing.T, mode TestMode) {
 		{enabled: true, backupTest: helmBrokerTest},
 		{enabled: true, backupTest: myEventBusTest},
 		{enabled: true, backupTest: myOryScenarioTest},
-		{enabled: false, backupTest: myApiGatewayScenarioTest}, //disabled due to bug: https://github.com/kyma-project/kyma/issues/7038
+		{enabled: true, backupTest: myApiGatewayScenarioTest}, //disabled due to bug: https://github.com/kyma-project/kyma/issues/7038
 		{enabled: true, backupTest: myEventMeshTest},
 		// Rafter is not enabled yet in Kyma
 		// rafterTest,

--- a/tests/end-to-end/backup/pkg/tests/ory/api_gateway.go
+++ b/tests/end-to-end/backup/pkg/tests/ory/api_gateway.go
@@ -92,7 +92,7 @@ func (ags *apiGatewayScenario) verifyTestAppNoAccess(t *testing.T) error {
 	testAppURL := ags.getSecuredTestAppURL(t)
 	ags.log(fmt.Sprintf("Test application URL: %s", testAppURL))
 
-	const expectedStatusCode = 403
+	const expectedStatusCode = 401
 	var accessToken = "Bearer Invalid"
 
 	tr := &http.Transport{


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Enable api-controller tests in e2e backup tests.
Fix in controller: https://github.com/kyma-incubator/api-gateway/pull/94

Note: due to recent changes in Oathkeeper, status code 403 is no longer valid (see diff).

**Related issue(s)**
#7038 
