### PR TITLE
Add info on requests and limits for functions

### DIFF
--- a/docs/rafter/05-01-rafter.md
+++ b/docs/rafter/05-01-rafter.md
@@ -17,33 +17,33 @@ This table lists the configurable parameters, their descriptions, and default va
 
 | Parameter | Description | Default value |
 |-----------|-------------|---------------|
-| **controller-manager.minio.persistence.enabled** | Enables MinIO persistence. Deactivate it only if you use [Gateway mode](#tutorials-set-minio-to-gateway-mode). | `true` |
-| **controller-manager.minio.environment.MINIO_BROWSER** | Enables browsing MinIO storage. By default, the MinIO browser is turned off for security reasons. You can change the value to `on` to use the browser. If you enable the browser, it is available at `https://storage.{DOMAIN}/minio/`, for example at `https://storage.kyma.local/minio/`. | `"off"` |
-| **controller-manager.minio.resources.requests.memory** | Defines requests for memory resources. | `32Mi` |
-| **controller-manager.minio.resources.requests.cpu** |  Defines requests for CPU resources. | `10m` |
-| **controller-manager.minio.resources.limits.memory** |  Defines limits for memory resources. | `128Mi` |
-| **controller-manager.minio.resources.limits.cpu** | Defines limits for CPU resources. | `100m` |
-| **controller-manager.deployment.replicas** | Defines the number of service replicas. | `1` |
-| **controller-manager.pod.resources.limits.cpu** |  Defines limits for CPU resources. | `150m` |
-| **controller-manager.pod.resources.limits.memory** | Defines limits for memory resources. | `128Mi` |
-| **controller-manager.pod.resources.requests.cpu** | Defines requests for CPU resources. | `10m` |
-| **controller-manager.pod.resources.requests.memory** | Defines requests for memory resources. | `32Mi` |
-| **controller-manager.envs.clusterAssetGroup.relistInterval** | Determines time intervals in which the Rafter Controller Manager verifies the ClusterAssetGroup for changes. | `5m` |
-| **controller-manager.envs.assetGroup.relistInterval** | Determines time intervals in which the Rafter Controller Manager verifies the AssetGroup for changes. | `5m` |
-| **controller-manager.envs.clusterBucket.region** | Specifies the regional location of the ClusterBucket in a given cloud storage. Use one of [these](https://github.com/kyma-project/kyma/blob/master/resources/cluster-essentials/templates/rafter.clusterbuckets.crd.yaml#L52) regions. | `us-east-1` |
-| **controller-manager.envs.bucket.region** | Specifies the regional location of the bucket in a given cloud storage. Use one of [these](https://github.com/kyma-project/kyma/blob/master/resources/cluster-essentials/templates/rafter.buckets.crd.yaml#L52) regions. | `us-east-1` |
-| **controller-manager.envs.clusterBucket.maxConcurrentReconciles** | Defines the maximum number of cluster bucket concurrent reconciles which will run. | `1` |
-| **controller-manager.envs.bucket.maxConcurrentReconciles** | Defines the maximum number of bucket concurrent reconciles which will run. | `1` |
-| **controller-manager.envs.clusterAsset.maxConcurrentReconciles** | Defines the maximum number of cluster asset concurrent reconciles which will run. | `1` |
-| **controller-manager.envs.asset.maxConcurrentReconciles** | Defines the maximum number of asset concurrent reconciles which will run. | `1` |
-| **controller-manager.minio.secretKey** | Defines the secret key. Add the parameter to set your own **secretkey** credentials. | By default, **secretKey** is automatically generated. |
-| **controller-manager.minio.accessKey** | Defines the access key. Add the parameter to set your own **accesskey** credentials. | By default, **accessKey** is automatically generated. |
-| **controller-manager.envs.store.uploadWorkers** | Defines the number of workers used in parallel to upload files to the storage bucket. | `10` |
-| **controller-manager.envs.webhooks.validation.workers** | Defines the number of workers used in parallel to validate files. | `10` |
-| **controller-manager.envs.webhooks.mutation.workers** | Defines the number of workers used in parallel to mutate files. | `10` |
-| **upload-service.deployment.replicas** | Defines the number of service replicas. | `1` |
+| **controller-manager.minio.persistence.enabled** | Parameter that enables MinIO persistence. Deactivate it only if you use [Gateway mode](#tutorials-set-minio-to-gateway-mode). | `true` |
+| **controller-manager.minio.environment.MINIO_BROWSER** | Parameter that enables browsing MinIO storage. By default, the MinIO browser is turned off for security reasons. You can change the value to `on` to use the browser. If you enable the browser, it is available at `https://storage.{DOMAIN}/minio/`, for example at `https://storage.kyma.local/minio/`. | `"off"` |
+| **controller-manager.minio.resources.requests.memory** | Requests for memory resources. | `32Mi` |
+| **controller-manager.minio.resources.requests.cpu** |  Requests for CPU resources. | `10m` |
+| **controller-manager.minio.resources.limits.memory** |  Limits for memory resources. | `128Mi` |
+| **controller-manager.minio.resources.limits.cpu** | Limits for CPU resources. | `100m` |
+| **controller-manager.deployment.replicas** | Number of service replicas. | `1` |
+| **controller-manager.pod.resources.limits.cpu** |  Limits for CPU resources. | `150m` |
+| **controller-manager.pod.resources.limits.memory** | Limits for memory resources. | `128Mi` |
+| **controller-manager.pod.resources.requests.cpu** | Requests for CPU resources. | `10m` |
+| **controller-manager.pod.resources.requests.memory** | Requests for memory resources. | `32Mi` |
+| **controller-manager.envs.clusterAssetGroup.relistInterval** | Time intervals in which the Rafter Controller Manager verifies the ClusterAssetGroup for changes. | `5m` |
+| **controller-manager.envs.assetGroup.relistInterval** | Time intervals in which the Rafter Controller Manager verifies the AssetGroup for changes. | `5m` |
+| **controller-manager.envs.clusterBucket.region** | Regional location of the ClusterBucket in a given cloud storage. Use one of [these](https://github.com/kyma-project/kyma/blob/master/resources/cluster-essentials/templates/rafter.clusterbuckets.crd.yaml#L52) regions. | `us-east-1` |
+| **controller-manager.envs.bucket.region** | Regional location of the bucket in a given cloud storage. Use one of [these](https://github.com/kyma-project/kyma/blob/master/resources/cluster-essentials/templates/rafter.buckets.crd.yaml#L52) regions. | `us-east-1` |
+| **controller-manager.envs.clusterBucket.maxConcurrentReconciles** | Maximum number of cluster bucket concurrent reconciles which will run. | `1` |
+| **controller-manager.envs.bucket.maxConcurrentReconciles** | Maximum number of bucket concurrent reconciles which will run. | `1` |
+| **controller-manager.envs.clusterAsset.maxConcurrentReconciles** | Maximum number of cluster asset concurrent reconciles which will run. | `1` |
+| **controller-manager.envs.asset.maxConcurrentReconciles** | Maximum number of asset concurrent reconciles which will run. | `1` |
+| **controller-manager.minio.secretKey** | Secret key. Add the parameter to set your own **secretkey** credentials. | By default, **secretKey** is automatically generated. |
+| **controller-manager.minio.accessKey** | Access key. Add the parameter to set your own **accesskey** credentials. | By default, **accessKey** is automatically generated. |
+| **controller-manager.envs.store.uploadWorkers** | Number of workers used in parallel to upload files to the storage bucket. | `10` |
+| **controller-manager.envs.webhooks.validation.workers** | Number of workers used in parallel to validate files. | `10` |
+| **controller-manager.envs.webhooks.mutation.workers** | Number of workers used in parallel to mutate files. | `10` |
+| **upload-service.deployment.replicas** | Number of service replicas. | `1` |
 | **upload-service.envs.verbose** | If set to `true`, you enable the extended logging mode that records more information on AsyncAPI Service activities than the usual logging mode which registers only errors and warnings. | `true` |
-| **front-matter-service.deployment.replicas** | Defines the number of service replicas. For more details, see the [Kubernetes documentation](https://kubernetes.io/docs/concepts/workloads/controllers/replicaset/).| `1` |
+| **front-matter-service.deployment.replicas** | Number of service replicas. For more details, see the [Kubernetes documentation](https://kubernetes.io/docs/concepts/workloads/controllers/replicaset/).| `1` |
 | **front-matter-service.envs.verbose** |  If set to `true`, you enable the extended logging mode that records more information on Front Matter Service activities than the usual logging mode which registers only errors and warnings. | `true` |
-| **asyncapi-service.deployment.replicas** | Defines the number of service replicas. | `1` |
+| **asyncapi-service.deployment.replicas** | Number of service replicas. | `1` |
 | **asyncapi-service.envs.verbose** |  If set to `true`, you enable the extended logging mode that records more information on AsyncAPI Service activities than the usual logging mode which registers only errors and warnings. | `true` |

--- a/docs/serverless/02-01-serverless.md
+++ b/docs/serverless/02-01-serverless.md
@@ -6,7 +6,7 @@ Serverless relies on [Knative Serving](https://knative.dev/docs/serving/) for de
 
 ![Serverless architecture](./assets/serverless-architecture.svg)
 
-> **CAUTION:** Serverless imposes some requirements on the setup of Namespaces. If you create a new Namespace, do not disable sidecar injection in it as Serverless requires Istio for other resources to communicate with functions correctly. Also, if you apply custom [LimitRanges](https://kyma-project.io/docs/#details-resource-quotas) for a new Namespace, they must be higher than the default values.
+> **CAUTION:** Serverless imposes some requirements on the setup of Namespaces. If you create a new Namespace, do not disable sidecar injection in it as Serverless requires Istio for other resources to communicate with functions correctly. Also, if you apply custom [LimitRanges](https://kyma-project.io/docs/#details-resource-quotas) for a new Namespace, they must be higher than or equal to the [limits for building Jobs' resources](#configuration-serverless-chart).
 
 1. Create a function either through the UI or by applying a Function custom resource (CR). This CR contains the function definition (business logic that you want to execute) and information on the environment on which it should run.
 

--- a/docs/serverless/02-01-serverless.md
+++ b/docs/serverless/02-01-serverless.md
@@ -6,6 +6,8 @@ Serverless relies on [Knative Serving](https://knative.dev/docs/serving/) for de
 
 ![Serverless architecture](./assets/serverless-architecture.svg)
 
+> **CAUTION:** Serverless imposes some requirements on the setup of Namespaces. If you create a new Namespace, do not disable sidecar injection in it as Serverless requires Istio for other resources to communicate with functions correctly. Also, if you apply custom [LimitRanges](https://kyma-project.io/docs/#details-resource-quotas) for a new Namespace, they must be higher than the default values.
+
 1. Create a function either through the UI or by applying a Function custom resource (CR). This CR contains the function definition (business logic that you want to execute) and information on the environment on which it should run.
 
     >**NOTE:** Function Controller sets the Node.js 12 runtime by default.

--- a/docs/serverless/02-01-serverless.md
+++ b/docs/serverless/02-01-serverless.md
@@ -6,7 +6,7 @@ Serverless relies on [Knative Serving](https://knative.dev/docs/serving/) for de
 
 ![Serverless architecture](./assets/serverless-architecture.svg)
 
-> **CAUTION:** Serverless imposes some requirements on the setup of Namespaces. If you create a new Namespace, do not disable sidecar injection in it as Serverless requires Istio for other resources to communicate with functions correctly. Also, if you apply custom [LimitRanges](https://kyma-project.io/docs/#details-resource-quotas) for a new Namespace, they must be higher than or equal to the [limits for building Jobs' resources](#configuration-serverless-chart).
+> **CAUTION:** Serverless imposes some requirements on the setup of Namespaces. If you create a new Namespace, do not disable sidecar injection in it as Serverless requires Istio for other resources to communicate with functions correctly. Also, if you apply custom [LimitRanges](/root/kyma/#details-resource-quotas) for a new Namespace, they must be higher than or equal to the [limits for building Jobs' resources](#configuration-serverless-chart).
 
 1. Create a function either through the UI or by applying a Function custom resource (CR). This CR contains the function definition (business logic that you want to execute) and information on the environment on which it should run.
 

--- a/docs/serverless/03-03-function-processing.md
+++ b/docs/serverless/03-03-function-processing.md
@@ -13,7 +13,7 @@ For a function to be considered ready, the status of all three conditions must b
 
 ```bash
 NAME                        CONFIGURED   BUILT   RUNNING   VERSION   AGE
-test-function                 True         True    True      1         18m
+test-function               True         True    True      1         18m
 ```
 
 When you update an existing function, conditions change asynchronously depending on the change type.  

--- a/docs/serverless/05-01-serverless.md
+++ b/docs/serverless/05-01-serverless.md
@@ -13,12 +13,8 @@ To configure the Serverless chart, override the default values of its `values.ya
 
 This table lists the configurable parameters, their descriptions, and default values for both cluster and local installations.
 
->**CAUTION:** Currently, there is no automated validation for CPU and memory requests and limits. If you update their default values, make sure that the values for CPU and memory requests are not lower than the default ones, and that values for requests are lower than or equal to those for the limits.
-
->**NOTE:** You can define all **envs** either by providing them as inline values or using the **valueFrom** object. See [this](https://github.com/kyma-project/rafter/tree/master/charts/rafter-controller-manager#change-values-for-envs-parameters) document for reference.
-
 | Parameter | Description | Default value | Minikube override |
-|-----------|-------------|---------------|
+|-----------|-------------|---------------|---------------|
 | **containers.manager.envs.buildRequestsCPU** | Specifies the number of CPUs requested by the image building Pod to operate. | `700m` | `100m`|
 | **containers.manager.envs.buildRequestsMemory** | Specifies the amount of memory requested by the image building Pod to operate.  | `700Mi` | `200Mi` |
 | **containers.manager.envs.buildLimitsCPU** | Defines the maximum number of CPUs available for the image building Pod to use. | `1100m` | `200m` |

--- a/docs/serverless/05-01-serverless.md
+++ b/docs/serverless/05-01-serverless.md
@@ -15,7 +15,7 @@ This table lists the configurable parameters, their descriptions, and default va
 
 | Parameter | Description | Default value | Minikube override |
 |-----------|-------------|---------------|---------------|
-| **containers.manager.envs.buildRequestsCPU** | Specifies the number of CPUs requested by the image building Pod to operate. | `700m` | `100m`|
-| **containers.manager.envs.buildRequestsMemory** | Specifies the amount of memory requested by the image building Pod to operate.  | `700Mi` | `200Mi` |
-| **containers.manager.envs.buildLimitsCPU** | Specifies the maximum number of CPUs available for the image building Pod to use. | `1100m` | `200m` |
-| **containers.manager.envs.buildLimitsMemory** | Specifies the maximum amount of memory available for the image building Pod to use. | `1100Mi` | `400Mi` |
+| **containers.manager.envs.buildRequestsCPU** | Number of CPUs requested by the image-building Pod to operate. | `700m` | `100m`|
+| **containers.manager.envs.buildRequestsMemory** | Amount of memory requested by the image-building Pod to operate.  | `700Mi` | `200Mi` |
+| **containers.manager.envs.buildLimitsCPU** | Maximum number of CPUs available for the image-building Pod to use. | `1100m` | `200m` |
+| **containers.manager.envs.buildLimitsMemory** | Maximum amount of memory available for the image-building Pod to use. | `1100Mi` | `400Mi` |

--- a/docs/serverless/05-01-serverless.md
+++ b/docs/serverless/05-01-serverless.md
@@ -1,0 +1,25 @@
+---
+title: Serverless chart
+type: Configuration
+---
+
+To configure the Serverless chart, override the default values of its `values.yaml` file. This document describes parameters that you can configure.
+
+>**TIP:** To learn more about how to use overrides in Kyma, see the following documents:
+>* [Helm overrides for Kyma installation](/root/kyma/#configuration-helm-overrides-for-kyma-installation)
+>* [Top-level charts overrides](/root/kyma/#configuration-helm-overrides-for-kyma-installation-top-level-charts-overrides)
+
+## Configurable parameters
+
+This table lists the configurable parameters, their descriptions, and default values for both cluster and local installations.
+
+>**CAUTION:** Currently, there is no automated validation for CPU and memory requests and limits. If you update their default values, make sure that the values for CPU and memory requests are not lower than the default ones, and that values for requests are lower than those for the limits.
+
+>**NOTE:** You can define all **envs** either by providing them as inline values or using the **valueFrom** object. See [this](https://github.com/kyma-project/rafter/tree/master/charts/rafter-controller-manager#change-values-for-envs-parameters) document for reference.
+
+| Parameter | Description | Default value | Minikube override |
+|-----------|-------------|---------------|
+| **containers.manager.envs.buildRequestsCPU** | Specifies the number of CPUs requested by the image building Pod to operate. | `700m` | `100m`|
+| **containers.manager.envs.buildRequestsMemory** | Specifies the amount of memory requested by the image building Pod to operate.  | `700Mi` | `200Mi` |
+| **containers.manager.envs.buildLimitsCPU** | Defines the maximum number of CPUs available for the image building Pod to use. | `1100m` | `200m` |
+| **containers.manager.envs.buildLimitsMemory** | Defines the maximum amount of memory available for the image building Pod to use. | `1100Mi` | `400Mi` |

--- a/docs/serverless/05-01-serverless.md
+++ b/docs/serverless/05-01-serverless.md
@@ -13,7 +13,7 @@ To configure the Serverless chart, override the default values of its `values.ya
 
 This table lists the configurable parameters, their descriptions, and default values for both cluster and local installations.
 
->**CAUTION:** Currently, there is no automated validation for CPU and memory requests and limits. If you update their default values, make sure that the values for CPU and memory requests are not lower than the default ones, and that values for requests are lower than those for the limits.
+>**CAUTION:** Currently, there is no automated validation for CPU and memory requests and limits. If you update their default values, make sure that the values for CPU and memory requests are not lower than the default ones, and that values for requests are lower than or equal to those for the limits.
 
 >**NOTE:** You can define all **envs** either by providing them as inline values or using the **valueFrom** object. See [this](https://github.com/kyma-project/rafter/tree/master/charts/rafter-controller-manager#change-values-for-envs-parameters) document for reference.
 

--- a/docs/serverless/05-01-serverless.md
+++ b/docs/serverless/05-01-serverless.md
@@ -17,5 +17,5 @@ This table lists the configurable parameters, their descriptions, and default va
 |-----------|-------------|---------------|---------------|
 | **containers.manager.envs.buildRequestsCPU** | Specifies the number of CPUs requested by the image building Pod to operate. | `700m` | `100m`|
 | **containers.manager.envs.buildRequestsMemory** | Specifies the amount of memory requested by the image building Pod to operate.  | `700Mi` | `200Mi` |
-| **containers.manager.envs.buildLimitsCPU** | Defines the maximum number of CPUs available for the image building Pod to use. | `1100m` | `200m` |
-| **containers.manager.envs.buildLimitsMemory** | Defines the maximum amount of memory available for the image building Pod to use. | `1100Mi` | `400Mi` |
+| **containers.manager.envs.buildLimitsCPU** | Specifies the maximum number of CPUs available for the image building Pod to use. | `1100m` | `200m` |
+| **containers.manager.envs.buildLimitsMemory** | Specifies the maximum amount of memory available for the image building Pod to use. | `1100Mi` | `400Mi` |

--- a/docs/serverless/08-01-create-function.md
+++ b/docs/serverless/08-01-create-function.md
@@ -22,6 +22,8 @@ Follows these steps:
     export NAMESPACE={FUNCTION_NAMESPACE}
     ```
 
+    > **CAUTION:** If you create a new Namespace, do not disable sidecar injection in it as Serverless requires Istio for other resources to communicate with functions correctly. Also, if you apply custom [LimitRanges](https://kyma-project.io/docs/#details-resource-quotas) for a new Namespace, they must be higher than the default values.
+
 2. Create a Function CR that specifies the function's logic:
 
     ```yaml
@@ -61,6 +63,8 @@ Follows these steps:
     </summary>
 
 1. Create a Namespace or select one from the drop-down list in the top navigation panel.
+
+    > **CAUTION:** If you create a new Namespace, do not disable sidecar injection in it as Serverless requires Istio for other resources to communicate with functions correctly. Also, if you apply custom [LimitRanges](https://kyma-project.io/docs/#details-resource-quotas) for a new Namespace, they must be higher than the default values.
 
 2. Go to the **Functions** view in the left navigation panel and select **Create Function**.
 

--- a/docs/serverless/08-01-create-function.md
+++ b/docs/serverless/08-01-create-function.md
@@ -22,8 +22,6 @@ Follows these steps:
     export NAMESPACE={FUNCTION_NAMESPACE}
     ```
 
-    > **CAUTION:** If you create a new Namespace, do not disable sidecar injection in it as Serverless requires Istio for other resources to communicate with functions correctly. Also, if you apply custom [LimitRanges](https://kyma-project.io/docs/#details-resource-quotas) for a new Namespace, they must be higher than the default values.
-
 2. Create a Function CR that specifies the function's logic:
 
     ```yaml
@@ -63,8 +61,6 @@ Follows these steps:
     </summary>
 
 1. Create a Namespace or select one from the drop-down list in the top navigation panel.
-
-    > **CAUTION:** If you create a new Namespace, do not disable sidecar injection in it as Serverless requires Istio for other resources to communicate with functions correctly. Also, if you apply custom [LimitRanges](https://kyma-project.io/docs/#details-resource-quotas) for a new Namespace, they must be higher than the default values.
 
 2. Go to the **Functions** view in the left navigation panel and select **Create Function**.
 


### PR DESCRIPTION

**Description**

Changes proposed in this pull request:

- Created the configuration doc for serverless that documents default `buildLimits` and `buildRequests` for CPU and memory and the Minikube overrides.
- Mentioned in docs that Istio is required for Namespaces in which you create functions (sidecar must be injected)
- Mentioned that currently there is no automated validation for CPU and memory requests and limits for functions.
- Clearly stated in docs that the values for CPU and memory requests must be not lower than the default ones, and that values for requests must be lower than those for the limits.
- Stated that LimitRanges you set for resources in a given Namespace for functions must not be lower than the default values.

**Related issue(s)**
See also #8176 
