### PR TITLE
Add liveness/readiness probe to compass runtime agent

### DIFF
--- a/resources/compass-runtime-agent/templates/deployment.yaml
+++ b/resources/compass-runtime-agent/templates/deployment.yaml
@@ -69,3 +69,17 @@ spec:
             - "compass-gateway.{{ .Values.global.ingress.domainName }}"
             - "compass-gateway-mtls.{{ .Values.global.ingress.domainName }}"
       {{ end }}
+      livenessProbe:
+        httpGet:
+          port: {{ .Values.compassRuntimeAgent.healthCheck.port }}
+          path: "/healthz"
+        initialDelaySeconds: {{ .Values.compassRuntimeAgent.livenessProbe.initialDelaySeconds }}
+        timeoutSeconds: {{ .Values.compassRuntimeAgent.livenessProbe.timeoutSeconds }}
+        periodSeconds: {{.Values.compassRuntimeAgent.livenessProbe.periodSeconds }}
+      readinessProbe:
+        httpGet:
+          port: {{.Values.compassRuntimeAgent.healthCheck.port }}
+          path: "/healthz"
+        initialDelaySeconds: {{ .Values.compassRuntimeAgent.readinessProbe.initialDelaySeconds }}
+        timeoutSeconds: {{ .Values.compassRuntimeAgent.readinessProbe.timeoutSeconds }}
+        periodSeconds: {{.Values.compassRuntimeAgent.readinessProbe.periodSeconds }}

--- a/resources/compass-runtime-agent/templates/service.yaml
+++ b/resources/compass-runtime-agent/templates/service.yaml
@@ -27,6 +27,9 @@ spec:
     - port: {{ .Values.compassRuntimeAgent.healthCheck.port }}
       protocol: TCP
       name: http-health
+    - port: {{ .Values.compassRuntimeAgent.healthCheck.proxyStatusPort }}
+      protocol: TCP
+      name: proxy-status
   selector:
     app: {{ .Chart.Name }}
     release: {{ .Release.Name }}

--- a/resources/compass-runtime-agent/values.yaml
+++ b/resources/compass-runtime-agent/values.yaml
@@ -58,6 +58,7 @@ compassRuntimeAgent:
     loggingTimeInterval: 30m
   healthCheck:
     port: 8090
+    proxyStatusPort: 15020
   tests:
     enabled: true
     mockService:
@@ -70,3 +71,11 @@ compassRuntimeAgent:
       url: "https://compass-gateway.{{ .Values.global.ingress.domainName }}/director/graphql"
     idProvider:
       clientTimeout: 10s
+  livenessProbe:
+    initialDelaySeconds: 30
+    timeoutSeconds: 1
+    periodSeconds: 10
+  readinessProbe:
+    initialDelaySeconds: 5
+    timeoutSeconds: 1
+    periodSeconds: 2


### PR DESCRIPTION
**Description**
Add liveness/readiness probe to compass runtime agent

Changes proposed in this pull request:
- Configure `:8090/healthz` as both liveness and readiness probe
- Expose istio proxy-status port on health `Service` so that other pods outside of the Istio service mesh (blackbox-exporter) could probe the runtime-agent health endpoint successfully through istio proxy (due to the [Istio probe rewrite](https://istio.io/docs/ops/configuration/mesh/app-health-check/#probe-rewrite) feature)


**Related issue(s)**
https://github.com/kyma-project/kyma/issues/8322
