### PR TITLE
Wait longer for api-server in SC test

### DIFF
--- a/resources/service-catalog/templates/tests/test.yaml
+++ b/resources/service-catalog/templates/tests/test.yaml
@@ -16,7 +16,6 @@ spec:
       annotations:
         sidecar.istio.io/inject: "true"
     spec:
-      shareProcessNamespace: true
       serviceAccountName: {{ .Chart.Name }}-tests
       containers:
       - name: tests
@@ -40,7 +39,6 @@ spec:
         - "/bin/sh"
         args:
         - "-c"
-        #TODO: there's no curl in the image. It depends on "shareProcessNamespace=true" and may not work in all environments.
-        - "echo 'TESTING start'; sleep 10; ./entrypoint.sh; exit_code=$?; echo code is $exit_code; echo 'killing pilot-agent...'; curl -XPOST http://127.0.0.1:15020/quitquitquit; sleep 4; exit $exit_code;"
+        - "echo 'TESTING start'; sleep 20; ./entrypoint.sh; exit_code=$?; echo code is $exit_code; echo 'killing pilot-agent...'; curl -XPOST http://127.0.0.1:15020/quitquitquit; sleep 4; exit $exit_code;"
     restartPolicy: Never
 {{- end }}


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/master/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- Sometimes it takes more than 10s to stabilize the Pod. For example in the [e2e-test](https://github.com/kyma-project/kyma/blob/master/resources/compass/charts/kyma-environment-broker/templates/tests/e2e-provisioning-gcp.yaml#L119) we wait 20s.
- removed outdated `shareProcessNamespace: true`

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
