### PR TITLE
Upgrade yaml.v2 version in APIServer proxy

### DIFF
--- a/components/apiserver-proxy/Gopkg.toml
+++ b/components/apiserver-proxy/Gopkg.toml
@@ -46,7 +46,7 @@ required = [
 
 [[constraint]]
   name = "gopkg.in/yaml.v2"
-  version = "2.2.1"
+  version = "2.2.8"
 
 [[constraint]]
   name = "github.com/prometheus/client_golang"


### PR DESCRIPTION
**Description**

yaml.v2 in version 2.2.1 contains security vulnerability (CVE-2019-11254) 

Changes proposed in this pull request:

- Upgrade yaml.v2 version to 2.2.8

**Related issue(s)**

