### PR TITLE
Make retry configurable and fix "core-test-external-solution-event-mesh" test

### DIFF
--- a/resources/core/templates/tests/test-external-solution.yaml
+++ b/resources/core/templates/tests/test-external-solution.yaml
@@ -1,4 +1,5 @@
 {{- if .Values.test.external_solution.event_mesh.enabled }}
+{{- $val := .Values.test.external_solution -}}
 ---
 apiVersion: "testing.kyma-project.io/v1alpha1"
 kind: TestDefinition

--- a/resources/core/templates/tests/test-external-solution.yaml
+++ b/resources/core/templates/tests/test-external-solution.yaml
@@ -4,11 +4,11 @@
 apiVersion: "testing.kyma-project.io/v1alpha1"
 kind: TestDefinition
 metadata:
-  name: {{ $.Chart.Name }}-test-external-solution-{{ $suffix | replace "_" "-" }}
+  name: {{ $.Chart.Name }}-test-external-solution
   labels:
     kyma-project.io/test-kind: e2e
     app: {{ $.Chart.Name }}-test-external-solution
-    app.kubernetes.io/name: {{ $.Chart.Name }}-test-external-solution-{{ $suffix | replace "_" "-" }}
+    app.kubernetes.io/name: {{ $.Chart.Name }}-test-external-solution
     app.kubernetes.io/managed-by: {{ $.Release.Service }}
     app.kubernetes.io/instance: {{ $.Release.Name }}
     helm.sh/chart: {{ $.Chart.Name }}-{{ $.Chart.Version | replace "+" "_" }}

--- a/resources/core/templates/tests/test-external-solution.yaml
+++ b/resources/core/templates/tests/test-external-solution.yaml
@@ -1,5 +1,5 @@
-{{- if .Values.test.external_solution.event_mesh.enabled }}
-{{- $val := .Values.test.external_solution -}}
+{{- range $suffix, $val := .Values.test.external_solution }}
+  {{- if and ( $val.enabled ) ( $.Capabilities.APIVersions.Has "testing.kyma-project.io/v1alpha1" ) }}
 ---
 apiVersion: "testing.kyma-project.io/v1alpha1"
 kind: TestDefinition
@@ -54,4 +54,5 @@ spec:
               curl -XPOST http://127.0.0.1:15020/quitquitquit
               sleep 4
               exit $exit_code
+  {{- end}}
 {{- end }}

--- a/resources/core/templates/tests/test-external-solution.yaml
+++ b/resources/core/templates/tests/test-external-solution.yaml
@@ -1,5 +1,4 @@
-{{- range $suffix, $val := .Values.test.external_solution }}
-  {{- if and ( $val.enabled ) ( $.Capabilities.APIVersions.Has "testing.kyma-project.io/v1alpha1" ) }}
+{{- if .Values.test.external_solution.event_mesh.enabled }}
 ---
 apiVersion: "testing.kyma-project.io/v1alpha1"
 kind: TestDefinition
@@ -54,5 +53,4 @@ spec:
               curl -XPOST http://127.0.0.1:15020/quitquitquit
               sleep 4
               exit $exit_code
-  {{- end}}
 {{- end }}

