### PR TITLE
Bump gce-proxy images to 1.16

### DIFF
--- a/resources/compass/charts/director/templates/deployment.yaml
+++ b/resources/compass/charts/director/templates/deployment.yaml
@@ -109,7 +109,7 @@ spec:
               mountPath: /secrets/cloudsql-instance-credentials
               readOnly: true
         - name: cloudsql-proxy
-          image: gcr.io/cloudsql-docker/gce-proxy:1.11
+          image: gcr.io/cloudsql-docker/gce-proxy:1.16
           command: ["/cloud_sql_proxy",
                     "-instances={{ .Values.global.database.managedGCP.instanceConnectionName }}=tcp:5432",
                     "-credential_file=/secrets/cloudsql-instance-credentials/credentials.json"]

--- a/resources/compass/charts/director/templates/tenant-loader-job.yaml
+++ b/resources/compass/charts/director/templates/tenant-loader-job.yaml
@@ -76,7 +76,7 @@ spec:
                     - "./tenantloader; exit_code=$?; sleep 5; echo '# KILLING PILOT-AGENT #'; pkill -INT cloud_sql_proxy; curl -XPOST http://127.0.0.1:15020/quitquitquit; sleep 5; exit $exit_code;"
               {{if eq .Values.global.database.embedded.enabled false}}
                 - name: cloudsql-proxy
-                  image: gcr.io/cloudsql-docker/gce-proxy:1.13
+                  image: gcr.io/cloudsql-docker/gce-proxy:1.16
                   command:
                     - /bin/sh
                   args:

--- a/resources/compass/charts/kyma-environment-broker/templates/deployment.yaml
+++ b/resources/compass/charts/kyma-environment-broker/templates/deployment.yaml
@@ -183,7 +183,7 @@ spec:
 
         {{- if eq .Values.global.database.embedded.enabled false}}
         - name: cloudsql-proxy
-          image: gcr.io/cloudsql-docker/gce-proxy:1.11
+          image: gcr.io/cloudsql-docker/gce-proxy:1.16
           command: ["/cloud_sql_proxy",
                     "-instances={{ .Values.global.database.managedGCP.instanceConnectionName }}=tcp:5432",
                     "-credential_file=/secrets/cloudsql-instance-credentials/credentials.json"]

--- a/resources/compass/charts/provisioner/templates/deployment.yaml
+++ b/resources/compass/charts/provisioner/templates/deployment.yaml
@@ -111,7 +111,7 @@ spec:
 
         {{if eq .Values.global.database.embedded.enabled false}}
         - name: cloudsql-proxy
-          image: gcr.io/cloudsql-docker/gce-proxy:1.11
+          image: gcr.io/cloudsql-docker/gce-proxy:1.16
           command: ["/cloud_sql_proxy",
                     "-instances={{ .Values.global.database.managedGCP.instanceConnectionName }}=tcp:5432",
                     "-credential_file=/secrets/cloudsql-instance-credentials/credentials.json"]

--- a/resources/compass/templates/migrator-job.yaml
+++ b/resources/compass/templates/migrator-job.yaml
@@ -21,7 +21,7 @@ spec:
             containers:
                 {{if eq .Values.global.database.embedded.enabled false}}
                 - name: cloudsql-proxy
-                  image: gcr.io/cloudsql-docker/gce-proxy:1.13
+                  image: gcr.io/cloudsql-docker/gce-proxy:1.16
                   command:
                   - /bin/sh
                   args:
@@ -106,7 +106,7 @@ spec:
             containers:
                 {{if eq .Values.global.database.embedded.enabled false}}
                 - name: cloudsql-proxy
-                  image: gcr.io/cloudsql-docker/gce-proxy:1.13
+                  image: gcr.io/cloudsql-docker/gce-proxy:1.16
                   command:
                   - /bin/sh
                   args:
@@ -191,7 +191,7 @@ spec:
             containers:
                 {{if eq .Values.global.database.embedded.enabled false}}
                 - name: cloudsql-proxy
-                  image: gcr.io/cloudsql-docker/gce-proxy:1.13
+                  image: gcr.io/cloudsql-docker/gce-proxy:1.16
                   command:
                   - /bin/sh
                   args:

--- a/resources/compass/templates/tenant-fetcher-job.yaml
+++ b/resources/compass/templates/tenant-fetcher-job.yaml
@@ -88,7 +88,7 @@ spec:
               - "./tenantfetcher; exit_code=$?; echo '# KILLING PILOT-AGENT #'; pkill -INT cloud_sql_proxy; curl -XPOST http://127.0.0.1:15020/quitquitquit; sleep 5; exit $exit_code;"
           {{if eq .Values.global.database.embedded.enabled false}}
           - name: cloudsql-proxy
-            image: gcr.io/cloudsql-docker/gce-proxy:1.13
+            image: gcr.io/cloudsql-docker/gce-proxy:1.16
             command:
               - /bin/sh
             args:


### PR DESCRIPTION
**Description**

Bump gce-proxy images to 1.16 in all deployments throughout Kyma. This ensures we only maintain and assess one gce-proxy image version as part of Protecode scans.
