### PR TITLE
expose status port on ory service

### DIFF
--- a/resources/ory/charts/oathkeeper/templates/service-proxy.yaml
+++ b/resources/ory/charts/oathkeeper/templates/service-proxy.yaml
@@ -15,6 +15,10 @@ spec:
       targetPort: http-proxy
       protocol: TCP
       name: http
+    - name: status-port
+      port: 15020
+      targetPort: 15020
+      protocol: TCP
   selector:
     app.kubernetes.io/name: {{ include "oathkeeper.name" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/master/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**
Exposes status-port on *ory-oathkeeper* service for third-party service endpoint health checks. 

By default, port 15020 is overwritten by Istio proxy if enabled, and service health endpoints are exposed at `:15020/app-health/oathkeeper/{livez,readyz}`


**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
