### PR TITLE
Add UI tutorials for Serverless

### DIFF
--- a/docs/serverless-v2/08-01-create-lambda.md
+++ b/docs/serverless-v2/08-01-create-lambda.md
@@ -61,21 +61,21 @@ Follows these steps:
 2. Go to the **Functions [preview]** view at the bottom of the left navigation panel and select **Create lambda**.
 3. In the pop-up box, provide lambda's name and select **Create** to confirm changes.
 
-The pop-up box closes and you will see the `Lambda created successfully` message.
+     The pop-up box closes and you will see the `Lambda created successfully` message.
 
 4. In the lambda details view that opens up automatically, go to the **Code** tab and enter the lambda's code:
 
-```
-module.exports = {
-  main: function (event, context) {
-  return 'Hello World!'
-  }
-}
-```
+    ```
+    module.exports = {
+      main: function (event, context) {
+      return 'Hello World!'
+      }
+    }
+    ```
 
 5. Select **Save** to confirm changes.
 
-You will get the `Lambda created successfully` message confirming the changes were saved. Once deployed, the new lambda should have the `RUNNING` status in the list of all lambdas under the **Functions [preview]** view.
+    You will get the `Lambda created successfully` message confirming the changes were saved. Once deployed, the new lambda should have the `RUNNING` status in the list of all lambdas under the **Functions [preview]** view.
 
     </details>
 </div>

--- a/docs/serverless-v2/08-01-create-lambda.md
+++ b/docs/serverless-v2/08-01-create-lambda.md
@@ -50,10 +50,10 @@ Follows these steps:
     ```
 
     </details>
-<details>
-<summary label="console-ui">
-Console UI
-</summary>
+    <details>
+    <summary label="console-ui">
+    Console UI
+    </summary>
 
 > **NOTE:** Serverless v2 is an experimental feature, and it is not enabled by default in the Console UI. To use its **Functions [preview]** view, enable **Experimental functionalities** in the **General Settings** view before you follow the steps.
 
@@ -77,5 +77,5 @@ module.exports = {
 
 You will get the `Lambda created successfully` message confirming the changes were saved. Once deployed, the new lambda should have the `RUNNING` status in the list of all lambdas under the **Functions [preview]** view.
 
-
     </details>
+</div>

--- a/docs/serverless-v2/08-01-create-lambda.md
+++ b/docs/serverless-v2/08-01-create-lambda.md
@@ -55,13 +55,13 @@ Follows these steps:
     Console UI
     </summary>
 
-> **NOTE:** Serverless v2 is an experimental feature, and it is not enabled by default in the Console UI. To use its **Functions [preview]** view, enable **Experimental functionalities** in the **General Settings** view before you follow the steps.
+> **NOTE:** Serverless v2 is an experimental feature, and it is not enabled by default in the Console UI. To use its **Functions [preview]** view, enable **Experimental functionalities** in the **General Settings** view before you follow the steps. Refresh the page after enabling this option.
 
-1. Select a Namespace from the drop-down list in the top navigation panel or create a new one.
+1. Create a Namespace or select one from the drop-down list in the top navigation panel.
 2. Go to the **Functions [preview]** view at the bottom of the left navigation panel and select **Create lambda**.
-3. In the pop-up box, provide lambda's name and select **Create** to confirm changes.
+3. In the pop-up box, provide the lambda's name and select **Create** to confirm changes.
 
-     The pop-up box closes and you will see the `Lambda created successfully` message.
+     The pop-up box closes and the `Lambda created successfully` message appears.
 
 4. In the lambda details view that opens up automatically, go to the **Code** tab and enter the lambda's code:
 
@@ -75,7 +75,7 @@ Follows these steps:
 
 5. Select **Save** to confirm changes.
 
-    You will get the `Lambda created successfully` message confirming the changes were saved. Once deployed, the new lambda should have the `RUNNING` status in the list of all lambdas under the **Functions [preview]** view.
+    The `Lambda {NAME} updated successfully` message appears confirming the changes were saved. Once deployed, the new lambda should have the `RUNNING` status in the list of all lambdas under the **Functions [preview]** view.
 
     </details>
 </div>

--- a/docs/serverless-v2/08-01-create-lambda.md
+++ b/docs/serverless-v2/08-01-create-lambda.md
@@ -9,12 +9,17 @@ This tutorial shows how you can create a simple "Hello World!" lambda.
 
 Follows these steps:
 
+<div tabs name="steps" group="create-lambda">
+  <details>
+  <summary label="kubectl">
+  kubectl
+  </summary>
+
 1. Export these variables:
 
     ```bash
-    export DOMAIN={DOMAIN_NAME}
     export NAME={LAMBDA_NAME}
