### PR TITLE
Align Helm charts of Kyma Environment Broker with compass version

### DIFF
--- a/resources/compass/charts/kyma-environment-broker/templates/deployment.yaml
+++ b/resources/compass/charts/kyma-environment-broker/templates/deployment.yaml
@@ -44,12 +44,6 @@ spec:
               value: "{{ .Values.enablePlans }}"
             - name: APP_PROVISIONING_URL
               value: "{{ .Values.provisioner.URL }}"
-            - name: APP_PROVISIONING_GCP_SECRET_NAME
-              value: "{{ .Values.provisioner.gcp.secretName }}"
-            - name: APP_PROVISIONING_AWS_SECRET_NAME
-              value: "{{ .Values.provisioner.aws.secretName }}"
-            - name: APP_PROVISIONING_AZURE_SECRET_NAME
-              value: "{{ .Values.provisioner.azure.secretName }}"
             - name: APP_PORT
               value: "{{ .Values.broker.port }}"
             - name: APP_AUTH_USERNAME
@@ -122,6 +116,10 @@ spec:
               value: {{ .Values.kymaVersion }}
             - name: APP_MANAGED_RUNTIME_COMPONENTS_YAML_FILE_PATH
               value: /config/additionalRuntimeComponents.yaml
+            - name: APP_GARDENER_PROJECT
+              value: {{ .Values.gardener.project }}
+            - name: APP_GARDENER_KUBECONFIG_PATH
+              value: {{ .Values.gardener.kubeconfigPath }}
           ports:
             - name: http
               containerPort: {{ .Values.broker.port }}
@@ -129,6 +127,9 @@ spec:
           resources:
               {{- toYaml .Values.resources | nindent 12 }}
           volumeMounts:
+            - mountPath: /gardener/kubeconfig
+              name: gardener-kubeconfig
+              readOnly: true
             - mountPath: /config
               name: config-volume
           {{if eq .Values.global.database.embedded.enabled false}}
@@ -161,3 +162,6 @@ spec:
         secret:
           secretName: cloudsql-instance-credentials
       {{- end}}
+      - name: gardener-kubeconfig
+        secret:
+          secretName: {{ .Values.gardener.secretName }}

--- a/resources/compass/charts/kyma-environment-broker/values.yaml
+++ b/resources/compass/charts/kyma-environment-broker/values.yaml
@@ -40,13 +40,6 @@ provisioner:
     secretName: "gardener"
     # name of the gardener project
     projectName: "gopher"
-  gcp:
-    # name of the secret in the gardener which holds the GCP Service Account key
-    secretName: "gcp-secret-name"
-  azure:
-    secretName: "azure-secret-name"
-  aws:
-    secretName: "aws-secret-name"
 
 additionalRuntimeComponents:
   - name: "service-manager-proxy"
@@ -59,6 +52,11 @@ additionalRuntimeComponents:
 kymaVersion: "1.10.0"
 
 enablePlans: "azure,gcp"
+
+gardener:
+  project: "kyma-dev" # Gardener project connected to SA for HAP credentials lookup
+  kubeconfigPath: "/gardener/kubeconfig/kubeconfig"
+  secretName: "gardener-credentials"
 
 # It is used to provide own creds for Service Manager instead of using the one provided by external system
 # who execute provision call on Kyma Environment Broker. You can define `overrideMode` to be one of: Always, WhenNotSentInRequest, Never

--- a/resources/compass/values.yaml
+++ b/resources/compass/values.yaml
@@ -34,7 +34,7 @@ global:
       version: "712f4623"
     provisioner:
       dir:
-      version: "0e7ca48a"
+      version: "34587c75"
     certs_setup_job:
       containerRegistry:
         path: eu.gcr.io/kyma-project
@@ -42,7 +42,7 @@ global:
       version: "0a651695"
     kyma_environment_broker:
       dir:
-      version: "37821477"
+      version: "34587c75"
     tests:
       director:
         dir:
@@ -52,7 +52,7 @@ global:
         version: "9cebaf5c"
       provisioner:
         dir:
-        version: "0e7ca48a"
+        version: "34587c75"
       e2e_provisioning:
         dir:
         version: "6b8099b5"


### PR DESCRIPTION
Adding support for Hyperscaler Account Pool functionality in KEB deployment

- Remove from configuration hardcoded secret names with accounts
- Provide way to specify secret with kubeconfig file to Gardener Seed cluster as mounted voulume 
- Bump up version of images 