### PR TITLE
Introduce runtimeViewer group

### DIFF
--- a/resources/core/charts/cluster-users/templates/rbac-roles.yaml
+++ b/resources/core/charts/cluster-users/templates/rbac-roles.yaml
@@ -435,6 +435,11 @@ subjects:
 - kind: User
   name: read-only-user@kyma.cx
   apiGroup: rbac.authorization.k8s.io
+{{ if .Values.global.kymaRuntime.viewerGroup }}
+- kind: Group
+  name: {{ .Values.global.kymaRuntime.viewerGroup }}
+  apiGroup: rbac.authorization.k8s.io
+{{ end }}
 {{- range .Values.bindings.kymaView.groups }}
 - kind: Group
   name: {{ .  }}

--- a/resources/core/charts/cluster-users/values.yaml
+++ b/resources/core/charts/cluster-users/values.yaml
@@ -69,6 +69,7 @@ global:
   # values.yaml in `uaa-activator` chart.
   kymaRuntime:
     adminGroup: runtimeAdmin
+    viewerGroup: runtimeViewer
     developerGroup: runtimeDeveloper
     namespaceAdminGroup: runtimeNamespaceAdmin
 

--- a/resources/uaa-activator/templates/secret.yaml
+++ b/resources/uaa-activator/templates/secret.yaml
@@ -20,6 +20,10 @@ stringData:
         "description": "Global admin access to all Kyma resources"
       },
       {
+        "name": "$XSAPPNAME.{{ .Values.global.kymaRuntime.viewerGroup }}",
+        "description": "Global viewer access to all Kyma resources"
+      },
+      {
         "name": "$XSAPPNAME.{{ .Values.global.kymaRuntime.developerGroup }}",
         "description": "Runtime developer access to all managed resources"
       },
@@ -37,6 +41,13 @@ stringData:
         "description": "Global admin access to all Kyma resources",
         "scope-references": [
           "$XSAPPNAME.{{ .Values.global.kymaRuntime.adminGroup }}"
+        ]
+      },
+      {
+        "name": "KymaViewer",
+        "description": "Global viewer access to all Kyma resources",
+        "scope-references": [
+          "$XSAPPNAME.{{ .Values.global.kymaRuntime.viewerGroup }}"
         ]
       },
       {

--- a/resources/uaa-activator/values.yaml
+++ b/resources/uaa-activator/values.yaml
@@ -5,6 +5,7 @@ job:
 global:
   kymaRuntime:
     adminGroup: runtimeAdmin
+    viewerGroup: runtimeViewer
     developerGroup: runtimeDeveloper
     namespaceAdminGroup: runtimeNamespaceAdmin
 


### PR DESCRIPTION

**Description**

Changes proposed in this pull request:

- Introduce `runtimeViewer` group. This might be used by L2 Operators to get read-only access to K8S resources in all namespaces.
- ...
- ...

**Related issue(s)**
N/A
