### PR TITLE
Rename runtimeViewer to runtimeOperator, omit role from UAA activation

### DIFF
--- a/resources/core/charts/cluster-users/templates/rbac-roles.yaml
+++ b/resources/core/charts/cluster-users/templates/rbac-roles.yaml
@@ -435,9 +435,9 @@ subjects:
 - kind: User
   name: read-only-user@kyma.cx
   apiGroup: rbac.authorization.k8s.io
-{{ if .Values.global.kymaRuntime.viewerGroup }}
+{{ if .Values.global.kymaRuntime.operatorGroup }}
 - kind: Group
-  name: {{ .Values.global.kymaRuntime.viewerGroup }}
+  name: {{ .Values.global.kymaRuntime.operatorGroup }}
   apiGroup: rbac.authorization.k8s.io
 {{ end }}
 {{- range .Values.bindings.kymaView.groups }}

--- a/resources/core/charts/cluster-users/values.yaml
+++ b/resources/core/charts/cluster-users/values.yaml
@@ -69,7 +69,7 @@ global:
   # values.yaml in `uaa-activator` chart.
   kymaRuntime:
     adminGroup: runtimeAdmin
-    viewerGroup: runtimeViewer
+    operatorGroup: runtimeOperator
     developerGroup: runtimeDeveloper
     namespaceAdminGroup: runtimeNamespaceAdmin
 

--- a/resources/uaa-activator/templates/secret.yaml
+++ b/resources/uaa-activator/templates/secret.yaml
@@ -20,10 +20,6 @@ stringData:
         "description": "Global admin access to all Kyma resources"
       },
       {
-        "name": "$XSAPPNAME.{{ .Values.global.kymaRuntime.viewerGroup }}",
-        "description": "Global viewer access to all Kyma resources"
-      },
-      {
         "name": "$XSAPPNAME.{{ .Values.global.kymaRuntime.developerGroup }}",
         "description": "Runtime developer access to all managed resources"
       },
@@ -41,13 +37,6 @@ stringData:
         "description": "Global admin access to all Kyma resources",
         "scope-references": [
           "$XSAPPNAME.{{ .Values.global.kymaRuntime.adminGroup }}"
-        ]
-      },
-      {
-        "name": "KymaViewer",
-        "description": "Global viewer access to all Kyma resources",
-        "scope-references": [
-          "$XSAPPNAME.{{ .Values.global.kymaRuntime.viewerGroup }}"
         ]
       },
       {

--- a/resources/uaa-activator/values.yaml
+++ b/resources/uaa-activator/values.yaml
@@ -5,7 +5,6 @@ job:
 global:
   kymaRuntime:
     adminGroup: runtimeAdmin
-    viewerGroup: runtimeViewer
     developerGroup: runtimeDeveloper
     namespaceAdminGroup: runtimeNamespaceAdmin
 


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:
- Rename runtimeViewer to runtimeOperator
- omit KymaViewer role from UAA activation as it shall be used by L2 Operators, it won't be needed for customers in XSUAA.
