### PR TITLE
Change kubectl image to alpine-kubectl:v20200310-5f52f407 in compass

### DIFF
--- a/resources/compass/charts/kyma-environment-broker/templates/pre-upgrade-job.yaml
+++ b/resources/compass/charts/kyma-environment-broker/templates/pre-upgrade-job.yaml
@@ -59,7 +59,7 @@ spec:
       restartPolicy: Never
       containers:
         - name: job
-          image: "linkyard/kubectl:1.14.2"
+          image: "eu.gcr.io/kyma-project/test-infra/alpine-kubectl:v20200310-5f52f407"
           env:
             - name: APP_SECRET_NAME
               value: "compass-postgresql"

--- a/resources/compass/templates/agent-configuration-job.yaml
+++ b/resources/compass/templates/agent-configuration-job.yaml
@@ -54,7 +54,7 @@ spec:
       restartPolicy: Never
       containers:
         - name: compass-agent-configuration
-          image: "linkyard/kubectl:1.14.2"
+          image: "eu.gcr.io/kyma-project/test-infra/alpine-kubectl:v20200310-5f52f407"
           command:
             - bash
             - -c

--- a/resources/compass/templates/registration-job.yaml
+++ b/resources/compass/templates/registration-job.yaml
@@ -48,7 +48,7 @@ spec:
       restartPolicy: Never
       containers:
         - name: {{ template "fullname" . }}-registration
-          image: "linkyard/kubectl:1.14.2"
+          image: "eu.gcr.io/kyma-project/test-infra/alpine-kubectl:v20200310-5f52f407"
           command:
             - bash
             - -c


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- switch kubectl image to an internal build
- ...
- ...

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