-    export NAMESPACE=serverless
+    export NAMESPACE={LAMBDA_NAMESPACE}
     ```
 
 2. Create a Function CR that specifies the lambda's logic and defines a runtime on which it should run:
@@ -43,3 +48,34 @@ Follows these steps:
     ```bash
     kubectl get functions $NAME -n $NAMESPACE -o=jsonpath='{.status.condition}'
     ```
+
+    </details>
+<details>
+<summary label="console-ui">
+Console UI
+</summary>
+
+> **NOTE:** Serverless v2 is an experimental feature, and it is not enabled by default in the Console UI. To use its **Functions [preview]** view, enable **Experimental functionalities** in the **General Settings** view before you follow the steps.
+
+1. Select a Namespace from the drop-down list in the top navigation panel or create a new one.
+2. Go to the **Functions [preview]** view at the bottom of the left navigation panel and select **Create lambda**.
+3. In the pop-up box, provide lambda's name and select **Create** to confirm changes.
+
+The pop-up box closes and you will see the `Lambda created successfully` message.
+
+4. In the lambda details view that opens up automatically, go to the **Code** tab and enter the lambda's code:
+
+```
+module.exports = {
+  main: function (event, context) {
+  return 'Hello World!'
+  }
+}
+```
+
+5. Select **Save** to confirm changes.
+
+You will get the `Lambda created successfully` message confirming the changes were saved. Once deployed, the new lambda should have the `RUNNING` status in the list of all lambdas under the **Functions [preview]** view.
+
+
+    </details>

--- a/docs/serverless-v2/08-01-create-lambda.md
+++ b/docs/serverless-v2/08-01-create-lambda.md
@@ -58,7 +58,9 @@ Follows these steps:
 > **NOTE:** Serverless v2 is an experimental feature, and it is not enabled by default in the Console UI. To use its **Functions [preview]** view, enable **Experimental functionalities** in the **General Settings** view before you follow the steps. Refresh the page after enabling this option.
 
 1. Create a Namespace or select one from the drop-down list in the top navigation panel.
+
 2. Go to the **Functions [preview]** view at the bottom of the left navigation panel and select **Create lambda**.
+
 3. In the pop-up box, provide the lambda's name and select **Create** to confirm changes.
 
      The pop-up box closes and the `Lambda created successfully` message appears.

--- a/docs/serverless-v2/08-02-expose-lambda.md
+++ b/docs/serverless-v2/08-02-expose-lambda.md
@@ -82,24 +82,24 @@ Follows these steps:
     Console UI
     </summary>
 
-> **NOTE:** The API Rules functionality that allow you to expose lambdas is an experimental feature, and it is not enabled by default in the Console UI. To use it, enable **Experimental functionalities** in the **General Settings** view before you follow the steps.
+> **NOTE:** The API Rules functionality that allow you to expose lambdas is an experimental feature, and it is not enabled by default in the Console UI. To use it, enable **Experimental functionalities** in the **General Settings** view before you follow the steps. Refresh the page after enabling this option.
 
-1. Select a Namespace from the drop-down list in the top navigation panel where there is an existing lambda which you want to expose through an API Rule.
+1. Select a Namespace from the drop-down list in the top navigation panel. Make sure the Namespace includes the lambda that you want to expose through an API Rule.
 2. Go to the **API Rules [preview]** view at the bottom of the left navigation panel and select **Add API Rule**.
 3. In the **General settings** section:
 
-    - Enter API Rule's **Name** matching the lambda's name.
+    - Enter the API Rule's **Name** matching the lambda's name.
 
     >**NOTE:** The APIRule CR can have a different name than lambda, but it is recommended that all related resources share a common name.
 
-    - Enter **Hostname** on which you want to expose lambda.
+    - Enter **Hostname** to indicate the host on which you want to expose lambda.
 
     - Select the lambda from the drop-down list in the **Service** column.
 
-4. In the **Access strategies** section, leave the default settings, with `GET`, `POST`, `PUT`, and `DELETE` methods and the `noop` handler.
+4. In the **Access strategies** section, leave the default settings, with `GET`, `POST`, `PUT`, and `DELETE` methods and the `noop` handler selected.
 5. Select **Create** to confirm changes.
 
-    You will get the `API Rule {NAME} created successfully` message confirming the changes were saved.
+    The `API Rule {NAME} created successfully` message appears confirming the changes were saved.
 
 6. In the API Rule's details view that opens up automatically, check if you can access lambda by selecting the HTTPS link under **Host**.
 

--- a/docs/serverless-v2/08-02-expose-lambda.md
+++ b/docs/serverless-v2/08-02-expose-lambda.md
@@ -90,9 +90,9 @@ Follows these steps:
 
     - Enter the API Rule's **Name** matching the lambda's name.
 
-    >**NOTE:** The APIRule CR can have a different name than lambda, but it is recommended that all related resources share a common name.
+    >**NOTE:** The APIRule CR can have a different name than the lambda, but it is recommended that all related resources share a common name.
 
-    - Enter **Hostname** to indicate the host on which you want to expose lambda.
+    - Enter **Hostname** to indicate the host on which you want to expose your lambda.
 
     - Select the lambda from the drop-down list in the **Service** column.
 
@@ -101,7 +101,7 @@ Follows these steps:
 
     The `API Rule {NAME} created successfully` message appears confirming the changes were saved.
 
-6. In the API Rule's details view that opens up automatically, check if you can access lambda by selecting the HTTPS link under **Host**.
+6. In the API Rule's details view that opens up automatically, check if you can access the lambda by selecting the HTTPS link under **Host**.
 
     </details>
 </div>

--- a/docs/serverless-v2/08-02-expose-lambda.md
+++ b/docs/serverless-v2/08-02-expose-lambda.md
@@ -88,17 +88,18 @@ Follows these steps:
 2. Go to the **API Rules [preview]** view at the bottom of the left navigation panel and select **Add API Rule**.
 3. In the **General settings** section:
 
-- Enter API Rule's **Name** matching the lambda's name.
+    - Enter API Rule's **Name** matching the lambda's name.
 
     >**NOTE:** The APIRule CR can have a different name than lambda, but it is recommended that all related resources share a common name.
 
-- Enter **Hostname** on which you want to expose lambda.
-- Select the lambda from the drop-down list in the **Service** column.
+    - Enter **Hostname** on which you want to expose lambda.
+
+    - Select the lambda from the drop-down list in the **Service** column.
 
 4. In the **Access strategies** section, leave the default settings, with `GET`, `POST`, `PUT`, and `DELETE` methods and the `noop` handler.
 5. Select **Create** to confirm changes.
 
-You will get the `API Rule {NAME} created successfully` message confirming the changes were saved.
+    You will get the `API Rule {NAME} created successfully` message confirming the changes were saved.
 
 6. In the API Rule's details view that opens up automatically, check if you can access lambda by selecting the HTTPS link under **Host**.
 

--- a/docs/serverless-v2/08-02-expose-lambda.md
+++ b/docs/serverless-v2/08-02-expose-lambda.md
@@ -20,14 +20,20 @@ This tutorial is based on an existing lambda. To create one, follow the [Create 
 
 Follows these steps:
 
+<div tabs name="steps" group="expose-lambda">
+  <details>
+  <summary label="kubectl">
+  kubectl
+  </summary>
+
 1. Export these variables:
 
     ```bash
     export DOMAIN={DOMAIN_NAME}
     export NAME={LAMBDA_NAME}
