### PR TITLE
add sub-routes for slack/victorops notification

### DIFF
--- a/docs/monitoring/05-01-alertmanager.md
+++ b/docs/monitoring/05-01-alertmanager.md
@@ -18,9 +18,7 @@ This table lists the configurable parameters, their descriptions, and default va
 | **global.alertTools.credentials.slack.apiurl** | Specifies the URL endpoint which sends alerts triggered by Prometheus rules.  | None |
 | **global.alertTools.credentials.slack.channel** | Refers to the Slack channel which receives notifications on new alerts. | None |
 | **global.alertTools.credentials.slack.matchExpression** | Notifications will be sent only for those alerts whose labels match the specified expression.  | "severity: critical" |
-| **global.alertTools.credentials.slack.routes** | Refers to the Slack subroutes which receives notifications on new filtered alerts. | None |
 | **global.alertTools.credentials.victorOps.routingkey** | Defines the team routing key in [VictorOps](https://help.victorops.com/). | None |
 | **global.alertTools.credentials.victorOps.apikey** | Defines the team API key in VictorOps. | None |
 | **global.alertTools.credentials.victorOps.matchExpression** | Notifications will be sent only for those alerts whose labels match the specified expression.  | "severity: critical" |
-| **global.alertTools.credentials.victorOps.routes** | Defines the victorOps subroutes which receive notifications on new filtered alerts. | None |
 >**NOTE:** Override all configurable values for the Alertmanager sub-chart using Secrets (`kind: Secret`).

--- a/docs/monitoring/05-01-alertmanager.md
+++ b/docs/monitoring/05-01-alertmanager.md
@@ -18,8 +18,10 @@ This table lists the configurable parameters, their descriptions, and default va
 | **global.alertTools.credentials.slack.apiurl** | Specifies the URL endpoint which sends alerts triggered by Prometheus rules.  | None |
 | **global.alertTools.credentials.slack.channel** | Refers to the Slack channel which receives notifications on new alerts. | None |
 | **global.alertTools.credentials.slack.matchExpression** | Notifications will be sent only for those alerts whose labels match the specified expression.  | "severity: critical" |
+| **global.alertTools.credentials.slack.routes** | Refers to the Slack subroutes which receives notifications on new filtered alerts. | None |
 | **global.alertTools.credentials.victorOps.routingkey** | Defines the team routing key in [VictorOps](https://help.victorops.com/). | None |
 | **global.alertTools.credentials.victorOps.apikey** | Defines the team API key in VictorOps. | None |
 | **global.alertTools.credentials.victorOps.matchExpression** | Notifications will be sent only for those alerts whose labels match the specified expression.  | "severity: critical" |
+| **global.alertTools.credentials.victorOps.routes** | Refers to the victorOps subroutes which receives notifications on new filtered alerts. | None |
 
 >**NOTE:** Override all configurable values for the Alertmanager sub-chart using Secrets (`kind: Secret`).

--- a/docs/monitoring/05-01-alertmanager.md
+++ b/docs/monitoring/05-01-alertmanager.md
@@ -18,8 +18,9 @@ This table lists the configurable parameters, their descriptions, and default va
 | **global.alertTools.credentials.slack.apiurl** | Specifies the URL endpoint which sends alerts triggered by Prometheus rules.  | None |
 | **global.alertTools.credentials.slack.channel** | Refers to the Slack channel which receives notifications on new alerts. | None |
 | **global.alertTools.credentials.slack.matchExpression** | Notifications will be sent only for those alerts whose labels match the specified expression.  | "severity: critical" |
+| **global.alertTools.credentials.slack.routes** | Refers to the Slack subroutes which receives notifications on new filtered alerts. | None |
 | **global.alertTools.credentials.victorOps.routingkey** | Defines the team routing key in [VictorOps](https://help.victorops.com/). | None |
 | **global.alertTools.credentials.victorOps.apikey** | Defines the team API key in VictorOps. | None |
 | **global.alertTools.credentials.victorOps.matchExpression** | Notifications will be sent only for those alerts whose labels match the specified expression.  | "severity: critical" |
-
+| **global.alertTools.credentials.victorOps.routes** | Refers to the victorOps subroutes which receives notifications on new filtered alerts. | None |
 >**NOTE:** Override all configurable values for the Alertmanager sub-chart using Secrets (`kind: Secret`).

--- a/docs/monitoring/05-01-alertmanager.md
+++ b/docs/monitoring/05-01-alertmanager.md
@@ -21,4 +21,5 @@ This table lists the configurable parameters, their descriptions, and default va
 | **global.alertTools.credentials.victorOps.routingkey** | Defines the team routing key in [VictorOps](https://help.victorops.com/). | None |
 | **global.alertTools.credentials.victorOps.apikey** | Defines the team API key in VictorOps. | None |
 | **global.alertTools.credentials.victorOps.matchExpression** | Notifications will be sent only for those alerts whose labels match the specified expression.  | "severity: critical" |
+
 >**NOTE:** Override all configurable values for the Alertmanager sub-chart using Secrets (`kind: Secret`).

--- a/docs/monitoring/05-01-alertmanager.md
+++ b/docs/monitoring/05-01-alertmanager.md
@@ -18,10 +18,8 @@ This table lists the configurable parameters, their descriptions, and default va
 | **global.alertTools.credentials.slack.apiurl** | Specifies the URL endpoint which sends alerts triggered by Prometheus rules.  | None |
 | **global.alertTools.credentials.slack.channel** | Refers to the Slack channel which receives notifications on new alerts. | None |
 | **global.alertTools.credentials.slack.matchExpression** | Notifications will be sent only for those alerts whose labels match the specified expression.  | "severity: critical" |
-| **global.alertTools.credentials.slack.routes** | Refers to the Slack subroutes which receives notifications on new filtered alerts. | None |
 | **global.alertTools.credentials.victorOps.routingkey** | Defines the team routing key in [VictorOps](https://help.victorops.com/). | None |
 | **global.alertTools.credentials.victorOps.apikey** | Defines the team API key in VictorOps. | None |
 | **global.alertTools.credentials.victorOps.matchExpression** | Notifications will be sent only for those alerts whose labels match the specified expression.  | "severity: critical" |
-| **global.alertTools.credentials.victorOps.routes** | Refers to the victorOps subroutes which receives notifications on new filtered alerts. | None |
 
 >**NOTE:** Override all configurable values for the Alertmanager sub-chart using Secrets (`kind: Secret`).

--- a/resources/monitoring/templates/kyma-additions/alertmanager.config.yaml
+++ b/resources/monitoring/templates/kyma-additions/alertmanager.config.yaml
@@ -23,7 +23,7 @@ route:
     match_re:
       {{ tpl ( toYaml .Values.global.alertTools.credentials.victorOps.matchExpression | indent 6) . }}
     routes:
-    {{ tpl ( toYaml .Values.global.alertTools.credentials.victorOps.routes) . }}
+    {{ .Files.Get "victorOps_subroute.json" }}
   {{- end }}
   {{- end }}
   {{- if and .Values.global.alertTools.credentials.slack }}
@@ -33,7 +33,7 @@ route:
     match_re:
       {{ tpl ( toYaml .Values.global.alertTools.credentials.slack.matchExpression | indent 6) . }}
     routes:
-    {{ tpl ( toYaml .Values.global.alertTools.credentials.slack.routes) . }}
+    {{ .Files.Get "slack_subroute.json" }}
   {{- end }}
   {{- end }}
 receivers:

--- a/resources/monitoring/templates/kyma-additions/alertmanager.config.yaml
+++ b/resources/monitoring/templates/kyma-additions/alertmanager.config.yaml
@@ -33,7 +33,7 @@ route:
     match_re:
       {{ tpl ( toYaml .Values.global.alertTools.credentials.slack.matchExpression | indent 6) . }}
     routes:
-    {{ tpl ( toYaml .Values.global.alertTools.credentials.slack.routes) .  }}
+    {{ tpl ( toYaml .Values.global.alertTools.credentials.slack.routes) . }}
   {{- end }}
   {{- end }}
 receivers:

--- a/resources/monitoring/templates/kyma-additions/alertmanager.config.yaml
+++ b/resources/monitoring/templates/kyma-additions/alertmanager.config.yaml
@@ -22,8 +22,10 @@ route:
     continue: true # If set to `false`, it stops after the first matching.
     match_re:
       {{ tpl ( toYaml .Values.global.alertTools.credentials.victorOps.matchExpression | indent 6) . }}
+  {{- with .Values.global.alertTools.credentials.victorOps.routes }}
     routes:
-    {{ .Files.Get "victorOps_subroute.json" }}
+    {{- tpl . $ | nindent 4}}
+  {{- end }}
   {{- end }}
   {{- end }}
   {{- if and .Values.global.alertTools.credentials.slack }}
@@ -32,8 +34,10 @@ route:
     continue: true # If set to `false`, it stops after the first matching.
     match_re:
       {{ tpl ( toYaml .Values.global.alertTools.credentials.slack.matchExpression | indent 6) . }}
+  {{- with .Values.global.alertTools.credentials.slack.routes }}
     routes:
-    {{ .Files.Get "slack_subroute.json" }}
+    {{- tpl . $ | nindent 4}}
+  {{- end }}
   {{- end }}
   {{- end }}
 receivers:

--- a/resources/monitoring/templates/kyma-additions/alertmanager.config.yaml
+++ b/resources/monitoring/templates/kyma-additions/alertmanager.config.yaml
@@ -22,6 +22,10 @@ route:
     continue: true # If set to `false`, it stops after the first matching.
     match_re:
       {{ tpl ( toYaml .Values.global.alertTools.credentials.victorOps.matchExpression | indent 6) . }}
+    routes:
+    {{- with .Values.global.alertTools.credentials.victorOps.routes }}
+    {{ tpl . $ }}
+    {{- end }}
   {{- end }}
   {{- end }}
   {{- if and .Values.global.alertTools.credentials.slack }}
@@ -30,6 +34,9 @@ route:
     continue: true # If set to `false`, it stops after the first matching.
     match_re:
       {{ tpl ( toYaml .Values.global.alertTools.credentials.slack.matchExpression | indent 6) . }}
+    {{- with .Values.global.alertTools.credentials.slack.routes }}
+    {{ tpl . $ }}
+    {{- end }}
   {{- end }}
   {{- end }}
 receivers:

--- a/resources/monitoring/templates/kyma-additions/alertmanager.config.yaml
+++ b/resources/monitoring/templates/kyma-additions/alertmanager.config.yaml
@@ -23,9 +23,7 @@ route:
     match_re:
       {{ tpl ( toYaml .Values.global.alertTools.credentials.victorOps.matchExpression | indent 6) . }}
     routes:
-    {{- with .Values.global.alertTools.credentials.victorOps.routes }}
-    {{ tpl . $ }}
-    {{- end }}
+    {{ tpl ( toYaml .Values.global.alertTools.credentials.victorOps.routes) }}
   {{- end }}
   {{- end }}
   {{- if and .Values.global.alertTools.credentials.slack }}
@@ -34,9 +32,8 @@ route:
     continue: true # If set to `false`, it stops after the first matching.
     match_re:
       {{ tpl ( toYaml .Values.global.alertTools.credentials.slack.matchExpression | indent 6) . }}
-    {{- with .Values.global.alertTools.credentials.slack.routes }}
-    {{ tpl . $ }}
-    {{- end }}
+    routes:
+    {{ tpl ( toYaml .Values.global.alertTools.credentials.slack.routes) }}
   {{- end }}
   {{- end }}
 receivers:

--- a/resources/monitoring/templates/kyma-additions/alertmanager.config.yaml
+++ b/resources/monitoring/templates/kyma-additions/alertmanager.config.yaml
@@ -23,7 +23,7 @@ route:
     match_re:
       {{ tpl ( toYaml .Values.global.alertTools.credentials.victorOps.matchExpression | indent 6) . }}
     routes:
-    {{ tpl ( toYaml .Values.global.alertTools.credentials.victorOps.routes) }}
+    {{ tpl ( toYaml .Values.global.alertTools.credentials.victorOps.routes) . }}
   {{- end }}
   {{- end }}
   {{- if and .Values.global.alertTools.credentials.slack }}
@@ -33,7 +33,7 @@ route:
     match_re:
       {{ tpl ( toYaml .Values.global.alertTools.credentials.slack.matchExpression | indent 6) . }}
     routes:
-    {{ tpl ( toYaml .Values.global.alertTools.credentials.slack.routes) }}
+    {{ tpl ( toYaml .Values.global.alertTools.credentials.slack.routes) .  }}
   {{- end }}
   {{- end }}
 receivers:

--- a/resources/monitoring/values.yaml
+++ b/resources/monitoring/values.yaml
@@ -27,13 +27,11 @@ global:
         channel: ""
         matchExpression:
           severity: critical
-        routes: ""
       victorOps:
         routingkey: ""
         apikey: ""
         matchExpression:
           severity: critical
-        routes: ""
 
   ## Reference to one or more secrets to be used when pulling images
   ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/

--- a/resources/monitoring/values.yaml
+++ b/resources/monitoring/values.yaml
@@ -27,12 +27,13 @@ global:
         channel: ""
         matchExpression:
           severity: critical
+        routes: ""
       victorOps:
         routingkey: ""
         apikey: ""
         matchExpression:
           severity: critical
-
+        routes: ""
 
   ## Reference to one or more secrets to be used when pulling images
   ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/

--- a/resources/monitoring/values.yaml
+++ b/resources/monitoring/values.yaml
@@ -27,11 +27,13 @@ global:
         channel: ""
         matchExpression:
           severity: critical
+        routes: |-
       victorOps:
         routingkey: ""
         apikey: ""
         matchExpression:
           severity: critical
+        routes: |-
 
   ## Reference to one or more secrets to be used when pulling images
   ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/


### PR DESCRIPTION
I want to add the sub-routes function (see 2nd routes for filterring check-kyma-installer-* job which will send to slack2 channel) for the slack notification:
routes:
  - receiver: 'null'
    match:
      alertname: Watchdog
  - receiver: "slack"
    continue: true # If set to `false`, it stops after the first matching.
    match_re:
            severity: critical|warning
    routes:
    - match_re:
        job_name: ^(check-kyma-installer-.*|e2e-azure-.*|e2e-gcp-.*)$
      receiver: "slack2"
