### PR TITLE
Update image of function-controller: Apply cluster local label on KService, not on Function CR

### DIFF
--- a/resources/function-controller/values.yaml
+++ b/resources/function-controller/values.yaml
@@ -23,7 +23,7 @@ serverlessNamespace:
 images:
   manager:
     repository: eu.gcr.io/kyma-project/function-controller
-    tag: b0ae7812
+    tag: e558a57e
     pullPolicy: IfNotPresent
   kubeRbacProxy:
     repository: gcr.io/kubebuilder/kube-rbac-proxy


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:
- Update image of function-controller: Apply cluster local label on KService, not on Function CR

**Related issue(s)**
https://github.com/kyma-project/kyma/issues/5582
