### PR TITLE
Display old/new applications based on global.enableAPIPackages flag

### DIFF
--- a/resources/application-connector/templates/applications-microfrontend.yaml
+++ b/resources/application-connector/templates/applications-microfrontend.yaml
@@ -1,3 +1,4 @@
+{{ if not .Values.global.enableAPIPackages }}
 apiVersion: "ui.kyma-project.io/v1alpha1"
 kind: ClusterMicroFrontend
 metadata:
@@ -31,3 +32,4 @@ spec:
       viewUrl: '/home/settings/apps/:name'
       settings:
         readOnly: {{ not .Values.connector_service.enabled }}
+{{ end }}

--- a/resources/compass-runtime-agent/templates/compass-apps-microfrontend.yaml
+++ b/resources/compass-runtime-agent/templates/compass-apps-microfrontend.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   displayName: Applications
   version: v1
-  category: Experimental
+  category: {{ if .Values.global.enableAPIPackages }}Integration{{ else }}Experimental{{ end }}
   placement: cluster
   viewBaseUrl: "https://core-ui.{{ js .Values.global.ingress.domainName }}"
   navigationNodes:

--- a/resources/compass-runtime-agent/values.yaml
+++ b/resources/compass-runtime-agent/values.yaml
@@ -1,4 +1,5 @@
 global:
+  enableAPIPackages: false
   images:
     containerRegistry:
       path: eu.gcr.io/kyma-project


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/master/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

Add **global.enableAPIPackages** flag in resources/compass-runtime-agent/values.yaml

If **global.enableAPIPackages** flag is **true**:
- display **new** applications under **integration** section
- hide old applications

If **global.enableAPIPackages** flag is **false**:
- display **old** applications under **integration** section
- display **new** applications under **experimental** section

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
https://github.com/kyma-project/console/issues/1585
https://github.com/kyma-incubator/compass/issues/915