### PR TITLE
Fluent-bit exclude path works only when there is not space around comma

### DIFF
--- a/resources/logging/charts/fluentbit/templates/_helpers.tpl
+++ b/resources/logging/charts/fluentbit/templates/_helpers.tpl
@@ -124,7 +124,7 @@ Return the arguments of the metrics-collection script
 {{- if .Values.conf.Input.Kubernetes_loki.exclude.namespaces -}}
 {{- $namespaces := splitList "," .Values.conf.Input.Kubernetes_loki.exclude.namespaces -}}
 {{- range $namespaces -}}
-{{- printf "/var/log/containers/*_%s_*.log, " . -}}
+{{- printf "/var/log/containers/*_%s_*.log," . -}}
 {{- end -}}
 {{- end -}}
 {{- if .Values.conf.Input.Kubernetes_loki.Exclude_Path -}}


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/master/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

-Fluent-bit exclude path config only works when there is no space before `,`

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
#7885
