### PR TITLE
Only migrate ServiceInstances related to a ServiceClass of type "Events"

### DIFF
--- a/components/event-bus/Gopkg.lock
+++ b/components/event-bus/Gopkg.lock
@@ -1611,6 +1611,7 @@
     "k8s.io/client-go/discovery",
     "k8s.io/client-go/discovery/fake",
     "k8s.io/client-go/dynamic",
+    "k8s.io/client-go/dynamic/fake",
     "k8s.io/client-go/kubernetes",
     "k8s.io/client-go/kubernetes/scheme",
     "k8s.io/client-go/plugin/pkg/client/auth/gcp",

--- a/components/event-bus/Gopkg.lock
+++ b/components/event-bus/Gopkg.lock
@@ -393,12 +393,12 @@
   version = "v0.2.2"
 
 [[projects]]
-  digest = "1:56dbf15e091bf7926cb33a57cb6bdfc658fc6d3498d2f76f10a97ce7856f1fde"
-  name = "github.com/markbates/inflect"
-  packages = ["."]
+  digest = "1:2bb48adcab604271cc38ddd4b6e60052d184e685d3b88e9c5e573874c2b1f76a"
+  name = "github.com/kyma-project/kyma"
+  packages = ["components/application-operator/pkg/apis/applicationconnector/v1alpha1"]
   pruneopts = "NUT"
-  revision = "24b83195037b3bc61fcda2d28b7b0518bce293b6"
-  version = "v1.0.4"
+  revision = "0a36a0f31d7e05c7ce75ae226f31c08e74203a89"
+  version = "1.10.0"
 
 [[projects]]
   branch = "master"
@@ -1575,6 +1575,7 @@
     "github.com/kubernetes-sigs/service-catalog/pkg/apis/servicecatalog/v1beta1",
     "github.com/kubernetes-sigs/service-catalog/pkg/client/clientset_generated/clientset",
     "github.com/kubernetes-sigs/service-catalog/pkg/client/clientset_generated/clientset/fake",
+    "github.com/kyma-project/kyma/components/application-operator/pkg/apis/applicationconnector/v1alpha1",
     "github.com/nats-io/go-nats-streaming",
     "github.com/opentracing/opentracing-go",
     "github.com/opentracing/opentracing-go/ext",
@@ -1609,6 +1610,7 @@
     "k8s.io/apimachinery/pkg/watch",
     "k8s.io/client-go/discovery",
     "k8s.io/client-go/discovery/fake",
+    "k8s.io/client-go/dynamic",
     "k8s.io/client-go/kubernetes",
     "k8s.io/client-go/kubernetes/scheme",
     "k8s.io/client-go/plugin/pkg/client/auth/gcp",

