### PR TITLE
Fix metrics upgrade test failure

### DIFF
--- a/tests/end-to-end/upgrade/chart/upgrade/values.yaml
+++ b/tests/end-to-end/upgrade/chart/upgrade/values.yaml
@@ -3,7 +3,7 @@ containerRegistry:
 
 image:
   dir:
-  version: PR-8156
+  version: PR-8271
   pullPolicy: "IfNotPresent"
 
 dex:

--- a/tests/end-to-end/upgrade/main.go
+++ b/tests/end-to-end/upgrade/main.go
@@ -5,22 +5,40 @@ import (
 	"fmt"
 	"time"
 
+	sc "github.com/kubernetes-incubator/service-catalog/pkg/client/clientset_generated/clientset"
+
+	eventingclientv1alpha1 "knative.dev/eventing/pkg/client/clientset/versioned/typed/eventing/v1alpha1"
+	messagingclientv1alpha1 "knative.dev/eventing/pkg/client/clientset/versioned/typed/messaging/v1alpha1"
+	servingclientset "knative.dev/serving/pkg/client/clientset/versioned"
+
 	"github.com/sirupsen/logrus"
 	"github.com/vrischmann/envconfig"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/dynamic"
 	k8sclientset "k8s.io/client-go/kubernetes"
 	restClient "k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 
 	"github.com/pkg/errors"
 
+	mfClient "github.com/kyma-project/kyma/common/microfrontend-client/pkg/client/clientset/versioned"
+	ab "github.com/kyma-project/kyma/components/application-broker/pkg/client/clientset/versioned"
+	ao "github.com/kyma-project/kyma/components/application-operator/pkg/client/clientset/versioned"
 	"github.com/kyma-project/kyma/components/kyma-operator/pkg/overrides"
+	bu "github.com/kyma-project/kyma/components/service-binding-usage-controller/pkg/client/clientset/versioned"
 	dex "github.com/kyma-project/kyma/tests/end-to-end/backup-restore-test/utils/fetch-dex-token"
 	"github.com/kyma-project/kyma/tests/end-to-end/upgrade/internal/platform/logger"
 	"github.com/kyma-project/kyma/tests/end-to-end/upgrade/internal/platform/signal"
 	"github.com/kyma-project/kyma/tests/end-to-end/upgrade/internal/runner"
+	"github.com/kyma-project/kyma/tests/end-to-end/upgrade/pkg/injector"
+	apigateway "github.com/kyma-project/kyma/tests/end-to-end/upgrade/pkg/tests/api-gateway"
+	applicationoperator "github.com/kyma-project/kyma/tests/end-to-end/upgrade/pkg/tests/application-operator"
+	"github.com/kyma-project/kyma/tests/end-to-end/upgrade/pkg/tests/eventmesh"
 	"github.com/kyma-project/kyma/tests/end-to-end/upgrade/pkg/tests/monitoring"
+	"github.com/kyma-project/kyma/tests/end-to-end/upgrade/pkg/tests/rafter"
+	servicecatalog "github.com/kyma-project/kyma/tests/end-to-end/upgrade/pkg/tests/service-catalog"
+	"github.com/kyma-project/kyma/tests/end-to-end/upgrade/pkg/tests/ui"
 	"github.com/kyma-project/kyma/tests/end-to-end/upgrade/pkg/waiter"
 )
 
