### PR TITLE
cacert in compass to separate secret

### DIFF
--- a/resources/compass/charts/connector/templates/certs-setup-job.yaml
+++ b/resources/compass/charts/connector/templates/certs-setup-job.yaml
@@ -22,7 +22,7 @@ spec:
         args:
           - "/appconnectivitycertssetupjob"
           - "--connectorCertificateSecret={{ .Values.global.connector.secrets.ca.namespace }}/{{ .Values.global.connector.secrets.ca.name }}"
-          - "--caCertificateSecret={{ .Values.global.connector.secrets.rootCA.namespace }}/{{ .Values.global.connector.secrets.rootCA.name }}"
+          - "--caCertificateSecret={{ .Values.global.connector.secrets.rootCA.namespace }}/{{ .Values.global.connector.secrets.rootCA.cacert }}"
           - "--caCertificate={{ .Values.global.connector.caCertificate }}"
           - "--caKey={{ .Values.global.connector.caKey }}"
           - "--generatedValidityTime={{ .Values.certsSetupJob.generatedCertificateValidity }}"

--- a/resources/compass/charts/gateway/templates/gateway-certs-mtls-cacert.yaml
+++ b/resources/compass/charts/gateway/templates/gateway-certs-mtls-cacert.yaml
@@ -1,0 +1,10 @@
+{{- if and (.Values.gateway.enabled) }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ .Values.global.connector.secrets.rootCA.cacert }}
+  namespace: istio-system
+type: Opaque
+data:
+  "cacert": "" # This value is populated by Connectivity Certs Setup Job
+  {{- end -}}

--- a/resources/compass/charts/gateway/templates/gateway-certs-mtls.yaml
+++ b/resources/compass/charts/gateway/templates/gateway-certs-mtls.yaml
@@ -8,5 +8,4 @@ type: Opaque
 data:
   "key": {{ .Values.global.ingress.tlsKey }}
   "cert": {{ .Values.global.ingress.tlsCrt }}
-  "cacert": "" # This value is populated by Connectivity Certs Setup Job
 {{- end -}}

--- a/resources/compass/values.yaml
+++ b/resources/compass/values.yaml
@@ -91,6 +91,7 @@ global:
       rootCA:
         name: kyma-gateway-certs
         namespace: istio-system # For Ingress Gateway to work properly the namespace needs to be istio-system
+        cacert: kyma-gateway-certs-cacert # For cert-rotation the cacert should be in different secret
     certificateDataHeader: "Certificate-Data"
     revocation:
       configmap:


### PR DESCRIPTION
In order to use external managed certificates (in MPS), the cacert needs to be in a different secret than the crt/key, because when the certificates are rotated, the cacert key will get deleted. Istio automatically checks for a cacert in the [SECRET]-cacert resource.