### PR TITLE
Create template for failing test report

### DIFF
--- a/.github/ISSUE_TEMPLATE/failed-tests.md
+++ b/.github/ISSUE_TEMPLATE/failed-tests.md
@@ -1,0 +1,28 @@
+---
+name: Failing test
+about: Report a failing test in CI/CD pipeline or other environment
+---
+
+<!-- Thank you for your contribution. Before you submit the issue:
+1. Search open and closed issues for duplicates.
+2. Read the contributing guidelines.
+-->
+
+**Description**
+
+<!-- Provide a clear and concise description of the problem.
+Describe where it appears, when it occurred, and what it affects.  -->
+
+<!-- Provide relevant technical details such as the Kubernetes version, the cluster name and provider, the Kyma version, the browser name and version, or the operating system. -->
+
+**Test logs**
+
+<!-- Describe what you expect to happen. -->
+
+**Failed builds**
+
+<!-- Add links to failed builds for better tracability. -->
+
+**Troubleshooting**
+
+<!-- Describe the steps you have already taken to solve the issue. -->


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/master/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**
Add new issue template to report tests failing on CI/CD pipeline. We usually use bug report for that, but a bug report structure does not fit the highly repetitive reports from CI/CD. This PR adds a dedicated template for that

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
