### PR TITLE
Shut down broker before eventing pre-upgrade

### DIFF
--- a/components/event-bus/Gopkg.lock
+++ b/components/event-bus/Gopkg.lock
@@ -393,14 +393,6 @@
   version = "v0.2.2"
 
 [[projects]]
-  digest = "1:56dbf15e091bf7926cb33a57cb6bdfc658fc6d3498d2f76f10a97ce7856f1fde"
-  name = "github.com/markbates/inflect"
-  packages = ["."]
-  pruneopts = "NUT"
-  revision = "24b83195037b3bc61fcda2d28b7b0518bce293b6"
-  version = "v1.0.4"
-
-[[projects]]
   branch = "master"
   digest = "1:0e9bfc47ab9941ecc3344e580baca5deb4091177e84dd9773b48b38ec26b93d5"
   name = "github.com/mattbaird/jsonpatch"
@@ -1592,6 +1584,7 @@
     "golang.org/x/lint/golint",
     "golang.org/x/tools/cmd/goimports",
     "k8s.io/api/apps/v1",
+    "k8s.io/api/autoscaling/v1",
     "k8s.io/api/core/v1",
     "k8s.io/apimachinery/pkg/api/equality",
     "k8s.io/apimachinery/pkg/api/errors",

--- a/components/event-bus/cmd/mesh-namespaces-migration/appbroker.go
+++ b/components/event-bus/cmd/mesh-namespaces-migration/appbroker.go
@@ -1,0 +1,99 @@
+package main
+
+import (
+	"fmt"
+	"log"
+	"time"
+
+	"github.com/pkg/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+
+	autoscalingv1 "k8s.io/api/autoscaling/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/kubernetes"
+
+	// allow client authentication against GKE clusters
+	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
+)
+
+const (
+	appBrokerNamespace = "kyma-integration"
+	appBrokerName      = "application-broker"
+)
+
+// appBrokerShutdownAndWait shuts down the Application broker and blocks until all its replicas have been terminated.
+// The undo function can be used to revert to the original state.
+func appBrokerShutdownAndWait(cli kubernetes.Interface) (undo func() error, err error) {
+	appBrokerKey := fmt.Sprintf("%s/%s", appBrokerNamespace, appBrokerName)
+
+	undo = func() error { return nil }
+
+	currentScale, err := cli.AppsV1().Deployments(appBrokerNamespace).GetScale(appBrokerName, metav1.GetOptions{})
+	switch {
+	case apierrors.IsNotFound(err):
+		return undo, nil
+	case err != nil:
+		return nil, errors.Wrapf(err, "getting scale of Deployment %q: %s", appBrokerKey)
+	}
+
+	currentScale.ResourceVersion = ""
+
+	newScale := currentScale.DeepCopy()
+	newScale.Spec.Replicas = 0
+
+	log.Print("Shutting down Application broker")
+
+	if _, err := cli.AppsV1().Deployments(appBrokerNamespace).UpdateScale(appBrokerName, newScale); err != nil {
+		return nil, errors.Wrapf(err, "scaling Deployment %q", appBrokerKey)
+	}
+
+	if err := waitForDeploymentShutdown(cli, appBrokerNamespace, appBrokerName); err != nil {
+		return nil, errors.Wrapf(err, "waiting for shutdown of Deployment %q", appBrokerKey)
+	}
+
+	undo = func() error {
+		log.Print("Re-starting Application broker")
+
+		if err := scaleDeploymentWithRetry(cli, appBrokerNamespace, appBrokerName, currentScale); err != nil {
+			return errors.Wrapf(err, "scaling Deployment %q", appBrokerKey)
+		}
+		return nil
+	}
+
+	return undo, nil
+}
+
+// waitForDeploymentShutdown waits until all replicas of a Deployment have been terminated.
+func waitForDeploymentShutdown(cli kubernetes.Interface, ns, name string) error {
+	var expectNoReplica wait.ConditionFunc = func() (bool, error) {
+		dep, err := cli.AppsV1().Deployments(ns).Get(name, metav1.GetOptions{})
+		if err != nil {
+			return false, err
+		}
+
+		if dep.Status.Replicas != 0 {
+			return false, nil
+		}
+
+		return true, nil
+	}
+
+	return wait.PollImmediateUntil(time.Second, expectNoReplica, make(<-chan struct{}))
+}
+
+// scaleDeploymentWithRetry scales a Deployment and retries in case of failure.
+func scaleDeploymentWithRetry(cli kubernetes.Interface, ns, name string, scale *autoscalingv1.Scale) error {
+	var expectSuccessfulDeploymentScale wait.ConditionFunc = func() (bool, error) {
+		_, err := cli.AppsV1().Deployments(ns).UpdateScale(name, scale)
+		switch {
+		case apierrors.IsConflict(err), apierrors.IsInvalid(err):
+			return false, err
+		case err != nil:
+			return false, nil
+		}
+		return true, nil
+	}
+
+	return wait.PollImmediateUntil(5*time.Second, expectSuccessfulDeploymentScale, make(<-chan struct{}))
+}

