### PR TITLE
Set proper restrictions for Rafter and Knative Serving resources

### DIFF
--- a/resources/cluster-users/templates/clusterroles-knative-serving.yaml
+++ b/resources/cluster-users/templates/clusterroles-knative-serving.yaml
@@ -1,56 +1,56 @@
 ---
-# View access to rafter resources
+# View access to knative serving resources
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: kyma-rafter-view
+  name: kyma-knative-serving-view
   labels:
     app: kyma
     chart: {{ .Chart.Name }}-{{ .Chart.Version }}
-    rbac.authorization.kyma-project.io/aggregate-to-kyma-rafter-view: "true"
+    rbac.authorization.kyma-project.io/aggregate-to-kyma-knative-serving-view: "true"
   annotations:
     helm.sh/hook-weight: "0"
 rules:
 - apiGroups:
-{{ toYaml .Values.clusterRoles.apiGroups.rafter | indent 4 }}
+{{ toYaml .Values.clusterRoles.apiGroups.knativeServing | indent 4 }}
   resources:
     - "*"
   verbs:
 {{ toYaml .Values.clusterRoles.verbs.view | indent 4 }}
 ---
-# Admin access to rafter resources
+# Admin access to knative serving resources
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: kyma-rafter-admin
+  name: kyma-knative-serving-admin
   labels:
     app: kyma
     chart: {{ .Chart.Name }}-{{ .Chart.Version }}
-    rbac.authorization.kyma-project.io/aggregate-to-kyma-rafter-admin: "true"
+    rbac.authorization.kyma-project.io/aggregate-to-kyma-knative-serving-admin: "true"
   annotations:
     helm.sh/hook-weight: "0"
 rules:
 - apiGroups:
-{{ toYaml .Values.clusterRoles.apiGroups.rafter | indent 4 }}
+{{ toYaml .Values.clusterRoles.apiGroups.knativeServing | indent 4 }}
   resources:
     - "*"
   verbs:
     - "*"
 ---
-# Edit access to rafter resources
+# Edit access to knative serving resources
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: kyma-rafter-edit
+  name: kyma-knative-serving-edit
   labels:
     app: kyma
     chart: {{ .Chart.Name }}-{{ .Chart.Version }}
-    rbac.authorization.kyma-project.io/aggregate-to-kyma-rafter-edit: "true"
+    rbac.authorization.kyma-project.io/aggregate-to-kyma-knative-serving-edit: "true"
   annotations:
     helm.sh/hook-weight: "0"
 rules:
 - apiGroups:
-{{ toYaml .Values.clusterRoles.apiGroups.rafter | indent 4 }}
+{{ toYaml .Values.clusterRoles.apiGroups.knativeServing | indent 4 }}
   resources:
     - "*"
   verbs:

--- a/resources/cluster-users/templates/rbac-roles.yaml
+++ b/resources/cluster-users/templates/rbac-roles.yaml
@@ -154,6 +154,8 @@ aggregationRule:
       rbac.authorization.kyma-project.io/aggregate-to-kyma-backup-view: "true"
   - matchLabels:
       rbac.authorization.kyma-project.io/aggregate-to-kyma-rafter-view: "true"
+  - matchLabels:
+      rbac.authorization.kyma-project.io/aggregate-to-kyma-knative-serving-view: "true"
 rules: []
 
 ---
@@ -255,6 +257,10 @@ aggregationRule:
       rbac.authorization.kyma-project.io/aggregate-to-ory-admin: "true"
   - matchLabels:
       rbac.authorization.kyma-project.io/aggregate-to-kyma-backup-admin: "true"
+  - matchLabels:
+      rbac.authorization.kyma-project.io/aggregate-to-kyma-rafter-admin: "true"
+  - matchLabels:
+      rbac.authorization.kyma-project.io/aggregate-to-kyma-knative-serving-admin: "true"
 rules: []
 
 ---
@@ -285,8 +291,6 @@ aggregationRule:
       rbac.authorization.kyma-project.io/aggregate-to-kyma-api-admin: "true"
   - matchLabels:
       rbac.authorization.kyma-project.io/aggregate-to-kyma-istio-admin: "true"