-    export NAMESPACE=serverless
+    export NAMESPACE={LAMBDA_NAMESPACE}
     ```
-    
+
     >**NOTE:** Lambda takes the name from the Function CR name. The APIRule CR can have a different name but for the purpose of this tutorial, all related resources share a common name defined under the **NAME** variable.
 
 2. Create an APIRule CR for your lambda. It is exposed on port `80` that is the default port of the [Service Placeholder](#architecture-architecture).
@@ -57,7 +63,7 @@ Follows these steps:
         port: 80
     EOF
     ```
-    
+
 3. Check if the API Rule was created successfully and has the `OK` status:
 
     ```bash
@@ -69,3 +75,31 @@ Follows these steps:
     ```bash
     curl https://$NAME.$DOMAIN
     ```
+
+    </details>
+<details>
+<summary label="console-ui">
+Console UI
+</summary>
+
+> **NOTE:** The API Rules functionality that allow you to expose lambdas is an experimental feature, and it is not enabled by default in the Console UI. To use it, enable **Experimental functionalities** in the **General Settings** view before you follow the steps.
+
+1. Select a Namespace from the drop-down list in the top navigation panel where there is an existing lambda which you want to expose through an API Rule.
+2. Go to the **API Rules [preview]** view at the bottom of the left navigation panel and select **Add API Rule**.
+3. In the **General settings** section:
+
+- Enter API Rule's **Name** matching the lambda's name.
+
+    >**NOTE:** The APIRule CR can have a different name than lambda, but it is recommended that all related resources share a common name.
+
+- Enter **Hostname** on which you want to expose lambda.
+- Select the lambda from the drop-down list in the **Service** column.
+
+4. In the **Access strategies** section, leave the default settings, with `GET`, `POST`, `PUT`, and `DELETE` methods and the `noop` handler.
+5. Select **Create** to confirm changes.
+
+You will get the `API Rule {NAME} created successfully` message confirming the changes were saved.
+
+6. In the API Rule's details view that opens up automatically, check if you can access lambda by selecting the HTTPS link under **Host**.
+
+    </details>

--- a/docs/serverless-v2/08-02-expose-lambda.md
+++ b/docs/serverless-v2/08-02-expose-lambda.md
@@ -77,10 +77,10 @@ Follows these steps:
     ```
 
     </details>
-<details>
-<summary label="console-ui">
-Console UI
-</summary>
+    <details>
+    <summary label="console-ui">
+    Console UI
+    </summary>
 
 > **NOTE:** The API Rules functionality that allow you to expose lambdas is an experimental feature, and it is not enabled by default in the Console UI. To use it, enable **Experimental functionalities** in the **General Settings** view before you follow the steps.
 
@@ -103,3 +103,4 @@ You will get the `API Rule {NAME} created successfully` message confirming the c
 6. In the API Rule's details view that opens up automatically, check if you can access lambda by selecting the HTTPS link under **Host**.
 
     </details>
+</div>

--- a/docs/serverless-v2/08-02-expose-lambda.md
+++ b/docs/serverless-v2/08-02-expose-lambda.md
@@ -85,7 +85,9 @@ Follows these steps:
 > **NOTE:** The API Rules functionality that allow you to expose lambdas is an experimental feature, and it is not enabled by default in the Console UI. To use it, enable **Experimental functionalities** in the **General Settings** view before you follow the steps. Refresh the page after enabling this option.
 
 1. Select a Namespace from the drop-down list in the top navigation panel. Make sure the Namespace includes the lambda that you want to expose through an API Rule.
+
 2. Go to the **API Rules [preview]** view at the bottom of the left navigation panel and select **Add API Rule**.
+
 3. In the **General settings** section:
 
     - Enter the API Rule's **Name** matching the lambda's name.
@@ -97,6 +99,7 @@ Follows these steps:
     - Select the lambda from the drop-down list in the **Service** column.
 
 4. In the **Access strategies** section, leave the default settings, with `GET`, `POST`, `PUT`, and `DELETE` methods and the `noop` handler selected.
+
 5. Select **Create** to confirm changes.
 
     The `API Rule {NAME} created successfully` message appears confirming the changes were saved.