--- a/components/event-bus/cmd/mesh-namespaces-migration/main.go
+++ b/components/event-bus/cmd/mesh-namespaces-migration/main.go
@@ -50,8 +50,17 @@ func main() {
 
 	// run migration
 
+	undoAppBrokerShutdown, err := appBrokerShutdownAndWait(k8sClient)
+	if err != nil {
+		log.Fatalf("Error shutting down Application broker: %s", err)
+	}
+
 	if err := serviceInstanceManager.recreateAll(); err != nil {
 		log.Fatalf("Error re-creating ServiceInstances: %s", err)
+	}
+
+	if err := undoAppBrokerShutdown(); err != nil {
+		log.Fatalf("Error re-starting Application broker: %s", err)
 	}
 
 	if err := subscriptionMigrator.migrateAll(); err != nil {

--- a/components/event-bus/cmd/mesh-namespaces-migration/main.go
+++ b/components/event-bus/cmd/mesh-namespaces-migration/main.go
@@ -65,7 +65,7 @@ func initClientSets() (*kubernetes.Clientset,
 	*kneventingclientset.Clientset,
 	*servicecatalogclientset.Clientset) {
 
-	cfg := getRESTConfig()
+	cfg := getRESTConfigOrDie()
 
 	return kubernetes.NewForConfigOrDie(cfg),
 		kymaeventingclientset.NewForConfigOrDie(cfg),
@@ -73,8 +73,8 @@ func initClientSets() (*kubernetes.Clientset,
 		servicecatalogclientset.NewForConfigOrDie(cfg)
 }
 
-// getRESTConfig returns a rest.Config to be used for Kubernetes client creation.
-func getRESTConfig() *rest.Config {
+// getRESTConfigOrDie returns a rest.Config to be used for Kubernetes client creation.
+func getRESTConfigOrDie() *rest.Config {
 	cfg, err := sharedmain.GetConfig("", kubeConfig)
 	if err != nil {
 		log.Fatal("Error building kubeconfig", err)

--- a/components/event-bus/cmd/mesh-namespaces-migration/serviceinstance.go
+++ b/components/event-bus/cmd/mesh-namespaces-migration/serviceinstance.go
@@ -54,7 +54,7 @@ func (m *serviceInstanceManager) populateServiceInstances(namespaces []string) e
 // recreateAll re-creates all ServiceInstance objects listed in the serviceInstanceManager. This ensures the Kyma
 // Application broker re-triggers the provisioning of Kyma Applications.
 func (m *serviceInstanceManager) recreateAll() error {
-	log.Printf("Starting re-creation of %d ServiceInstances", len(m.serviceInstances))
+	log.Printf("Starting re-creation of %d ServiceInstance(s)", len(m.serviceInstances))
 
 	for _, svci := range m.serviceInstances {
 		if err := m.recreateServiceInstance(svci); err != nil {

--- a/components/event-bus/cmd/mesh-namespaces-migration/subscription.go
+++ b/components/event-bus/cmd/mesh-namespaces-migration/subscription.go
@@ -101,7 +101,7 @@ func (m *subscriptionMigrator) populateTriggers(namespaces []string) error {
 
 // migrateAll migrates all Kyma Subscriptions listed in the subscriptionMigrator.
 func (m *subscriptionMigrator) migrateAll() error {
-	log.Printf("Starting migration of %d Subscriptions", len(m.subscriptions))
+	log.Printf("Starting migration of %d Subscription(s)", len(m.subscriptions))
 
 	for _, sub := range m.subscriptions {
 		objKey := fmt.Sprintf("%s/%s", sub.Namespace, sub.Name)


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Shut down broker before re-creating ServiceInstances in eventing pre-upgrade

The intention here is to avoid de-provisioning the ServiceInstance. We are only interested in provisioning the same instance one more time.

**Related issue(s)**

#7301
#7235