--- a/components/event-bus/Gopkg.toml
+++ b/components/event-bus/Gopkg.toml
@@ -22,6 +22,10 @@ required = [
   branch = "release-0.12"
 
 [[constraint]]
+  name = "github.com/kyma-project/kyma"
+  version = "1.10.0"
+
+[[constraint]]
   name = "github.com/opentracing/opentracing-go"
   version = "1.0.2"
 

--- a/components/event-bus/cmd/mesh-namespaces-migration/errors.go
+++ b/components/event-bus/cmd/mesh-namespaces-migration/errors.go
@@ -1,0 +1,33 @@
+package main
+
+import (
+	"fmt"
+	"log"
+	"os"
+
+	"github.com/pkg/errors"
+)
+
+// TypeNotFoundError is returned when a CRD is missing / a type is not registered.
+type TypeNotFoundError string
+
+// Error implements the error interface.
+func (e *TypeNotFoundError) Error() string {
+	return fmt.Sprintf("CRD %q does not exist", *e)
+}
+
+// NewTypeNotFoundError returns a new TypeNotFoundError.
+func NewTypeNotFoundError(msg string) error {
+	typeErr := TypeNotFoundError(msg)
+	return &typeErr
+}
+
+// handleAndTerminate logs an error and terminates the program.
+func handleAndTerminate(err error, context string) {
+	if _, ok := errors.Cause(err).(*TypeNotFoundError); ok {
+		log.Printf("Skipping migration: %s", err)
+		os.Exit(0)
+	}
+
+	log.Fatalf("Error %s: %s", context, err)
+}

--- a/components/event-bus/cmd/mesh-namespaces-migration/main.go
+++ b/components/event-bus/cmd/mesh-namespaces-migration/main.go
@@ -7,7 +7,10 @@ import (
 	"time"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
 
 	// allow client authentication against GKE clusters
@@ -18,6 +21,7 @@ import (
 	kneventingclientset "knative.dev/eventing/pkg/client/clientset/versioned"
 	"knative.dev/pkg/injection/sharedmain"
 
+	appconnectorv1alpha1 "github.com/kyma-project/kyma/components/application-operator/pkg/apis/applicationconnector/v1alpha1"
 	kymaeventingclientset "github.com/kyma-project/kyma/components/event-bus/client/generated/clientset/internalclientset"
 )
 
@@ -28,12 +32,19 @@ var kubeConfig string
 
 func init() {
 	flag.StringVar(&kubeConfig, "kubeconfig", "", "Path to a kubeconfig. Only required if out-of-cluster.")
+
+	sb := runtime.NewSchemeBuilder(
+		appconnectorv1alpha1.AddToScheme,
+	)
+	if err := sb.AddToScheme(scheme.Scheme); err != nil {
+		log.Fatalf("Error adding custom resources to Scheme: %v", err)
+	}
 }
 
 func main() {
 	flag.Parse()
 
-	k8sClient, kymaClient, knativeClient, servicecatalogClient := initClientSets()
+	k8sClient, kymaClient, knativeClient, servicecatalogClient, dynClient := initClientSets()
 
 	userNamespaces, err := listUserNamespaces(k8sClient)
 	if err != nil {
@@ -42,7 +53,7 @@ func main() {
 
 	// initialize managers
 
-	serviceInstanceManager, err := newServiceInstanceManager(servicecatalogClient, kymaClient, userNamespaces)
+	serviceInstanceManager, err := newServiceInstanceManager(servicecatalogClient, kymaClient, dynClient, userNamespaces)
 	if err != nil {
 		handleAndTerminate(err, "initializing serviceInstanceManager")
 	}
@@ -55,11 +66,11 @@ func main() {
 	// run migration
 
 	if err := serviceInstanceManager.recreateAll(); err != nil {
-		log.Fatalf("Error re-creating ServiceInstances: %s", err)
+		handleAndTerminate(err, "re-creating ServiceInstances")
 	}
 
 	if err := subscriptionMigrator.migrateAll(); err != nil {
-		log.Fatalf("Error migrating Kyma Subscriptions: %s", err)
+		handleAndTerminate(err, "migrating Kyma Subscriptions")
 	}
 }
 
@@ -67,14 +78,16 @@ func main() {
 func initClientSets() (*kubernetes.Clientset,
 	*kymaeventingclientset.Clientset,
 	*kneventingclientset.Clientset,
-	*servicecatalogclientset.Clientset) {
+	*servicecatalogclientset.Clientset,
+	dynamic.Interface) {
 
 	cfg := getRESTConfig()
 
 	return kubernetes.NewForConfigOrDie(cfg),
 		kymaeventingclientset.NewForConfigOrDie(cfg),
 		kneventingclientset.NewForConfigOrDie(cfg),
-		servicecatalogclientset.NewForConfigOrDie(cfg)
+		servicecatalogclientset.NewForConfigOrDie(cfg),
+		dynamic.NewForConfigOrDie(cfg)
 }
 
 // getRESTConfig returns a rest.Config to be used for Kubernetes client creation.

--- a/components/event-bus/cmd/mesh-namespaces-migration/main.go
+++ b/components/event-bus/cmd/mesh-namespaces-migration/main.go
@@ -44,12 +44,12 @@ func main() {
 
 	serviceInstanceManager, err := newServiceInstanceManager(servicecatalogClient, kymaClient, userNamespaces)
 	if err != nil {
-		log.Fatalf("Error initializing serviceInstanceManager: %s", err)
+		handleAndTerminate(err, "initializing serviceInstanceManager")
 	}
 
 	subscriptionMigrator, err := newSubscriptionMigrator(kymaClient, knativeClient, userNamespaces)
 	if err != nil {
-		log.Fatalf("Error initializing subscriptionMigrator: %s", err)
+		handleAndTerminate(err, "initializing subscriptionMigrator")
 	}
 
 	// run migration

--- a/components/event-bus/cmd/mesh-namespaces-migration/serviceinstance.go
+++ b/components/event-bus/cmd/mesh-namespaces-migration/serviceinstance.go
@@ -29,7 +29,7 @@ const (
 	eventsServiceEntryType = "Events"
 )
 
-type servicesInstanceList []servicecatalogv1beta1.ServiceInstance
+type serviceInstancesList []servicecatalogv1beta1.ServiceInstance
 
 type eventActivationsByServiceInstance map[string][]string
 type eventActivationsByServiceInstanceAndNamespace map[string]eventActivationsByServiceInstance
@@ -40,7 +40,7 @@ type serviceInstanceManager struct {
 	kymaClient       kymaeventingclientset.Interface
 	dynClient        dynamic.Interface
 
-	serviceInstances      servicesInstanceList
+	serviceInstances      serviceInstancesList
 	eventActivationsIndex eventActivationsByServiceInstanceAndNamespace
 }
 

--- a/components/event-bus/cmd/mesh-namespaces-migration/serviceinstance.go
+++ b/components/event-bus/cmd/mesh-namespaces-migration/serviceinstance.go
@@ -67,7 +67,10 @@ func (m *serviceInstanceManager) populateServiceInstances(namespaces []string) e
 
 	for _, ns := range namespaces {
 		svcis, err := m.svcCatalogClient.ServicecatalogV1beta1().ServiceInstances(ns).List(metav1.ListOptions{})
-		if err != nil {
+		switch {
+		case apierrors.IsNotFound(err):
+			return NewTypeNotFoundError(err.(*apierrors.StatusError).ErrStatus.Details.Kind)
+		case err != nil:
 			return errors.Wrapf(err, "listing ServiceInstances in namespace %s", ns)
 		}
 
@@ -94,7 +97,10 @@ func (m *serviceInstanceManager) buildServiceBrokerIndex(namespaces []string) (s
 		svcBrokersBySvcClass := make(serviceBrokersByServiceClass)
 
 		serviceClasses, err := m.svcCatalogClient.ServicecatalogV1beta1().ServiceClasses(ns).List(metav1.ListOptions{})
-		if err != nil {
+		switch {
+		case apierrors.IsNotFound(err):
+			return nil, NewTypeNotFoundError(err.(*apierrors.StatusError).ErrStatus.Details.Kind)
+		case err != nil:
 			return nil, errors.Wrapf(err, "listing ServiceClasses in namespace %s", ns)
 		}
 
@@ -116,7 +122,10 @@ func (m *serviceInstanceManager) populateEventActivationIndex(namespaces []strin
 		eventActivationsBySvcInstance := make(eventActivationsByServiceInstance)
 
 		eventActivations, err := m.kymaClient.ApplicationconnectorV1alpha1().EventActivations(ns).List(metav1.ListOptions{})
-		if err != nil {
+		switch {
+		case apierrors.IsNotFound(err):
+			return NewTypeNotFoundError(err.(*apierrors.StatusError).ErrStatus.Details.Kind)
+		case err != nil:
 			return errors.Wrapf(err, "listing EventActivations in namespace %s", ns)
 		}
 

--- a/components/event-bus/cmd/mesh-namespaces-migration/serviceinstance_test.go
+++ b/components/event-bus/cmd/mesh-namespaces-migration/serviceinstance_test.go
@@ -251,7 +251,7 @@ func TestNewserviceInstanceManager(t *testing.T) {
 		eventActivationsToObjectSlice(testEventActivations)...,
 	)
 
-	m, err := newServiceInstanceManager(scCli, kymaCli, testUserNamespaces)
+	m, err := newServiceInstanceManager(scCli, kymaCli, nil, testUserNamespaces)
 	if err != nil {
 		t.Fatalf("Failed to initialize serviceInstanceManager: %s", err)
 	}
@@ -289,7 +289,7 @@ func TestNewserviceInstanceManager(t *testing.T) {
 			"some-svci-ns4": []string{"my-ea-ns4-2"},
 		},
 	}
-	gotEA := m.eventActivationIndex
+	gotEA := m.eventActivationsIndex
 
 	if diff := cmp.Diff(expectEA, gotEA); diff != "" {
 		t.Errorf("Unexpected EventActivation index: (-:expect, +:got) %s", diff)

--- a/components/event-bus/cmd/mesh-namespaces-migration/serviceinstance_test.go
+++ b/components/event-bus/cmd/mesh-namespaces-migration/serviceinstance_test.go
@@ -1,19 +1,23 @@
 package main
 
 import (
+	"encoding/json"
 	"fmt"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/sets"
+	dynamicfakeclientset "k8s.io/client-go/dynamic/fake"
 
 	servicecatalogv1beta1 "github.com/kubernetes-sigs/service-catalog/pkg/apis/servicecatalog/v1beta1"
 	servicecatalogfakeclientset "github.com/kubernetes-sigs/service-catalog/pkg/client/clientset_generated/clientset/fake"
 
-	applicationconnectorv1alpha1 "github.com/kyma-project/kyma/components/event-bus/apis/applicationconnector/v1alpha1"
+	appoperatorappconnectorv1alpha1 "github.com/kyma-project/kyma/components/application-operator/pkg/apis/applicationconnector/v1alpha1"
+	eventbusappconnectorv1alpha1 "github.com/kyma-project/kyma/components/event-bus/apis/applicationconnector/v1alpha1"
 	kymaeventingfakeclientset "github.com/kyma-project/kyma/components/event-bus/client/generated/clientset/internalclientset/fake"
 )
 
@@ -25,43 +29,117 @@ func TestNewserviceInstanceManager(t *testing.T) {
 		"ns4",
 	}
 
+	testApplications := []*appoperatorappconnectorv1alpha1.Application{
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "my-app-1",
+			},
+			Spec: appoperatorappconnectorv1alpha1.ApplicationSpec{
+				Services: []appoperatorappconnectorv1alpha1.Service{
+					// matches 2 "events" ServiceClasses IDs
+					{
+						ID: "my-appbroker-class-ns1-2",
+						Entries: []appoperatorappconnectorv1alpha1.Entry{{
+							Type: "Foo",
+						}, {
+							Type: eventsServiceEntryType,
+						}, {
+							Type: "Bar",
+						}},
+					},
+					{
+						ID: "my-appbroker-class-ns2",
+						Entries: []appoperatorappconnectorv1alpha1.Entry{{
+							Type: eventsServiceEntryType,
+						}},
+					},
+				},
+			},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "my-app-2",
+			},
+			Spec: appoperatorappconnectorv1alpha1.ApplicationSpec{
+				Services: []appoperatorappconnectorv1alpha1.Service{
+					// matches 0 "events" ServiceClasses ID
+					{
+						ID: "my-appbroker-class-ns1-3",
+						Entries: []appoperatorappconnectorv1alpha1.Entry{{
+							Type: "Foo",
+						}, {
+							Type: "Bar",
+						}},
+					},
+				},
+			},
+		},
+	}
+
 	testServiceClasses := []servicecatalogv1beta1.ServiceClass{
 		// ns1
 		{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      "my-appbroker-class",
+				Name:      "my-appbroker-class-ns1-1",
 				Namespace: "ns1",
 			},
 			Spec: servicecatalogv1beta1.ServiceClassSpec{
+				// has Application broker class,
+				// is NOT referenced by any "events" Application
+				ServiceBrokerName: appBrokerServiceClass,
+			},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "my-appbroker-class-ns1-2",
+				Namespace: "ns1",
+			},
+			Spec: servicecatalogv1beta1.ServiceClassSpec{
+				// has Application broker class,
+				// is referenced by 1 "events" Application
+				ServiceBrokerName: appBrokerServiceClass,
+			},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "my-appbroker-class-ns1-3",
+				Namespace: "ns1",
+			},
+			Spec: servicecatalogv1beta1.ServiceClassSpec{
+				// has Application broker class,
+				// is NOT referenced by any "events" Application
 				ServiceBrokerName: appBrokerServiceClass,
 			},
 		},
 		// ns2
 		{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      "my-foo-class",
+				Name:      "my-foo-class-ns2",
 				Namespace: "ns2",
 			},
 			Spec: servicecatalogv1beta1.ServiceClassSpec{
+				// has non- Application broker class
 				ServiceBrokerName: "foo-broker",
 			},
 		},
 		{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      "my-appbroker-class",
+				Name:      "my-appbroker-class-ns2",
 				Namespace: "ns2",
 			},
 			Spec: servicecatalogv1beta1.ServiceClassSpec{
+				// has Application broker class
 				ServiceBrokerName: appBrokerServiceClass,
 			},
 		},
 		// ns4
 		{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      "my-helm-class",
+				Name:      "my-helm-class-ns4",
 				Namespace: "ns4",
 			},
 			Spec: servicecatalogv1beta1.ServiceClassSpec{
+				// has non- Application broker class
 				ServiceBrokerName: "helm-broker",
 			},
 		},
@@ -75,8 +153,10 @@ func TestNewserviceInstanceManager(t *testing.T) {
 				Namespace: "ns1",
 			},
 			Spec: servicecatalogv1beta1.ServiceInstanceSpec{
+				// references Application broker class
+				// class is referenced by 1 "events" Application
 				ServiceClassRef: &servicecatalogv1beta1.LocalObjectReference{
-					Name: "my-appbroker-class",
+					Name: "my-appbroker-class-ns1-2",
 				},
 			},
 		},
@@ -86,8 +166,22 @@ func TestNewserviceInstanceManager(t *testing.T) {
 				Namespace: "ns1",
 			},
 			Spec: servicecatalogv1beta1.ServiceInstanceSpec{
+				// references non- Application broker class
 				ServiceClassRef: &servicecatalogv1beta1.LocalObjectReference{
 					Name: "does-no-exist",
+				},
+			},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "my-events-ns1-3",
+				Namespace: "ns1",
+			},
+			Spec: servicecatalogv1beta1.ServiceInstanceSpec{
+				// references Application broker class
+				// class is referenced by a non- "events" Application
+				ServiceClassRef: &servicecatalogv1beta1.LocalObjectReference{
+					Name: "my-appbroker-class-ns1-3",
 				},
 			},
 		},
@@ -98,8 +192,9 @@ func TestNewserviceInstanceManager(t *testing.T) {
 				Namespace: "ns2",
 			},
 			Spec: servicecatalogv1beta1.ServiceInstanceSpec{
+				// references non- Application broker class
 				ServiceClassRef: &servicecatalogv1beta1.LocalObjectReference{
-					Name: "my-foo-class",
+					Name: "my-foo-class-ns2",
 				},
 			},
 		},
@@ -109,8 +204,10 @@ func TestNewserviceInstanceManager(t *testing.T) {
 				Namespace: "ns2",
 			},
 			Spec: servicecatalogv1beta1.ServiceInstanceSpec{
+				// references Application broker class
+				// class is referenced by 1 "events" Application
 				ServiceClassRef: &servicecatalogv1beta1.LocalObjectReference{
-					Name: "my-appbroker-class",
+					Name: "my-appbroker-class-ns2",
 				},
 			},
 		},