--- a/docs/serverless-v2/08-03-bind-service-instance.md
+++ b/docs/serverless-v2/08-03-bind-service-instance.md
@@ -17,11 +17,17 @@ This tutorial is based on an existing lambda. To create one, follow the [Create 
 
 Follows these steps:
 
+<div tabs name="steps" group="bind-lambda">
+  <details>
+  <summary label="kubectl">
+  kubectl
+  </summary>
+
 1. Export these variables:
 
     ```bash
     export NAME={LAMBDA_NAME}
-    export NAMESPACE=serverless
+    export NAMESPACE={LAMBDA_NAMESPACE}
     ```
 
     > **NOTE:** Lambda takes the name from the Function CR name. The ServiceInstance, ServiceBinding, and ServiceBindingUsage CRs can have different names, but for the purpose of this tutorial, all related resources share a common name defined under the **NAME** variable.
@@ -144,6 +150,56 @@ Follows these steps:
     ```
 
     > **NOTE:** If you added the **REDIS_** prefix for environmental variables in step 6, all variables will start with it. For example, the **PORT** variable will take the form of **REDIS_PORT**.
+
+    </details>
+<details>
+<summary label="console-ui">
+Console UI
+</summary>
+
+> **NOTE:** Serverless v2 is an experimental feature, and it is not enabled by default in the Console UI. To use its **Functions [preview]** view, enable **Experimental functionalities** in the **General Settings** view before you follow the steps.
+
+To create a binding, you must first create a sample service instance to which you can bind the lambda. Follow the sections and steps to complete this tutorial.
+
+### Provision a Redis service using an Addon
+
+> **NOTE:** If you already have a Redis instance provisioned on your cluster, move directly to the **Bind the lambda with the service Instance** section.
+
+Follow these steps:
+
+1. Select a Namespace from the drop-down list in the top navigation panel where you want to provision the Redis service.
+2. Go to the **Addons** view in the left navigation panel and select **Add New Configuration**.
+2. Enter `https://github.com/kyma-project/addons/releases/download/0.11.0/index-testing.yaml` in the **Urls** field. The Addon name is automatically generated.
+3. Select **Add** to confirm changes.
+
+You will see that the Addon has the `Ready` status.
+
+### Create a Service Instance
+
+1. Go to the Catalog view where you can see the list of all available Addons and select **Redis**.
+2. Select **Add** to provision the Redis ServiceClass and create its instance in your Namespace.
+3. Change the **Name** to match the lambda, select `micro` from the **Plan** drop-down list, and set **Image pull policy** to `Always`.
+
+    > **NOTE:** The Service Instance, Service Binding, and Service Binding Usage can have different names than lambda, but it is recommended that all related resources share a common name.
+
+4. Select **Create** to confirm changes.
+
+Wait until the status of the instance changes from `PROVISIONING` to `RUNNING`.
+
+### Bind the lambda with the service Instance
+
+1. Go to the **Functions [preview]** view at the bottom of the left navigation panel and select the lambda you want to bind to the Service Instance.
+2. Select **Select Service Bindings** in the **Service Bindings** section.
+3. Select the Redis service from the **Service Instance** drop-down list, add `REDIS_` as **Prefix for injected variables**, and make sure **Create new Secret** is checked.
+4. Select **Create** to confirm changes.
+
+You will see the `Service Binding creating...` message and the binding available under the **Service Bindings** section in your lambda, along with **Environment Variable Names**.
+
+    > **NOTE:** The **Prefix for injected variables** field is optional. It adds a prefix to all environment variables injected by a given Secret from the Service Binding to the lambda. In our example, the prefix is set to `REDIS_`, so all environmental variables will follow the `REDIS_{env}` naming pattern.
+
+    > **TIP:** It is considered good practice to use prefixes for environment variables. In some cases, a lambda must use several instances of a given Service Class. Prefixes allow you to distinguish between instances and make sure that one Secret does not overwrite another one.
+
+    </details>
 
 ## Test the lambda
 

--- a/docs/serverless-v2/08-03-bind-service-instance.md
+++ b/docs/serverless-v2/08-03-bind-service-instance.md
@@ -169,10 +169,10 @@ Follow these steps:
 
 1. Select a Namespace from the drop-down list in the top navigation panel where you want to provision the Redis service.
 2. Go to the **Addons** view in the left navigation panel and select **Add New Configuration**.
-2. Enter `https://github.com/kyma-project/addons/releases/download/0.11.0/index-testing.yaml` in the **Urls** field. The Addon name is automatically generated.
-3. Select **Add** to confirm changes.
+3. Enter `https://github.com/kyma-project/addons/releases/download/0.11.0/index-testing.yaml` in the **Urls** field. The Addon name is automatically generated.
+4. Select **Add** to confirm changes.
 
-You will see that the Addon has the `Ready` status.
+    You will see that the Addon has the `Ready` status.
 
 ### Create a Service Instance
 
@@ -184,7 +184,7 @@ You will see that the Addon has the `Ready` status.
 
 4. Select **Create** to confirm changes.
 
-Wait until the status of the instance changes from `PROVISIONING` to `RUNNING`.
+    Wait until the status of the instance changes from `PROVISIONING` to `RUNNING`.
 
 ### Bind the lambda with the service Instance
 
@@ -193,11 +193,11 @@ Wait until the status of the instance changes from `PROVISIONING` to `RUNNING`.
 3. Select the Redis service from the **Service Instance** drop-down list, add `REDIS_` as **Prefix for injected variables**, and make sure **Create new Secret** is checked.
 4. Select **Create** to confirm changes.
 
-You will see the `Service Binding creating...` message and the binding available under the **Service Bindings** section in your lambda, along with **Environment Variable Names**.
+    You will see the `Service Binding creating...` message and the binding available under the **Service Bindings** section in your lambda, along with **Environment Variable Names**.
 
-    > **NOTE:** The **Prefix for injected variables** field is optional. It adds a prefix to all environment variables injected by a given Secret from the Service Binding to the lambda. In our example, the prefix is set to `REDIS_`, so all environmental variables will follow the `REDIS_{env}` naming pattern.
+The **Prefix for injected variables** field is optional. It adds a prefix to all environment variables injected by a given Secret from the Service Binding to the lambda. In our example, the prefix is set to `REDIS_`, so all environmental variables will follow the `REDIS_{env}` naming pattern.
 
-    > **TIP:** It is considered good practice to use prefixes for environment variables. In some cases, a lambda must use several instances of a given Service Class. Prefixes allow you to distinguish between instances and make sure that one Secret does not overwrite another one.
+> **TIP:** It is considered good practice to use prefixes for environment variables. In some cases, a lambda must use several instances of a given Service Class. Prefixes allow you to distinguish between instances and make sure that one Secret does not overwrite another one.
 
     </details>
 </div>

--- a/docs/serverless-v2/08-03-bind-service-instance.md
+++ b/docs/serverless-v2/08-03-bind-service-instance.md
@@ -180,13 +180,13 @@ Follow these steps:
 2. Select **Add** to provision the Redis ServiceClass and create its instance in your Namespace.
 3. Change the **Name** to match the lambda, select `micro` from the **Plan** drop-down list, and set **Image pull policy** to `Always`.
 
-    > **NOTE:** The Service Instance, Service Binding, and Service Binding Usage can have different names than lambda, but it is recommended that all related resources share a common name.
+    > **NOTE:** The Service Instance, Service Binding, and Service Binding Usage can have different names than the lambda, but it is recommended that all related resources share a common name.
 
 4. Select **Create** to confirm changes.
 
     Wait until the status of the instance changes from `PROVISIONING` to `RUNNING`.
 
-### Bind the lambda with the service Instance
+### Bind the lambda with the Service Instance
 
 1. Go to the **Functions [preview]** view at the bottom of the left navigation panel and select the lambda you want to bind to the Service Instance.
 2. Select **Select Service Bindings** in the **Service Bindings** section.

--- a/docs/serverless-v2/08-03-bind-service-instance.md
+++ b/docs/serverless-v2/08-03-bind-service-instance.md
@@ -123,11 +123,11 @@ Follows these steps:
     EOF    
     ```
 
-    - The **spec.serviceBindingRef** and **spec.usedBy** fields are required. **spec.serviceBindingRef** points to the Service Binding you have just created and **spec.usedBy** points to the lambda. More specifically, **spec.usedBy** refers to the name of the related KService CR (`name: $NAME`) and the cluster-specific [UsageKind CR](https://kyma-project.io/docs/components/service-catalog/#custom-resource-usage-kind) (`kind: knative-service`) that defines how Secrets should be injected to your lambda through the Service Binding.
+    - The **spec.serviceBindingRef** and **spec.usedBy** fields are required. **spec.serviceBindingRef** points to the Service Binding you have just created and **spec.usedBy** points to the lambda. More specifically, **spec.usedBy** refers to the name of the related KService CR (`name: $NAME`) and the cluster-specific [UsageKind CR](https://kyma-project.io/docs/components/service-catalog/#custom-resource-usage-kind) (`kind: knative-service`) that defines how Secrets should be injected to your lambda when creating a Service Binding.
 
-    - The **spec.parameters.envPrefix.name** field is optional. It adds a prefix to all environment variables injected by a given Secret from the Service Binding to the lambda. In our example, **envPrefix** is `REDIS_`, so all environmental variables will follow the `REDIS_{env}` naming pattern.
+    - The **spec.parameters.envPrefix.name** field is optional. It adds a prefix to all environment variables injected in a Secret to the lambda when creating a Service Binding. In our example, **envPrefix** is `REDIS_`, so all environmental variables will follow the `REDIS_{env}` naming pattern.
 
-        > **TIP:** It is considered good practice to use **envPrefix**. In some cases, a lambda must use several instances of a given Service Class. Prefixes allow you to distinguish between instances and make sure that one Secret does not overwrite another one.
+        > **TIP:** It is considered good practice to use **envPrefix**. In some cases, a lambda must use several instances of a given ServiceClass. Prefixes allow you to distinguish between instances and make sure that one Secret does not overwrite another one.
 
 9. Check if the ServiceBindingUsage CR was created successfully. The last condition in the CR status should state `Ready True`:
 
@@ -157,13 +157,13 @@ Follows these steps:
     Console UI
     </summary>
 
-> **NOTE:** Serverless v2 is an experimental feature, and it is not enabled by default in the Console UI. To use its **Functions [preview]** view, enable **Experimental functionalities** in the **General Settings** view before you follow the steps.
+> **NOTE:** Serverless v2 is an experimental feature, and it is not enabled by default in the Console UI. To use its **Functions [preview]** view, enable **Experimental functionalities** in the **General Settings** view before you follow the steps. Refresh the page after enabling this option.
 
-To create a binding, you must first create a sample service instance to which you can bind the lambda. Follow the sections and steps to complete this tutorial.
+To create a binding, you must first create a sample Service Instance to which you can bind the lambda. Follow the sections and steps to complete this tutorial.
 
 ### Provision a Redis service using an Addon
 
-> **NOTE:** If you already have a Redis instance provisioned on your cluster, move directly to the **Bind the lambda with the service Instance** section.
+> **NOTE:** If you already have a Redis instance provisioned on your cluster, move directly to the **Bind the lambda with the Service Instance** section.
 
 Follow these steps:
 
@@ -176,7 +176,7 @@ Follow these steps:
 
 ### Create a Service Instance
 
-1. Go to the Catalog view where you can see the list of all available Addons and select **Redis**.
+1. Go to the **Catalog** view where you can see the list of all available Addons and select **[Experimental] Redis**.
 2. Select **Add** to provision the Redis ServiceClass and create its instance in your Namespace.
 3. Change the **Name** to match the lambda, select `micro` from the **Plan** drop-down list, and set **Image pull policy** to `Always`.
 
@@ -190,14 +190,14 @@ Follow these steps:
 
 1. Go to the **Functions [preview]** view at the bottom of the left navigation panel and select the lambda you want to bind to the Service Instance.
 2. Select **Select Service Bindings** in the **Service Bindings** section.
-3. Select the Redis service from the **Service Instance** drop-down list, add `REDIS_` as **Prefix for injected variables**, and make sure **Create new Secret** is checked.
+3. Select the Redis service from the **Service Instance** drop-down list, add `REDIS_` as **Prefix for injected variables**, and make sure **Create new Secret** is selected.
 4. Select **Create** to confirm changes.
 
-  You will see the `Service Binding creating...` message and the binding available under the **Service Bindings** section in your lambda, along with **Environment Variable Names**.
+  The `Service Binding creating...` message appears and the binding will be available in the **Service Bindings** section in your lambda, along with **Environment Variable Names**.
 
-The **Prefix for injected variables** field is optional. It adds a prefix to all environment variables injected by a given Secret from the Service Binding to the lambda. In our example, the prefix is set to `REDIS_`, so all environmental variables will follow the `REDIS_{env}` naming pattern.
+The **Prefix for injected variables** field is optional. It adds a prefix to all environment variables injected in a Secret to the lambda when creating a Service Binding. In our example, the prefix is set to `REDIS_`, so all environmental variables will follow the `REDIS_{ENVIRONMENT_VARIABLE}` naming pattern.
 
-> **TIP:** It is considered good practice to use prefixes for environment variables. In some cases, a lambda must use several instances of a given Service Class. Prefixes allow you to distinguish between instances and make sure that one Secret does not overwrite another one.
+> **TIP:** It is considered good practice to use prefixes for environment variables. In some cases, a lambda must use several instances of a given ServiceClass. Prefixes allow you to distinguish between instances and make sure that one Secret does not overwrite another one.
 
     </details>
 </div>

--- a/docs/serverless-v2/08-03-bind-service-instance.md
+++ b/docs/serverless-v2/08-03-bind-service-instance.md
@@ -152,10 +152,10 @@ Follows these steps:
     > **NOTE:** If you added the **REDIS_** prefix for environmental variables in step 6, all variables will start with it. For example, the **PORT** variable will take the form of **REDIS_PORT**.
 
     </details>
-<details>
-<summary label="console-ui">
-Console UI
-</summary>
+    <details>
+    <summary label="console-ui">
+    Console UI
+    </summary>
 
 > **NOTE:** Serverless v2 is an experimental feature, and it is not enabled by default in the Console UI. To use its **Functions [preview]** view, enable **Experimental functionalities** in the **General Settings** view before you follow the steps.
 
@@ -200,6 +200,7 @@ You will see the `Service Binding creating...` message and the binding available
     > **TIP:** It is considered good practice to use prefixes for environment variables. In some cases, a lambda must use several instances of a given Service Class. Prefixes allow you to distinguish between instances and make sure that one Secret does not overwrite another one.
 
     </details>
+</div>
 
 ## Test the lambda
 

--- a/docs/serverless-v2/08-03-bind-service-instance.md
+++ b/docs/serverless-v2/08-03-bind-service-instance.md
@@ -193,7 +193,7 @@ Follow these steps:
 3. Select the Redis service from the **Service Instance** drop-down list, add `REDIS_` as **Prefix for injected variables**, and make sure **Create new Secret** is checked.
 4. Select **Create** to confirm changes.
 
-    You will see the `Service Binding creating...` message and the binding available under the **Service Bindings** section in your lambda, along with **Environment Variable Names**.
+  You will see the `Service Binding creating...` message and the binding available under the **Service Bindings** section in your lambda, along with **Environment Variable Names**.
 
 The **Prefix for injected variables** field is optional. It adds a prefix to all environment variables injected by a given Secret from the Service Binding to the lambda. In our example, the prefix is set to `REDIS_`, so all environmental variables will follow the `REDIS_{env}` naming pattern.
 

--- a/docs/serverless-v2/08-03-bind-service-instance.md
+++ b/docs/serverless-v2/08-03-bind-service-instance.md
@@ -193,7 +193,7 @@ Follow these steps:
 3. Select the Redis service from the **Service Instance** drop-down list, add `REDIS_` as **Prefix for injected variables**, and make sure **Create new Secret** is selected.
 4. Select **Create** to confirm changes.
 
-  The `Service Binding creating...` message appears and the binding will be available in the **Service Bindings** section in your lambda, along with **Environment Variable Names**.
+The `Service Binding creating...` message appears and the binding will be available in the **Service Bindings** section in your lambda, along with **Environment Variable Names**.
 
 The **Prefix for injected variables** field is optional. It adds a prefix to all environment variables injected in a Secret to the lambda when creating a Service Binding. In our example, the prefix is set to `REDIS_`, so all environmental variables will follow the `REDIS_{ENVIRONMENT_VARIABLE}` naming pattern.
 

--- a/docs/serverless-v2/08-03-bind-service-instance.md
+++ b/docs/serverless-v2/08-03-bind-service-instance.md
@@ -195,7 +195,8 @@ Follow these steps:
 
 The `Service Binding creating...` message appears and the binding will be available in the **Service Bindings** section in your lambda, along with **Environment Variable Names**.
 
-The **Prefix for injected variables** field is optional. It adds a prefix to all environment variables injected in a Secret to the lambda when creating a Service Binding. In our example, the prefix is set to `REDIS_`, so all environmental variables will follow the `REDIS_{ENVIRONMENT_VARIABLE}` naming pattern. 
+
+The **Prefix for injected variables** field is optional. It adds a prefix to all environment variables injected in a Secret to the lambda when creating a Service Binding. In our example, the prefix is set to `REDIS_`, so all environmental variables will follow the `REDIS_{ENVIRONMENT_VARIABLE}` naming pattern.
 
 > **TIP:** It is considered good practice to use prefixes for environment variables. In some cases, a lambda must use several instances of a given ServiceClass. Prefixes allow you to distinguish between instances and make sure that one Secret does not overwrite another one.
 

--- a/docs/serverless-v2/08-03-bind-service-instance.md
+++ b/docs/serverless-v2/08-03-bind-service-instance.md
@@ -195,9 +195,7 @@ Follow these steps:
 
 The `Service Binding creating...` message appears and the binding will be available in the **Service Bindings** section in your lambda, along with **Environment Variable Names**.
 
-
-The **Prefix for injected variables** field is optional. It adds a prefix to all environment variables injected in a Secret to the lambda when creating a Service Binding. In our example, the prefix is set to `REDIS_`, so all environmental variables will follow the `REDIS_{ENVIRONMENT_VARIABLE}` naming pattern.
-
+>**NOTE:** The **Prefix for injected variables** field is optional. It adds a prefix to all environment variables injected in a Secret to the lambda when creating a Service Binding. In our example, the prefix is set to `REDIS_`, so all environmental variables will follow the `REDIS_{ENVIRONMENT_VARIABLE}` naming pattern.
 
 > **TIP:** It is considered good practice to use prefixes for environment variables. In some cases, a lambda must use several instances of a given ServiceClass. Prefixes allow you to distinguish between instances and make sure that one Secret does not overwrite another one.
 

--- a/docs/serverless-v2/08-03-bind-service-instance.md
+++ b/docs/serverless-v2/08-03-bind-service-instance.md
@@ -168,8 +168,11 @@ To create a binding, you must first create a sample Service Instance to which yo
 Follow these steps:
 
 1. Select a Namespace from the drop-down list in the top navigation panel where you want to provision the Redis service.
+
 2. Go to the **Addons** view in the left navigation panel and select **Add New Configuration**.
+
 3. Enter `https://github.com/kyma-project/addons/releases/download/0.11.0/index-testing.yaml` in the **Urls** field. The Addon name is automatically generated.
+
 4. Select **Add** to confirm changes.
 
     You will see that the Addon has the `Ready` status.
@@ -177,7 +180,9 @@ Follow these steps:
 ### Create a Service Instance
 
 1. Go to the **Catalog** view where you can see the list of all available Addons and select **[Experimental] Redis**.
+
 2. Select **Add** to provision the Redis ServiceClass and create its instance in your Namespace.
+
 3. Change the **Name** to match the lambda, select `micro` from the **Plan** drop-down list, and set **Image pull policy** to `Always`.
 
     > **NOTE:** The Service Instance, Service Binding, and Service Binding Usage can have different names than the lambda, but it is recommended that all related resources share a common name.
@@ -189,8 +194,11 @@ Follow these steps:
 ### Bind the lambda with the Service Instance
 
 1. Go to the **Functions [preview]** view at the bottom of the left navigation panel and select the lambda you want to bind to the Service Instance.
+
 2. Select **Select Service Bindings** in the **Service Bindings** section.
+
 3. Select the Redis service from the **Service Instance** drop-down list, add `REDIS_` as **Prefix for injected variables**, and make sure **Create new Secret** is selected.
+
 4. Select **Create** to confirm changes.
 
 The `Service Binding creating...` message appears and the binding will be available in the **Service Bindings** section in your lambda, along with **Environment Variable Names**.

--- a/docs/serverless-v2/08-03-bind-service-instance.md
+++ b/docs/serverless-v2/08-03-bind-service-instance.md
@@ -193,10 +193,11 @@ Follow these steps:
 3. Select the Redis service from the **Service Instance** drop-down list, add `REDIS_` as **Prefix for injected variables**, and make sure **Create new Secret** is selected.
 4. Select **Create** to confirm changes.
 
-  The `Service Binding creating...` message appears and the binding will be available in the **Service Bindings** section in your lambda, along with **Environment Variable Names**.
+The `Service Binding creating...` message appears and the binding will be available in the **Service Bindings** section in your lambda, along with **Environment Variable Names**.
 
 
 The **Prefix for injected variables** field is optional. It adds a prefix to all environment variables injected in a Secret to the lambda when creating a Service Binding. In our example, the prefix is set to `REDIS_`, so all environmental variables will follow the `REDIS_{ENVIRONMENT_VARIABLE}` naming pattern.
+
 
 > **TIP:** It is considered good practice to use prefixes for environment variables. In some cases, a lambda must use several instances of a given ServiceClass. Prefixes allow you to distinguish between instances and make sure that one Secret does not overwrite another one.
 

--- a/docs/serverless-v2/08-03-bind-service-instance.md
+++ b/docs/serverless-v2/08-03-bind-service-instance.md
@@ -193,7 +193,7 @@ Follow these steps:
 3. Select the Redis service from the **Service Instance** drop-down list, add `REDIS_` as **Prefix for injected variables**, and make sure **Create new Secret** is selected.
 4. Select **Create** to confirm changes.
 
-The `Service Binding creating...` message appears and the binding will be available in the **Service Bindings** section in your lambda, along with **Environment Variable Names**.
+  The `Service Binding creating...` message appears and the binding will be available in the **Service Bindings** section in your lambda, along with **Environment Variable Names**.
 
 
 The **Prefix for injected variables** field is optional. It adds a prefix to all environment variables injected in a Secret to the lambda when creating a Service Binding. In our example, the prefix is set to `REDIS_`, so all environmental variables will follow the `REDIS_{ENVIRONMENT_VARIABLE}` naming pattern.

--- a/docs/serverless-v2/08-03-bind-service-instance.md
+++ b/docs/serverless-v2/08-03-bind-service-instance.md
@@ -193,7 +193,7 @@ Follow these steps:
 3. Select the Redis service from the **Service Instance** drop-down list, add `REDIS_` as **Prefix for injected variables**, and make sure **Create new Secret** is selected.
 4. Select **Create** to confirm changes.
 
-    The `Service Binding creating...` message appears and the binding will be available in the **Service Bindings** section in your lambda, along with **Environment Variable Names**.
+  The `Service Binding creating...` message appears and the binding will be available in the **Service Bindings** section in your lambda, along with **Environment Variable Names**.
 
 
   The **Prefix for injected variables** field is optional. It adds a prefix to all environment variables injected in a Secret to the lambda when creating a Service Binding. In our example, the prefix is set to `REDIS_`, so all environmental variables will follow the `REDIS_{ENVIRONMENT_VARIABLE}` naming pattern.

--- a/docs/serverless-v2/08-03-bind-service-instance.md
+++ b/docs/serverless-v2/08-03-bind-service-instance.md
@@ -193,9 +193,10 @@ Follow these steps:
 3. Select the Redis service from the **Service Instance** drop-down list, add `REDIS_` as **Prefix for injected variables**, and make sure **Create new Secret** is selected.
 4. Select **Create** to confirm changes.
 
-The `Service Binding creating...` message appears and the binding will be available in the **Service Bindings** section in your lambda, along with **Environment Variable Names**.
+    The `Service Binding creating...` message appears and the binding will be available in the **Service Bindings** section in your lambda, along with **Environment Variable Names**.
 
-The **Prefix for injected variables** field is optional. It adds a prefix to all environment variables injected in a Secret to the lambda when creating a Service Binding. In our example, the prefix is set to `REDIS_`, so all environmental variables will follow the `REDIS_{ENVIRONMENT_VARIABLE}` naming pattern.
+
+  The **Prefix for injected variables** field is optional. It adds a prefix to all environment variables injected in a Secret to the lambda when creating a Service Binding. In our example, the prefix is set to `REDIS_`, so all environmental variables will follow the `REDIS_{ENVIRONMENT_VARIABLE}` naming pattern.
 
 > **TIP:** It is considered good practice to use prefixes for environment variables. In some cases, a lambda must use several instances of a given ServiceClass. Prefixes allow you to distinguish between instances and make sure that one Secret does not overwrite another one.
 

--- a/docs/serverless-v2/08-03-bind-service-instance.md
+++ b/docs/serverless-v2/08-03-bind-service-instance.md
@@ -193,7 +193,7 @@ Follow these steps:
 3. Select the Redis service from the **Service Instance** drop-down list, add `REDIS_` as **Prefix for injected variables**, and make sure **Create new Secret** is selected.
 4. Select **Create** to confirm changes.
 
-    The `Service Binding creating...` message appears and the binding will be available in the **Service Bindings** section in your lambda, along with **Environment Variable Names**.
+    The `Service Binding creating...` message appears and the binding will be available in the **Service Bindings** section in your lambda, along with **Environment Variable Names**. 
 
 The **Prefix for injected variables** field is optional. It adds a prefix to all environment variables injected in a Secret to the lambda when creating a Service Binding. In our example, the prefix is set to `REDIS_`, so all environmental variables will follow the `REDIS_{ENVIRONMENT_VARIABLE}` naming pattern.
 

--- a/docs/serverless-v2/08-03-bind-service-instance.md
+++ b/docs/serverless-v2/08-03-bind-service-instance.md
@@ -193,9 +193,9 @@ Follow these steps:
 3. Select the Redis service from the **Service Instance** drop-down list, add `REDIS_` as **Prefix for injected variables**, and make sure **Create new Secret** is selected.
 4. Select **Create** to confirm changes.
 
-    The `Service Binding creating...` message appears and the binding will be available in the **Service Bindings** section in your lambda, along with **Environment Variable Names**. 
+The `Service Binding creating...` message appears and the binding will be available in the **Service Bindings** section in your lambda, along with **Environment Variable Names**.
 
-The **Prefix for injected variables** field is optional. It adds a prefix to all environment variables injected in a Secret to the lambda when creating a Service Binding. In our example, the prefix is set to `REDIS_`, so all environmental variables will follow the `REDIS_{ENVIRONMENT_VARIABLE}` naming pattern.
+The **Prefix for injected variables** field is optional. It adds a prefix to all environment variables injected in a Secret to the lambda when creating a Service Binding. In our example, the prefix is set to `REDIS_`, so all environmental variables will follow the `REDIS_{ENVIRONMENT_VARIABLE}` naming pattern. 
 
 > **TIP:** It is considered good practice to use prefixes for environment variables. In some cases, a lambda must use several instances of a given ServiceClass. Prefixes allow you to distinguish between instances and make sure that one Secret does not overwrite another one.
 

--- a/docs/serverless-v2/08-03-bind-service-instance.md
+++ b/docs/serverless-v2/08-03-bind-service-instance.md
@@ -193,10 +193,9 @@ Follow these steps:
 3. Select the Redis service from the **Service Instance** drop-down list, add `REDIS_` as **Prefix for injected variables**, and make sure **Create new Secret** is selected.
 4. Select **Create** to confirm changes.
 
-  The `Service Binding creating...` message appears and the binding will be available in the **Service Bindings** section in your lambda, along with **Environment Variable Names**.
+    The `Service Binding creating...` message appears and the binding will be available in the **Service Bindings** section in your lambda, along with **Environment Variable Names**.
 
-
-  The **Prefix for injected variables** field is optional. It adds a prefix to all environment variables injected in a Secret to the lambda when creating a Service Binding. In our example, the prefix is set to `REDIS_`, so all environmental variables will follow the `REDIS_{ENVIRONMENT_VARIABLE}` naming pattern.
+The **Prefix for injected variables** field is optional. It adds a prefix to all environment variables injected in a Secret to the lambda when creating a Service Binding. In our example, the prefix is set to `REDIS_`, so all environmental variables will follow the `REDIS_{ENVIRONMENT_VARIABLE}` naming pattern.
 
 > **TIP:** It is considered good practice to use prefixes for environment variables. In some cases, a lambda must use several instances of a given ServiceClass. Prefixes allow you to distinguish between instances and make sure that one Secret does not overwrite another one.
 


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Prepared UI versions of the existing Serverless v2 tutorials nad placed them under separate tabs in docs:
   - [Create a lambda](https://kyma-project.io/docs/master/components/serverless-v2/#tutorials-create-a-lambda)
   - [Expose the lambda with an API Rule](https://kyma-project.io/docs/master/components/serverless-v2/#tutorials-expose-the-lambda-with-an-api-rule)
   - [Bind a Service Instance to a lambda](https://kyma-project.io/docs/master/components/serverless-v2/#tutorials-bind-a-service-instance-to-a-lambda)


