### PR TITLE
use templating in kiali and jaeger CR to support complex overrides

### DIFF
--- a/resources/kiali/templates/kiali.yaml
+++ b/resources/kiali/templates/kiali.yaml
@@ -9,7 +9,5 @@ metadata:
     chart: {{ template "kiali.chart" . }}
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
-{{- with .Values.kiali.spec }}
 spec:
-{{ toYaml . | indent 2}}
-{{- end }}
+{{ tpl (toYaml .Values.kiali.spec | indent 2) . }}

--- a/resources/tracing/templates/jaeger.yaml
+++ b/resources/tracing/templates/jaeger.yaml
@@ -3,10 +3,8 @@ apiVersion: jaegertracing.io/v1
 kind: Jaeger
 metadata:
   name: {{ include "jaeger-operator.fullname" . }}-jaeger
-{{- with .Values.jaeger.spec }}
 spec:
-{{ toYaml . | indent 2}}
-{{- end }}
+{{ tpl (toYaml .Values.jaeger.spec | indent 2) . }}
 {{- /*
   Customization: This if block was added to support for badger PVs.
 */ -}}


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/master/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- The configuration for kiali and jaeger requires complex structures like arrays or objects. I added the template function for the CR rendering so that such structures can be configured via overrides
- ...
- ...

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
