### PR TITLE
Rename serverless deployment and serviceAccount

### DIFF
--- a/resources/serverless/templates/auth-proxy-role-binding.yaml
+++ b/resources/serverless/templates/auth-proxy-role-binding.yaml
@@ -11,6 +11,6 @@ roleRef:
   name: {{ template "fullname" . }}-auth-proxy
 subjects:
 - kind: ServiceAccount
-  name: {{ template "fullname" . }}
+  name: {{ template "fullname" . }}-controller-manager
   namespace: {{ .Release.Namespace }}
 {{- end }}

--- a/resources/serverless/templates/cluster-role-binding.yaml
+++ b/resources/serverless/templates/cluster-role-binding.yaml
@@ -10,5 +10,5 @@ roleRef:
   name: {{ template "fullname" . }}
 subjects:
 - kind: ServiceAccount
-  name: {{ template "fullname" . }}
+  name: {{ template "fullname" . }}-controller-manager
   namespace: {{ .Release.Namespace }}

--- a/resources/serverless/templates/deployment.yaml
+++ b/resources/serverless/templates/deployment.yaml
@@ -1,7 +1,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ template "fullname" . }}
+  name: {{ template "fullname" . }}-controller-manager
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "tplValue" ( dict "value" .Values.global.commonLabels "context" . ) | nindent 4 }}
@@ -37,7 +37,7 @@ spec:
       {{- end }}
       {{- end }}
     spec:
-      serviceAccountName: {{ template "fullname" . }}
+      serviceAccountName: {{ template "fullname" . }}-controller-manager
       {{- if .Values.pod.extraProperties }}
       {{ include "tplValue" ( dict "value" .Values.pod.extraProperties  "context" . ) | nindent 6 }}
       {{- end }}

--- a/resources/serverless/templates/leader-election-role-binding.yaml
+++ b/resources/serverless/templates/leader-election-role-binding.yaml
@@ -11,6 +11,6 @@ roleRef:
   name: {{ template "fullname" . }}-leader-election
 subjects:
 - kind: ServiceAccount
-  name: {{ template "fullname" . }}
+  name: {{ template "fullname" . }}-controller-manager
   namespace: {{ .Release.Namespace }}
 {{- end }}

--- a/resources/serverless/templates/service-account.yaml
+++ b/resources/serverless/templates/service-account.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: {{ template "fullname" . }}
+  name: {{ template "fullname" . }}-controller-manager
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "tplValue" ( dict "value" .Values.global.commonLabels "context" . ) | nindent 4 }}

--- a/resources/serverless/templates/service-account.yaml
+++ b/resources/serverless/templates/service-account.yaml
@@ -6,7 +6,16 @@ metadata:
   labels:
     {{- include "tplValue" ( dict "value" .Values.global.commonLabels "context" . ) | nindent 4 }}
     serverless.kyma-project.io/config: service-account
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ template "fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "tplValue" ( dict "value" .Values.global.commonLabels "context" . ) | nindent 4 }}
+    serverless.kyma-project.io/config: service-account
 secrets:
-- name: {{ template "fullname" . }}-registry-credentials
+  - name: {{ template "fullname" . }}-registry-credentials
 imagePullSecrets:
-- name: {{ template "fullname" . }}-image-pull-secret
+  - name: {{ template "fullname" . }}-image-pull-secret

--- a/resources/serverless/templates/service-account.yaml
+++ b/resources/serverless/templates/service-account.yaml
@@ -5,7 +5,6 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "tplValue" ( dict "value" .Values.global.commonLabels "context" . ) | nindent 4 }}
-    serverless.kyma-project.io/config: service-account
 ---
 apiVersion: v1
 kind: ServiceAccount

--- a/resources/serverless/templates/service.yaml
+++ b/resources/serverless/templates/service.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ template "fullname" . }}
+  name: {{ template "fullname" . }}-controller-manager
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "tplValue" ( dict "value" .Values.global.commonLabels "context" . ) | nindent 4 }}

--- a/resources/serverless/values.yaml
+++ b/resources/serverless/values.yaml
@@ -87,7 +87,7 @@ containers:
       imagePullSecretName:
         value: "{{ template \"fullname\" . }}-registry-credentials"
       imagePullAccountName:
-        value: "{{ template \"fullname\" . }}"
+        value: "{{ template \"fullname\" . }}-controller-manager"
       functionRequeueDuration:
         value: 1m
       functionBuildExecutorImage:

--- a/resources/serverless/values.yaml
+++ b/resources/serverless/values.yaml
@@ -87,7 +87,7 @@ containers:
       imagePullSecretName:
         value: "{{ template \"fullname\" . }}-registry-credentials"
       imagePullAccountName:
-        value: "{{ template \"fullname\" . }}-controller-manager"
+        value: "{{ template \"fullname\" . }}"
       functionRequeueDuration:
         value: 1m
       functionBuildExecutorImage:


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/master/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- Change the name of the `deployment` and the `serviceAccount` stored in the `serverless` chart to the `serverless-controller-manager`

**Related issue(s)**
[Issue #8202](https://github.com/kyma-project/kyma/issues/8202)