### PR TITLE
core: add service ports to core console components

### DIFF
--- a/resources/core/charts/console/templates/service-compass-mfs.yaml
+++ b/resources/core/charts/console/templates/service-compass-mfs.yaml
@@ -14,6 +14,9 @@ spec:
     - port: {{ .Values.compass_mfs.service.externalPort }}
       name: http2-compass-mfs
       targetPort: {{ .Values.compass_mfs.service.internalPort }}
+    - port: {{ .Values.compass_mfs.statusPort }}
+      name: status-port-compass-mfs
+      targetPort: {{ .Values.compass_mfs.statusPort }}
   selector:
     app: core-{{ template "name" . }}
     release: {{ .Release.Name }}

--- a/resources/core/charts/console/templates/service-core-ui.yaml
+++ b/resources/core/charts/console/templates/service-core-ui.yaml
@@ -14,6 +14,9 @@ spec:
     - port: {{ .Values.core_ui.service.externalPort }}
       name: http2-core-ui
       targetPort: {{ .Values.core_ui.service.internalPort }}
+    - port: {{ .Values.core_ui.statusPort }}
+      name: status-port-core-ui
+      targetPort: {{ .Values.core_ui.statusPort }}
   selector:
     app: core-{{ template "name" . }}
     release: {{ .Release.Name }}

--- a/resources/core/charts/console/templates/service.yaml
+++ b/resources/core/charts/console/templates/service.yaml
@@ -14,6 +14,9 @@ spec:
     - port: {{ .Values.console.service.externalPort }}
       name: http2-console
       targetPort: {{ .Values.console.service.internalPort }}
+    - port: {{ .Values.console.statusPort }}
+      name: status-port-console
+      targetPort: {{ .Values.console.statusPort }}
   selector:
     app: core-{{ template "name" . }}
     release: {{ .Release.Name }}


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/master/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Exposes health endpoint ports of `core-console` services, annotated by `core-SERVICE-NAME`, as services share the same annotations, we didn't want to introduce breaking changes.

Following services were updated
- `core-console` - exposes port `status-port-console`
- `core-console-core-ui` - exposes port `status-port-core-ui`
- `core-console-compass-mfs` - exposes port `status-port-compass-mfs`

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
