### PR TITLE
Wait for deletion of EventActivations before recreating ServiceInstance

### DIFF
--- a/components/event-bus/cmd/mesh-namespaces-migration/main.go
+++ b/components/event-bus/cmd/mesh-namespaces-migration/main.go
@@ -21,7 +21,7 @@ import (
 	kymaeventingclientset "github.com/kyma-project/kyma/components/event-bus/client/generated/clientset/internalclientset"
 )
 
-const defaultTimeoutDuration = 30 * time.Second
+const defaultTimeoutDuration = 5 * time.Minute
 
 // Configuration flags
 var kubeConfig string

--- a/components/event-bus/cmd/mesh-namespaces-migration/main.go
+++ b/components/event-bus/cmd/mesh-namespaces-migration/main.go
@@ -38,7 +38,7 @@ func main() {
 
 	// initialize managers
 
-	serviceInstanceManager, err := newServiceInstanceManager(servicecatalogClient, userNamespaces)
+	serviceInstanceManager, err := newServiceInstanceManager(servicecatalogClient, kymaClient, userNamespaces)
 	if err != nil {
 		log.Fatalf("Error initializing serviceInstanceManager: %s", err)
 	}

--- a/components/event-bus/cmd/mesh-namespaces-migration/main.go
+++ b/components/event-bus/cmd/mesh-namespaces-migration/main.go
@@ -1,8 +1,10 @@
 package main
 
 import (
+	"context"
 	"flag"
 	"log"
+	"time"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
@@ -18,6 +20,8 @@ import (
 
 	kymaeventingclientset "github.com/kyma-project/kyma/components/event-bus/client/generated/clientset/internalclientset"
 )
+
+const defaultTimeoutDuration = 30 * time.Second
 
 // Configuration flags
 var kubeConfig string
@@ -114,4 +118,10 @@ func listUserNamespaces(k8sClient kubernetes.Interface) ([]string, error) {
 	}
 
 	return userNamespaces, nil
+}
+
+// newTimeoutChannel returns a channel that receives a value after a default timeout.
+func newTimeoutChannel() <-chan struct{} {
+	ctx, _ := context.WithTimeout(context.TODO(), defaultTimeoutDuration)
+	return ctx.Done()
 }

--- a/components/event-bus/cmd/mesh-namespaces-migration/serviceinstance.go
+++ b/components/event-bus/cmd/mesh-namespaces-migration/serviceinstance.go
@@ -210,7 +210,7 @@ func (m *serviceInstanceManager) recreateServiceInstance(svci servicecatalogv1be
 	svci.Spec.ServicePlanRef = nil
 	svci.ResourceVersion = ""
 
-	log.Printf("Re-creating ServiceInstance %q", svciKey)
+	log.Printf("+ Re-creating ServiceInstance %q", svciKey)
 
 	if err := m.createServiceInstanceWithRetry(svci); err != nil {
 		return errors.Wrapf(err, "creating ServiceInstance %q", svciKey)

--- a/components/event-bus/cmd/mesh-namespaces-migration/serviceinstance.go
+++ b/components/event-bus/cmd/mesh-namespaces-migration/serviceinstance.go
@@ -232,7 +232,7 @@ func (m *serviceInstanceManager) waitForServiceInstanceDeletion(ns, name string)
 		return false, nil
 	}
 
-	return wait.PollImmediateUntil(time.Second, expectNoServiceInstance, make(<-chan struct{}))
+	return wait.PollImmediateUntil(time.Second, expectNoServiceInstance, newTimeoutChannel())
 }
 
 // waitForEventActivationDeletion waits for the deletion of an EventActivation.
@@ -248,7 +248,7 @@ func (m *serviceInstanceManager) waitForEventActivationDeletion(ns, name string)
 		return false, nil
 	}
 
-	return wait.PollImmediateUntil(time.Second, expectNoEventActivation, make(<-chan struct{}))
+	return wait.PollImmediateUntil(time.Second, expectNoEventActivation, newTimeoutChannel())
 }
 
 // createServiceInstanceWithRetry creates a ServiceInstance and retries in case of failure.
@@ -261,5 +261,5 @@ func (m *serviceInstanceManager) createServiceInstanceWithRetry(svci servicecata
 		return true, nil
 	}
 
