### PR TITLE
Add more precise info to Events API spec

### DIFF
--- a/docs/application-connector/assets/eventsapi.yaml
+++ b/docs/application-connector/assets/eventsapi.yaml
@@ -9,7 +9,7 @@ info:
 paths:
   /v1/health:
     get:
-      summary: 'Returns health of a service'
+      summary: 'Returns health of a service (internal)'
       operationId: 'getHealth'
       tags:
       - 'health'


### PR DESCRIPTION
**Description**

The `/v1/health` path in the Events API is internal, but there was no info about that in the API specification on the website, which was the source of confusion to some users.

Changes proposed in this pull request:

- Add `(internal)` to the `/v1/health` path's description. 
