### PR TITLE
Improve retries in Application Connector Tests

### DIFF
--- a/resources/application-connector/values.yaml
+++ b/resources/application-connector/values.yaml
@@ -88,5 +88,5 @@ tests:
     skipSslVerify: true
     image:
       dir:
-      version: fbf1000b
+      version: PR-7462
       pullPolicy: IfNotPresent

--- a/tests/application-connector-tests/test/applicationaccess/suite.go
+++ b/tests/application-connector-tests/test/applicationaccess/suite.go
@@ -211,7 +211,7 @@ func (ts *TestSuite) ShouldAccessApplication(t *testing.T, credentials connector
 		}
 
 		if errorResponse.Code == http.StatusServiceUnavailable || errorResponse.Code == http.StatusNotFound {
-			t.Logf("Application Registry not ready, received %d status", errorResponse.Code)
+			t.Logf("Event Service not ready, received %d status", errorResponse.Code)
 			return true, nil
 		}
 

--- a/tests/application-connector-tests/test/testkit/retry.go
+++ b/tests/application-connector-tests/test/testkit/retry.go
@@ -36,5 +36,5 @@ func Retry(config RetryConfig, shouldRetry func() (bool, error)) error {
 		}
 	}
 
-	return fmt.Errorf("error: retries limit reachd")
+	return fmt.Errorf("retries limit reached")
 }

--- a/tests/application-connector-tests/test/testkit/retry.go
+++ b/tests/application-connector-tests/test/testkit/retry.go
@@ -1,6 +1,7 @@
 package testkit
 
 import (
+	"fmt"
 	"time"
 )
 
@@ -16,9 +17,7 @@ var DefaultRetryConfig RetryConfig = RetryConfig{
 	Factor:     1.5,
 }
 
-func RetryOnError(config RetryConfig, function func() error) error {
-	var err error
-
+func Retry(config RetryConfig, shouldRetry func() (bool, error)) error {
 	duration := config.Duration
 
 	for i := 0; i < config.MaxRetries; i++ {
@@ -27,10 +26,15 @@ func RetryOnError(config RetryConfig, function func() error) error {
 			duration = duration * time.Duration(config.Factor)
 		}
 
-		if err = function(); err == nil {
+		retry, err := shouldRetry()
+		if err != nil {
+			return err
+		}
+
+		if !retry {
 			return nil
 		}
 	}
 
-	return err
+	return fmt.Errorf("error: retries limit reachd")
 }

--- a/tests/application-connector-tests/test/testkit/wait.go
+++ b/tests/application-connector-tests/test/testkit/wait.go
@@ -5,11 +5,11 @@ import (
 	"time"
 )
 
-func WaitForFunction(interval, timeout time.Duration, conditionalFunc func() bool) error {
+func WaitForFunction(interval, timeout time.Duration, isReady func() bool) error {
 	done := time.After(timeout)
 
 	for {
-		if conditionalFunc() {
+		if isReady() {
 			return nil
 		}
 

--- a/tests/application-connector-tests/test/testkit/wait.go
+++ b/tests/application-connector-tests/test/testkit/wait.go
@@ -5,11 +5,11 @@ import (
 	"time"
 )
 
-func WaitForFunction(interval, timeout time.Duration, isReady func() bool) error {
+func WaitForFunction(interval, timeout time.Duration, conditionalFunc func() bool) error {
 	done := time.After(timeout)
 
 	for {
-		if isReady() {
+		if conditionalFunc() {
 			return nil
 		}
 


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/master/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Application Connector tests have random failures around calling Event Service. The service responds with 503 status code, which most likely indicates that the Istio Sidecar is not yet properly initialized.

Changes proposed in this pull request:

- Perform retries on Event Service call
- Perform retries only in case of 503 and 404 status codes

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
