### PR TITLE
Add more memory

### DIFF
--- a/resources/apiserver-proxy/charts/apiserver-proxy-init/templates/generate-certs-job.yaml
+++ b/resources/apiserver-proxy/charts/apiserver-proxy-init/templates/generate-certs-job.yaml
@@ -24,6 +24,11 @@ spec:
       containers:
       - name: generate-certs
         image: {{ .Values.global.containerRegistry.path }}/{{ .Values.global.xip_patch.dir }}xip-patch:{{ .Values.global.xip_patch.version }}
+        resources:
+          limits:
+            memory: 128Mi
+          requests:
+            memory: 32Mi
         envFrom:
         - configMapRef:
             name: {{ template "name" . }}


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/master/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**
- Looks like kubectl on gardener in the current job has not enough memory when applying configmap.

It's reproducible when you limit memory to 56 min constantly. With current 96 it happens quite often...
I was playing around, trying to find how much kubectl on gardener needs for such a simple operation...
128 seems to be enough.
Changes proposed in this pull request:


- Higher memory limits than the one from limit ranges


**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