-  - matchLabels:
-      rbac.authorization.kyma-project.io/aggregate-to-kyma-knative-serving-admin: "true"
   - matchLabels:
       rbac.authorization.kyma-project.io/aggregate-to-kyma-knative-eventing-admin: "true"
   - matchLabels:

--- a/resources/cluster-users/values.yaml
+++ b/resources/cluster-users/values.yaml
@@ -53,6 +53,11 @@ clusterRoles:
       - "velero.io"
     rafter:
       - "rafter.kyma-project.io"
+    knativeServing:
+      - "networking.internal.knative.dev"
+      - "caching.internal.knative.dev"
+      - "autoscaling.internal.knative.dev"
+      - "serving.knative.dev"
   verbs:
     edit:
       - "create"

--- a/resources/cluster-users/values.yaml
+++ b/resources/cluster-users/values.yaml
@@ -1,7 +1,7 @@
 tests:
   enabled: true
   image:
-    version: 08e313d5
+    version: PR-8160
   env:
     namespace: default
 

--- a/resources/knative-serving/templates/serving.yaml
+++ b/resources/knative-serving/templates/serving.yaml
@@ -114,7 +114,6 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    rbac.authorization.k8s.io/aggregate-to-admin: "true"
     serving.knative.dev/release: "{{ .Values.global.version }}"
   name: knative-serving-namespaced-admin
 rules:
@@ -133,7 +132,6 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    rbac.authorization.k8s.io/aggregate-to-edit: "true"
     serving.knative.dev/release: "{{ .Values.global.version }}"
   name: knative-serving-namespaced-edit
 rules:
@@ -154,7 +152,6 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    rbac.authorization.k8s.io/aggregate-to-view: "true"
     serving.knative.dev/release: "{{ .Values.global.version }}"
   name: knative-serving-namespaced-view
 rules:

--- a/tests/integration/cluster-users/sar-test.sh
+++ b/tests/integration/cluster-users/sar-test.sh
@@ -19,7 +19,7 @@ RETRY_TIME=3 #Seconds
 MAX_RETRIES=5
 
 readonly VIEW_OPERATIONS=( "get" "list" )
