### PR TITLE
Increase default istio-proxy memory quota

### DIFF
--- a/resources/istio/files/kyma_cluster_istio_control_plane.yaml
+++ b/resources/istio/files/kyma_cluster_istio_control_plane.yaml
@@ -353,10 +353,10 @@ spec:
         resources:
           limits:
             cpu: 200m
-            memory: 64Mi
+            memory: 128Mi
           requests:
             cpu: 20m
-            memory: 32Mi
+            memory: 64Mi
         statusPort: 15020
         tracer: zipkin
       proxy_init:

--- a/resources/istio/files/kyma_cluster_istio_control_plane.yaml
+++ b/resources/istio/files/kyma_cluster_istio_control_plane.yaml
@@ -356,7 +356,7 @@ spec:
             memory: 128Mi
           requests:
             cpu: 20m
-            memory: 64Mi
+            memory: 32Mi
         statusPort: 15020
         tracer: zipkin
       proxy_init:


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/master/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- Increase default memory quota to:
  - limit: 128Mi

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
- Fix for #7432