### PR TITLE
Increase OathKeeper HTTP read timeout and thresholds for ORY probes

### DIFF
--- a/resources/compass/values.yaml
+++ b/resources/compass/values.yaml
@@ -17,7 +17,7 @@ global:
       version: "d068b250"
     connectivity_adapter:
       dir:
-      version: "d068b250"
+      version: "76738d5c"
     pairing_adapter:
       dir:
       version: "d068b250"

--- a/resources/ory/charts/hydra/templates/deployment.yaml
+++ b/resources/ory/charts/hydra/templates/deployment.yaml
@@ -78,16 +78,16 @@ spec:
             httpGet:
               path: /health/alive
               port: http-admin
-            initialDelaySeconds: 30
+            initialDelaySeconds: 45
             periodSeconds: 10
-            failureThreshold: 5
+            failureThreshold: 10
           readinessProbe:
             httpGet:
               path: /health/ready
               port: http-admin
-            initialDelaySeconds: 30
+            initialDelaySeconds: 45
             periodSeconds: 10
-            failureThreshold: 5
+            failureThreshold: 10
           env:
             {{- $issuer := include "hydra.config.urls.issuer" . -}}
             {{- if $issuer }}

--- a/resources/ory/charts/oathkeeper/templates/deployment-controller.yaml
+++ b/resources/ory/charts/oathkeeper/templates/deployment-controller.yaml
@@ -77,10 +77,16 @@ spec:
             httpGet:
               path: /health/alive
               port: http-api
+            initialDelaySeconds: 45
+            periodSeconds: 10
+            failureThreshold: 10
           readinessProbe:
             httpGet:
               path: /health/ready
               port: http-api
+            initialDelaySeconds: 45
+            periodSeconds: 10
+            failureThreshold: 10
           resources:
             {{- toYaml .Values.deployment.resources | nindent 12 }}
       {{- with .Values.deployment.nodeSelector }}

--- a/resources/ory/charts/oathkeeper/templates/deployment-with-sidecar.yaml
+++ b/resources/ory/charts/oathkeeper/templates/deployment-with-sidecar.yaml
@@ -89,10 +89,16 @@ spec:
             httpGet:
               path: /health/alive
               port: http-api
+            initialDelaySeconds: 45
+            periodSeconds: 10
+            failureThreshold: 10
           readinessProbe:
             httpGet:
               path: /health/ready
               port: http-api
+            initialDelaySeconds: 45
+            periodSeconds: 10
+            failureThreshold: 10
           resources:
             {{- toYaml .Values.deployment.resources | nindent 12 }}
         - name: {{ .Chart.Name }}-maester

--- a/resources/ory/values.yaml
+++ b/resources/ory/values.yaml
@@ -175,6 +175,10 @@ oathkeeper:
       serve:
         proxy:
           port: 4455
+          timeout:
+            read: 120s
+            write: 120s
+            idle: 120s
         api:
           port: 4456
   deployment:


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Increase OathKeeper HTTP read timeout and thresholds for ORY probes
- Bump Connectivity Adapter (https://github.com/kyma-incubator/compass/pull/1321)