### PR TITLE
Add command line for cert-import on linux.

### DIFF
--- a/docs/kyma/04-04-cluster-installation.md
+++ b/docs/kyma/04-04-cluster-installation.md
@@ -289,7 +289,7 @@ For Linux with Chrome, run:
 ```bash
   tmpfile=$(mktemp /tmp/temp-cert.XXXXXX) \
   && kubectl get configmap net-global-overrides -n kyma-installer -o jsonpath='{.data.global\.ingress\.tlsCrt}' | base64 --decode > $tmpfile \
-  && certutil -d sql:$HOME/.pki/nssdb -A -t "C,," -n "My Kyma Cluster" -i $tmpfile \
+  && certutil -d sql:$HOME/.pki/nssdb -A -t "{TRUST_ARGUMENTS}" -n "{CERTIFICATE_NAME}" -i $tmpfile \
   && rm $tmpfile
 ```
 

--- a/docs/kyma/04-04-cluster-installation.md
+++ b/docs/kyma/04-04-cluster-installation.md
@@ -283,7 +283,15 @@ After the installation, add the custom Kyma [`xip.io`](http://xip.io/) self-sign
   && kubectl get configmap net-global-overrides -n kyma-installer -o jsonpath='{.data.global\.ingress\.tlsCrt}' | base64 --decode > $tmpfile \
   && sudo security add-trusted-cert -d -r trustRoot -k /Library/Keychains/System.keychain $tmpfile \
   && rm $tmpfile
-  ```
+```
+
+For Linux with Chrome run:
+```bash
+  tmpfile=$(mktemp /tmp/temp-cert.XXXXXX) \
+  && kubectl get configmap net-global-overrides -n kyma-installer -o jsonpath='{.data.global\.ingress\.tlsCrt}' | base64 --decode > $tmpfile \
+  && certutil -d sql:$HOME/.pki/nssdb -A -t "C,," -n "My Kyma Cluster" -i $tmpfile \
+  && rm $tmpfile
+```
 
 ### Access the cluster
 

--- a/docs/kyma/04-04-cluster-installation.md
+++ b/docs/kyma/04-04-cluster-installation.md
@@ -285,7 +285,7 @@ After the installation, add the custom Kyma [`xip.io`](http://xip.io/) self-sign
   && rm $tmpfile
 ```
 
-For Linux with Chrome run:
+For Linux with Chrome, run:
 ```bash
   tmpfile=$(mktemp /tmp/temp-cert.XXXXXX) \
   && kubectl get configmap net-global-overrides -n kyma-installer -o jsonpath='{.data.global\.ingress\.tlsCrt}' | base64 --decode > $tmpfile \


### PR DESCRIPTION
To use the Kyma-Console on Linux with Chrome we also need to import the self-signed certificate to the browsers keystore.

This is the command line for this use-case.