### PR TITLE
Refactor event-service informer

### DIFF
--- a/components/event-service/internal/events/subscribed/events.go
+++ b/components/event-service/internal/events/subscribed/events.go
@@ -45,6 +45,7 @@ type eventsClient struct {
 
 // waitForInformersSyncOrDie blocks until all informer caches are synced, or panics after a timeout.
 func waitForInformersSyncOrDie(f externalversions.SharedInformerFactory) {
+	log.Println("waiting for informers caches sync...")
 	ctx, cancel := context.WithTimeout(context.Background(), informerSyncTimeout)
 	defer cancel()
 
@@ -67,11 +68,13 @@ func hasSynced(ctx context.Context, fn waitForCacheSyncFunc) error {
 	stopWait := make(chan struct{})
 	defer close(stopWait)
 
+	// close the synced channel after the `WaitForCacheSync()` to announce that it finished the execution
 	go func() {
 		fn(stopWait)
 		close(synced)
 	}()
 
+	// wait for closure of the goroutine or return an error if it timed out
 	select {
 	case <-ctx.Done():
 		return ctx.Err()
@@ -87,6 +90,7 @@ func NewEventsClient(client versioned.Interface) EventsClient {
 	lister := informerFactory.Eventing().V1alpha1().Triggers().Lister()
 	ctx := signals.NewContext()
 	informerFactory.Start(ctx.Done())
+	informerFactory.WaitForCacheSync(ctx.Done())
 	waitForInformersSyncOrDie(informerFactory)
 
 	return &eventsClient{

--- a/components/event-service/internal/events/subscribed/events.go
+++ b/components/event-service/internal/events/subscribed/events.go
@@ -1,6 +1,11 @@
 package subscribed
 
 import (
+	"context"
+	"log"
+	"reflect"
+	"time"
+
 	"k8s.io/apimachinery/pkg/labels"
 
 	knv1alpha1 "knative.dev/eventing/pkg/apis/eventing/v1alpha1"
@@ -14,6 +19,8 @@ const (
 	keySource           = "source"
 	keyEventType        = "type"
 	keyEventTypeVersion = "eventtypeversion"
+
+	informerSyncTimeout = time.Second * 5
 )
 
 //EventsClient interface
@@ -36,13 +43,51 @@ type eventsClient struct {
 	triggerLister kneventinglister.TriggerLister
 }
 
+// waitForInformersSyncOrDie blocks until all informer caches are synced, or panics after a timeout.
+func waitForInformersSyncOrDie(f externalversions.SharedInformerFactory) {
+	ctx, cancel := context.WithTimeout(context.Background(), informerSyncTimeout)
+	defer cancel()
+
+	err := hasSynced(ctx, f.WaitForCacheSync)
+	if err != nil {
+		log.Fatalf("Error waiting for caches sync: %s", err)
+	}
+}
+
+type waitForCacheSyncFunc func(stopCh <-chan struct{}) map[reflect.Type]bool
+
+// hasSynced blocks until the given informer sync waiting function completes. It returns an error if the passed context
+// gets canceled.
+func hasSynced(ctx context.Context, fn waitForCacheSyncFunc) error {
+	// synced gets closed as soon as fn returns
+	synced := make(chan struct{})
+
+	// closing stopWait forces fn to return, which happens whenever ctx
+	// gets canceled
+	stopWait := make(chan struct{})
+	defer close(stopWait)
+
+	go func() {
+		fn(stopWait)
+		close(synced)
+	}()
+
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-synced:
+	}
+
+	return nil
+}
+
 //NewEventsClient function creates client for retrieving all active events
 func NewEventsClient(client versioned.Interface) EventsClient {
 	informerFactory := externalversions.NewSharedInformerFactory(client, 0)
 	lister := informerFactory.Eventing().V1alpha1().Triggers().Lister()
 	ctx := signals.NewContext()
 	informerFactory.Start(ctx.Done())
-	informerFactory.WaitForCacheSync(ctx.Done())
+	waitForInformersSyncOrDie(informerFactory)
 
 	return &eventsClient{
 		triggerLister: lister,


### PR DESCRIPTION
Applying a get or die pattern when waiting for the informers cache sync.

See also #7449