### PR TITLE
Exclude Knative Serving queue proxy from Service Mesh

### DIFF
--- a/components/event-sources/reconciler/httpsource/reconcile.go
+++ b/components/event-sources/reconciler/httpsource/reconcile.go
@@ -95,6 +95,12 @@ const adapterHealthEndpoint = "/healthz"
 
 const applicationNameLabelKey = "application-name"
 
+// Istio config
+const (
+	istioExcludeInboundPortsAnnotation = "traffic.sidecar.istio.io/excludeInboundPorts"
+	knServingQueueProxyPort9091        = "9091"
+)
+
 // Reconcile compares the actual state of a HTTPSource object referenced by key
 // with its desired state, and attempts to converge the two.
 func (r *Reconciler) Reconcile(ctx context.Context, key string) error {
@@ -296,6 +302,8 @@ func (r *Reconciler) makeKnService(src *sourcesv1alpha1.HTTPSource,
 		object.WithControllerRef(src.ToOwner()),
 		object.WithLabel(routeconfig.VisibilityLabelKey, routeconfig.VisibilityClusterLocal),
 		object.WithLabel(applicationNameLabelKey, src.Name),
+		// allow prometheus to scrape the metrics; it needs to be excluded from the service mesh because prometheus is not part of the mesh
+		object.WithPodAnnotations(istioExcludeInboundPortsAnnotation, knServingQueueProxyPort9091),
 		object.WithPodLabel(dashboardLabelKey, dashboardLabelValue),
 	)
 }

--- a/components/event-sources/reconciler/object/service.go
+++ b/components/event-sources/reconciler/object/service.go
@@ -66,6 +66,11 @@ func WithPort(port int32) ObjectOption {
 // WithMinScale specifies the minimum number of Pods this Service should have
 // at any given time.
 func WithMinScale(replicas int) ObjectOption {
+	return WithPodAnnotations(autoscaling.MinScaleAnnotationKey, strconv.Itoa(replicas))
+}
+
+// WithPodAnnotations sets annotations on the pod
+func WithPodAnnotations(key, val string) ObjectOption {
 	return func(o metav1.Object) {
 		s := o.(*servingv1alpha1.Service)
 
@@ -73,7 +78,7 @@ func WithMinScale(replicas int) ObjectOption {
 		if *tpl == nil {
 			*tpl = &servingv1alpha1.RevisionTemplateSpec{}
 		}
-		metav1.SetMetaDataAnnotation(&(*tpl).ObjectMeta, autoscaling.MinScaleAnnotationKey, strconv.Itoa(replicas))
+		metav1.SetMetaDataAnnotation(&(*tpl).ObjectMeta, key, val)
 	}
 }
 

--- a/components/event-sources/reconciler/object/service_test.go
+++ b/components/event-sources/reconciler/object/service_test.go
@@ -39,6 +39,8 @@ func TestNewService(t *testing.T) {
 		WithPort(8081),
 		WithProbe("/are/you/alive"),
 		WithEnvVar("TEST_ENV2", "val2"),
+		WithPodLabel("label1", "val1"),
+		WithPodAnnotations("annotation1", "val1"),
 	)
 
 	expectKsvc := &servingv1alpha1.Service{
@@ -49,6 +51,14 @@ func TestNewService(t *testing.T) {
 		Spec: servingv1alpha1.ServiceSpec{
 			ConfigurationSpec: servingv1alpha1.ConfigurationSpec{
 				Template: &servingv1alpha1.RevisionTemplateSpec{
+					ObjectMeta: metav1.ObjectMeta{
+						Annotations: map[string]string{
+							"annotation1": "val1",
+						},
+						Labels: map[string]string{
+							"label1": "val1",
+						},
+					},
 					Spec: servingv1alpha1.RevisionSpec{
 						RevisionSpec: servingv1.RevisionSpec{
 							PodSpec: corev1.PodSpec{


### PR DESCRIPTION
**Description**

**WIP**

!!Maybe the PR is not required!!

Changes proposed in this pull request:

- Exclude Knative Serving queue proxy from Service Mesh
- Add test for `WithPodLabel `

**Related issue(s)**
#7240 

**Why**
- queue-metrics on port 9091 is monitored by Prometheus and used in Grafana dashboard `Event Mesh / Delivery`, graph `HTTP Adapter Events`
- with the new `authorizationpolicies.security.istio.io` for the Http Source Adapter (see #7240) the communication between `Prometheus` and `HTTP Adapter queue-proxy port 9091` is not allowed anymore. Since Prometheus is outside the Service Mesh, it seems we cannot whitelist using `authorizationpolicies`. 
