### PR TITLE
Workaround knative-eventing bug for retry

### DIFF
--- a/resources/knative-eventing-kafka/values.yaml
+++ b/resources/knative-eventing-kafka/values.yaml
@@ -11,7 +11,7 @@ image:
   controller: kafka-channel-controller
   dispatcher: knative-kafka-dispatcher
   channel: knative-kafka-channel
-  tag: v0.12.1
+  tag: v0.12.2
   pullPolicy: Always
 
 # Networking Configuration for the Pods container and the K8S Service


### PR DESCRIPTION

**Description**
Fix for #341, bumps the knative-kafka version.  This is a workaround for a knative-eventing bug where the filter service does not propagate the HTTP status to the dispatcher.  This bug was preventing the dispatcher from retrying.

