### PR TITLE
Roll back to gce-proxy:1.14 for Job sidecars

### DIFF
--- a/resources/compass/charts/director/templates/tenant-loader-job.yaml
+++ b/resources/compass/charts/director/templates/tenant-loader-job.yaml
@@ -76,7 +76,7 @@ spec:
                     - "./tenantloader; exit_code=$?; sleep 5; echo '# KILLING PILOT-AGENT #'; pkill -INT cloud_sql_proxy; curl -XPOST http://127.0.0.1:15020/quitquitquit; sleep 5; exit $exit_code;"
               {{if eq .Values.global.database.embedded.enabled false}}
                 - name: cloudsql-proxy
-                  image: gcr.io/cloudsql-docker/gce-proxy:1.16
+                  image: gcr.io/cloudsql-docker/gce-proxy:1.14
                   command:
                     - /bin/sh
                   args:

--- a/resources/compass/templates/migrator-job.yaml
+++ b/resources/compass/templates/migrator-job.yaml
@@ -21,7 +21,7 @@ spec:
             containers:
                 {{if eq .Values.global.database.embedded.enabled false}}
                 - name: cloudsql-proxy
-                  image: gcr.io/cloudsql-docker/gce-proxy:1.16
+                  image: gcr.io/cloudsql-docker/gce-proxy:1.14
                   command:
                   - /bin/sh
                   args:
@@ -106,7 +106,7 @@ spec:
             containers:
                 {{if eq .Values.global.database.embedded.enabled false}}
                 - name: cloudsql-proxy
-                  image: gcr.io/cloudsql-docker/gce-proxy:1.16
+                  image: gcr.io/cloudsql-docker/gce-proxy:1.14
                   command:
                   - /bin/sh
                   args:
@@ -191,7 +191,7 @@ spec:
             containers:
                 {{if eq .Values.global.database.embedded.enabled false}}
                 - name: cloudsql-proxy
-                  image: gcr.io/cloudsql-docker/gce-proxy:1.16
+                  image: gcr.io/cloudsql-docker/gce-proxy:1.14
                   command:
                   - /bin/sh
                   args:

--- a/resources/compass/templates/tenant-fetcher-job.yaml
+++ b/resources/compass/templates/tenant-fetcher-job.yaml
@@ -88,7 +88,7 @@ spec:
               - "./tenantfetcher; exit_code=$?; echo '# KILLING PILOT-AGENT #'; pkill -INT cloud_sql_proxy; curl -XPOST http://127.0.0.1:15020/quitquitquit; sleep 5; exit $exit_code;"
           {{if eq .Values.global.database.embedded.enabled false}}
           - name: cloudsql-proxy
-            image: gcr.io/cloudsql-docker/gce-proxy:1.16
+            image: gcr.io/cloudsql-docker/gce-proxy:1.14
             command:
               - /bin/sh
             args:


### PR DESCRIPTION
**Description**
`gce-proxy:1.14` is the latest image which contains `/bin/sh`. Shell is needed to specify a custom command when using the container as a sidecar in `Job`s.
