### PR TITLE
Switch bintami/kubectl image to alpine-kubectl

### DIFF
--- a/resources/knative-eventing/charts/knative-eventing/templates/pre-upgrade-job.yaml
+++ b/resources/knative-eventing/charts/knative-eventing/templates/pre-upgrade-job.yaml
@@ -127,7 +127,7 @@ spec:
                 cp /scripts/pre-upgrade.sh /tmp
                 chmod +x /tmp/pre-upgrade.sh
                 /tmp/pre-upgrade.sh
-            image: bitnami/kubectl:1.17.3
+            image: eu.gcr.io/kyma-project/test-infra/alpine-kubectl:v20200310-5f52f407
             imagePullPolicy: IfNotPresent
             volumeMounts:
               - mountPath: /scripts

--- a/resources/knative-serving/templates/pre-upgrade-job.yaml
+++ b/resources/knative-serving/templates/pre-upgrade-job.yaml
@@ -94,7 +94,7 @@ spec:
       restartPolicy: OnFailure
       containers:
       - command: ["sh", "/scripts/delete-resources.sh"]
-        image: bitnami/kubectl:1.16.3
+        image: eu.gcr.io/kyma-project/test-infra/alpine-kubectl:v20200310-5f52f407
         imagePullPolicy: IfNotPresent
         name: pre-upgrade-delete-knative-serving-resources
         volumeMounts:

--- a/resources/ory/charts/oathkeeper/charts/oathkeeper-master/templates/crd-job.yaml
+++ b/resources/ory/charts/oathkeeper/charts/oathkeeper-master/templates/crd-job.yaml
@@ -17,7 +17,7 @@ spec:
       serviceAccountName: {{ .Release.Name }}-crd-init
       containers:
       - name: {{ .Release.Name }}-crd-rules
-        image: "bitnami/kubectl:latest"
+        image: "eu.gcr.io/kyma-project/test-infra/alpine-kubectl:v20200310-5f52f407"
         volumeMounts:
         - name: crd-rules
           mountPath: /etc/ory/crd

--- a/resources/rafter/templates/pre-upgrade-delete-vs-job.yaml
+++ b/resources/rafter/templates/pre-upgrade-delete-vs-job.yaml
@@ -90,7 +90,7 @@ spec:
       restartPolicy: OnFailure
       containers:
       - command: ["sh", "/scripts/delete-resources.sh"]
-        image: bitnami/kubectl:1.16.3
+        image: eu.gcr.io/kyma-project/test-infra/alpine-kubectl:v20200310-5f52f407
         imagePullPolicy: IfNotPresent
         name: pre-upgrade-delete-vs-rafter-minio
         volumeMounts:


### PR DESCRIPTION
**Description**

The bitami/kubectl images are debian based and have some security vulnerabilities.
We should replace it with an image that we can control.

Changes proposed in this pull request:

- bitnami images replaced with alpine-kubectl from test-infra repo
- ...
- ...

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