-	return wait.PollImmediateUntil(5*time.Second, expectSuccessfulServiceInstanceCreation, make(<-chan struct{}))
+	return wait.PollImmediateUntil(5*time.Second, expectSuccessfulServiceInstanceCreation, newTimeoutChannel())
 }

--- a/components/event-bus/cmd/mesh-namespaces-migration/serviceinstance_test.go
+++ b/components/event-bus/cmd/mesh-namespaces-migration/serviceinstance_test.go
@@ -154,12 +154,12 @@ func TestNewserviceInstanceManager(t *testing.T) {
 						Name:       "dummy",
 					},
 					{
-						APIVersion: serviceInstanceAPIVersion(),
+						APIVersion: "servicecatalog.k8s.io/v0",
 						Kind:       serviceInstanceKind,
 						Name:       "some-svci-ns1-1",
 					},
 					{
-						APIVersion: serviceInstanceAPIVersion(),
+						APIVersion: "servicecatalog.k8s.io/v0",
 						Kind:       serviceInstanceKind,
 						Name:       "some-svci-ns1-2",
 					},
@@ -173,7 +173,7 @@ func TestNewserviceInstanceManager(t *testing.T) {
 				OwnerReferences: []metav1.OwnerReference{
 					// matches 1 ServiceInstance
 					{
-						APIVersion: serviceInstanceAPIVersion(),
+						APIVersion: "servicecatalog.k8s.io/v0",
 						Kind:       serviceInstanceKind,
 						Name:       "some-svci-ns1-2",
 					},
@@ -203,7 +203,7 @@ func TestNewserviceInstanceManager(t *testing.T) {
 				OwnerReferences: []metav1.OwnerReference{
 					// matches 1 ServiceInstance
 					{
-						APIVersion: serviceInstanceAPIVersion(),
+						APIVersion: "servicecatalog.k8s.io/v0",
 						Kind:       serviceInstanceKind,
 						Name:       "some-svci-ns3",
 					},
@@ -232,7 +232,7 @@ func TestNewserviceInstanceManager(t *testing.T) {
 				OwnerReferences: []metav1.OwnerReference{
 					// matches 1 ServiceInstance
 					{
-						APIVersion: serviceInstanceAPIVersion(),
+						APIVersion: "servicecatalog.k8s.io/v0",
 						Kind:       serviceInstanceKind,
 						Name:       "some-svci-ns4",
 					},

--- a/components/event-bus/cmd/mesh-namespaces-migration/serviceinstance_test.go
+++ b/components/event-bus/cmd/mesh-namespaces-migration/serviceinstance_test.go
@@ -186,7 +186,7 @@ func TestRecreateServiceInstance(t *testing.T) {
 	}
 
 	m := serviceInstanceManager{
-		cli: servicecatalogfakeclientset.NewSimpleClientset(testServiceInstance),
+		svcCatalogClient: servicecatalogfakeclientset.NewSimpleClientset(testServiceInstance),
 	}
 
 	err := m.recreateServiceInstance(*testServiceInstance)
@@ -194,7 +194,7 @@ func TestRecreateServiceInstance(t *testing.T) {
 		t.Fatalf("Failed to recreate ServiceInstance: %s", err)
 	}
 
-	svci, err := m.cli.ServicecatalogV1beta1().ServiceInstances("ns").Get("my-events", metav1.GetOptions{})
+	svci, err := m.svcCatalogClient.ServicecatalogV1beta1().ServiceInstances("ns").Get("my-events", metav1.GetOptions{})
 	if err != nil {
 		t.Fatalf("Error getting ServiceInstance from cluster: %s", err)
 	}

--- a/components/event-bus/cmd/mesh-namespaces-migration/subscription.go
+++ b/components/event-bus/cmd/mesh-namespaces-migration/subscription.go
@@ -104,16 +104,16 @@ func (m *subscriptionMigrator) migrateAll() error {
 	log.Printf("Starting migration of %d Subscriptions", len(m.subscriptions))
 
 	for _, sub := range m.subscriptions {
-		objKey := fmt.Sprintf("%s/%s", sub.Namespace, sub.Name)
+		subKey := fmt.Sprintf("%s/%s", sub.Namespace, sub.Name)
 
 		if err := m.migrateSubscription(sub); err != nil {
-			return errors.Wrapf(err, "migrating Subscription %q", objKey)
+			return errors.Wrapf(err, "migrating Subscription %q", subKey)
 		}
 
-		log.Printf("Deleting Subscription %q", objKey)
+		log.Printf("+ Deleting Subscription %q", subKey)
 
 		if err := m.deleteSubscriptionWithRetry(sub.Namespace, sub.Name); err != nil {
-			return errors.Wrapf(err, "deleting Subscription %q", objKey)
+			return errors.Wrapf(err, "deleting Subscription %q", subKey)
 		}
 	}
 
@@ -135,20 +135,20 @@ func (m *subscriptionMigrator) deleteSubscriptionWithRetry(ns, name string) erro
 
 // migrateSubscription migrates a single Kyma Subscription.
 func (m *subscriptionMigrator) migrateSubscription(sub kymaeventingv1alpha1.Subscription) error {
-	objKey := fmt.Sprintf("%s/%s", sub.Namespace, sub.Name)
+	subKey := fmt.Sprintf("%s/%s", sub.Namespace, sub.Name)
 
-	log.Printf("Checking Subscription %q", objKey)
+	log.Printf("+ Checking Subscription %q", subKey)
 	if m.findTriggerForSubscription(sub) != nil {
-		log.Printf("Trigger already exists for Subscription %q, skipping", objKey)
+		log.Printf("+ Trigger already exists for Subscription %q, skipping", subKey)
 		return nil
 	}
 
-	log.Printf("Trigger not found for Subscription %q", objKey)
+	log.Printf("+ Trigger not found for Subscription %q", subKey)
 	trigger, err := m.createTriggerForSubscription(sub)
 	if err != nil {
-		return errors.Wrapf(err, "creating Trigger for Subscription %q", objKey)
+		return errors.Wrapf(err, "creating Trigger for Subscription %q", subKey)
 	}
-	log.Printf("Trigger \"%s/%s\" created for Subscription %q", trigger.Namespace, trigger.Name, objKey)
+	log.Printf("+ Trigger \"%s/%s\" created for Subscription %q", trigger.Namespace, trigger.Name, subKey)
 
 	return nil
 }
@@ -181,11 +181,11 @@ func (m *subscriptionMigrator) findTriggerForSubscription(sub kymaeventingv1alph
 
 // createTriggerForSubscription creates a Knative Trigger equivalent to the given Kyma Subscription.
 func (m *subscriptionMigrator) createTriggerForSubscription(sub kymaeventingv1alpha1.Subscription) (*kneventingv1alpha1.Trigger, error) {
-	objKey := fmt.Sprintf("%s/%s", sub.Namespace, sub.Name)
+	subKey := fmt.Sprintf("%s/%s", sub.Namespace, sub.Name)
 
 	tr, err := newTriggerForSubscription(sub)
 	if err != nil {
-		return nil, errors.Wrapf(err, "generating Trigger object for Subscription %q", objKey)
+		return nil, errors.Wrapf(err, "generating Trigger object for Subscription %q", subKey)
 	}
 
 	if tr, err = m.knativeClient.EventingV1alpha1().Triggers(sub.Namespace).Create(tr); err != nil {

--- a/components/event-bus/cmd/mesh-namespaces-migration/subscription.go
+++ b/components/event-bus/cmd/mesh-namespaces-migration/subscription.go
@@ -130,7 +130,7 @@ func (m *subscriptionMigrator) deleteSubscriptionWithRetry(ns, name string) erro
 		return true, nil
 	}
 
-	return wait.PollImmediateUntil(5*time.Second, expectSuccessfulSubscriptionDeletion, make(<-chan struct{}))
+	return wait.PollImmediateUntil(5*time.Second, expectSuccessfulSubscriptionDeletion, newTimeoutChannel())
 }
 
 // migrateSubscription migrates a single Kyma Subscription.


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Wait for deletion of EventActivations before recreating ServiceInstance

Without that change, the re-provision request is sometimes faster than the delay required to delete the old EventActivation, and the new EventActivation never gets re-created.

**Related issue(s)**

#7301
#7235