### PR TITLE
Fix overrides CM in KEB

### DIFF
--- a/resources/compass/charts/kyma-environment-broker/templates/provisioning-runtime-overrides.yaml
+++ b/resources/compass/charts/kyma-environment-broker/templates/provisioning-runtime-overrides.yaml
@@ -31,5 +31,4 @@ metadata:
   labels:
     provisioning-runtime-override: "true"
 data:
-  # Can be remove when the compass will be enabled by default in Kyma. (after 1.12)
-  global.enableAPIPackages: "true"
+  global.disableLegacyConnectivity: "true"


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Fix overrides CM in KEB

The problem is that in KEB we are sending the override but in master-91a18c32 version the override name was changed from `enableAPIPackages` to `disableLegacyConnectivity` (https://github.com/kyma-project/kyma/pull/7769)