### PR TITLE
Extend admin permissions test

### DIFF
--- a/resources/core/charts/cluster-users/templates/clusterroles-k8s-io.yaml
+++ b/resources/core/charts/cluster-users/templates/clusterroles-k8s-io.yaml
@@ -96,7 +96,7 @@ rules:
   resources:
     - "customresourcedefinitions"
   verbs:
-    - "list"
+{{ toYaml .Values.clusterRoles.verbs.view | indent 4 }}
 
 ---
 #View access to K8s resources

--- a/resources/core/charts/cluster-users/values.yaml
+++ b/resources/core/charts/cluster-users/values.yaml
@@ -21,7 +21,7 @@ clusterRoles:
       - "servicecatalog.k8s.io"
       - "settings.k8s.io"
       - "metrics.k8s.io"
-      - "coordination.k8s.io "
+      - "coordination.k8s.io"
     istio:
       - "authentication.istio.io"
       - "config.istio.io"

--- a/resources/core/values.yaml
+++ b/resources/core/values.yaml
@@ -61,7 +61,7 @@ global:
     version: e2ed2a2d
   cluster_users_integration_tests:
     dir:
-    version: PR-7461
+    version: PR-7428
   xip_patch:
     dir:
     version: 4664d0f6

--- a/tests/integration/cluster-users/sar-test.sh
+++ b/tests/integration/cluster-users/sar-test.sh
@@ -109,6 +109,8 @@ function testPermissions() {
 	TEST_NS="$3"
 	EXPECTED="$4"
 
+	sleep 0.1
+
 	set +e
 	TEST=$(kubectl auth can-i "${OPERATION}" "${RESOURCE}" -n "${TEST_NS}")
 	set -e
@@ -139,6 +141,8 @@ function testPermissionsClusterScoped() {
 	OPERATION="$1"
 	RESOURCE="$2"
 	EXPECTED="$4"
+
+	sleep 0.1
 
 	set +e
 	TEST=$(kubectl auth can-i "${OPERATION}" "${RESOURCE}" --all-namespaces)
@@ -410,24 +414,117 @@ function runTests() {
 	echo "--> ${NAMESPACE_ADMIN_EMAIL} should NOT be able to create clusterrolebindings in the cluster"
 	testPermissionsClusterScoped "create" "clusterrolebinding" "no"
 
-	# namespace admin should be able to get/create k8s and kyma resources in the namespace they created
+	# namespace admin should be able to get/list/create/delete k8s and kyma resources in the namespace they created
 	echo "--> ${NAMESPACE_ADMIN_EMAIL} should be able to list Deployments in the namespace they created"
-	testPermissions "list" "deployment" "${CUSTOM_NAMESPACE}" "yes"
+	testPermissions "list" "deployments" "${CUSTOM_NAMESPACE}" "yes"
 
-	echo "--> ${NAMESPACE_ADMIN_EMAIL} should be able to get Pods in the namespace they created"
+	echo "--> ${NAMESPACE_ADMIN_EMAIL} should be able to create Deployment in the namespace they created"
+	testPermissions "create" "deployment" "${CUSTOM_NAMESPACE}" "yes"
+
+	echo "--> ${NAMESPACE_ADMIN_EMAIL} should be able to update Deployment in the namespace they created"
+	testPermissions "update" "deployment" "${CUSTOM_NAMESPACE}" "yes"
+
+	echo "--> ${NAMESPACE_ADMIN_EMAIL} should be able to get Deployment in the namespace they created"
+	testPermissions "get" "deployment" "${CUSTOM_NAMESPACE}" "yes"
+
+	echo "--> ${NAMESPACE_ADMIN_EMAIL} should be able to delete Deployment in the namespace they created"
+	testPermissions "delete" "deployment" "${CUSTOM_NAMESPACE}" "yes"
+
+	echo "--> ${NAMESPACE_ADMIN_EMAIL} should be able to list Pods in the namespace they created"
+	testPermissions "list" "pods" "${CUSTOM_NAMESPACE}" "yes"
+
+	echo "--> ${NAMESPACE_ADMIN_EMAIL} should be able to create Pod in the namespace they created"
+	testPermissions "create" "pod" "${CUSTOM_NAMESPACE}" "yes"
+
+	echo "--> ${NAMESPACE_ADMIN_EMAIL} should be able to update Pod in the namespace they created"
+	testPermissions "update" "pod" "${CUSTOM_NAMESPACE}" "yes"
+
+	echo "--> ${NAMESPACE_ADMIN_EMAIL} should be able to get Pod in the namespace they created"
 	testPermissions "get" "pod" "${CUSTOM_NAMESPACE}" "yes"
 
-	echo "--> ${NAMESPACE_ADMIN_EMAIL} should be able to create ory Access Rule in the namespace they created"
+	echo "--> ${NAMESPACE_ADMIN_EMAIL} should be able to delete Pod in the namespace they created"
+	testPermissions "delete" "pod" "${CUSTOM_NAMESPACE}" "yes"
+
+	echo "--> ${NAMESPACE_ADMIN_EMAIL} should be able to list ConfigMaps in the namespace they created"
+	testPermissions "list" "configmaps" "${CUSTOM_NAMESPACE}" "yes"
+
+	echo "--> ${NAMESPACE_ADMIN_EMAIL} should be able to create ConfigMap in the namespace they created"
+	testPermissions "create" "configmap" "${CUSTOM_NAMESPACE}" "yes"
+
+	echo "--> ${NAMESPACE_ADMIN_EMAIL} should be able to update ConfigMap in the namespace they created"
+	testPermissions "update" "configmap" "${CUSTOM_NAMESPACE}" "yes"
+
+	echo "--> ${NAMESPACE_ADMIN_EMAIL} should be able to get ConfigMap in the namespace they created"
+	testPermissions "get" "configmap" "${CUSTOM_NAMESPACE}" "yes"
+
+	echo "--> ${NAMESPACE_ADMIN_EMAIL} should be able to delete ConfigMap in the namespace they created"
+	testPermissions "delete" "configmap" "${CUSTOM_NAMESPACE}" "yes"
+
+	echo "--> ${NAMESPACE_ADMIN_EMAIL} should be able to list ORY Access Rules in the namespace they created"
+	testPermissions "list" "rules.oathkeeper.ory.sh" "${CUSTOM_NAMESPACE}" "yes"
+
+	echo "--> ${NAMESPACE_ADMIN_EMAIL} should be able to create ORY Access Rule in the namespace they created"
 	testPermissions "create" "rule.oathkeeper.ory.sh" "${CUSTOM_NAMESPACE}" "yes"
 
-	echo "--> ${NAMESPACE_ADMIN_EMAIL} should be able to create secret in the namespace they created"
+	echo "--> ${NAMESPACE_ADMIN_EMAIL} should be able to update ORY Access Rule in the namespace they created"
+	testPermissions "update" "rule.oathkeeper.ory.sh" "${CUSTOM_NAMESPACE}" "yes"
+
+	echo "--> ${NAMESPACE_ADMIN_EMAIL} should be able to get ORY Access Rule in the namespace they created"
+	testPermissions "get" "rule.oathkeeper.ory.sh" "${CUSTOM_NAMESPACE}" "yes"
+
+	echo "--> ${NAMESPACE_ADMIN_EMAIL} should be able to delete ORY Access Rule in the namespace they created"
+	testPermissions "delete" "rule.oathkeeper.ory.sh" "${CUSTOM_NAMESPACE}" "yes"
+
+	echo "--> ${NAMESPACE_ADMIN_EMAIL} should be able to list Secrets in the namespace they created"
+	testPermissions "list" "secrets" "${CUSTOM_NAMESPACE}" "yes"
+
+	echo "--> ${NAMESPACE_ADMIN_EMAIL} should be able to create Secret in the namespace they created"
 	testPermissions "create" "secret" "${CUSTOM_NAMESPACE}" "yes"
 
-	echo "--> ${NAMESPACE_ADMIN_EMAIL} should be able to delete namespace they created in the cluster"
-	testPermissionsClusterScoped "delete" "namespace" "yes"
+	echo "--> ${NAMESPACE_ADMIN_EMAIL} should be able to update Secret in the namespace they created"
+	testPermissions "update" "secret" "${CUSTOM_NAMESPACE}" "yes"
+
+	echo "--> ${NAMESPACE_ADMIN_EMAIL} should be able to get Secret in the namespace they created"
+	testPermissions "get" "secret" "${CUSTOM_NAMESPACE}" "yes"
+
+	echo "--> ${NAMESPACE_ADMIN_EMAIL} should be able to delete Secret in the namespace they created"
+	testPermissions "delete" "secret" "${CUSTOM_NAMESPACE}" "yes"
+
+	echo "--> ${NAMESPACE_ADMIN_EMAIL} should be able to list Roles in the namespace they created"
+	testPermissions "list" "roles.rbac.authorization.k8s.io" "${CUSTOM_NAMESPACE}" "yes"
+
+	echo "--> ${NAMESPACE_ADMIN_EMAIL} should be able to create Role in the namespace they created"
+	testPermissions "create" "role.rbac.authorization.k8s.io" "${CUSTOM_NAMESPACE}" "yes"
+
+	echo "--> ${NAMESPACE_ADMIN_EMAIL} should be able to get Role in the namespace they created"
+	testPermissions "get" "role.rbac.authorization.k8s.io" "${CUSTOM_NAMESPACE}" "yes"
+
+	echo "--> ${NAMESPACE_ADMIN_EMAIL} should be able to update Role in the namespace they created"
+	testPermissions "update" "role.rbac.authorization.k8s.io" "${CUSTOM_NAMESPACE}" "yes"
+
+	echo "--> ${NAMESPACE_ADMIN_EMAIL} should be able to delete Role in the namespace they created"
+	testPermissions "delete" "role.rbac.authorization.k8s.io" "${CUSTOM_NAMESPACE}" "yes"
+
+	echo "--> ${NAMESPACE_ADMIN_EMAIL} should be able to list RoleBindings in the namespace they created"
+	testPermissions "list" "rolebindings.rbac.authorization.k8s.io" "${CUSTOM_NAMESPACE}" "yes"
+
+	echo "--> ${NAMESPACE_ADMIN_EMAIL} should be able to create RoleBinding in the namespace they created"
+	testPermissions "create" "rolebinding.rbac.authorization.k8s.io" "${CUSTOM_NAMESPACE}" "yes"
+
+	echo "--> ${NAMESPACE_ADMIN_EMAIL} should be able to get RoleBinding in the namespace they created"
+	testPermissions "get" "rolebinding.rbac.authorization.k8s.io" "${CUSTOM_NAMESPACE}" "yes"
+
+	echo "--> ${NAMESPACE_ADMIN_EMAIL} should be able to update RoleBinding in the namespace they created"
+	testPermissions "update" "rolebinding.rbac.authorization.k8s.io" "${CUSTOM_NAMESPACE}" "yes"
+
+	echo "--> ${NAMESPACE_ADMIN_EMAIL} should be able to delete RoleBinding in the namespace they created"
+	testPermissions "delete" "rolebinding.rbac.authorization.k8s.io" "${CUSTOM_NAMESPACE}" "yes"
 
 	echo "--> ${NAMESPACE_ADMIN_EMAIL} should be able to create rolebindings to kyma-developer clusterrole in the namespace they created"
 	createRoleBindingForNamespaceDeveloper
+
+	echo "--> ${NAMESPACE_ADMIN_EMAIL} should be able to delete namespace they created in the cluster"
+	testPermissionsClusterScoped "delete" "namespace" "yes"
 
 	echo "--> ${NAMESPACE_ADMIN_EMAIL} should be able to get addonsconfigurations.addons.kyma-project.io in the namespace they created"
 	testPermissions "get" "addonsconfigurations.addons.kyma-project.io" "${CUSTOM_NAMESPACE}" "yes"
@@ -448,6 +545,42 @@ function runTests() {
 	testPermissions "delete" "addonsconfigurations.addons.kyma-project.io" "${CUSTOM_NAMESPACE}" "yes"
 
 	testRafter "${NAMESPACE_ADMIN_EMAIL}" "${CUSTOM_NAMESPACE}"
+
+	echo "--> ${NAMESPACE_ADMIN_EMAIL} should be able to get addonsconfigurations.addons.kyma-project.io in the namespace they created"
+	testPermissions "get" "addonsconfigurations/status.addons.kyma-project.io" "${CUSTOM_NAMESPACE}" "yes"
+
+	echo "--> ${NAMESPACE_ADMIN_EMAIL} should be able to list addonsconfigurations.addons.kyma-project.io in the namespace they created"
+	testPermissions "list" "addonsconfigurations/status.addons.kyma-project.io" "${CUSTOM_NAMESPACE}" "yes"
+
+	echo "--> ${NAMESPACE_ADMIN_EMAIL} should be able to watch addonsconfigurations.addons.kyma-project.io in the namespace they created"
+	testPermissions "watch" "addonsconfigurations/status.addons.kyma-project.io" "${CUSTOM_NAMESPACE}" "yes"
+
+	echo "--> ${NAMESPACE_ADMIN_EMAIL} should be able to create addonsconfiguration.addons.kyma-project.io in the namespace they created"
+	testPermissions "create" "addonsconfiguration/status.addons.kyma-project.io" "${CUSTOM_NAMESPACE}" "yes"
+
+	echo "--> ${NAMESPACE_ADMIN_EMAIL} should be able to update addonsconfigurations.addons.kyma-project.io in the namespace they created"
+	testPermissions "update" "addonsconfigurations/status.addons.kyma-project.io" "${CUSTOM_NAMESPACE}" "yes"
+
+	echo "--> ${NAMESPACE_ADMIN_EMAIL} should be able to delete addonsconfigurations.addons.kyma-project.io in the namespace they created"
+	testPermissions "delete" "addonsconfigurations/status.addons.kyma-project.io" "${CUSTOM_NAMESPACE}" "yes"
+
+	echo "--> ${NAMESPACE_ADMIN_EMAIL} should be able to get addonsconfigurations.addons.kyma-project.io in the namespace they created"
+	testPermissions "get" "addonsconfigurations/finalizers.addons.kyma-project.io" "${CUSTOM_NAMESPACE}" "yes"
+
+	echo "--> ${NAMESPACE_ADMIN_EMAIL} should be able to list addonsconfigurations.addons.kyma-project.io in the namespace they created"
+	testPermissions "list" "addonsconfigurations/finalizers.addons.kyma-project.io" "${CUSTOM_NAMESPACE}" "yes"
+
+	echo "--> ${NAMESPACE_ADMIN_EMAIL} should be able to watch addonsconfigurations.addons.kyma-project.io in the namespace they created"
+	testPermissions "watch" "addonsconfigurations/finalizers.addons.kyma-project.io" "${CUSTOM_NAMESPACE}" "yes"
+
+	echo "--> ${NAMESPACE_ADMIN_EMAIL} should be able to create addonsconfiguration.addons.kyma-project.io in the namespace they created"
+	testPermissions "create" "addonsconfiguration/finalizers.addons.kyma-project.io" "${CUSTOM_NAMESPACE}" "yes"
+
+	echo "--> ${NAMESPACE_ADMIN_EMAIL} should be able to update addonsconfigurations.addons.kyma-project.io in the namespace they created"
+	testPermissions "update" "addonsconfigurations/finalizers.addons.kyma-project.io" "${CUSTOM_NAMESPACE}" "yes"
+
+	echo "--> ${NAMESPACE_ADMIN_EMAIL} should be able to delete addonsconfigurations.addons.kyma-project.io in the namespace they created"
+	testPermissions "delete" "addonsconfigurations/finalizers.addons.kyma-project.io" "${CUSTOM_NAMESPACE}" "yes"
 
 	# developer who was granted kyma-developer role should be able to operate in the scope of its namespace
 	EMAIL=${DEVELOPER_EMAIL} PASSWORD=${DEVELOPER_PASSWORD} getConfigFile

--- a/tests/integration/cluster-users/sar-test.sh
+++ b/tests/integration/cluster-users/sar-test.sh
@@ -402,13 +402,13 @@ function runTests() {
 	echo "--> ${NAMESPACE_ADMIN_EMAIL} should NOT be able to create secret in system namespace"
 	testPermissions "create" "secret" "${SYSTEM_NAMESPACE}" "no"
 
-	echo "--> ${NAMESPACE_ADMIN_EMAIL} should NOT be able to delete system namespace"
-	testPermissions "delete" "namespace" "${SYSTEM_NAMESPACE}" "no"
+	echo "--> ${NAMESPACE_ADMIN_EMAIL} should NOT be able to delete system namespace in the cluster"
+	testPermissionsClusterScoped "delete" "namespace" "no"
 
 	# namespace admin should not be able to create clusterrolebindings - if they can't create it in one namespace,
 	# that means they can't create it in any namespace (resource is non namespaced and RBAC is permissive)
-	echo "--> ${NAMESPACE_ADMIN_EMAIL} should NOT be able to create clusterrolebindings"
-	testPermissions "create" "clusterrolebinding" "${SYSTEM_NAMESPACE}" "no"
+	echo "--> ${NAMESPACE_ADMIN_EMAIL} should NOT be able to create clusterrolebindings in the cluster"
+	testPermissionsClusterScoped "create" "clusterrolebinding" "no"
 
 	# namespace admin should be able to get/create k8s and kyma resources in the namespace they created
 	echo "--> ${NAMESPACE_ADMIN_EMAIL} should be able to list Deployments in the namespace they created"
@@ -423,8 +423,8 @@ function runTests() {
 	echo "--> ${NAMESPACE_ADMIN_EMAIL} should be able to create secret in the namespace they created"
 	testPermissions "create" "secret" "${CUSTOM_NAMESPACE}" "yes"
 
-	echo "--> ${NAMESPACE_ADMIN_EMAIL} should be able to delete namespace they created"
-	testPermissions "delete" "namespace" "${CUSTOM_NAMESPACE}" "yes"
+	echo "--> ${NAMESPACE_ADMIN_EMAIL} should be able to delete namespace they created in the cluster"
+	testPermissionsClusterScoped "delete" "namespace" "yes"
 
 	echo "--> ${NAMESPACE_ADMIN_EMAIL} should be able to create rolebindings to kyma-developer clusterrole in the namespace they created"
 	createRoleBindingForNamespaceDeveloper

--- a/tests/integration/cluster-users/sar-test.sh
+++ b/tests/integration/cluster-users/sar-test.sh
@@ -402,7 +402,7 @@ function runTests() {
 	echo "--> ${ADMIN_EMAIL} should be able to describe Pods in ${SYSTEM_NAMESPACE}"
 	testDescribe "pods" "${SYSTEM_NAMESPACE}" "yes"
 
-  echo "--> ${ADMIN_EMAIL} should be able to describe Nodes in the cluster"
+	echo "--> ${ADMIN_EMAIL} should be able to describe Nodes in the cluster"
 	testDescribeClusterScoped "nodes" "yes"
 
 	EMAIL=${VIEW_EMAIL} PASSWORD=${VIEW_PASSWORD} getConfigFile

--- a/tests/integration/cluster-users/sar-test.sh
+++ b/tests/integration/cluster-users/sar-test.sh
@@ -79,40 +79,6 @@ function __createNamespaceForNamespaceAdmin() {
 	return 1
 }
 
-function __testPermissionsDebug() {
-	local OPERATION="$1"
-	local RESOURCE="$2"
-	local TEST_NS="$3"
-	local EXPECTED="$4"
-	local TEST="not-set-yet"
-
-	if [[ "${TEST_NS}" != "--all-namespaces" ]]; then
-		TEST_NS="-n${TEST_NS}"
-	fi
-
-	sleep 0.1
-
-	set +e
-	echo "__testPermissionsDebug() ====================>"
-	echo "kubectl auth can-i list deployments -n  $3  -v10"
-	      kubectl auth can-i list deployments -n "$3" -v10
-	echo "========================================"
-	echo "kubectl auth can-i  ${OPERATION}   ${RESOURCE}   ${TEST_NS}  -v10"
-	      kubectl auth can-i "${OPERATION}" "${RESOURCE}" "${TEST_NS}" -v10
-	echo "__testPermissionsDebug() <===================="
-	echo "${TEST}"
-	TEST=$(kubectl auth can-i "${OPERATION}" "${RESOURCE}" "${TEST_NS}" -v10)
-	echo "expected: ${EXPECTED}, actual: ${TEST}"
-	set -e
-	if [[ "${TEST}" == "${EXPECTED}" ]]; then
-		echo "----> PASSED"
-		return 0
-	fi
-
-	echo "----> |FAIL| Expected: ${EXPECTED}, Actual: ${TEST}"
-	return 1
-}
-
 function __testPermissions() {
 	local OPERATION="$1"
 	local RESOURCE="$2"
@@ -213,15 +179,6 @@ function createRoleBindingForNamespaceDeveloper() {
 
 function createNamespaceForNamespaceAdmin() {
 	__createNamespaceForNamespaceAdmin || (echo "Re-trying one more time..." && sleep ${RETRY_TIME} && __createNamespaceForNamespaceAdmin || return 1)
-}
-
-
-function testPermissionsDebug() {
-	echo "testPermissionsDebug() ====================>"
-	echo "kubectl auth can-i list deployments -n  $3  -v10"
-	      kubectl auth can-i list deployments -n "$3" -v10
-	echo "testPermissionsDebug() <===================="
-	__testPermissionsDebug "$@" || return 1
 }
 
 function testPermissions() {
@@ -445,9 +402,6 @@ function runTests() {
 	echo "--> ${ADMIN_EMAIL} should be able to describe Pods in ${SYSTEM_NAMESPACE}"
 	testDescribe "pods" "${SYSTEM_NAMESPACE}" "yes"
 
-	echo "--> ${ADMIN_EMAIL} should be able to describe Pods in ${SYSTEM_NAMESPACE}"
-	testDescribe "pods" "${SYSTEM_NAMESPACE}" "yes"
-
   echo "--> ${ADMIN_EMAIL} should be able to describe Nodes in the cluster"
 	testDescribeClusterScoped "nodes" "yes"
 
@@ -505,7 +459,7 @@ function runTests() {
 
 	# namespace admin should be able to get/list/create/delete k8s and kyma resources in the namespace they created
   echo "--> ${NAMESPACE_ADMIN_EMAIL} should be able to list Deployments in the namespace they created"
-	testPermissionsDebug "list" "deployments" "${CUSTOM_NAMESPACE}" "yes"
+	testPermissions "list" "deployments" "${CUSTOM_NAMESPACE}" "yes"
 
 	echo "--> ${NAMESPACE_ADMIN_EMAIL} should be able to create Deployment in the namespace they created"
 	testPermissions "create" "deployment" "${CUSTOM_NAMESPACE}" "yes"

--- a/tests/integration/cluster-users/sar-test.sh
+++ b/tests/integration/cluster-users/sar-test.sh
@@ -303,17 +303,20 @@ function runTests() {
 	echo "--> ${ADMIN_EMAIL} should be able to create ory Access Rule"
 	testPermissions "create" "rule.oathkeeper.ory.sh" "${NAMESPACE}" "yes"
 
-	echo "--> ${ADMIN_EMAIL} should be able to get ApplicationConnector/Applications"
-	testPermissions "get" "application.applicationconnector.kyma-project.io" "${NAMESPACE}" "yes"
+	echo "--> ${ADMIN_EMAIL} should be able to get applications.applicationconnector.kyma-project.io"
+	testPermissions "get" "applications.applicationconnector.kyma-project.io" "${NAMESPACE}" "yes"
 
-	echo "--> ${ADMIN_EMAIL} should be able to list ApplicationConnector/Applications"
+	echo "--> ${ADMIN_EMAIL} should be able to list applications.applicationconnector.kyma-project.io"
 	testPermissions "list" "applications.applicationconnector.kyma-project.io" "${NAMESPACE}" "yes"
 
-	echo "--> ${ADMIN_EMAIL} should be able to create ApplicationConnector/ApplicationMappings"
-	testPermissions "create" "applicationmapping.applicationconnector.kyma-project.io" "${NAMESPACE}" "yes"
+	echo "--> ${ADMIN_EMAIL} should be able to watch applications.applicationconnector.kyma-project.io"
+	testPermissions "watch" "applications.applicationconnector.kyma-project.io" "${NAMESPACE}" "yes"
 
-	echo "--> ${ADMIN_EMAIL} should be able to list ApplicationConnector/ApplicationMappings"
+	echo "--> ${ADMIN_EMAIL} should be able to list applicationmappings.applicationconnector.kyma-project.io"
 	testPermissions "list" "applicationmappings.applicationconnector.kyma-project.io" "${NAMESPACE}" "yes"
+
+	echo "--> ${ADMIN_EMAIL} should be able to create applicationmapping.applicationconnector.kyma-project.io"
+	testPermissions "create" "applicationmapping.applicationconnector.kyma-project.io" "${NAMESPACE}" "yes"
 
 	echo "--> ${ADMIN_EMAIL} should be able to delete specific CRD"
 	testPermissions "delete" "crd/installations.installer.kyma-project.io" "${NAMESPACE}" "yes"
@@ -392,6 +395,24 @@ function runTests() {
 
 	echo "--> ${NAMESPACE_ADMIN_EMAIL} should be able to create rolebindings to kyma-developer clusterrole in the namespace they created"
 	createRoleBindingForNamespaceDeveloper
+
+	echo "--> ${NAMESPACE_ADMIN_EMAIL} should be able to get addonsconfigurations.addons.kyma-project.io in the namespace they created"
+	testPermissions "get" "addonsconfigurations.addons.kyma-project.io" "${CUSTOM_NAMESPACE}" "yes"
+
+	echo "--> ${NAMESPACE_ADMIN_EMAIL} should be able to list addonsconfigurations.addons.kyma-project.io in the namespace they created"
+	testPermissions "list" "addonsconfigurations.addons.kyma-project.io" "${CUSTOM_NAMESPACE}" "yes"
+
+	echo "--> ${NAMESPACE_ADMIN_EMAIL} should be able to watch addonsconfigurations.addons.kyma-project.io in the namespace they created"
+	testPermissions "watch" "addonsconfigurations.addons.kyma-project.io" "${CUSTOM_NAMESPACE}" "yes"
+
+	echo "--> ${NAMESPACE_ADMIN_EMAIL} should be able to create addonsconfiguration.addons.kyma-project.io in the namespace they created"
+	testPermissions "create" "addonsconfiguration.addons.kyma-project.io" "${CUSTOM_NAMESPACE}" "yes"
+
+	echo "--> ${NAMESPACE_ADMIN_EMAIL} should be able to update addonsconfigurations.addons.kyma-project.io in the namespace they created"
+	testPermissions "update" "addonsconfigurations.addons.kyma-project.io" "${CUSTOM_NAMESPACE}" "yes"
+
+	echo "--> ${NAMESPACE_ADMIN_EMAIL} should be able to delete addonsconfigurations.addons.kyma-project.io in the namespace they created"
+	testPermissions "delete" "addonsconfigurations.addons.kyma-project.io" "${CUSTOM_NAMESPACE}" "yes"
 
 	testRafter "${NAMESPACE_ADMIN_EMAIL}" "${CUSTOM_NAMESPACE}"
 

--- a/tests/integration/cluster-users/sar-test.sh
+++ b/tests/integration/cluster-users/sar-test.sh
@@ -693,15 +693,13 @@ function runTests() {
 	echo "--> ${DEVELOPER_EMAIL} should NOT be able to create rolebindings in system namespace"
 	testPermissions "create" "rolebinding" "${SYSTEM_NAMESPACE}" "no"
 
-<<<<<<< HEAD
 	testRafter "${DEVELOPER_EMAIL}" "${SYSTEM_NAMESPACE}"
-=======
+
 	echo "--> ${DEVELOPER_EMAIL} should be able to describe Pods in ${CUSTOM_NAMESPACE}"
 	testDescribe "pods" "${CUSTOM_NAMESPACE}" "yes"
 
 	echo "--> ${DEVELOPER_EMAIL} should NOT be able to describe Pods in ${SYSTEM_NAMESPACE}"
 	testDescribe "pods" "${SYSTEM_NAMESPACE}" "no"
->>>>>>> Debug
 }
 
 function cleanup() {

--- a/tests/integration/cluster-users/sar-test.sh
+++ b/tests/integration/cluster-users/sar-test.sh
@@ -322,10 +322,10 @@ function runTests() {
 	EMAIL=${ADMIN_EMAIL} PASSWORD=${ADMIN_PASSWORD} getConfigFile
 	export KUBECONFIG="${PWD}/kubeconfig"
 
-	echo "--> ${ADMIN_EMAIL} should be able to get ClusterRole in the cluster"
+	echo "--> ${ADMIN_EMAIL} should be able to get ClusterRole"
 	testPermissionsClusterScoped "get" "clusterrole" "yes"
 
-	echo "--> ${ADMIN_EMAIL} should be able to delete ClusterRole in the cluster"
+	echo "--> ${ADMIN_EMAIL} should be able to delete ClusterRole"
 	testPermissionsClusterScoped "delete" "clusterrole" "yes"
 
 	echo "--> ${ADMIN_EMAIL} should be able to delete Deployments"
@@ -366,13 +366,13 @@ function runTests() {
 	EMAIL=${VIEW_EMAIL} PASSWORD=${VIEW_PASSWORD} getConfigFile
 	export KUBECONFIG="${PWD}/kubeconfig"
 
-	echo "--> ${VIEW_EMAIL} should be able to get ClusterRole in the cluster"
+	echo "--> ${VIEW_EMAIL} should be able to get ClusterRole"
 	testPermissionsClusterScoped "get" "clusterrole" "yes"
 
 	echo "--> ${VIEW_EMAIL} should be able to list Deployments"
 	testPermissions "list" "deployment" "${NAMESPACE}" "yes"
 
-	echo "--> ${VIEW_EMAIL} should NOT be able to create Namespace in the cluster"
+	echo "--> ${VIEW_EMAIL} should NOT be able to create Namespace"
 	testPermissionsClusterScoped "create" "ns" "no"
 
 	echo "--> ${VIEW_EMAIL} should NOT be able to patch pod"
@@ -406,12 +406,12 @@ function runTests() {
 	echo "--> ${NAMESPACE_ADMIN_EMAIL} should NOT be able to create secret in system namespace"
 	testPermissions "create" "secret" "${SYSTEM_NAMESPACE}" "no"
 
-	echo "--> ${NAMESPACE_ADMIN_EMAIL} should NOT be able to delete system namespace in the cluster"
-	testPermissionsClusterScoped "delete" "namespace" "no"
+	echo "--> ${NAMESPACE_ADMIN_EMAIL} should NOT be able to delete system namespace"
+	testPermissions "delete" "namespace" "${SYSTEM_NAMESPACE}" "no"
 
 	# namespace admin should not be able to create clusterrolebindings - if they can't create it in one namespace,
 	# that means they can't create it in any namespace (resource is non namespaced and RBAC is permissive)
-	echo "--> ${NAMESPACE_ADMIN_EMAIL} should NOT be able to create clusterrolebindings in the cluster"
+	echo "--> ${NAMESPACE_ADMIN_EMAIL} should NOT be able to create clusterrolebindings"
 	testPermissionsClusterScoped "create" "clusterrolebinding" "no"
 
 	# namespace admin should be able to get/list/create/delete k8s and kyma resources in the namespace they created

--- a/tests/integration/cluster-users/sar-test.sh
+++ b/tests/integration/cluster-users/sar-test.sh
@@ -637,7 +637,7 @@ function runTests() {
 	echo "--> ${NAMESPACE_ADMIN_EMAIL} should NOT be able to describe Pods in ${SYSTEM_NAMESPACE}"
 	testDescribe "pods" "${SYSTEM_NAMESPACE}" "no"
 
-  echo "--> ${NAMESPACE_ADMIN_EMAIL} should NOT be able to describe Nodes in the cluster"
+	echo "--> ${NAMESPACE_ADMIN_EMAIL} should NOT be able to describe Nodes in the cluster"
 	testDescribeClusterScoped "nodes" "no"
 
 	# developer who was granted kyma-developer role should be able to operate in the scope of its namespace

--- a/tests/integration/cluster-users/sar-test.sh
+++ b/tests/integration/cluster-users/sar-test.sh
@@ -49,11 +49,12 @@ function __deleteTestNamespace() {
 
 function __createRoleBindingForNamespaceDeveloper() {
 	set +e
+	local result=1
 	kubectl create rolebinding 'namespace-developer' --clusterrole='kyma-developer' --user="${DEVELOPER_EMAIL}" -n "${CUSTOM_NAMESPACE}"
-	result = $?
+	result=$?
 	set -e
 
-	if [ result -eq 0 ]; then
+	if [[ ${result} -eq 0 ]]; then
 		echo "----> PASSED"
 		return 0
 	fi
@@ -63,11 +64,12 @@ function __createRoleBindingForNamespaceDeveloper() {
 
 function __createNamespaceForNamespaceAdmin() {
 	set +e
+	local result=1
 	kubectl create namespace "${CUSTOM_NAMESPACE}"
-	result = $?
+	result=$?
 	set -e
 
-	if [ result -eq 0 ]; then
+	if [[ ${result} -eq 0 ]]; then
 		echo "----> PASSED"
 		return 0
 	fi

--- a/tests/integration/cluster-users/sar-test.sh
+++ b/tests/integration/cluster-users/sar-test.sh
@@ -66,12 +66,12 @@ function __createNamespaceForNamespaceAdmin() {
 	kubectl create namespace "${CUSTOM_NAMESPACE}"
 	result = $?
 	set -e
-  
+
 	if [ result -eq 0 ]; then
 		echo "----> PASSED"
 		return 0
 	fi
-  
+
 	echo "----> |FAIL|"
 }
 
@@ -303,6 +303,18 @@ function runTests() {
 	echo "--> ${ADMIN_EMAIL} should be able to create ory Access Rule"
 	testPermissions "create" "rule.oathkeeper.ory.sh" "${NAMESPACE}" "yes"
 
+	echo "--> ${ADMIN_EMAIL} should be able to get ApplicationConnector/Applications"
+	testPermissions "get" "application.applicationconnector.kyma-project.io" "${NAMESPACE}" "yes"
+
+	echo "--> ${ADMIN_EMAIL} should be able to list ApplicationConnector/Applications"
+	testPermissions "list" "applications.applicationconnector.kyma-project.io" "${NAMESPACE}" "yes"
+
+	echo "--> ${ADMIN_EMAIL} should be able to create ApplicationConnector/ApplicationMappings"
+	testPermissions "create" "applicationmapping.applicationconnector.kyma-project.io" "${NAMESPACE}" "yes"
+
+	echo "--> ${ADMIN_EMAIL} should be able to list ApplicationConnector/ApplicationMappings"
+	testPermissions "list" "applicationmappings.applicationconnector.kyma-project.io" "${NAMESPACE}" "yes"
+
 	echo "--> ${ADMIN_EMAIL} should be able to delete specific CRD"
 	testPermissions "delete" "crd/installations.installer.kyma-project.io" "${NAMESPACE}" "yes"
 
@@ -357,7 +369,7 @@ function runTests() {
 	echo "--> ${NAMESPACE_ADMIN_EMAIL} should NOT be able to delete system namespace"
 	testPermissions "delete" "namespace" "${SYSTEM_NAMESPACE}" "no"
 
-	# namespace admin should not be able to create clusterrolebindings - if they can't create it in one namespace, 
+	# namespace admin should not be able to create clusterrolebindings - if they can't create it in one namespace,
 	# that means they can't create it in any namespace (resource is non namespaced and RBAC is permissive)
 	echo "--> ${NAMESPACE_ADMIN_EMAIL} should NOT be able to create clusterrolebindings"
 	testPermissions "create" "clusterrolebinding" "${SYSTEM_NAMESPACE}" "no"

--- a/tests/integration/cluster-users/sar-test.sh
+++ b/tests/integration/cluster-users/sar-test.sh
@@ -130,16 +130,16 @@ function __testDescribe() {
 	result=$?
 	set -e
 
-	local IS_OK="no"
+	local IS_OK="false"
 
 	if [[ "${EXPECTED}" == "yes" ]] && [[ ${result} -eq 0 ]]; then
-		IS_OK="yes"
+		IS_OK="true"
 	fi
 	if [[ "${EXPECTED}" == "no" ]] && [[ ${result} -ne 0 ]]; then
-		IS_OK="yes"
+		IS_OK="true"
 	fi
 
-	if [[ "${IS_OK}" == "yes" ]]; then
+	if [[ "${IS_OK}" == "true" ]]; then
 			echo "----> PASSED"
 			return 0
 	fi
@@ -452,8 +452,6 @@ function runTests() {
 	echo "--> ${NAMESPACE_ADMIN_EMAIL} should NOT be able to delete system namespace"
 	testPermissions "delete" "namespace" "${SYSTEM_NAMESPACE}" "no"
 
-	# namespace admin should not be able to create clusterrolebindings - if they can't create it in one namespace,
-	# that means they can't create it in any namespace (resource is non namespaced and RBAC is permissive)
 	echo "--> ${NAMESPACE_ADMIN_EMAIL} should NOT be able to create clusterrolebindings"
 	testPermissionsClusterScoped "create" "clusterrolebinding" "no"
 
@@ -566,7 +564,7 @@ function runTests() {
 	echo "--> ${NAMESPACE_ADMIN_EMAIL} should be able to create rolebindings to kyma-developer clusterrole in the namespace they created"
 	createRoleBindingForNamespaceDeveloper
 
-	echo "--> ${NAMESPACE_ADMIN_EMAIL} should NOT be able to delete any namespace in the cluster"
+	echo "--> ${NAMESPACE_ADMIN_EMAIL} should NOT be able to delete arbitrary namespaces in the cluster"
 	testPermissionsClusterScoped "delete" "namespace" "no"
 
 	echo "--> ${NAMESPACE_ADMIN_EMAIL} should NOT be able to delete system namespace"

--- a/tests/integration/cluster-users/sar-test.sh
+++ b/tests/integration/cluster-users/sar-test.sh
@@ -93,9 +93,7 @@ function __testPermissions() {
 	sleep 0.1
 
 	set +e
-	echo kubectl auth can-i "${OPERATION}" "${RESOURCE}" "${TEST_NS}"
 	TEST=$(kubectl auth can-i "${OPERATION}" "${RESOURCE}" "${TEST_NS}")
-	echo "expected: ${EXPECTED}, actual: ${TEST}"
 	set -e
 	if [[ "${TEST}" == "${EXPECTED}" ]]; then
 		echo "----> PASSED"


### PR DESCRIPTION
**Description**

Extend admin permissions

Changes proposed in this pull request:

- Fixed syntax errors in sar-test.sh
- Extended test coverage for Kyma namespace admin permissions (common k8s objects)
- Introduced function to test global (non-namespaced) permissions

**Related issue(s)**
See also #7343
