### PR TITLE
Refactor Runtime Agent metrics schema

### DIFF
--- a/components/compass-runtime-agent/internal/metrics/logger.go
+++ b/components/compass-runtime-agent/internal/metrics/logger.go
@@ -64,20 +64,17 @@ func (l *logger) fetchClusterInfo() (ClusterInfo, error) {
 	}
 
 	return ClusterInfo{
-		ShouldBeFetched: true,
-		Resources:       resources,
-		Usage:           metrics,
-		Time:            time.Now(),
+		Resources: resources,
+		Usage:     metrics,
 	}, nil
 }
 
 func (l *logger) printLogs(clusterInfo ClusterInfo) {
-	log.SetFormatter(&log.JSONFormatter{
-		DisableTimestamp: true,
-	})
+	log.SetFormatter(&log.JSONFormatter{})
 
 	log.WithFields(log.Fields{
-		"metrics": clusterInfo,
+		"clusterInfo": clusterInfo,
+		"metrics":     true,
 	}).Info("Cluster metrics logged successfully.")
 
 	log.SetFormatter(&log.TextFormatter{})

--- a/components/compass-runtime-agent/internal/metrics/logger_test.go
+++ b/components/compass-runtime-agent/internal/metrics/logger_test.go
@@ -2,9 +2,11 @@ package metrics
 
 import (
 	"bytes"
+	"encoding/json"
 	"fmt"
 	log "github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	meta "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -21,6 +23,14 @@ const (
 	loggingInterval = time.Millisecond
 	loggingWaitTime = time.Millisecond * 10
 )
+
+type Log struct {
+	Level       string      `json:"level"`
+	Metrics     bool        `json:"metrics"`
+	Msg         string      `json:"msg"`
+	Time        time.Time   `json:"time"`
+	ClusterInfo ClusterInfo `json:"clusterInfo"`
+}
 
 func Test_Log(t *testing.T) {
 	t.Run("should log metrics", func(t *testing.T) {
@@ -80,12 +90,20 @@ func Test_Log(t *testing.T) {
 
 		// then
 		logs := buffer.String()
-		assert.Equal(t, true, strings.Contains(logs, "Cluster metrics logged successfully."), "did not log metrics")
+		logsSlice := strings.Split(logs, "\n")
+		require.NotEqual(t, 0, len(logsSlice), "there are no logs")
+
+		var singleLog Log
+		err := json.Unmarshal([]byte(logsSlice[0]), &singleLog)
+		require.NoError(t, err, "failed to unmarshal the first log")
+
+		assert.Equal(t, true, singleLog.Metrics)
+		assert.Equal(t, "info", singleLog.Level)
+		assert.Equal(t, "Cluster metrics logged successfully.", singleLog.Msg)
+		assert.NotEqual(t, 0, len(singleLog.ClusterInfo.Resources))
+		assert.NotEqual(t, 0, len(singleLog.ClusterInfo.Usage))
+
 		assert.Equal(t, true, strings.Contains(logs, "Logging stopped."), "did not finish gracefully")
-		assert.Equal(t, true, strings.Contains(logs, "\"metrics\":true"), "metrics flag is not true")
-		assert.Equal(t, true, strings.Contains(logs, "\"time\""), "there is no timestamp in the log")
-		assert.Equal(t, false, strings.Contains(logs, "\"resources\":[]"), "resources are not empty")
-		assert.Equal(t, false, strings.Contains(logs, "\"usage\":[]"), "usage is not empty")
 		assert.Equal(t, false, strings.Contains(logs, "error"), "logged an error")
 	})
 

--- a/components/compass-runtime-agent/internal/metrics/logger_test.go
+++ b/components/compass-runtime-agent/internal/metrics/logger_test.go
@@ -83,6 +83,7 @@ func Test_Log(t *testing.T) {
 		assert.Equal(t, true, strings.Contains(logs, "Cluster metrics logged successfully."), "did not log metrics")
 		assert.Equal(t, true, strings.Contains(logs, "Logging stopped."), "did not finish gracefully")
 		assert.Equal(t, true, strings.Contains(logs, "\"metrics\":true"), "metrics flag is not true")
+		assert.Equal(t, true, strings.Contains(logs, "\"time\""), "there is no timestamp in the log")
 		assert.Equal(t, false, strings.Contains(logs, "\"resources\":[]"), "resources are not empty")
 		assert.Equal(t, false, strings.Contains(logs, "\"usage\":[]"), "usage is not empty")
 		assert.Equal(t, false, strings.Contains(logs, "error"), "logged an error")

--- a/components/compass-runtime-agent/internal/metrics/logger_test.go
+++ b/components/compass-runtime-agent/internal/metrics/logger_test.go
@@ -82,7 +82,7 @@ func Test_Log(t *testing.T) {
 		logs := buffer.String()
 		assert.Equal(t, true, strings.Contains(logs, "Cluster metrics logged successfully."), "did not log metrics")
 		assert.Equal(t, true, strings.Contains(logs, "Logging stopped."), "did not finish gracefully")
-		assert.Equal(t, true, strings.Contains(logs, "\"shouldBeFetched\":true"), "shouldBeFetched flag is not true")
+		assert.Equal(t, true, strings.Contains(logs, "\"metrics\":true"), "metrics flag is not true")
 		assert.Equal(t, false, strings.Contains(logs, "\"resources\":[]"), "resources are not empty")
 		assert.Equal(t, false, strings.Contains(logs, "\"usage\":[]"), "usage is not empty")
 		assert.Equal(t, false, strings.Contains(logs, "error"), "logged an error")

--- a/components/compass-runtime-agent/internal/metrics/model.go
+++ b/components/compass-runtime-agent/internal/metrics/model.go
@@ -3,10 +3,8 @@ package metrics
 import "time"
 
 type ClusterInfo struct {
-	ShouldBeFetched bool            `json:"shouldBeFetched"`
-	Time            time.Time       `json:"time"`
-	Resources       []NodeResources `json:"resources"`
-	Usage           []NodeMetrics   `json:"usage"`
+	Resources []NodeResources `json:"resources"`
+	Usage     []NodeMetrics   `json:"usage"`
 }
 
 type NodeResources struct {

--- a/resources/compass-runtime-agent/values.yaml
+++ b/resources/compass-runtime-agent/values.yaml
@@ -4,7 +4,7 @@ global:
       path: eu.gcr.io/kyma-project
     runtimeAgent:
       dir:
-      version: "PR-7197"
+      version: "PR-7403"
     runtimeAgentTests:
       dir:
       version: "cfcfa726"


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Change the `shouldBeFetched` flag to the `metrics` one 
- Clean up the log schema

<details>
<summary>See the JSON schema of the log</summary>

```json
{
  "type": "object",
  "properties": {
    "clusterInfo": {
      "type": "object",
      "title": "Cluster info.",
      "properties": {
        "resources": {
          "type": "array",
          "title": "List of nodes resources.",
          "items": [
            {
              "type": "object",
              "properties": {
                "nodeName": {
                  "type": "string",
                  "title": "Name of the node. Example: minikube"
                },
                "instanceType": {
                  "type": "string",
                  "title": "Instance type. Example: n1-standard-4"
                },
                "capacity": {
                  "type": "object",
                  "title": "Total resources of the node.",
                  "properties": {
                    "cpu": {
                      "type": "string",
                      "title": "CPU limit if specified. Example: 4"
                    },
                    "ephemeralStorage": {
                      "type": "string",
                      "title": "Local ephemeral storage. Example: 25497928Ki"
                    },
                    "memory": {
                      "type": "string",
                      "title": "Memory limit if specified. Example: 8163684Ki"
                    },
                    "pods": {
                      "type": "string",
                      "title": "Number of pods. Example: 110"
                    }
                  },
                  "required": [
                    "cpu",
                    "ephemeralStorage",
                    "memory",
                    "pods"
                  ]
                }
              },
              "required": [
                "nodeName",
                "instanceType",
                "capacity"
              ]
            }
          ]
        },
        "usage": {
          "type": "array",
          "title": "List of metrics for nodes.",
          "items": [
            {
              "type": "object",
              "properties": {
                "nodeName": {
                  "type": "string",
                  "title": "Node name. Example: gke-aaaaaa-default-pool-aaaaaaaa-aaaa"
                },
                "startCollectingTimestamp": {
                  "type": "string",
                  "title": "Timestamp from when metrics are collected. Example: 2020-02-12T13:33:52.39459378Z"
                },
                "usage": {
                  "type": "object",
                  "title": "Memory usage which is the memory working set.",
                  "properties": {
                    "cpu": {
                      "type": "string",
                      "title": "CPU limit if specified. Example: 760412892n"
                    },
                    "ephemeralStorage": {
                      "type": "string",
                      "title": "Local ephemeral storage. Example: 0"
                    },
                    "memory": {
                      "type": "string",
                      "title": "Memory limit if specified. Example: 8163684Ki"
                    },
                    "pods": {
                      "type": "string",
                      "title": "Number of pods. Example: 0"
                    }
                  },
                  "required": [
                    "cpu",
                    "ephemeralStorage",
                    "memory",
                    "pods"
                  ]
                }
              },
              "required": [
                "nodeName",
                "startCollectingTimestamp",
                "usage"
              ]
            }
          ]
        }
      },
      "required": [
        "resources",
        "usage"
      ]
    },
    "level": {
      "type": "string",
      "title": "Log level. Example: info"
    },
    "metrics": {
      "type": "boolean",
      "title": "The FluentBit matcher. Example: true"
    },
    "msg": {
      "type": "string",
      "title": "Log message. Example: Cluster metrics logged successfully."
    },
    "time": {
      "type": "string",
      "title": "Time of the log. Example: 2020-02-12T13:33:52.39459378Z"
    }
  },
  "required": [
    "clusterInfo",
    "level",
    "metrics",
    "msg",
    "time"
  ]
}
```

</details>

<details>
<summary>See the log example</summary>

```json
{
   "clusterInfo":{
      "resources":[
         {
            "nodeName":"somename",
            "instanceType":"somelabel",
            "capacity":{
               "cpu":"1",
               "ephemeralStorage":"1",
               "memory":"1",
               "pods":"1"
            }
         }
      ],
      "usage":[
         {
            "nodeName":"somename",
            "startCollectingTimestamp":"2020-02-28T15:39:44.885369+01:00",
            "usage":{
               "cpu":"1",
               "ephemeralStorage":"1",
               "memory":"1",
               "pods":"1"
            }
         }
      ]
   },
   "level":"info",
   "metrics":true,
   "msg":"Cluster metrics logged successfully.",
   "time":"2020-02-28T15:39:44+01:00"
}
```

</details>

**Related issue(s)**

still none
