### PR TITLE
Fix ORY Oathkeeper sync-job

### DIFF
--- a/resources/ory/charts/hydra/charts/hydra-maester/templates/sync-job.yaml
+++ b/resources/ory/charts/hydra/charts/hydra-maester/templates/sync-job.yaml
@@ -24,7 +24,7 @@ spec:
             - |
               set -ex
               kubectl delete pod -n kyma-system -l "app.kubernetes.io/name=hydra"
-              while [[ $(kubectl get pods -n kyma-system -l "app.kubernetes.io/name=hydra" -o 'jsonpath={..status.conditions[?(@.type=="Ready")].status}') != "True" ]]; do 
+              while [[ $(kubectl get pods -n kyma-system -l "app.kubernetes.io/name=hydra" -o 'jsonpath={..status.conditions[?(@.type=="Ready")].status}') =~ "False" ]]; do 
                 sleep 10
               done
               kubectl delete pod -n kyma-system -l "app.kubernetes.io/name=hydra-maester"


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/master/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- Fix Ory Oathkeeper sync-job when more than one hydra replica is used.
```
++ kubectl get pods -n kyma-system -l app.kubernetes.io/name=hydra -o 'jsonpath={..status.conditions[?(@.type=="Ready")].status}'
+ [[ True True != \T\r\u\e ]]
+ sleep 10
++ kubectl get pods -n kyma-system -l app.kubernetes.io/name=hydra -o 'jsonpath={..status.conditions[?(@.type=="Ready")].status}'
+ [[ False False False != \T\r\u\e ]]
+ sleep 10
```

