### PR TITLE
Fix a broken link

### DIFF
--- a/docs/compass/05-01-provisioner-entry-parameteres.md
+++ b/docs/compass/05-01-provisioner-entry-parameteres.md
@@ -5,7 +5,7 @@ type: Configuration
 
 To configure the Runtime Provisioner chart, override the default values of its `values.yaml` file. This document describes the parameters that you can configure.
 
->**TIP:** To learn more about how to use overrides in Kyma, see [Helm overrides for Kyma installation](root/kyma#configuration-helm-overrides-for-kyma-installation).
+>**TIP:** To learn more about how to use overrides in Kyma, see [Helm overrides for Kyma installation](/root/kyma/#configuration-helm-overrides-for-kyma-installation).
 
 ## Configurable parameters
 


### PR DESCRIPTION
**Description**

The link to **Helm overrides for Kyma installation** in `docs/compass/05-01-provisioner-entry-parameters.md` is wrong. It doesn't work [here](https://kyma-project.io/docs/components/compass#configuration-runtime-provisioner-chart) but it works [here](https://kyma-project.io/docs/components/helm-broker/#configuration-helm-broker-chart) (provided for comparison).

Changes proposed in this pull request:

- Fix the link to **Helm overrides for Kyma installation** from [`root/kyma#configuration-helm-overrides-for-kyma-installation`](https://kyma-project.io/root/kyma#configuration-helm-overrides-for-kyma-installation) to [`/root/kyma/#configuration-helm-overrides-for-kyma-installation`](https://kyma-project.io/docs/#configuration-helm-overrides-for-kyma-installation) in `docs/compass/05-01-provisioner-entry-parameters.md`.
