### PR TITLE
Specify namespace for Istio gateway for Grafana virtual service

### DIFF
--- a/resources/monitoring/charts/grafana/templates/kyma-additions/virtualservice.yaml
+++ b/resources/monitoring/charts/grafana/templates/kyma-additions/virtualservice.yaml
@@ -23,7 +23,7 @@ spec:
   hosts:
   - grafana.{{ .Values.global.ingress.domainName }}
   gateways:
-  - {{ .Values.global.istio.gateway.name }}
+  - {{ .Values.global.istio.gateway.name }}.{{ .Values.global.istio.gateway.namespace }}
   http:
   - match:
     - uri:

--- a/resources/monitoring/charts/grafana/templates/kyma-additions/virtualservice.yaml
+++ b/resources/monitoring/charts/grafana/templates/kyma-additions/virtualservice.yaml
@@ -23,7 +23,7 @@ spec:
   hosts:
   - grafana.{{ .Values.global.ingress.domainName }}
   gateways:
-  - {{ .Values.global.istio.gateway.name }}.{{ .Values.global.istio.gateway.namespace }}
+  - {{ .Values.global.istio.gateway.name }}.{{ .Values.global.istio.gateway.namespace }}.svc.cluster.local
   http:
   - match:
     - uri:


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/master/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- Added this line " - {{ .Values.global.istio.gateway.name }}.{{ .Values.global.istio.gateway.namespace }}.svc.cluster.local " to the Grafana virtual service yaml file. With this change, we can specify the namespace for the istio gateway, which solves the issue that the virtual service and the gateway are under 2 different namespaces.


**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