-readonly EDIT_OPERATIONS=( "create" "delete" "deletecollection" "get" "list" "patch" "update" "watch" )
+readonly EDIT_OPERATIONS=( "create" "delete" "deletecollection" "patch" "update" "watch" )
 
 # Helper used to count retry attempts
 function __retry() {

--- a/tests/integration/cluster-users/sar-test.sh
+++ b/tests/integration/cluster-users/sar-test.sh
@@ -18,7 +18,9 @@
 RETRY_TIME=3 #Seconds
 MAX_RETRIES=5
 
+# resources/cluster-users/values.yaml clusterRoles.verbs.view
 readonly VIEW_OPERATIONS=( "get" "list" )
+# resources/cluster-users/values.yaml clusterRoles.verbs.edit - clusterRoles.verbs.view
 readonly EDIT_OPERATIONS=( "create" "delete" "deletecollection" "patch" "update" "watch" )
 
 # Helper used to count retry attempts

--- a/tests/integration/cluster-users/sar-test.sh
+++ b/tests/integration/cluster-users/sar-test.sh
@@ -281,7 +281,7 @@ function testKnativeServing() {
 	fi
 	readonly isAdminText
 
-	local -r resources=( "services.serving.knative.dev" "routes.serving.knative.dev" "revisions.serving.knative.dev" "configurations.serving.knative.dev" "clusteringresses.networking.internal.knative.dev" "podautoscalers.autoscaling.internal.knative.dev" "images.caching.internal.knative.dev" )
+	local -r resources=( "services.serving.knative.dev" "routes.serving.knative.dev" "revisions.serving.knative.dev" "configurations.serving.knative.dev" "podautoscalers.autoscaling.internal.knative.dev" "images.caching.internal.knative.dev" )
 
 	# View
 	for resource in "${resources[@]}"; do

--- a/tests/integration/cluster-users/sar-test.sh
+++ b/tests/integration/cluster-users/sar-test.sh
@@ -279,15 +279,21 @@ function testKnativeServing() {
 	if [[ "${isAdmin}" == "no" ]]; then
 		isAdminText=" NOT"
 	fi
-	readonly isAdminText
+	local viewAccess="yes"
+	local viewAccessText=""
+	if [[ "${testNamespace}" == "${SYSTEM_NAMESPACE}" ]]; then
+		viewAccess="no"
+		viewAccessText=" NOT"
+	fi
+	readonly isAdminText viewAccess viewAccessText
 
 	local -r resources=( "services.serving.knative.dev" "routes.serving.knative.dev" "revisions.serving.knative.dev" "configurations.serving.knative.dev" "podautoscalers.autoscaling.internal.knative.dev" "images.caching.internal.knative.dev" )
 
 	# View
 	for resource in "${resources[@]}"; do
 		for operation in "${VIEW_OPERATIONS[@]}"; do
-			echo "--> ${userEmail} should be able to ${operation} ${resource} CR in ${testNamespace}"
-			testPermissions "${operation}" "${resource}" "${testNamespace}" "yes"
+			echo "--> ${userEmail} should${viewAccessText} be able to ${operation} ${resource} CR in ${testNamespace}"
+			testPermissions "${operation}" "${resource}" "${testNamespace}" "${viewAccess}"
 		done
 	done
 
@@ -394,7 +400,6 @@ function runTests() {
 	testPermissions "create" "servicebindings" "${NAMESPACE}" "yes"
 
 	testRafter "${ADMIN_EMAIL}" "${NAMESPACE}" "yes"
-
 	testKnativeServing "${ADMIN_EMAIL}" "${NAMESPACE}" "yes"
 
 	echo "--> ${ADMIN_EMAIL} should be able to delete any namespace in the cluster"
@@ -437,7 +442,6 @@ function runTests() {
 	testPermissions "create" "rule.oathkeeper.ory.sh" "${NAMESPACE}" "no"
 
 	testRafter "${VIEW_EMAIL}" "${NAMESPACE}" "no"
-
 	testKnativeServing "${VIEW_EMAIL}" "${NAMESPACE}" "no"
 
 	echo "--> ${VIEW_EMAIL} should NOT be able to create serviceinstances in ${CUSTOM_NAMESPACE}"
@@ -476,6 +480,9 @@ function runTests() {
 	echo "--> ${NAMESPACE_ADMIN_EMAIL} should NOT be able to create servicebindings in ${SYSTEM_NAMESPACE}"
 	testPermissions "create" "servicebindings" "${SYSTEM_NAMESPACE}" "no"
 
+	testRafter "${NAMESPACE_ADMIN_EMAIL}" "${SYSTEM_NAMESPACE}" "no"
+	testKnativeServing "${NAMESPACE_ADMIN_EMAIL}" "${SYSTEM_NAMESPACE}" "no"
+
 	# namespace admin should not be able to create clusterrolebindings - if they can't create it in one namespace,
 	# that means they can't create it in any namespace (resource is non namespaced and RBAC is permissive)
 	echo "--> ${NAMESPACE_ADMIN_EMAIL} should NOT be able to create clusterrolebindings"
@@ -489,7 +496,7 @@ function runTests() {
 	testPermissionsClusterScoped "list" "usagekinds" "yes"
 
 	# namespace admin should be able to get/list/create/delete k8s and kyma resources in the namespace they created
-  echo "--> ${NAMESPACE_ADMIN_EMAIL} should be able to list Deployments in the namespace they created"
+	echo "--> ${NAMESPACE_ADMIN_EMAIL} should be able to list Deployments in the namespace they created"
 	testPermissions "list" "deployments" "${CUSTOM_NAMESPACE}" "yes"
 
 	echo "--> ${NAMESPACE_ADMIN_EMAIL} should be able to create Deployment in the namespace they created"
@@ -629,7 +636,6 @@ function runTests() {
 	testPermissions "list" "addonsconfigurations.addons.kyma-project.io" "${CUSTOM_NAMESPACE}" "yes"
 
 	testRafter "${NAMESPACE_ADMIN_EMAIL}" "${CUSTOM_NAMESPACE}" "no"
-
 	testKnativeServing "${NAMESPACE_ADMIN_EMAIL}" "${CUSTOM_NAMESPACE}" "no"
 
 	echo "--> ${NAMESPACE_ADMIN_EMAIL} should be able to get addonsconfigurations.addons.kyma-project.io in the namespace they created"
@@ -714,6 +720,9 @@ function runTests() {
 	echo "--> ${DEVELOPER_EMAIL} should be able to delete servicebindingusages in ${CUSTOM_NAMESPACE}"
 	testPermissions "delete" "servicebindingusages" "${CUSTOM_NAMESPACE}" "yes"
 
+	testRafter "${DEVELOPER_EMAIL}" "${CUSTOM_NAMESPACE}" "no"
+	testKnativeServing "${DEVELOPER_EMAIL}" "${CUSTOM_NAMESPACE}" "no"
+
 	# developer who was granted kyma-developer role should not be able to operate in system namespaces
 	echo "--> ${DEVELOPER_EMAIL} should NOT be able to list Deployments in system namespace"
 	testPermissions "list" "deployment" "${SYSTEM_NAMESPACE}" "no"
@@ -740,7 +749,6 @@ function runTests() {
 	testPermissions "create" "servicebindings" "${SYSTEM_NAMESPACE}" "no"
 
 	testRafter "${DEVELOPER_EMAIL}" "${SYSTEM_NAMESPACE}" "no"
-
 	testKnativeServing "${DEVELOPER_EMAIL}" "${SYSTEM_NAMESPACE}" "no"
 
 	echo "--> ${DEVELOPER_EMAIL} should NOT be able to create servicebindingusages in system namespace"

--- a/tests/integration/cluster-users/sar-test.sh
+++ b/tests/integration/cluster-users/sar-test.sh
@@ -628,9 +628,9 @@ function runTests() {
 	echo "--> ${NAMESPACE_ADMIN_EMAIL} should be able to list addonsconfigurations.addons.kyma-project.io in the namespace they created"
 	testPermissions "list" "addonsconfigurations.addons.kyma-project.io" "${CUSTOM_NAMESPACE}" "yes"
 
-	testRafter "${NAMESPACE_ADMIN_EMAIL}" "${CUSTOM_NAMESPACE}" "yes"
+	testRafter "${NAMESPACE_ADMIN_EMAIL}" "${CUSTOM_NAMESPACE}" "no"
 
-	testKnativeServing "${NAMESPACE_ADMIN_EMAIL}" "${CUSTOM_NAMESPACE}" "yes"
+	testKnativeServing "${NAMESPACE_ADMIN_EMAIL}" "${CUSTOM_NAMESPACE}" "no"
 
 	echo "--> ${NAMESPACE_ADMIN_EMAIL} should be able to get addonsconfigurations.addons.kyma-project.io in the namespace they created"
 	testPermissions "get" "addonsconfigurations/status.addons.kyma-project.io" "${CUSTOM_NAMESPACE}" "yes"

--- a/tests/integration/cluster-users/sar-test.sh
+++ b/tests/integration/cluster-users/sar-test.sh
@@ -628,9 +628,9 @@ function runTests() {
 	echo "--> ${NAMESPACE_ADMIN_EMAIL} should be able to list addonsconfigurations.addons.kyma-project.io in the namespace they created"
 	testPermissions "list" "addonsconfigurations.addons.kyma-project.io" "${CUSTOM_NAMESPACE}" "yes"
 
-	testRafter "${NAMESPACE_ADMIN_EMAIL}" "${CUSTOM_NAMESPACE}" "no"
+	testRafter "${NAMESPACE_ADMIN_EMAIL}" "${CUSTOM_NAMESPACE}" "yes"
 
-	testKnativeServing "${NAMESPACE_ADMIN_EMAIL}" "${CUSTOM_NAMESPACE}" "no"
+	testKnativeServing "${NAMESPACE_ADMIN_EMAIL}" "${CUSTOM_NAMESPACE}" "yes"
 
 	echo "--> ${NAMESPACE_ADMIN_EMAIL} should be able to get addonsconfigurations.addons.kyma-project.io in the namespace they created"
 	testPermissions "get" "addonsconfigurations/status.addons.kyma-project.io" "${CUSTOM_NAMESPACE}" "yes"


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/master/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- Set read-only access for all
- Set full access for admin

Rafter and Knative Serving are Kyma dependencies, not functionalities. Because of that, users shouldn't be able to modify/create/delete their resources. For debugging purposes, they should have view access to them.