### PR TITLE
Enable external mTLS cacert management

### DIFF
--- a/resources/compass/charts/connector/templates/certs-setup-job.yaml
+++ b/resources/compass/charts/connector/templates/certs-setup-job.yaml
@@ -1,3 +1,4 @@
+{{- if (.Values.certsSetupJob.enable) }}
 apiVersion: batch/v1
 kind: Job
 metadata:
@@ -30,3 +31,4 @@ spec:
       securityContext:
 {{ toYaml . | indent 12 }}
       {{- end }}
+{{- end -}}

--- a/resources/compass/charts/connector/templates/certs-setup-job.yaml
+++ b/resources/compass/charts/connector/templates/certs-setup-job.yaml
@@ -1,4 +1,4 @@
-{{- if (.Values.certsSetupJob.enable) }}
+{{- if (.Values.certsSetupJob.enabled) }}
 apiVersion: batch/v1
 kind: Job
 metadata:

--- a/resources/compass/charts/connector/templates/certs-setup-role-binding.yaml
+++ b/resources/compass/charts/connector/templates/certs-setup-role-binding.yaml
@@ -1,4 +1,4 @@
-{{- if (.Values.certsSetupJob.enable) }}
+{{- if (.Values.certsSetupJob.enabled) }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/resources/compass/charts/connector/templates/certs-setup-role-binding.yaml
+++ b/resources/compass/charts/connector/templates/certs-setup-role-binding.yaml
@@ -1,3 +1,4 @@
+{{- if (.Values.certsSetupJob.enable) }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -67,3 +68,4 @@ roleRef:
   kind: Role
   name: {{ .Chart.Name }}-certs-setup-job-connector-cert-role
   apiGroup: rbac.authorization.k8s.io
+{{- end -}}

--- a/resources/compass/charts/connector/values.yaml
+++ b/resources/compass/charts/connector/values.yaml
@@ -20,7 +20,7 @@ deployment:
     allowPrivilegeEscalation: false
 
 certsSetupJob:
-  enable: true
+  enabled: true
   generatedCertificateValidity: 92d
   securityContext: # Set on container level
     runAsUser: 2000

--- a/resources/compass/charts/connector/values.yaml
+++ b/resources/compass/charts/connector/values.yaml
@@ -20,6 +20,7 @@ deployment:
     allowPrivilegeEscalation: false
 
 certsSetupJob:
+  enable: true
   generatedCertificateValidity: 92d
   securityContext: # Set on container level
     runAsUser: 2000

--- a/resources/compass/charts/gateway/templates/gateway-certs-mtls-cacert.yaml
+++ b/resources/compass/charts/gateway/templates/gateway-certs-mtls-cacert.yaml
@@ -1,4 +1,4 @@
-{{- if and (.Values.gateway.enabled) (eq .Values.gateway.manageCerts true) }}
+{{- if and (.Values.gateway.enabled) (.Values.gateway.manageCerts) }}
 apiVersion: v1
 kind: Secret
 metadata:

--- a/resources/compass/charts/gateway/templates/gateway-certs-mtls-cacert.yaml
+++ b/resources/compass/charts/gateway/templates/gateway-certs-mtls-cacert.yaml
@@ -1,4 +1,4 @@
-{{- if and (.Values.gateway.enabled) }}
+{{- if and (.Values.gateway.enabled) (eq .Values.gateway.manageCerts true) }}
 apiVersion: v1
 kind: Secret
 metadata:


### PR DESCRIPTION
The setup-certs-job only creates a cacert that's valid for 3 months, the cacert needs to be frequently rotated on the MPS via cert-manager. Disable running the certs-setup-job so that cert-manager can handle this.
