### PR TITLE
Fix logging Kn Sub in App Broker

### DIFF
--- a/components/application-broker/internal/broker/provision.go
+++ b/components/application-broker/internal/broker/provision.go
@@ -399,10 +399,11 @@ func (svc *ProvisionService) persistKnativeSubscription(applicationName internal
 	case apiErrors.IsNotFound(err):
 		// subscription not found, create a new one
 		newSubscription := knative.Subscription(knSubscriptionNamePrefix, integrationNamespace).Spec(channel, defaultBrokerURI).Labels(labels).Build()
-		if _, err := svc.knClient.CreateSubscription(newSubscription); err != nil {
-			return errors.Wrapf(err, "creating Subscription %s", newSubscription.Name)
+		createdSub, err := svc.knClient.CreateSubscription(newSubscription)
+		if err != nil {
+			return errors.Wrapf(err, "while creating Knative Subscription")
 		}
-		svc.log.Printf("created Knative Subscription: [%v]", newSubscription.Name)
+		svc.log.Printf("Created Knative Subscription: [%v]", createdSub.Name)
 		return nil
 	case err != nil:
 		return errors.Wrapf(err, "getting Subscription by labels [%v]", labels)


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

Currently, we have a bug, and we are logging such entry:
```
{"level":"info","log":{"message":"created Knative Subscription: []","service":"provisioner","time":"2020-02-28T16:42:46.112Z"}}
```
This is because the name of the Knative Sub is generated by k8s, so we need to change a way how we are doing the logging.

**Related issue(s)**

- https://github.com/kyma-project/kyma/issues/7201
