### PR TITLE
Update the Runtime Provisioner documentation after zone changed to a list of zones

### DIFF
--- a/docs/compass/08-02-provisioner-provisioning-gardener.md
+++ b/docs/compass/08-02-provisioner-provisioning-gardener.md
@@ -112,7 +112,7 @@ This tutorial shows how to provision clusters with Kyma Runtimes on Google Cloud
                 autoScalerMax: 4
                 maxSurge: 4
                 maxUnavailable: 1
-                providerSpecificConfig: { gcpConfig: { zone: ["europe-west4-a"] } }
+                providerSpecificConfig: { gcpConfig: { zones: ["europe-west4-a"] } }
               }
             }
             kymaConfig: {

--- a/docs/compass/08-02-provisioner-provisioning-gardener.md
+++ b/docs/compass/08-02-provisioner-provisioning-gardener.md
@@ -284,7 +284,6 @@ This tutorial shows how to provision clusters with Kyma Runtimes on Google Cloud
                 kubernetesVersion: "1.15.4"
                 diskType: "gp2"
                 volumeSizeGB: 35
-                nodeCount: 3
                 machineType: "m4.2xlarge"
                 region: "eu-west-1"
                 provider: "aws"

--- a/docs/compass/08-02-provisioner-provisioning-gardener.md
+++ b/docs/compass/08-02-provisioner-provisioning-gardener.md
@@ -102,7 +102,6 @@ This tutorial shows how to provision clusters with Kyma Runtimes on Google Cloud
                 kubernetesVersion: "1.15.4"
                 diskType: "pd-standard"
                 volumeSizeGB: 30
-                nodeCount: 3
                 machineType: "n1-standard-4"
                 region: "europe-west4"
                 provider: "gcp"
@@ -113,7 +112,7 @@ This tutorial shows how to provision clusters with Kyma Runtimes on Google Cloud
                 autoScalerMax: 4
                 maxSurge: 4
                 maxUnavailable: 1
-                providerSpecificConfig: { gcpConfig: { zone: "europe-west4-a" } }
+                providerSpecificConfig: { gcpConfig: { zone: ["europe-west4-a"] } }
               }
             }
             kymaConfig: {
@@ -194,7 +193,6 @@ This tutorial shows how to provision clusters with Kyma Runtimes on Google Cloud
                 kubernetesVersion: "1.15.4"
                 diskType: "Standard_LRS"
                 volumeSizeGB: 35
-                nodeCount: 3
                 machineType: "Standard_D2_v3"
                 region: "westeurope"
                 provider: "azure"
@@ -205,7 +203,7 @@ This tutorial shows how to provision clusters with Kyma Runtimes on Google Cloud
                 autoScalerMax: 4
                 maxSurge: 4
                 maxUnavailable: 1
-                providerSpecificConfig: { azureConfig: { vnetCidr: "10.250.0.0/19" } }
+                providerSpecificConfig: { azureConfig: { vnetCidr: "10.250.0.0/19", zones : ["westeurope-1"] } }
               }
             }
             kymaConfig: {

--- a/docs/compass/08-04-provisioner-runtime-status.md
+++ b/docs/compass/08-04-provisioner-runtime-status.md
@@ -25,7 +25,7 @@ query { runtimeStatus(id: "{RUNTIME_ID}") {
         __typename ... on GCPConfig {
           bootDiskSizeGB name numberOfNodes kubernetesVersion projectName machineType zone region }
           ... on GardenerConfig { 
-          name workerCidr region diskType maxSurge nodeCount volumeSizeGB projectName machineType targetSecret 
+          name workerCidr region diskType maxSurge volumeSizeGB machineType targetSecret 
           autoScalerMin autoScalerMax provider maxUnavailable kubernetesVersion }
       }
       kymaConfig {


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Update the Runtime Provisioner documentation after the field zone provided in the Runtime provisioning mutation changed to a list of zones.

**Related issue(s)**
- kyma-incubator/compass#1277 
- kyma-incubator/compass#1296 
- #8386
- kyma-incubator/compass#1306 
- kyma-incubator/compass#1312