### PR TITLE
Expose KEB istio-proxy sidecar status-port for AVS probing

### DIFF
--- a/resources/compass/charts/kyma-environment-broker/templates/service.yaml
+++ b/resources/compass/charts/kyma-environment-broker/templates/service.yaml
@@ -11,6 +11,9 @@ spec:
       targetPort: http
       protocol: TCP
       name: http
+    - port: {{ .Values.global.istio.proxy.port }}
+      protocol: TCP
+      name: proxy-status
   selector:
     app.kubernetes.io/name: {{ include "kyma-env-broker.name" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}


### PR DESCRIPTION
**Description**
Expose KEB istio-proxy sidecar status-port. Since Istio probe rewrite is in place, the livenessProbe is reconfigured to go through the sidecar. We would like to probe the same liveness endpoint and forward results to AVS.
