### PR TITLE
Show admin nodes also for runtimeAdmins

### DIFF
--- a/resources/core/charts/console/templates/configmap.yaml
+++ b/resources/core/charts/console/templates/configmap.yaml
@@ -31,7 +31,8 @@ data:
       compassDefaultTenant: '{{ js $compassDefaultTenant }}',
       defaultIdpJwksUri: '{{ js $defaultIdpJwksUri }}',
       defaultIdpIssuer: 'https://dex.{{ js .Values.global.ingress.domainName }}',
-      adminsGroupName: '{{ js .Values.cluster.adminsGroupName }}'
+      namespaceAdminGroupName: '{{ js .Values.cluster.namespaceAdminGroupName }}',
+      runtimeAdminGroupName: '{{ js .Values.cluster.runtimeAdminGroupName }}'
     };
     
   nginx-extended.conf: |

--- a/resources/core/charts/console/values.yaml
+++ b/resources/core/charts/console/values.yaml
@@ -4,8 +4,8 @@
 replicaCount: 1
 console:
   image:
-    dir: /pr
-    tag: PR-1603
+    dir:
+    tag: 11cefefa
     pullPolicy: IfNotPresent
   service:
     name: nginx

--- a/resources/core/charts/console/values.yaml
+++ b/resources/core/charts/console/values.yaml
@@ -4,8 +4,8 @@
 replicaCount: 1
 console:
   image:
-    dir:
-    tag: 34cd17bd
+    dir: /pr
+    tag: PR-1603
     pullPolicy: IfNotPresent
   service:
     name: nginx
@@ -62,7 +62,8 @@ cluster:
   disabledNavigationNodes: ""
   # Provide a list of Namespaces that should be considered as system Namespaces. The Console UI gives you the possibility to toggle the visibility of system Namespaces.
   systemNamespaces: "istio-system knative-eventing knative-serving kube-public kube-system kyma-backup kyma-installer kyma-integration kyma-system natss compass-system kube-node-lease kubernetes-dashboard tekton-pipelines"
-  adminsGroupName: "runtimeNamespaceAdmin"
+  runtimeAdminGroupName: "runtimeAdmin"
+  namespaceAdminGroupName: "runtimeNamespaceAdmin"
 
 test:
   acceptance:


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Distinguish namespace-/ from runtimeAdmins
- Show administrative nodes also for runtimeAdmins
- Do not store personal data in session storage

