### PR TITLE
Remove a deprecated example

### DIFF
--- a/docs/kyma/16-01-try-out-kyma.md
+++ b/docs/kyma/16-01-try-out-kyma.md
@@ -10,7 +10,6 @@ Follow the links to examples' code and content sources, and try them on your own
 | Example | Description | Technology |
 |---|---|---|
 | [HTTP DB Service](https://github.com/kyma-project/examples/blob/master/http-db-service/README.md) | Test the service that exposes an HTTP API to access a database on the cluster. | Go, MSSQL |
-| [Gateway](https://github.com/kyma-project/examples/blob/master/gateway/README.md) | Expose APIs for functions or services.  | Serverless |
 | [Alert Rules](https://github.com/kyma-project/examples/blob/master/monitoring-alert-rules/README.md) | Configure alert rules in Kyma.  | Prometheus |
 | [Custom Metrics in Kyma](https://github.com/kyma-project/examples/blob/master/monitoring-custom-metrics/README.md) | Expose custom metrics in Kyma.  | Go, Prometheus |
 | [Event Email Service](https://github.com/kyma-project/examples/blob/master/event-email-service/README.md) | Send an automated email upon receiving an Event.  | NodeJS |


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Removed the deprecated gateway example based on the kubeless solution

