### PR TITLE
Fluentbit psp capabilities add

### DIFF
--- a/resources/logging/charts/fluentbit/templates/pod-security-policy.yaml
+++ b/resources/logging/charts/fluentbit/templates/pod-security-policy.yaml
@@ -12,6 +12,9 @@ metadata:
 spec:
   privileged: false
   allowPrivilegeEscalation: true
+  allowedCapabilities:
+  - NET_ADMIN
+  - NET_RAW
   volumes:
     - 'configMap'
     - 'emptyDir'


### PR DESCRIPTION
Istio-sidecar injected to the fluentbit pod needs the NET_ADMIN & NET_RAW capabilities on PSP enabled clusters in order to work.