@@ -121,8 +218,10 @@ func TestNewserviceInstanceManager(t *testing.T) {
 				Namespace: "ns3",
 			},
 			Spec: servicecatalogv1beta1.ServiceInstanceSpec{
+				// references Application broker class
+				// class is NOT referenced by any "events" Application
 				ServiceClassRef: &servicecatalogv1beta1.LocalObjectReference{
-					Name: "my-appbroker-class",
+					Name: "my-appbroker-class-ns3",
 				},
 			},
 		},
@@ -133,21 +232,22 @@ func TestNewserviceInstanceManager(t *testing.T) {
 				Namespace: "ns4",
 			},
 			Spec: servicecatalogv1beta1.ServiceInstanceSpec{
+				// references non- Application broker class
 				ServiceClassRef: &servicecatalogv1beta1.LocalObjectReference{
-					Name: "my-helm-class",
+					Name: "my-helm-class-ns4",
 				},
 			},
 		},
 	}
 
-	testEventActivations := []*applicationconnectorv1alpha1.EventActivation{
+	testEventActivations := []*eventbusappconnectorv1alpha1.EventActivation{
 		// ns1
 		{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "my-ea-ns1-1",
 				Namespace: "ns1",
 				OwnerReferences: []metav1.OwnerReference{
-					// matches 2 ServiceInstances
+					// references 2 ServiceInstances
 					{
 						APIVersion: "test/v1",
 						Kind:       "Test",
@@ -171,7 +271,7 @@ func TestNewserviceInstanceManager(t *testing.T) {
 				Name:      "my-ea-ns1-2",
 				Namespace: "ns1",
 				OwnerReferences: []metav1.OwnerReference{
-					// matches 1 ServiceInstance
+					// references 1 ServiceInstance
 					{
 						APIVersion: "servicecatalog.k8s.io/v0",
 						Kind:       serviceInstanceKind,
@@ -186,7 +286,7 @@ func TestNewserviceInstanceManager(t *testing.T) {
 				Name:      "my-ea-ns2",
 				Namespace: "ns2",
 				OwnerReferences: []metav1.OwnerReference{
-					// matches 0 ServiceInstance
+					// references 0 ServiceInstance
 					{
 						APIVersion: "test/v1",
 						Kind:       "Test",
@@ -201,7 +301,7 @@ func TestNewserviceInstanceManager(t *testing.T) {
 				Name:      "my-ea-ns3",
 				Namespace: "ns3",
 				OwnerReferences: []metav1.OwnerReference{
-					// matches 1 ServiceInstance
+					// references 1 ServiceInstance
 					{
 						APIVersion: "servicecatalog.k8s.io/v0",
 						Kind:       serviceInstanceKind,
@@ -216,7 +316,7 @@ func TestNewserviceInstanceManager(t *testing.T) {
 				Name:      "my-ea-ns4-1",
 				Namespace: "ns4",
 				OwnerReferences: []metav1.OwnerReference{
-					// matches 0 ServiceInstance
+					// references 0 ServiceInstance
 					{
 						APIVersion: "test/v1",
 						Kind:       "Test",
@@ -230,7 +330,7 @@ func TestNewserviceInstanceManager(t *testing.T) {
 				Name:      "my-ea-ns4-2",
 				Namespace: "ns4",
 				OwnerReferences: []metav1.OwnerReference{
-					// matches 1 ServiceInstance
+					// references 1 ServiceInstance
 					{
 						APIVersion: "servicecatalog.k8s.io/v0",
 						Kind:       serviceInstanceKind,
@@ -251,7 +351,15 @@ func TestNewserviceInstanceManager(t *testing.T) {
 		eventActivationsToObjectSlice(testEventActivations)...,
 	)
 
-	m, err := newServiceInstanceManager(scCli, kymaCli, nil, testUserNamespaces)
+	fakeScheme := runtime.NewScheme()
+	if err := appoperatorappconnectorv1alpha1.AddToScheme(fakeScheme); err != nil {
+		t.Fatalf("Failed to build fake Scheme: %s", err)
+	}
+	dynCli := dynamicfakeclientset.NewSimpleDynamicClient(fakeScheme,
+		applicationsToObjectSlice(testApplications)...,
+	)
+
+	m, err := newServiceInstanceManager(scCli, kymaCli, dynCli, testUserNamespaces)
 	if err != nil {
 		t.Fatalf("Failed to initialize serviceInstanceManager: %s", err)
 	}
@@ -332,6 +440,22 @@ func TestRecreateServiceInstance(t *testing.T) {
 	}
 }
 
+func applicationsToObjectSlice(apps []*appoperatorappconnectorv1alpha1.Application) []runtime.Object {
+	objects := make([]runtime.Object, len(apps))
+	for i, app := range apps {
+		app.TypeMeta.APIVersion = appoperatorappconnectorv1alpha1.SchemeGroupVersion.String()
+		app.TypeMeta.Kind = "Application"
+
+		appData, _ := json.Marshal(app)
+		appUnstr := &unstructured.Unstructured{}
+
+		_ = json.Unmarshal(appData, appUnstr)
+
+		objects[i] = appUnstr
+	}
+	return objects
+}
+
 func serviceClassesToObjectSlice(serviceClasses []servicecatalogv1beta1.ServiceClass) []runtime.Object {
 	objects := make([]runtime.Object, len(serviceClasses))
 	for i := range serviceClasses {
@@ -348,7 +472,7 @@ func serviceInstancesToObjectSlice(svcis []*servicecatalogv1beta1.ServiceInstanc
 	return objects
 }
 
-func eventActivationsToObjectSlice(eas []*applicationconnectorv1alpha1.EventActivation) []runtime.Object {
+func eventActivationsToObjectSlice(eas []*eventbusappconnectorv1alpha1.EventActivation) []runtime.Object {
 	objects := make([]runtime.Object, len(eas))
 	for i := range eas {
 		objects[i] = eas[i]

--- a/components/event-bus/cmd/mesh-namespaces-migration/subscription.go
+++ b/components/event-bus/cmd/mesh-namespaces-migration/subscription.go
@@ -34,7 +34,7 @@ const (
 	brokerLabel       = "eventing.knative.dev/broker"
 )
 
-type triggersByNamespaceMap map[string][]kneventingv1alpha1.Trigger
+type triggersByNamespaces map[string][]kneventingv1alpha1.Trigger
 type subscriptionsList []kymaeventingv1alpha1.Subscription
 
 // subscriptionMigrator performs migrations of Kyma Subscriptions to Knative Triggers.
@@ -43,7 +43,7 @@ type subscriptionMigrator struct {
 	knativeClient kneventingclientset.Interface
 
 	subscriptions       subscriptionsList
-	triggersByNamespace triggersByNamespaceMap
+	triggersByNamespace triggersByNamespaces
 }
 
 // newSubscriptionMigrator creates and initializes a subscriptionMigrator.
@@ -87,7 +87,7 @@ func (m *subscriptionMigrator) populateSubscriptions(namespaces []string) error 
 
 // populateTriggers populates the local triggersByNamespace map.
 func (m *subscriptionMigrator) populateTriggers(namespaces []string) error {
-	triggersByNamespace := make(triggersByNamespaceMap)
+	m.triggersByNamespace = make(triggersByNamespaces)
 
 	for _, ns := range namespaces {
 		triggers, err := m.knativeClient.EventingV1alpha1().Triggers(ns).List(metav1.ListOptions{})
@@ -97,17 +97,16 @@ func (m *subscriptionMigrator) populateTriggers(namespaces []string) error {
 		case err != nil:
 			return errors.Wrapf(err, "listing Triggers in namespace %s", ns)
 		}
-		triggersByNamespace[ns] = triggers.Items
-	}
 
-	m.triggersByNamespace = triggersByNamespace
+		m.triggersByNamespace[ns] = triggers.Items
+	}
 
 	return nil
 }
 
 // migrateAll migrates all Kyma Subscriptions listed in the subscriptionMigrator.
 func (m *subscriptionMigrator) migrateAll() error {
-	log.Printf("Starting migration of %d Subscriptions", len(m.subscriptions))
+	log.Printf("Starting migration of %d Subscription(s)", len(m.subscriptions))
 
 	for _, sub := range m.subscriptions {
 		subKey := fmt.Sprintf("%s/%s", sub.Namespace, sub.Name)

--- a/components/event-bus/cmd/mesh-namespaces-migration/subscription.go
+++ b/components/event-bus/cmd/mesh-namespaces-migration/subscription.go
@@ -71,7 +71,10 @@ func (m *subscriptionMigrator) populateSubscriptions(namespaces []string) error 
 
 	for _, ns := range namespaces {
 		subs, err := m.kymaClient.EventingV1alpha1().Subscriptions(ns).List(metav1.ListOptions{})
-		if err != nil {
+		switch {
+		case apierrors.IsNotFound(err):
+			return NewTypeNotFoundError(err.(*apierrors.StatusError).ErrStatus.Details.Kind)
+		case err != nil:
 			return errors.Wrapf(err, "listing Subscriptions in namespace %s", ns)
 		}
 		kymaSubscriptions = append(kymaSubscriptions, subs.Items...)
@@ -88,7 +91,10 @@ func (m *subscriptionMigrator) populateTriggers(namespaces []string) error {
 
 	for _, ns := range namespaces {
 		triggers, err := m.knativeClient.EventingV1alpha1().Triggers(ns).List(metav1.ListOptions{})
-		if err != nil {
+		switch {
+		case apierrors.IsNotFound(err):
+			return NewTypeNotFoundError(err.(*apierrors.StatusError).ErrStatus.Details.Kind)
+		case err != nil:
 			return errors.Wrapf(err, "listing Triggers in namespace %s", ns)
 		}
 		triggersByNamespace[ns] = triggers.Items

--- a/components/event-bus/cmd/mesh-namespaces-migration/subscription_test.go
+++ b/components/event-bus/cmd/mesh-namespaces-migration/subscription_test.go
@@ -193,7 +193,7 @@ func TestMigrateSubscription(t *testing.T) {
 					triggersToObjectSlice(tc.triggers)...,
 				),
 				subscriptions:       subscriptionsList{*testSubscription},
-				triggersByNamespace: triggersByNamespaceMap{"ns": tc.triggers},
+				triggersByNamespace: triggersByNamespaces{"ns": tc.triggers},
 			}
 
 			err := m.migrateAll()
@@ -213,7 +213,7 @@ func TestMigrateSubscription(t *testing.T) {
 				expectTriggerCount++
 			}
 			if count := len(triggers.Items); count != expectTriggerCount {
-				found := triggersToKeys(triggersByNamespaceMap{
+				found := triggersToKeys(triggersByNamespaces{
 					"ns": triggers.Items,
 				})
 				t.Fatalf("Expected %d Triggers, got %d: %q", expectTriggerCount, count, found)
@@ -276,7 +276,7 @@ func subscriptionsToKeys(subs subscriptionsList) []string {
 	return keys
 }
 
-func triggersToKeys(triggersByNs triggersByNamespaceMap) []string {
+func triggersToKeys(triggersByNs triggersByNamespaces) []string {
 	var keys []string
 	for _, triggers := range triggersByNs {
 		for _, trigger := range triggers {


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Only migrate ServiceInstances related to a ServiceClass of type "Events"

**Related issue(s)**

#7235
#7301
#7500