### PR TITLE
Introduce changes necessary for Api to ApiRule migration

### DIFF
--- a/resources/api-gateway/files/crd-apirules.yaml
+++ b/resources/api-gateway/files/crd-apirules.yaml
@@ -433,7 +433,7 @@ spec:
                     type: array
                   path:
                     description: Path to be exposed
-                    pattern: ^([0-9a-zA-Z./*(]+)
+                    pattern: ^([0-9a-zA-Z./*()?!\\_-]+)
                     type: string
                 required:
                   - path

--- a/resources/api-gateway/files/crd-apirules.yaml
+++ b/resources/api-gateway/files/crd-apirules.yaml
@@ -433,7 +433,7 @@ spec:
                     type: array
                   path:
                     description: Path to be exposed
-                    pattern: ^/([0-9a-zA-Z./*]+)
+                    pattern: ^([0-9a-zA-Z./*(]+)
                     type: string
                 required:
                   - path

--- a/resources/ory/charts/oathkeeper/values.yaml
+++ b/resources/ory/charts/oathkeeper/values.yaml
@@ -11,7 +11,7 @@ image:
   # ORY Oathkeeper image
   repository: oryd/oathkeeper
   # ORY Oathkeeper version
-  tag: v0.35.5-beta.1-alpine
+  tag: v0.36.0-beta.4-alpine
   # Image pull policy
   pullPolicy: IfNotPresent
 


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/master/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

A newer version of Oathkeeper supports the usage of `negative lookahead` in path regex, which is necessary to allow complete migration from Api CRD to ApiRule CRD.

Path validation pattern in ApiRule CRD have to be adjusted to support defining prefix, suffix and negative lookahead.

Changes proposed in this pull request:

- bump oathkeeper version
- change validation pattern for paths in ApiRule CRD

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
Related to #5283 