### PR TITLE
Revert "Remove pods subscriptions inside namespaces subscriptions"

### DIFF
--- a/components/console-backend-service/internal/domain/k8s/export_test.go
+++ b/components/console-backend-service/internal/domain/k8s/export_test.go
@@ -141,8 +141,8 @@ func NewNamespaceService(informer cache.SharedIndexInformer, podService podSvc, 
 	return newNamespaceService(informer, podService, client)
 }
 
-func NewNamespaceResolver(namespaceSvc namespaceSvc, appRetriever shared.ApplicationRetriever, systemNamespaces []string) *namespaceResolver {
-	return newNamespaceResolver(namespaceSvc, appRetriever, systemNamespaces)
+func NewNamespaceResolver(namespaceSvc namespaceSvc, appRetriever shared.ApplicationRetriever, systemNamespaces []string, podService podSvc) *namespaceResolver {
+	return newNamespaceResolver(namespaceSvc, appRetriever, systemNamespaces, podService)
 }
 
 //Kyma Version

--- a/components/console-backend-service/internal/domain/k8s/k8s.go
+++ b/components/console-backend-service/internal/domain/k8s/k8s.go
@@ -72,7 +72,7 @@ func New(restConfig *rest.Config, informerResyncPeriod time.Duration, applicatio
 	selfSubjectRulesService := newSelfSubjectRulesService(clientset.AuthorizationV1())
 	return &Resolver{
 		resourceResolver:            newResourceResolver(resourceService),
-		namespaceResolver:           newNamespaceResolver(namespaceSvc, applicationRetriever, systemNamespaces),
+		namespaceResolver:           newNamespaceResolver(namespaceSvc, applicationRetriever, systemNamespaces, podService),
 		secretResolver:              newSecretResolver(*secretService),
 		deploymentResolver:          newDeploymentResolver(deploymentService, scRetriever, scaRetriever),
 		podResolver:                 newPodResolver(podService),

--- a/components/console-backend-service/internal/domain/k8s/namespace_resolver.go
+++ b/components/console-backend-service/internal/domain/k8s/namespace_resolver.go
@@ -32,14 +32,16 @@ type namespaceResolver struct {
 	appRetriever       shared.ApplicationRetriever
 	namespaceConverter namespaceConverter
 	systemNamespaces   []string
+	podService         podSvc
 }
 
-func newNamespaceResolver(namespaceSvc namespaceSvc, appRetriever shared.ApplicationRetriever, systemNamespaces []string) *namespaceResolver {
+func newNamespaceResolver(namespaceSvc namespaceSvc, appRetriever shared.ApplicationRetriever, systemNamespaces []string, podService podSvc) *namespaceResolver {
 	return &namespaceResolver{
 		namespaceSvc:       namespaceSvc,
 		appRetriever:       appRetriever,
 		namespaceConverter: *newNamespaceConverter(systemNamespaces),
 		systemNamespaces:   systemNamespaces,
+		podService:         podService,
 	}
 }
 
@@ -154,12 +156,31 @@ func (r *namespaceResolver) NamespaceEventSubscription(ctx context.Context, with
 	}
 	namespaceListener := listener.NewNamespace(namespaceChannel, filter, &r.namespaceConverter, r.systemNamespaces)
 
+	allowAll := func(_ *v1.Pod) bool { return true }
+	podChannel := make(chan gqlschema.PodEvent, 1)
+	podsListener := listener.NewPod(podChannel, allowAll, &podConverter{})
+
 	r.namespaceSvc.Subscribe(namespaceListener)
+	r.podService.Subscribe(podsListener)
 
 	go func() {
 		defer close(namespaceChannel)
+		defer close(podChannel)
 		defer r.namespaceSvc.Unsubscribe(namespaceListener)
-		<-ctx.Done()
+		defer r.podService.Unsubscribe(podsListener)
+
+		for {
+			select {
+			case podEvent := <-podChannel:
+				ns, err := r.namespaceSvc.Find(podEvent.Pod.Namespace)
+				if err != nil {
+					continue
+				}
+				namespaceListener.OnUpdate(ns, ns)
+			case <-ctx.Done():
+				return
+			}
+		}
 	}()
 
 	return namespaceChannel, nil

--- a/components/console-backend-service/internal/domain/k8s/namespace_resolver_test.go
+++ b/components/console-backend-service/internal/domain/k8s/namespace_resolver_test.go
@@ -50,7 +50,8 @@ func TestNamespaceResolver_NamespacesQuery(t *testing.T) {
 		svc.On("List").Return(resources, nil).Times(3)
 		defer svc.AssertExpectations(t)
 
-		resolver := k8s.NewNamespaceResolver(svc, appRetriever, []string{systemName})
+		podSvc := automock.NewPodSvc()
+		resolver := k8s.NewNamespaceResolver(svc, appRetriever, []string{systemName}, podSvc)
 
 		// check with default values
 		result, err := resolver.NamespacesQuery(nil, nil, nil)
@@ -90,7 +91,8 @@ func TestNamespaceResolver_NamespacesQuery(t *testing.T) {
 		svc.On("List").Return(resources, nil).Once()
 		defer svc.AssertExpectations(t)
 
-		resolver := k8s.NewNamespaceResolver(svc, appRetriever, []string{})
+		podSvc := automock.NewPodSvc()
+		resolver := k8s.NewNamespaceResolver(svc, appRetriever, []string{}, podSvc)
 
 		result, err := resolver.NamespacesQuery(nil, nil, nil)
 
@@ -103,8 +105,8 @@ func TestNamespaceResolver_NamespacesQuery(t *testing.T) {
 		appRetriever := new(appAutomock.ApplicationRetriever)
 		svc.On("List").Return(nil, errors.New("test error")).Once()
 		defer svc.AssertExpectations(t)
-
-		resolver := k8s.NewNamespaceResolver(svc, appRetriever, []string{})
+		podSvc := automock.NewPodSvc()
+		resolver := k8s.NewNamespaceResolver(svc, appRetriever, []string{}, podSvc)
 
 		result, err := resolver.NamespacesQuery(nil, nil, nil)
 
@@ -132,7 +134,8 @@ func TestNamespaceResolver_NamespaceQuery(t *testing.T) {
 		svc.On("Find", name).Return(resource, nil).Once()
 		defer svc.AssertExpectations(t)
 
-		resolver := k8s.NewNamespaceResolver(svc, appRetriever, []string{})
+		podSvc := automock.NewPodSvc()
+		resolver := k8s.NewNamespaceResolver(svc, appRetriever, []string{}, podSvc)
 
 		result, err := resolver.NamespaceQuery(nil, name)
 
@@ -146,7 +149,8 @@ func TestNamespaceResolver_NamespaceQuery(t *testing.T) {
 		svc.On("Find", name).Return(nil, nil).Once()
 		defer svc.AssertExpectations(t)
 
-		resolver := k8s.NewNamespaceResolver(svc, appRetriever, []string{})
+		podSvc := automock.NewPodSvc()
+		resolver := k8s.NewNamespaceResolver(svc, appRetriever, []string{}, podSvc)
 
 		result, err := resolver.NamespaceQuery(nil, name)
 
@@ -160,7 +164,8 @@ func TestNamespaceResolver_NamespaceQuery(t *testing.T) {
 		svc.On("Find", name).Return(nil, errors.New("test error")).Once()
 		defer svc.AssertExpectations(t)
 
-		resolver := k8s.NewNamespaceResolver(svc, appRetriever, []string{})
+		podSvc := automock.NewPodSvc()
+		resolver := k8s.NewNamespaceResolver(svc, appRetriever, []string{}, podSvc)
 
 		result, err := resolver.NamespaceQuery(nil, name)
 
@@ -189,7 +194,8 @@ func TestNamespaceResolver_CreateNamespace(t *testing.T) {
 		svc.On("Create", name, labels).Return(resource, nil).Once()
 		defer svc.AssertExpectations(t)
 
-		resolver := k8s.NewNamespaceResolver(svc, appRetriever, []string{})
+		podSvc := automock.NewPodSvc()
+		resolver := k8s.NewNamespaceResolver(svc, appRetriever, []string{}, podSvc)
 
 		result, err := resolver.CreateNamespace(nil, name, &labels)
 
@@ -205,7 +211,8 @@ func TestNamespaceResolver_CreateNamespace(t *testing.T) {
 		svc.On("Create", name, labels).Return(nil, errors.New("test error")).Once()
 		defer svc.AssertExpectations(t)
 
-		resolver := k8s.NewNamespaceResolver(svc, appRetriever, []string{})
+		podSvc := automock.NewPodSvc()
+		resolver := k8s.NewNamespaceResolver(svc, appRetriever, []string{}, podSvc)
 
 		result, err := resolver.CreateNamespace(nil, name, &labels)
 
@@ -233,7 +240,8 @@ func TestNamespaceResolver_UpdateNamespace(t *testing.T) {
 		svc.On("Update", name, labels).Return(resource, nil).Once()
 		defer svc.AssertExpectations(t)
 
-		resolver := k8s.NewNamespaceResolver(svc, appRetriever, []string{})
+		podSvc := automock.NewPodSvc()
+		resolver := k8s.NewNamespaceResolver(svc, appRetriever, []string{}, podSvc)
 
 		result, err := resolver.UpdateNamespace(nil, name, labels)
 
@@ -247,7 +255,8 @@ func TestNamespaceResolver_UpdateNamespace(t *testing.T) {
 		svc.On("Update", name, labels).Return(nil, errors.New("test error")).Once()
 		defer svc.AssertExpectations(t)
 
-		resolver := k8s.NewNamespaceResolver(svc, appRetriever, []string{})
+		podSvc := automock.NewPodSvc()
+		resolver := k8s.NewNamespaceResolver(svc, appRetriever, []string{}, podSvc)
 
 		result, err := resolver.UpdateNamespace(nil, name, labels)
 
@@ -276,7 +285,8 @@ func TestNamespaceResolver_DeleteNamespace(t *testing.T) {
 		svc.On("Delete", name).Return(nil).Once()
 		defer svc.AssertExpectations(t)
 
-		resolver := k8s.NewNamespaceResolver(svc, appRetriever, []string{})
+		podSvc := automock.NewPodSvc()
+		resolver := k8s.NewNamespaceResolver(svc, appRetriever, []string{}, podSvc)
 
 		result, err := resolver.DeleteNamespace(nil, name)
 
@@ -290,7 +300,8 @@ func TestNamespaceResolver_DeleteNamespace(t *testing.T) {
 		svc.On("Find", name).Return(nil, errors.New("test error")).Once()
 		defer svc.AssertExpectations(t)
 
-		resolver := k8s.NewNamespaceResolver(svc, appRetriever, []string{})
+		podSvc := automock.NewPodSvc()
+		resolver := k8s.NewNamespaceResolver(svc, appRetriever, []string{}, podSvc)
 
 		result, err := resolver.DeleteNamespace(nil, name)
 
@@ -307,7 +318,8 @@ func TestNamespaceResolver_DeleteNamespace(t *testing.T) {
 		svc.On("Find", name).Return(resource, nil).Once()
 		defer svc.AssertExpectations(t)
 
-		resolver := k8s.NewNamespaceResolver(svc, appRetriever, []string{})
+		podSvc := automock.NewPodSvc()
+		resolver := k8s.NewNamespaceResolver(svc, appRetriever, []string{}, podSvc)
 
 		svc.On("Delete", name).Return(errors.New("test error")).Once()
 
@@ -325,16 +337,20 @@ func TestNamespaceResolver_NamespaceEventSubscription(t *testing.T) {
 		cancel()
 
 		svc := automock.NewNamespaceSvc()
+		podSvc := automock.NewPodSvc()
 		svc.On("Subscribe", mock.Anything).Once()
 		svc.On("Unsubscribe", mock.Anything).Once()
+		podSvc.On("Subscribe", mock.Anything).Once()
+		podSvc.On("Unsubscribe", mock.Anything).Once()
 
 		appRetriever := new(appAutomock.ApplicationRetriever)
-		resolver := k8s.NewNamespaceResolver(svc, appRetriever, []string{})
+		resolver := k8s.NewNamespaceResolver(svc, appRetriever, []string{}, podSvc)
 
 		_, err := resolver.NamespaceEventSubscription(ctx, nil)
 		require.NoError(t, err)
 
 		svc.AssertCalled(t, "Subscribe", mock.Anything)
+		podSvc.AssertCalled(t, "Subscribe", mock.Anything)
 	})
 
 	t.Run("Unsubscribe after connection close", func(t *testing.T) {
@@ -342,11 +358,14 @@ func TestNamespaceResolver_NamespaceEventSubscription(t *testing.T) {
 		cancel()
 
 		svc := automock.NewNamespaceSvc()
+		podSvc := automock.NewPodSvc()
 		svc.On("Subscribe", mock.Anything).Once()
 		svc.On("Unsubscribe", mock.Anything).Once()
+		podSvc.On("Subscribe", mock.Anything).Once()
+		podSvc.On("Unsubscribe", mock.Anything).Once()
 
 		appRetriever := new(appAutomock.ApplicationRetriever)
-		resolver := k8s.NewNamespaceResolver(svc, appRetriever, []string{})
+		resolver := k8s.NewNamespaceResolver(svc, appRetriever, []string{}, podSvc)
 
 		channel, err := resolver.NamespaceEventSubscription(ctx, nil)
 		require.NoError(t, err)
@@ -355,6 +374,7 @@ func TestNamespaceResolver_NamespaceEventSubscription(t *testing.T) {
 		assert.False(t, ok)
 
 		svc.AssertCalled(t, "Unsubscribe", mock.Anything)
+		podSvc.AssertCalled(t, "Unsubscribe", mock.Anything)
 	})
 }
 

--- a/tests/console-backend-service/internal/domain/k8s/namespace_test.go
+++ b/tests/console-backend-service/internal/domain/k8s/namespace_test.go
@@ -55,6 +55,11 @@ func TestNamespace(t *testing.T) {
 	suite.thenNamespaceAfterUpdateExistsInK8s(t)
 	suite.thenUpdateEventIsSent(t, subscription, "Active")
 
+	t.Log("Adding pod to namespace...")
+	err = suite.whenPodIsAdded(t)
+	suite.thenThereIsNoError(t, err)
+	suite.thenUpdateEventIsSent(t, subscription, "Active")
+
 	t.Log("Deleting namespace...")
 	deleteRsp, err := suite.whenNamespaceIsDeleted()
 	suite.thenThereIsNoError(t, err)
@@ -177,6 +182,13 @@ func (s testNamespaceSuite) thenNamespaceAfterUpdateExistsInK8s(t *testing.T) {
 func (s testNamespaceSuite) thenUpdateEventIsSent(t *testing.T, subscription *graphql.Subscription, status string) {
 	expectedEvent := fixNamespaceEvent("UPDATE", namespaceObj{Name: s.namespaceName, IsSystemNamespace: false, Labels: s.updatedLabels, Status: status})
 	checkNamespaceEvent(t, expectedEvent, subscription)
+}
+
+func (s testNamespaceSuite) whenPodIsAdded(t *testing.T) error {
+	k8sClient, _, err := client.NewClientWithConfig()
+	require.NoError(t, err)
+	_, err = k8sClient.Pods(s.namespaceName).Create(fixPod("test-pod", s.namespaceName))
+	return err
 }
 
 //delete


### PR DESCRIPTION
Reverts kyma-project/kyma#7239. The suspected memory leak was probably in number of subscriptions opened by the console, so nested subscriptions are not an issue.