### PR TITLE
Update the Kyma environment broker image

### DIFF
--- a/resources/compass/values.yaml
+++ b/resources/compass/values.yaml
@@ -43,7 +43,7 @@ global:
       version: "0a651695"
     kyma_environment_broker:
       dir:
-      version: "PR-1126" # TODO(marcobebway) change to the final image
+      version: "cbf30894"
     tests:
       director:
         dir:

--- a/resources/compass/values.yaml
+++ b/resources/compass/values.yaml
@@ -43,7 +43,7 @@ global:
       version: "0a651695"
     kyma_environment_broker:
       dir:
-      version: "33e3a301"
+      version: "PR-1126" # TODO(marcobebway) change to the final image
     tests:
       director:
         dir:


### PR DESCRIPTION
**Description**

Update the Kyma environment broker image which has the tags for the Azure Resource Group and EventHubs namespace.

**Related issue(s)**
- https://github.com/kyma-incubator/compass/issues/967
- https://github.com/kyma-incubator/compass/pull/1126