### PR TITLE
Unify Runtime Agent naming across docs

### DIFF
--- a/docs/compass/02-01-components.md
+++ b/docs/compass/02-01-components.md
@@ -19,7 +19,7 @@ Runtime is a system to which you can apply configuration provided by Compass. Yo
 
 ## Runtime Agent
 
-Runtime Agent is an integral part of every Runtime and it fetches the latest configuration from Compass. It also provides Runtime specific information that is displayed in the Compass UI, such as Runtime UI URL, and it provides Compass with Runtime configuration, such as Event Gateway URL, that should be passed to an Application.
+Runtime Agent is an integral part of every Runtime and it fetches the latest configuration from Compass. It also provides Runtime-specific information that is displayed in the Compass UI, such as Runtime UI URL, and it provides Compass with Runtime configuration, such as Event Gateway URL, that should be passed to an Application.
 In the future releases, Runtime Agent will send Runtime health checks to Compass.
 
 ## Cockpit

--- a/docs/compass/02-10-runtime-agent-workflow.md
+++ b/docs/compass/02-10-runtime-agent-workflow.md
@@ -3,7 +3,7 @@ title: Runtime Agent architecture
 type: Architecture
 ---
 
-This document presents the workflow of Runtime Agent. 
+This document presents the workflow of the Runtime Agent. 
 
 ![Runtime Agent architecture](./assets/runtime-agent-architecture.svg)
 

--- a/docs/compass/04-01-compass.md
+++ b/docs/compass/04-01-compass.md
@@ -9,7 +9,7 @@ To enable Compass in Kyma, follow the instructions for the [custom component ins
 
 ![Kyma mode1](./assets/kyma-mode1.svg)
 
-This is a single-tenant mode which provides the complete cluster Kyma installation with all components, including Compass and the Runtime Agent. In this mode, the Runtime Agent is already connected to Compass and they both work in a single-tenant mode as well. Using this mode, you can register external Applications in Kyma. To enable it, follow the cluster Kyma installation using the [`installer-cr-cluster-with-compass.yaml.tpl`](https://github.com/kyma-project/kyma/blob/master/installation/resources/installer-cr-cluster-with-compass.yaml.tpl) configuration file. Before you start the installation, apply the following ConfigMap which enables the [API Packages](https://github.com/kyma-incubator/compass/blob/master/docs/compass/03-packages-api.md) functionality:
+This is a single-tenant mode which provides the complete cluster Kyma installation with all components, including Compass and the Runtime Agent. In this mode, Runtime Agent is already connected to Compass and they both work in a single-tenant mode as well. Using this mode, you can register external Applications in Kyma. To enable it, follow the cluster Kyma installation using the [`installer-cr-cluster-with-compass.yaml.tpl`](https://github.com/kyma-project/kyma/blob/master/installation/resources/installer-cr-cluster-with-compass.yaml.tpl) configuration file. Before you start the installation, apply the following ConfigMap which enables the [API Packages](https://github.com/kyma-incubator/compass/blob/master/docs/compass/03-packages-api.md) functionality:
 
 ```yaml
 cat <<EOF | kubectl apply -f -

--- a/docs/compass/06-01-runtime-agent-compass-connection.md
+++ b/docs/compass/06-01-runtime-agent-compass-connection.md
@@ -3,7 +3,7 @@ title: CompassConnection
 type: Custom Resource
 ---
 
-The `compassconnections.compass.kyma-project.io` CustomResourceDefinition (CRD) is a detailed description of the kind of data and the format used to preserve the status of the connection between Runtime Agent and Compass. The `CompassConnection` custom resource (CR) contains the connection statuses and Compass URLs. To get the up-to-date CRD and show the output in the `yaml` format, run this command:
+The `compassconnections.compass.kyma-project.io` CustomResourceDefinition (CRD) is a detailed description of the kind of data and the format used to preserve the status of the connection between the Runtime Agent and Compass. The `CompassConnection` custom resource (CR) contains the connection statuses and Compass URLs. To get the up-to-date CRD and show the output in the `yaml` format, run this command:
 
 ```bash
 kubectl get crd compassconnections.compass.kyma-project.io -o yaml
@@ -11,7 +11,7 @@ kubectl get crd compassconnections.compass.kyma-project.io -o yaml
 
 ## Sample custom resource
 
-This is a sample resource that registers the `compass-agent-connection` CompassConnection which preserves the status of the connection between Runtime Agent and Compass. It also stores the URLs for the Connector and the Director. 
+This is a sample resource that registers the `compass-agent-connection` CompassConnection which preserves the status of the connection between the Runtime Agent and Compass. It also stores the URLs for the Connector and the Director. 
 
 ```yaml
 apiVersion: compass.kyma-project.io/v1alpha1


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Unify Runtime Agent naming across the whole documentation (`the Runtime Agent`)

**Related PR**
See also [#1033](https://github.com/kyma-incubator/compass/pull/1033)