@@ -67,38 +85,38 @@ func main() {
 	k8sCli, err := k8sclientset.NewForConfig(k8sConfig)
 	fatalOnError(err, "while creating k8s clientset")
 
-	// scCli, err := sc.NewForConfig(k8sConfig)
-	// fatalOnError(err, "while creating Service Catalog clientset")
+	scCli, err := sc.NewForConfig(k8sConfig)
+	fatalOnError(err, "while creating Service Catalog clientset")
 
-	// buCli, err := bu.NewForConfig(k8sConfig)
-	// fatalOnError(err, "while creating Binding Usage clientset")
+	buCli, err := bu.NewForConfig(k8sConfig)
+	fatalOnError(err, "while creating Binding Usage clientset")
 
-	// appConnectorCli, err := ao.NewForConfig(k8sConfig)
-	// fatalOnError(err, "while creating Application Connector clientset")
+	appConnectorCli, err := ao.NewForConfig(k8sConfig)
+	fatalOnError(err, "while creating Application Connector clientset")
 
-	// appBrokerCli, err := ab.NewForConfig(k8sConfig)
-	// fatalOnError(err, "while creating Application Broker clientset")
+	appBrokerCli, err := ab.NewForConfig(k8sConfig)
+	fatalOnError(err, "while creating Application Broker clientset")
 
-	// messagingCli, err := messagingclientv1alpha1.NewForConfig(k8sConfig)
-	// fatalOnError(err, "while creating knative Messaging clientset")
+	messagingCli, err := messagingclientv1alpha1.NewForConfig(k8sConfig)
+	fatalOnError(err, "while creating knative Messaging clientset")
 
-	// domainName, err := getDomainNameFromCluster(k8sCli)
-	// fatalOnError(err, "while reading domain name from cluster")
+	domainName, err := getDomainNameFromCluster(k8sCli)
+	fatalOnError(err, "while reading domain name from cluster")
 
-	// mfCli, err := mfClient.NewForConfig(k8sConfig)
-	// fatalOnError(err, "while creating Microfrontends clientset")
+	mfCli, err := mfClient.NewForConfig(k8sConfig)
+	fatalOnError(err, "while creating Microfrontends clientset")
 
-	// dynamicCli, err := dynamic.NewForConfig(k8sConfig)
-	// fatalOnError(err, "while creating K8s Dynamic client")
+	dynamicCli, err := dynamic.NewForConfig(k8sConfig)
+	fatalOnError(err, "while creating K8s Dynamic client")
 
-	// dexConfig, err := getDexConfigFromCluster(k8sCli, cfg.DexUserSecret, cfg.DexNamespace, domainName)
-	// fatalOnError(err, "while reading dex config from cluster")
+	dexConfig, err := getDexConfigFromCluster(k8sCli, cfg.DexUserSecret, cfg.DexNamespace, domainName)
+	fatalOnError(err, "while reading dex config from cluster")
 
-	// servingCli, err := servingclientset.NewForConfig(k8sConfig)
-	// fatalOnError(err, "while generating knative serving client")
+	servingCli, err := servingclientset.NewForConfig(k8sConfig)
+	fatalOnError(err, "while generating knative serving client")
 
-	// eventingCli, err := eventingclientv1alpha1.NewForConfig(k8sConfig)
-	// fatalOnError(err, "while generating knative eventing client")
+	eventingCli, err := eventingclientv1alpha1.NewForConfig(k8sConfig)
+	fatalOnError(err, "while generating knative eventing client")
 
 	// Register tests. Convention:
 	// <test-name> : <test-instance>
@@ -110,21 +128,22 @@ func main() {
 	metricUpgradeTest, err := monitoring.NewMetricsUpgradeTest(k8sCli)
 	fatalOnError(err, "while creating Metrics Upgrade Test")
 
-	// aInjector, err := injector.NewAddons("end-to-end-upgrade-test", cfg.TestingAddonsURL)
-	// fatalOnError(err, "while creating addons configuration injector")
+	aInjector, err := injector.NewAddons("end-to-end-upgrade-test", cfg.TestingAddonsURL)
+	fatalOnError(err, "while creating addons configuration injector")
 
 	tests := map[string]runner.UpgradeTest{
-		// "HelmBrokerUpgradeTest":           servicecatalog.NewHelmBrokerTest(aInjector, k8sCli, scCli, buCli),
-		// "HelmBrokerConflictUpgradeTest":   servicecatalog.NewHelmBrokerConflictTest(aInjector, k8sCli, scCli, buCli),
-		// "ApplicationBrokerUpgradeTest":    servicecatalog.NewAppBrokerUpgradeTest(scCli, k8sCli, buCli, appBrokerCli, appConnectorCli, messagingCli),
-		// "GrafanaUpgradeTest":              monitoring.NewGrafanaUpgradeTest(k8sCli),
-		"MetricsUpgradeTest": metricUpgradeTest,
-		// "MicrofrontendUpgradeTest":        ui.NewMicrofrontendUpgradeTest(mfCli),
-		// "ClusterMicrofrontendUpgradeTest": ui.NewClusterMicrofrontendUpgradeTest(mfCli),
-		// "ApiGatewayUpgradeTest":           apigateway.NewApiGatewayTest(k8sCli, dynamicCli, domainName, dexConfig.IdProviderConfig()),
-		// "ApplicationOperatorUpgradeTest":  applicationoperator.NewApplicationOperatorUpgradeTest(appConnectorCli, *k8sCli),
-		// "RafterUpgradeTest":               rafter.NewRafterUpgradeTest(dynamicCli),
-		// "EventMeshUpgradeTest":            eventmesh.NewEventMeshUpgradeTest(appConnectorCli, k8sCli, messagingCli, servingCli, appBrokerCli, scCli, eventingCli),
+		"HelmBrokerUpgradeTest":           servicecatalog.NewHelmBrokerTest(aInjector, k8sCli, scCli, buCli),
+		"HelmBrokerConflictUpgradeTest":   servicecatalog.NewHelmBrokerConflictTest(aInjector, k8sCli, scCli, buCli),
+		"ApplicationBrokerUpgradeTest":    servicecatalog.NewAppBrokerUpgradeTest(scCli, k8sCli, buCli, appBrokerCli, appConnectorCli, messagingCli),
+		"GrafanaUpgradeTest":              monitoring.NewGrafanaUpgradeTest(k8sCli),
+		"TargetsAndRulesUpgradeTest":      monitoring.NewTargetsAndRulesTest(k8sCli),
+		"MetricsUpgradeTest":              metricUpgradeTest,
+		"MicrofrontendUpgradeTest":        ui.NewMicrofrontendUpgradeTest(mfCli),
+		"ClusterMicrofrontendUpgradeTest": ui.NewClusterMicrofrontendUpgradeTest(mfCli),
+		"ApiGatewayUpgradeTest":           apigateway.NewApiGatewayTest(k8sCli, dynamicCli, domainName, dexConfig.IdProviderConfig()),
+		"ApplicationOperatorUpgradeTest":  applicationoperator.NewApplicationOperatorUpgradeTest(appConnectorCli, *k8sCli),
+		"RafterUpgradeTest":               rafter.NewRafterUpgradeTest(dynamicCli),
+		"EventMeshUpgradeTest":            eventmesh.NewEventMeshUpgradeTest(appConnectorCli, k8sCli, messagingCli, servingCli, appBrokerCli, scCli, eventingCli),
 		//"LoggingUpgradeTest":            logging.NewLoggingTest(k8sCli, domainName, dexConfig.IdProviderConfig()),
 	}
 	tRegistry, err := runner.NewConfigMapTestRegistry(k8sCli, cfg.WorkingNamespace, cfg.TestsInfoConfigMapName)

--- a/tests/end-to-end/upgrade/main.go
+++ b/tests/end-to-end/upgrade/main.go
@@ -5,40 +5,22 @@ import (
 	"fmt"
 	"time"
 
-	sc "github.com/kubernetes-incubator/service-catalog/pkg/client/clientset_generated/clientset"
-
-	eventingclientv1alpha1 "knative.dev/eventing/pkg/client/clientset/versioned/typed/eventing/v1alpha1"
-	messagingclientv1alpha1 "knative.dev/eventing/pkg/client/clientset/versioned/typed/messaging/v1alpha1"
-	servingclientset "knative.dev/serving/pkg/client/clientset/versioned"
-
 	"github.com/sirupsen/logrus"
 	"github.com/vrischmann/envconfig"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/client-go/dynamic"
 	k8sclientset "k8s.io/client-go/kubernetes"
 	restClient "k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 
 	"github.com/pkg/errors"
 
-	mfClient "github.com/kyma-project/kyma/common/microfrontend-client/pkg/client/clientset/versioned"
-	ab "github.com/kyma-project/kyma/components/application-broker/pkg/client/clientset/versioned"
-	ao "github.com/kyma-project/kyma/components/application-operator/pkg/client/clientset/versioned"
 	"github.com/kyma-project/kyma/components/kyma-operator/pkg/overrides"
-	bu "github.com/kyma-project/kyma/components/service-binding-usage-controller/pkg/client/clientset/versioned"
 	dex "github.com/kyma-project/kyma/tests/end-to-end/backup-restore-test/utils/fetch-dex-token"
 	"github.com/kyma-project/kyma/tests/end-to-end/upgrade/internal/platform/logger"
 	"github.com/kyma-project/kyma/tests/end-to-end/upgrade/internal/platform/signal"
 	"github.com/kyma-project/kyma/tests/end-to-end/upgrade/internal/runner"
-	"github.com/kyma-project/kyma/tests/end-to-end/upgrade/pkg/injector"
-	apigateway "github.com/kyma-project/kyma/tests/end-to-end/upgrade/pkg/tests/api-gateway"
-	applicationoperator "github.com/kyma-project/kyma/tests/end-to-end/upgrade/pkg/tests/application-operator"
-	"github.com/kyma-project/kyma/tests/end-to-end/upgrade/pkg/tests/eventmesh"
 	"github.com/kyma-project/kyma/tests/end-to-end/upgrade/pkg/tests/monitoring"
-	"github.com/kyma-project/kyma/tests/end-to-end/upgrade/pkg/tests/rafter"
-	servicecatalog "github.com/kyma-project/kyma/tests/end-to-end/upgrade/pkg/tests/service-catalog"
-	"github.com/kyma-project/kyma/tests/end-to-end/upgrade/pkg/tests/ui"
 	"github.com/kyma-project/kyma/tests/end-to-end/upgrade/pkg/waiter"
 )
 
@@ -85,38 +67,38 @@ func main() {
 	k8sCli, err := k8sclientset.NewForConfig(k8sConfig)
 	fatalOnError(err, "while creating k8s clientset")
 
-	scCli, err := sc.NewForConfig(k8sConfig)
-	fatalOnError(err, "while creating Service Catalog clientset")
+	// scCli, err := sc.NewForConfig(k8sConfig)
+	// fatalOnError(err, "while creating Service Catalog clientset")
 
-	buCli, err := bu.NewForConfig(k8sConfig)
-	fatalOnError(err, "while creating Binding Usage clientset")
+	// buCli, err := bu.NewForConfig(k8sConfig)
+	// fatalOnError(err, "while creating Binding Usage clientset")
 
-	appConnectorCli, err := ao.NewForConfig(k8sConfig)
-	fatalOnError(err, "while creating Application Connector clientset")
+	// appConnectorCli, err := ao.NewForConfig(k8sConfig)
+	// fatalOnError(err, "while creating Application Connector clientset")
 
-	appBrokerCli, err := ab.NewForConfig(k8sConfig)
-	fatalOnError(err, "while creating Application Broker clientset")
+	// appBrokerCli, err := ab.NewForConfig(k8sConfig)
+	// fatalOnError(err, "while creating Application Broker clientset")
 
-	messagingCli, err := messagingclientv1alpha1.NewForConfig(k8sConfig)
-	fatalOnError(err, "while creating knative Messaging clientset")
+	// messagingCli, err := messagingclientv1alpha1.NewForConfig(k8sConfig)
+	// fatalOnError(err, "while creating knative Messaging clientset")
 
-	domainName, err := getDomainNameFromCluster(k8sCli)
-	fatalOnError(err, "while reading domain name from cluster")
+	// domainName, err := getDomainNameFromCluster(k8sCli)
+	// fatalOnError(err, "while reading domain name from cluster")
 
-	mfCli, err := mfClient.NewForConfig(k8sConfig)
-	fatalOnError(err, "while creating Microfrontends clientset")
+	// mfCli, err := mfClient.NewForConfig(k8sConfig)
+	// fatalOnError(err, "while creating Microfrontends clientset")
 
-	dynamicCli, err := dynamic.NewForConfig(k8sConfig)
-	fatalOnError(err, "while creating K8s Dynamic client")
+	// dynamicCli, err := dynamic.NewForConfig(k8sConfig)
+	// fatalOnError(err, "while creating K8s Dynamic client")
 
-	dexConfig, err := getDexConfigFromCluster(k8sCli, cfg.DexUserSecret, cfg.DexNamespace, domainName)
-	fatalOnError(err, "while reading dex config from cluster")
+	// dexConfig, err := getDexConfigFromCluster(k8sCli, cfg.DexUserSecret, cfg.DexNamespace, domainName)
+	// fatalOnError(err, "while reading dex config from cluster")
 
-	servingCli, err := servingclientset.NewForConfig(k8sConfig)
-	fatalOnError(err, "while generating knative serving client")
+	// servingCli, err := servingclientset.NewForConfig(k8sConfig)
+	// fatalOnError(err, "while generating knative serving client")
 
-	eventingCli, err := eventingclientv1alpha1.NewForConfig(k8sConfig)
-	fatalOnError(err, "while generating knative eventing client")
+	// eventingCli, err := eventingclientv1alpha1.NewForConfig(k8sConfig)
+	// fatalOnError(err, "while generating knative eventing client")
 
 	// Register tests. Convention:
 	// <test-name> : <test-instance>
@@ -125,25 +107,24 @@ func main() {
 	// Test name is sanitized and used for creating dedicated namespace for given test,
 	// so it cannot overlap with others.
 
-	// metricUpgradeTest, err := monitoring.NewMetricsUpgradeTest(k8sCli)
-	// fatalOnError(err, "while creating Metrics Upgrade Test")
+	metricUpgradeTest, err := monitoring.NewMetricsUpgradeTest(k8sCli)
+	fatalOnError(err, "while creating Metrics Upgrade Test")
 
-	aInjector, err := injector.NewAddons("end-to-end-upgrade-test", cfg.TestingAddonsURL)
-	fatalOnError(err, "while creating addons configuration injector")
+	// aInjector, err := injector.NewAddons("end-to-end-upgrade-test", cfg.TestingAddonsURL)
+	// fatalOnError(err, "while creating addons configuration injector")
 
 	tests := map[string]runner.UpgradeTest{
-		"HelmBrokerUpgradeTest":         servicecatalog.NewHelmBrokerTest(aInjector, k8sCli, scCli, buCli),
-		"HelmBrokerConflictUpgradeTest": servicecatalog.NewHelmBrokerConflictTest(aInjector, k8sCli, scCli, buCli),
-		"ApplicationBrokerUpgradeTest":  servicecatalog.NewAppBrokerUpgradeTest(scCli, k8sCli, buCli, appBrokerCli, appConnectorCli, messagingCli),
-		"GrafanaUpgradeTest":            monitoring.NewGrafanaUpgradeTest(k8sCli),
-		"TargetsAndRulesUpgradeTest":    monitoring.NewTargetsAndRulesTest(k8sCli),
-		//"MetricsUpgradeTest":            metricUpgradeTest,
-		"MicrofrontendUpgradeTest":        ui.NewMicrofrontendUpgradeTest(mfCli),
-		"ClusterMicrofrontendUpgradeTest": ui.NewClusterMicrofrontendUpgradeTest(mfCli),
-		"ApiGatewayUpgradeTest":           apigateway.NewApiGatewayTest(k8sCli, dynamicCli, domainName, dexConfig.IdProviderConfig()),
-		"ApplicationOperatorUpgradeTest":  applicationoperator.NewApplicationOperatorUpgradeTest(appConnectorCli, *k8sCli),
-		"RafterUpgradeTest":               rafter.NewRafterUpgradeTest(dynamicCli),
-		"EventMeshUpgradeTest":            eventmesh.NewEventMeshUpgradeTest(appConnectorCli, k8sCli, messagingCli, servingCli, appBrokerCli, scCli, eventingCli),
+		// "HelmBrokerUpgradeTest":           servicecatalog.NewHelmBrokerTest(aInjector, k8sCli, scCli, buCli),
+		// "HelmBrokerConflictUpgradeTest":   servicecatalog.NewHelmBrokerConflictTest(aInjector, k8sCli, scCli, buCli),
+		// "ApplicationBrokerUpgradeTest":    servicecatalog.NewAppBrokerUpgradeTest(scCli, k8sCli, buCli, appBrokerCli, appConnectorCli, messagingCli),
+		// "GrafanaUpgradeTest":              monitoring.NewGrafanaUpgradeTest(k8sCli),
+		"MetricsUpgradeTest": metricUpgradeTest,
+		// "MicrofrontendUpgradeTest":        ui.NewMicrofrontendUpgradeTest(mfCli),
+		// "ClusterMicrofrontendUpgradeTest": ui.NewClusterMicrofrontendUpgradeTest(mfCli),
+		// "ApiGatewayUpgradeTest":           apigateway.NewApiGatewayTest(k8sCli, dynamicCli, domainName, dexConfig.IdProviderConfig()),
+		// "ApplicationOperatorUpgradeTest":  applicationoperator.NewApplicationOperatorUpgradeTest(appConnectorCli, *k8sCli),
+		// "RafterUpgradeTest":               rafter.NewRafterUpgradeTest(dynamicCli),
+		// "EventMeshUpgradeTest":            eventmesh.NewEventMeshUpgradeTest(appConnectorCli, k8sCli, messagingCli, servingCli, appBrokerCli, scCli, eventingCli),
 		//"LoggingUpgradeTest":            logging.NewLoggingTest(k8sCli, domainName, dexConfig.IdProviderConfig()),
 	}
 	tRegistry, err := runner.NewConfigMapTestRegistry(k8sCli, cfg.WorkingNamespace, cfg.TestsInfoConfigMapName)

--- a/tests/end-to-end/upgrade/pkg/tests/monitoring/metrics.go
+++ b/tests/end-to-end/upgrade/pkg/tests/monitoring/metrics.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"log"
+	myLogger "log"
 	"time"
 
 	prometheus "github.com/prometheus/client_golang/api"
@@ -57,7 +57,7 @@ func (ut *MetricsUpgradeTest) CreateResources(stop <-chan struct{}, log logrus.F
 	if err != nil {
 		return err
 	}
-	log.Printf("data before storing: %v", result)
+	myLogger.Printf("data before storing: %v", result)
 	err = ut.storeMetrics(result, time)
 	if err != nil {
 		return err
@@ -66,7 +66,7 @@ func (ut *MetricsUpgradeTest) CreateResources(stop <-chan struct{}, log logrus.F
 	if err != nil {
 		return err
 	}
-	log.Printf("data retrieved from configmap before upgrade: %v:", data)
+	myLogger.Printf("data retrieved from configmap before upgrade: %v:", data)
 	return nil
 }
 
@@ -135,7 +135,7 @@ func (ut *MetricsUpgradeTest) retrievePreviousMetrics() (time.Time, model.Vector
 
 func (ut *MetricsUpgradeTest) compareMetrics() error {
 	time, previous, err := ut.retrievePreviousMetrics()
-	log.Printf("data retrieved from configmap after upgrade: %v:", previous)
+	myLogger.Printf("data retrieved from configmap after upgrade: %v:", previous)
 	if err != nil {
 		return err
 	}

--- a/tests/end-to-end/upgrade/pkg/tests/monitoring/metrics.go
+++ b/tests/end-to-end/upgrade/pkg/tests/monitoring/metrics.go
@@ -52,7 +52,7 @@ func (ut *MetricsUpgradeTest) CreateResources(stop <-chan struct{}, log logrus.F
 	ut.namespace = namespace
 	ut.log = log
 
-	time := time.Now().Add(-time.Minute)
+	time := time.Now()
 	result, err := ut.collectMetrics(time)
 	if err != nil {
 		return err

--- a/tests/end-to-end/upgrade/pkg/tests/monitoring/metrics.go
+++ b/tests/end-to-end/upgrade/pkg/tests/monitoring/metrics.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"log"
 	"time"
 
 	prometheus "github.com/prometheus/client_golang/api"
@@ -56,8 +57,17 @@ func (ut *MetricsUpgradeTest) CreateResources(stop <-chan struct{}, log logrus.F
 	if err != nil {
 		return err
 	}
+	log.Printf("data before storing: %v", result)
 	err = ut.storeMetrics(result, time)
-	return err
+	if err != nil {
+		return err
+	}
+	_, data, err := ut.retrievePreviousMetrics()
+	if err != nil {
+		return err
+	}
+	log.Printf("data retrieved from configmap before upgrade: %v:", data)
+	return nil
 }
 
 // TestResources retrieves previously installed metrics values and compares it to the metrics returned for the same query and the same time
@@ -125,6 +135,7 @@ func (ut *MetricsUpgradeTest) retrievePreviousMetrics() (time.Time, model.Vector
 
 func (ut *MetricsUpgradeTest) compareMetrics() error {
 	time, previous, err := ut.retrievePreviousMetrics()
+	log.Printf("data retrieved from configmap after upgrade: %v:", previous)
 	if err != nil {
 		return err
 	}

--- a/tests/end-to-end/upgrade/pkg/tests/monitoring/metrics.go
+++ b/tests/end-to-end/upgrade/pkg/tests/monitoring/metrics.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	myLogger "log"
 	"time"
 
 	prometheus "github.com/prometheus/client_golang/api"
@@ -57,17 +56,8 @@ func (ut *MetricsUpgradeTest) CreateResources(stop <-chan struct{}, log logrus.F
 	if err != nil {
 		return err
 	}
-	myLogger.Printf("data before storing: %v", result)
 	err = ut.storeMetrics(result, time)
-	if err != nil {
-		return err
-	}
-	_, data, err := ut.retrievePreviousMetrics()
-	if err != nil {
-		return err
-	}
-	myLogger.Printf("data retrieved from configmap before upgrade: %v:", data)
-	return nil
+	return err
 }
 
 // TestResources retrieves previously installed metrics values and compares it to the metrics returned for the same query and the same time
@@ -135,7 +125,6 @@ func (ut *MetricsUpgradeTest) retrievePreviousMetrics() (time.Time, model.Vector
 
 func (ut *MetricsUpgradeTest) compareMetrics() error {
 	time, previous, err := ut.retrievePreviousMetrics()
-	myLogger.Printf("data retrieved from configmap after upgrade: %v:", previous)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/master/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- The time used for prometheus query was `time.Now().Add(-time.Minute)` which lead to getting an empty result from prometheus. Now, the time used is changed to `time.Now()` which results in getting a non-empty result from prometheus

- Enabled back Metrics upgrade test

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
#8216