### PR TITLE
Update Runtime provisioning documentation with custom component sourceURL info

### DIFF
--- a/docs/compass/03-10-provisioner-details.md
+++ b/docs/compass/03-10-provisioner-details.md
@@ -11,7 +11,7 @@ It allows you to provision the clusters in the following ways:
     * Microsoft Azure
     * Amazon Web Services (AWS).
 
-During the operation of provisioning, you can pass a list of Kyma components you want installed on the provisioned Runtime with their custom configuration, as well as a custom Runtime configuration. 
+During the operation of provisioning, you can pass a list of Kyma components you want installed on the provisioned Runtime with their custom configuration, as well as a custom Runtime configuration. To install a customized version of a given component, you can also provide an [external URL as the installation source](docs/#configuration-install-components-from-user-defined-ur-ls) for the component. See the [provisioning tutorial](#tutorials-provision-clusters-through-gardener) for more details.
 
 Note that the operations of provisioning and deprovisioning are asynchronous. The operation of provisioning returns the Runtime Operation Status containing the Runtime ID and the operation ID. The operation of deprovisioning returns the operation ID. You can use the operation ID to [check the Runtime Operation Status](#tutorials-check-runtime-operation-status) and the Runtime ID to [check the Runtime Status](#tutorials-check-runtime-status).
   

--- a/docs/compass/08-02-provisioner-provisioning-gardener.md
+++ b/docs/compass/08-02-provisioner-provisioning-gardener.md
@@ -129,6 +129,7 @@ This tutorial shows how to provision clusters with Kyma Runtimes on Google Cloud
                       secret: {true|false} # Specifies if the property is confidential
                     }
                   ]
+                  sourceURL: "{CUSTOM_COMPONENT_SOURCE_URL}"
                 }
               ]
               configuration: [
@@ -220,6 +221,7 @@ This tutorial shows how to provision clusters with Kyma Runtimes on Google Cloud
                       secret: {true|false} # Specifies if the property is confidential
                     }
                   ]
+                  sourceURL: "{CUSTOM_COMPONENT_SOURCE_URL}"
                 }
               ]
               configuration: [
@@ -318,6 +320,7 @@ This tutorial shows how to provision clusters with Kyma Runtimes on Google Cloud
                       secret: {true|false} # Specifies if the property is confidential
                     }
                   ]
+                  sourceURL: "{CUSTOM_COMPONENT_SOURCE_URL}"
                 }
               ]
               configuration: [

--- a/docs/compass/08-04-provisioner-runtime-status.md
+++ b/docs/compass/08-04-provisioner-runtime-status.md
@@ -36,6 +36,7 @@ query { runtimeStatus(id: "{RUNTIME_ID}") {
             value
             secret
           }
+          sourceURL
         }
         configuration {
           key value secret


### PR DESCRIPTION
**Description**

With the recent addition to Kyma Installer, there is now a possibility to define the URL Source of a component to be installed. Following this change, such functionality has also been added to the Runtime Provisioner. 

Changes proposed in this pull request:

- Update documentation on Runtime provisioning with information on the custom component source URL.

**Related issue(s)**
See [#942](https://github.com/kyma-incubator/compass/issues/942) in Compass

**Related PR(s)**
See [#1046](https://github.com/kyma-incubator/compass/pull/1046), [#1097](https://github.com/kyma-incubator/compass/pull/1097) in Compass