### PR TITLE
Update of Helm charts for Connector audit logs - issue 1180

### DIFF
--- a/resources/compass/charts/connectivity-adapter/templates/deployment.yaml
+++ b/resources/compass/charts/connectivity-adapter/templates/deployment.yaml
@@ -31,7 +31,7 @@ spec:
             - name: APP_APP_REGISTRY_DIRECTOR_ENDPOINT
               value: "http://compass-gateway.{{ .Release.Namespace }}.svc.cluster.local:{{ .Values.global.gateway.port }}/director/graphql"
             - name: APP_CONNECTOR_CONNECTOR_ENDPOINT
-              value: "http://compass-connector.{{ .Release.Namespace }}.svc.cluster.local:{{ .Values.global.connector.graphql.external.port }}/graphql"
+              value: "http://compass-gateway.{{ .Release.Namespace }}.svc.cluster.local:{{ .Values.global.gateway.port }}/connector/graphql"
             - name: APP_CONNECTOR_ADAPTER_BASE_URL
               value: "https://{{ .Values.global.connectivity_adapter.tls.host }}.{{ .Values.global.ingress.domainName }}"
             - name: APP_CONNECTOR_ADAPTER_MTLS_BASE_URL

--- a/resources/compass/charts/gateway/templates/oathkeeper-rules.yaml
+++ b/resources/compass/charts/gateway/templates/oathkeeper-rules.yaml
@@ -130,6 +130,11 @@ spec:
   mutators:
   - handler: hydrator
 {{ toYaml .Values.global.oathkeeper.mutators.tokenResolverService | indent 4 }}
+  - handler: hydrator
+{{ toYaml .Values.global.oathkeeper.mutators.tenantMappingService | indent 4 }}
+  - handler: id_token
+    config:
+      claims: {{ .Values.global.oathkeeper.idTokenConfig.claims | quote }}
 ---
 apiVersion: oathkeeper.ory.sh/v1alpha1
 kind: Rule
@@ -150,3 +155,8 @@ spec:
   mutators:
   - handler: hydrator
 {{ toYaml .Values.global.oathkeeper.mutators.certificateResolverService | indent 4 }}
+  - handler: hydrator
+{{ toYaml .Values.global.oathkeeper.mutators.tenantMappingService | indent 4 }}
+  - handler: id_token
+    config:
+      claims: {{ .Values.global.oathkeeper.idTokenConfig.claims | quote }}

--- a/resources/compass/values.yaml
+++ b/resources/compass/values.yaml
@@ -17,7 +17,7 @@ global:
       version: "2a54a16c"
     connectivity_adapter:
       dir:
-      version: "a272bec9"
+      version: "PR-1208"
     pairing_adapter:
       dir:
       version: "9fae2df7"
@@ -26,7 +26,7 @@ global:
       version: "22072888"
     gateway:
       dir:
-      version: "9fae2df7"
+      version: "PR-1208"
     healthchecker:
       dir:
       version: "109f4dc2"

--- a/resources/compass/values.yaml
+++ b/resources/compass/values.yaml
@@ -17,7 +17,7 @@ global:
       version: "2a54a16c"
     connectivity_adapter:
       dir:
-      version: "PR-1208"
+      version: "93462f94"
     pairing_adapter:
       dir:
       version: "9fae2df7"
@@ -26,7 +26,7 @@ global:
       version: "22072888"
     gateway:
       dir:
-      version: "PR-1208"
+      version: "93462f94"
     healthchecker:
       dir:
       version: "109f4dc2"


### PR DESCRIPTION
This PR is about to update Kyma Helm Charts to be in line with Compass PR 1208. 

This PR adds functionality to send audit logs from operations on Connector and Connectivity Adapter