--- a/tests/end-to-end/external-solution-integration/cmd/fakelambda/main.go
+++ b/tests/end-to-end/external-solution-integration/cmd/fakelambda/main.go
@@ -8,8 +8,9 @@ import (
 	"os"
 	"strings"
 
-	"github.com/kyma-project/kyma/tests/end-to-end/external-solution-integration/pkg/testsuite"
 	"github.com/sirupsen/logrus"
+
+	"github.com/kyma-project/kyma/tests/end-to-end/external-solution-integration/pkg/testsuite"
 )
 
 type cfg struct {

--- a/tests/end-to-end/external-solution-integration/internal/http/cloudevent_client.go
+++ b/tests/end-to-end/external-solution-integration/internal/http/cloudevent_client.go
@@ -27,7 +27,7 @@ func NewWrappedCloudEventClient(ceClient cloudevents.Client, opts ...retrygo.Opt
 }
 
 func (c *WrappedCloudEventClient) Send(ctx context.Context, event cloudevents.Event) (ct context.Context, evt *cloudevents.Event, err error) {
-	err = retry.WithCustomOpts(func() error {
+	err = retry.Do(func() error {
 		ct, evt, err = c.underlying.Send(ctx, event)
 		return err
 	}, c.options...)

--- a/tests/end-to-end/external-solution-integration/internal/http/cloudevent_client.go
+++ b/tests/end-to-end/external-solution-integration/internal/http/cloudevent_client.go
@@ -2,12 +2,21 @@ package http
 
 import (
 	"context"
+	"time"
 
 	retrygo "github.com/avast/retry-go"
 	cloudevents "github.com/cloudevents/sdk-go"
 
 	"github.com/kyma-project/kyma/tests/end-to-end/external-solution-integration/pkg/retry"
 )
+
+const retryAttemptsCount = 20
+const retryDelay = 250 * time.Millisecond
+
+var defaultOpts = []retrygo.Option{
+	retrygo.Attempts(retryAttemptsCount),
+	retrygo.Delay(retryDelay),
+}
 
 type WrappedCloudEventClient struct {
 	underlying cloudevents.Client
@@ -21,7 +30,7 @@ type ResilientCloudEventClient interface {
 func NewWrappedCloudEventClient(ceClient cloudevents.Client, opts ...retrygo.Option) *WrappedCloudEventClient {
 	var client = &WrappedCloudEventClient{
 		underlying: ceClient,
-		options:    opts,
+		options:    append(defaultOpts, opts...),
 	}
 	return client
 }

--- a/tests/end-to-end/external-solution-integration/internal/scenario/event_mesh/event_mesh.go
+++ b/tests/end-to-end/external-solution-integration/internal/scenario/event_mesh/event_mesh.go
@@ -2,6 +2,13 @@ package event_mesh
 
 import (
 	servicecatalogclientset "github.com/kubernetes-incubator/service-catalog/pkg/client/clientset_generated/clientset"
+	log "github.com/sirupsen/logrus"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/dynamic"
+	k8s "k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+	eventingclientset "knative.dev/eventing/pkg/client/clientset/versioned"
+
 	appbrokerclientset "github.com/kyma-project/kyma/components/application-broker/pkg/client/clientset/versioned"
 	appoperatorclientset "github.com/kyma-project/kyma/components/application-operator/pkg/client/clientset/versioned"
 	connectiontokenhandlerclientset "github.com/kyma-project/kyma/components/connection-token-handler/pkg/client/clientset/versioned"
@@ -12,12 +19,6 @@ import (
 	"github.com/kyma-project/kyma/tests/end-to-end/external-solution-integration/pkg/step"
 	"github.com/kyma-project/kyma/tests/end-to-end/external-solution-integration/pkg/testkit"
 	"github.com/kyma-project/kyma/tests/end-to-end/external-solution-integration/pkg/testsuite"
-	log "github.com/sirupsen/logrus"
-	"k8s.io/apimachinery/pkg/runtime/schema"
-	"k8s.io/client-go/dynamic"
-	k8s "k8s.io/client-go/kubernetes"
-	"k8s.io/client-go/rest"
-	eventingclientset "knative.dev/eventing/pkg/client/clientset/versioned"
 )
 
 const (

--- a/tests/end-to-end/external-solution-integration/internal/scenario/event_mesh/event_mesh.go
+++ b/tests/end-to-end/external-solution-integration/internal/scenario/event_mesh/event_mesh.go
@@ -1,8 +1,6 @@
 package event_mesh
 
 import (
-	"time"
-
 	servicecatalogclientset "github.com/kubernetes-incubator/service-catalog/pkg/client/clientset_generated/clientset"
 	appbrokerclientset "github.com/kyma-project/kyma/components/application-broker/pkg/client/clientset/versioned"
 	appoperatorclientset "github.com/kyma-project/kyma/components/application-operator/pkg/client/clientset/versioned"
@@ -29,7 +27,6 @@ const (
 
 var (
 	apiRuleRes = schema.GroupVersionResource{Group: "gateway.kyma-project.io", Version: "v1alpha1", Resource: "apirules"}
-	sleep      = func(s *Scenario) time.Duration { return time.Duration(s.waitTime) * time.Second }
 )
 
 // Steps return scenario steps
@@ -76,7 +73,7 @@ func (s *Scenario) Steps(config *rest.Config) ([]step.Step, error) {
 			coreClientset.CoreV1().Pods(s.testID),
 			true),
 		testsuite.NewStartTestServer(testService),
-		testsuite.NewSleep(sleep(s)),
+		testsuite.NewSleep(s.waitTime),
 		testsuite.NewConnectApplication(connector, state, s.applicationTenant, s.applicationGroup),
 		testsuite.NewRegisterTestService(s.testID, testService, state),
 		testsuite.NewCreateLegacyServiceInstance(s.testID, s.testID, state.GetServiceClassID,
@@ -86,9 +83,9 @@ func (s *Scenario) Steps(config *rest.Config) ([]step.Step, error) {
 		testsuite.NewCreateServiceBindingUsage(s.testID, s.testID, s.testID,
 			serviceBindingUsageClientset.ServicecatalogV1alpha1().ServiceBindingUsages(s.testID),
 			knativeEventingClientSet.EventingV1alpha1().Brokers(s.testID), knativeEventingClientSet.MessagingV1alpha1().Subscriptions(kymaIntegrationNamespace)),
-		testsuite.NewSleep(sleep(s)),
+		testsuite.NewSleep(s.waitTime),
 		testsuite.NewCreateKnativeTrigger(s.testID, defaultBrokerName, lambdaEndpoint, knativeEventingClientSet.EventingV1alpha1().Triggers(s.testID)),
-		testsuite.NewSleep(sleep(s)),
+		testsuite.NewSleep(s.waitTime),
 		testsuite.NewSendEventToMesh(s.testID, helpers.LambdaPayload, state),
 		NewWrappedCounterPod(testService, 1),
 		testsuite.NewSendEventToCompatibilityLayer(s.testID, helpers.LambdaPayload, state),

--- a/tests/end-to-end/external-solution-integration/internal/scenario/event_mesh/event_mesh.go
+++ b/tests/end-to-end/external-solution-integration/internal/scenario/event_mesh/event_mesh.go
@@ -87,8 +87,8 @@ func (s *Scenario) Steps(config *rest.Config) ([]step.Step, error) {
 			knativeEventingClientSet.EventingV1alpha1().Brokers(s.testID), knativeEventingClientSet.MessagingV1alpha1().Subscriptions(kymaIntegrationNamespace)),
 		testsuite.NewCreateKnativeTrigger(s.testID, defaultBrokerName, lambdaEndpoint, knativeEventingClientSet.EventingV1alpha1().Triggers(s.testID)),
 		testsuite.NewSendEventToMesh(s.testID, helpers.LambdaPayload, state),
-		testsuite.NewCheckCounterPod(testService, 1),
+		NewWrappedCounterPod(testService, 1),
 		testsuite.NewSendEventToCompatibilityLayer(s.testID, helpers.LambdaPayload, state),
-		testsuite.NewCheckCounterPod(testService, 2),
+		NewWrappedCounterPod(testService, 2),
 	}, nil
 }

--- a/tests/end-to-end/external-solution-integration/internal/scenario/event_mesh/scenario.go
+++ b/tests/end-to-end/external-solution-integration/internal/scenario/event_mesh/scenario.go
@@ -3,8 +3,9 @@ package event_mesh
 import (
 	"time"
 
-	"github.com/kyma-project/kyma/tests/end-to-end/external-solution-integration/internal/scenario"
 	"github.com/spf13/pflag"
+
+	"github.com/kyma-project/kyma/tests/end-to-end/external-solution-integration/internal/scenario"
 )
 
 // E2EScenario executes complete external solution integration test scenario

--- a/tests/end-to-end/external-solution-integration/internal/scenario/event_mesh/scenario.go
+++ b/tests/end-to-end/external-solution-integration/internal/scenario/event_mesh/scenario.go
@@ -13,6 +13,7 @@ type Scenario struct {
 	skipSSLVerify     bool
 	applicationTenant string
 	applicationGroup  string
+	waitTime          int
 }
 
 // AddFlags adds CLI flags to given FlagSet
@@ -22,6 +23,7 @@ func (s *Scenario) AddFlags(set *pflag.FlagSet) {
 	pflag.BoolVar(&s.skipSSLVerify, "skipSSLVerify", false, "Skip verification of service SSL certificates")
 	pflag.StringVar(&s.applicationTenant, "applicationTenant", "", "Application CR Tenant")
 	pflag.StringVar(&s.applicationGroup, "applicationGroup", "", "Application CR Group")
+	pflag.IntVar(&s.waitTime, "waitTime", 10, "Wait time in seconds")
 }
 
 func (s *Scenario) NewState() *state {

--- a/tests/end-to-end/external-solution-integration/internal/scenario/event_mesh/scenario.go
+++ b/tests/end-to-end/external-solution-integration/internal/scenario/event_mesh/scenario.go
@@ -1,9 +1,10 @@
 package event_mesh
 
 import (
-	"github.com/spf13/pflag"
+	"time"
 
 	"github.com/kyma-project/kyma/tests/end-to-end/external-solution-integration/internal/scenario"
+	"github.com/spf13/pflag"
 )
 
 // E2EScenario executes complete external solution integration test scenario
@@ -13,7 +14,7 @@ type Scenario struct {
 	skipSSLVerify     bool
 	applicationTenant string
 	applicationGroup  string
-	waitTime          int
+	waitTime          time.Duration
 }
 
 // AddFlags adds CLI flags to given FlagSet
@@ -23,7 +24,7 @@ func (s *Scenario) AddFlags(set *pflag.FlagSet) {
 	pflag.BoolVar(&s.skipSSLVerify, "skipSSLVerify", false, "Skip verification of service SSL certificates")
 	pflag.StringVar(&s.applicationTenant, "applicationTenant", "", "Application CR Tenant")
 	pflag.StringVar(&s.applicationGroup, "applicationGroup", "", "Application CR Group")
-	pflag.IntVar(&s.waitTime, "waitTime", 10, "Wait time in seconds")
+	s.waitTime = time.Duration(*pflag.Int("waitTime", 10, "Wait time in seconds")) * time.Second
 }
 
 func (s *Scenario) NewState() *state {

--- a/tests/end-to-end/external-solution-integration/internal/scenario/event_mesh/wrapper_counter_pod.go
+++ b/tests/end-to-end/external-solution-integration/internal/scenario/event_mesh/wrapper_counter_pod.go
@@ -4,6 +4,7 @@ import (
 	"time"
 
 	retrygo "github.com/avast/retry-go"
+
 	"github.com/kyma-project/kyma/tests/end-to-end/external-solution-integration/pkg/testkit"
 	"github.com/kyma-project/kyma/tests/end-to-end/external-solution-integration/pkg/testsuite"
 )

--- a/tests/end-to-end/external-solution-integration/internal/scenario/event_mesh/wrapper_counter_pod.go
+++ b/tests/end-to-end/external-solution-integration/internal/scenario/event_mesh/wrapper_counter_pod.go
@@ -1,10 +1,11 @@
 package event_mesh
 
 import (
+	"time"
+
 	retrygo "github.com/avast/retry-go"
 	"github.com/kyma-project/kyma/tests/end-to-end/external-solution-integration/pkg/testkit"
 	"github.com/kyma-project/kyma/tests/end-to-end/external-solution-integration/pkg/testsuite"
-	"time"
 )
 
 const retryAttemptsCount = 240

--- a/tests/end-to-end/external-solution-integration/internal/scenario/event_mesh/wrapper_counter_pod.go
+++ b/tests/end-to-end/external-solution-integration/internal/scenario/event_mesh/wrapper_counter_pod.go
@@ -1,0 +1,21 @@
+package event_mesh
+
+import (
+	retrygo "github.com/avast/retry-go"
+	"github.com/kyma-project/kyma/tests/end-to-end/external-solution-integration/pkg/testkit"
+	"github.com/kyma-project/kyma/tests/end-to-end/external-solution-integration/pkg/testsuite"
+	"time"
+)
+
+const retryAttemptsCount = 240
+const retryDelay = 1 * time.Second
+
+var opts = []retrygo.Option{
+	retrygo.Attempts(retryAttemptsCount),
+	retrygo.Delay(retryDelay),
+}
+
+// NewCheckCounterPod returns a new CheckCounterPod
+func NewWrappedCounterPod(testService *testkit.TestService, expectedValue int) *testsuite.CheckCounterPod {
+	return testsuite.NewCheckCounterPod(testService, expectedValue, opts...)
+}

--- a/tests/end-to-end/external-solution-integration/pkg/helpers/compass_fixtures.go
+++ b/tests/end-to-end/external-solution-integration/pkg/helpers/compass_fixtures.go
@@ -3,8 +3,9 @@ package helpers
 import (
 	"fmt"
 
-	"github.com/kyma-incubator/compass/components/director/pkg/graphql/graphqlizer"
 	gcli "github.com/machinebox/graphql"
+
+	"github.com/kyma-incubator/compass/components/director/pkg/graphql/graphqlizer"
 )
 
 type CompassFixtures struct {

--- a/tests/end-to-end/external-solution-integration/pkg/retry/retry.go
+++ b/tests/end-to-end/external-solution-integration/pkg/retry/retry.go
@@ -15,12 +15,7 @@ var defaultOpts = []retry.Option{
 	retry.DelayType(retry.FixedDelay),
 }
 
-func Do(fn retry.RetryableFunc) error {
-	return retry.Do(fn, defaultOpts...)
-}
-
-func WithCustomOpts(fn retry.RetryableFunc, opts ...retry.Option) error {
+func Do(fn retry.RetryableFunc, opts ...retry.Option) error {
 	allOpts := append(defaultOpts, opts...)
-
 	return retry.Do(fn, allOpts...)
 }

--- a/tests/end-to-end/external-solution-integration/pkg/testkit/compass_director.go
+++ b/tests/end-to-end/external-solution-integration/pkg/testkit/compass_director.go
@@ -120,7 +120,7 @@ func (dc *CompassDirectorClient) runOperation(req *gcli.Request, resp interface{
 }
 
 func (dc *CompassDirectorClient) withRetryOnTemporaryConnectionProblems(risky func() error) error {
-	return retry.WithCustomOpts(risky, retrygo.OnRetry(func(n uint, err error) {
+	return retry.Do(risky, retrygo.OnRetry(func(n uint, err error) {
 		logrus.WithField("component", "TestContext").Warnf("OnRetry: attempts: %d, error: %v", n, err)
 
 	}), retrygo.LastErrorOnly(true), retrygo.RetryIf(func(err error) bool {

--- a/tests/end-to-end/external-solution-integration/pkg/testkit/events.go
+++ b/tests/end-to-end/external-solution-integration/pkg/testkit/events.go
@@ -42,7 +42,7 @@ func NewEventSender(httpClient *http.Client, domain, application string) *EventS
 	return &EventSender{
 		httpClient: resilient.WrapHttpClient(httpClient),
 		domain:     domain,
-		ceClient:   ceClient,
+		ceClient:   http2.NewWrappedCloudEventClient(ceClient),
 	}
 }
 

--- a/tests/end-to-end/external-solution-integration/pkg/testkit/testservice.go
+++ b/tests/end-to-end/external-solution-integration/pkg/testkit/testservice.go
@@ -11,7 +11,6 @@ import (
 	"k8s.io/client-go/dynamic"
 
 	"github.com/hashicorp/go-multierror"
-	apiRulev1alpha1 "github.com/kyma-incubator/api-gateway/api/v1alpha1"
 	rulev1alpha1 "github.com/ory/oathkeeper-maester/api/v1alpha1"
 	"github.com/pkg/errors"
 	appsv1 "k8s.io/api/apps/v1"
@@ -21,6 +20,8 @@ import (
 	"k8s.io/apimachinery/pkg/util/intstr"
 	appsclient "k8s.io/client-go/kubernetes/typed/apps/v1"
 	coreclient "k8s.io/client-go/kubernetes/typed/core/v1"
+
+	apiRulev1alpha1 "github.com/kyma-incubator/api-gateway/api/v1alpha1"
 )
 
 const (

--- a/tests/end-to-end/external-solution-integration/pkg/testsuite/check_counter_pod.go
+++ b/tests/end-to-end/external-solution-integration/pkg/testsuite/check_counter_pod.go
@@ -13,7 +13,7 @@ import (
 type CheckCounterPod struct {
 	testService   *testkit.TestService
 	expectedValue int
-	retry_opts    []retrygo.Option
+	retryOpts     []retrygo.Option
 }
 
 var _ step.Step = &CheckCounterPod{}
@@ -23,7 +23,7 @@ func NewCheckCounterPod(testService *testkit.TestService, expectedValue int, opt
 	return &CheckCounterPod{
 		testService:   testService,
 		expectedValue: expectedValue,
-		retry_opts:    opts,
+		retryOpts:     opts,
 	}
 }
 
@@ -36,7 +36,7 @@ func (s *CheckCounterPod) Name() string {
 func (s *CheckCounterPod) Run() error {
 	err := retry.Do(func() error {
 		return s.testService.WaitForCounterPodToUpdateValue(s.expectedValue)
-	}, s.retry_opts...)
+	}, s.retryOpts...)
 	if err != nil {
 		return errors.Wrapf(err, "the counter pod is not updated")
 	}

--- a/tests/end-to-end/external-solution-integration/pkg/testsuite/check_counter_pod.go
+++ b/tests/end-to-end/external-solution-integration/pkg/testsuite/check_counter_pod.go
@@ -1,8 +1,8 @@
 package testsuite
 
 import (
-	"github.com/pkg/errors"
 	retrygo "github.com/avast/retry-go"
+	"github.com/pkg/errors"
 
 	"github.com/kyma-project/kyma/tests/end-to-end/external-solution-integration/pkg/retry"
 	"github.com/kyma-project/kyma/tests/end-to-end/external-solution-integration/pkg/step"
@@ -13,7 +13,7 @@ import (
 type CheckCounterPod struct {
 	testService   *testkit.TestService
 	expectedValue int
-	retry_opts []retrygo.Option
+	retry_opts    []retrygo.Option
 }
 
 var _ step.Step = &CheckCounterPod{}
@@ -23,7 +23,7 @@ func NewCheckCounterPod(testService *testkit.TestService, expectedValue int, opt
 	return &CheckCounterPod{
 		testService:   testService,
 		expectedValue: expectedValue,
-		retry_opts: opts,
+		retry_opts:    opts,
 	}
 }
 

--- a/tests/end-to-end/external-solution-integration/pkg/testsuite/deploy_fake_lambda.go
+++ b/tests/end-to-end/external-solution-integration/pkg/testsuite/deploy_fake_lambda.go
@@ -3,9 +3,10 @@ package testsuite
 import (
 	"fmt"
 
-	"github.com/kyma-project/kyma/tests/end-to-end/external-solution-integration/pkg/retry"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/util/intstr"
+
+	"github.com/kyma-project/kyma/tests/end-to-end/external-solution-integration/pkg/retry"
 
 	"github.com/pkg/errors"
 	appsv1 "k8s.io/api/apps/v1"


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/master/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- Make "retry" configurable per default and refactor code
- Extend CheckCounterPod to allow configurable "options" 
- Fix the E2E Event Mesh  scenario to make it more robust 

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
See also #8283