### PR TITLE
Configure db pool for Director, Tenant Loader and Tenant Fetcher

### DIFF
--- a/resources/compass/charts/director/templates/deployment.yaml
+++ b/resources/compass/charts/director/templates/deployment.yaml
@@ -67,6 +67,10 @@ spec:
                 secretKeyRef:
                   name: compass-postgresql
                   key: postgresql-sslMode
+            - name: APP_DB_MAX_OPEN_CONNECTIONS
+              value: "{{.Values.deployment.dbPool.maxOpenConnections}}"
+            - name: APP_DB_MAX_IDLE_CONNECTIONS
+              value: "{{.Values.deployment.dbPool.maxIdleConnections}}"
             - name: APP_ONE_TIME_TOKEN_URL
               value: "http://compass-connector-internal.{{ .Release.Namespace }}.svc.cluster.local:{{ .Values.global.connector.graphql.internal.port }}/graphql"
             - name: APP_CONNECTOR_URL

--- a/resources/compass/charts/director/templates/tenant-loader-job.yaml
+++ b/resources/compass/charts/director/templates/tenant-loader-job.yaml
@@ -54,6 +54,10 @@ spec:
                             secretKeyRef:
                                 name: compass-postgresql
                                 key: postgresql-sslMode
+                      - name: APP_DB_MAX_OPEN_CONNECTIONS
+                        value: "{{.Values.global.tenantConfig.dbPool.maxOpenConnections}}"
+                      - name: APP_DB_MAX_IDLE_CONNECTIONS
+                        value: "{{.Values.global.tenantConfig.dbPool.maxIdleConnections}}"
                   volumeMounts:
                     {{if eq .Values.global.tenantConfig.useDefaultTenants true}}
                     - name: default-tenant-config

--- a/resources/compass/charts/director/values.yaml
+++ b/resources/compass/charts/director/values.yaml
@@ -7,3 +7,6 @@ deployment:
     runAsUser: 2000
     allowPrivilegeEscalation: false
   allowJWTSigningNone: true # To run integration tests, it has to be enabled
+  dbPool:
+    maxOpenConnections: 30
+    maxIdleConnections: 2

--- a/resources/compass/templates/tenant-fetcher-job.yaml
+++ b/resources/compass/templates/tenant-fetcher-job.yaml
@@ -46,6 +46,10 @@ spec:
                   secretKeyRef:
                     name: compass-postgresql
                     key: postgresql-sslMode
+              - name: APP_DB_MAX_OPEN_CONNECTIONS
+                value: "{{.Values.global.tenantFetcher.dbPool.maxOpenConnections}}"
+              - name: APP_DB_MAX_IDLE_CONNECTIONS
+                value: "{{.Values.global.tenantFetcher.dbPool.maxIdleConnections}}"
               - name: APP_ENDPOINT_TENANT_CREATED
                 value: {{ .Values.global.tenantFetcher.endpoints.tenantCreated }}
               - name: APP_ENDPOINT_TENANT_DELETED

--- a/resources/compass/values.yaml
+++ b/resources/compass/values.yaml
@@ -22,7 +22,7 @@ global:
       version: "ffe1a7c3"
     director:
       dir:
-      version: "23e4ef8e"
+      version: "7c3f2ae6"
     gateway:
       dir:
       version: "14e0e984"
@@ -79,6 +79,9 @@ global:
   tenantConfig:
     useDefaultTenants: true
     useExternalTenants: false
+    dbPool:
+      maxOpenConnections: 1
+      maxIdleConnections: 1
 
   connector:
     graphql:
@@ -251,6 +254,9 @@ global:
       nameField: "name"
       discriminatorField: ""
       discriminatorValue: ""
+    dbPool:
+      maxOpenConnections: 1
+      maxIdleConnections: 1
 
 pairing-adapter:
   enabled: false


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/master/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:


DB pool configuration for Director: 30 active/2 idle - by default Postgres (embedded and GCP managed) has configured max_connections = 100, because of Director, Broker, and Provisioner uses the same Postgres server, I decided to use 1/3 of available connections.
Average Grapgl query for runtimes (when 300 runtimes defined) takes 1.93s.
For 50 active/5 idle connections it was only a little bit faster: 1.86s. For max one active and one idle connection, average time was 25s.
Tenant Loader and tenant fetcher: 1 active/1 idle because these two components do not perform concurrent requests to DB.

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
