### PR TITLE
Fix monitoring test

### DIFF
--- a/resources/monitoring/values.yaml
+++ b/resources/monitoring/values.yaml
@@ -11,7 +11,7 @@ global:
   monitoring_integration_tests:
     name: monitoring-integration-tests
     dir:
-    version: PR-8156
+    version: PR-8446
     tests:
       enabled: true
 

--- a/tests/integration/monitoring/promAPI/targets.go
+++ b/tests/integration/monitoring/promAPI/targets.go
@@ -18,7 +18,4 @@ type ActiveTarget struct {
 	Health    string `json:"health"`
 }
 
-type Labels struct {
-	Instance string `json:"instance"`
-	Job      string `json:"job"`
-}
+type Labels map[string]string

--- a/tests/integration/monitoring/test-monitoring.go
+++ b/tests/integration/monitoring/test-monitoring.go
@@ -170,7 +170,7 @@ func testTargetsAreHealthy() {
 
 }
 
-func hasLabels(targetLabels promAPI.Labels, labelsToBeIgnored promAPI.Labels) bool {
+func hasLabels(targetLabels, labelsToBeIgnored promAPI.Labels) bool {
 	for l, _ := range targetLabels {
 		if labelsToBeIgnored[l] == targetLabels[l] {
 			return true

--- a/tests/integration/monitoring/test-monitoring.go
+++ b/tests/integration/monitoring/test-monitoring.go
@@ -153,7 +153,7 @@ func testTargetsAreHealthy() {
 			timeoutMessage = ""
 			for _, target := range activeTargets {
 				// Ignoring the targets with certain labels
-				if hasAnyLabels(target.Labels, labelsToBeIgnored) {
+				if hasAnyLabel(target.Labels, labelsToBeIgnored) {
 					continue
 				}
 				if target.Health != "up" {
@@ -170,7 +170,7 @@ func testTargetsAreHealthy() {
 
 }
 
-func hasAnyLabels(target, anyOf promAPI.Labels) bool {
+func hasAnyLabel(target, anyOf promAPI.Labels) bool {
 	for l, _ := range target {
 		if target[l] == anyOf[l] {
 			return true

--- a/tests/integration/monitoring/test-monitoring.go
+++ b/tests/integration/monitoring/test-monitoring.go
@@ -128,6 +128,9 @@ func testPodsAreReady() {
 func testTargetsAreHealthy() {
 	timeout := time.After(3 * time.Minute)
 	tick := time.NewTicker(30 * time.Second)
+	var labelsToBeIgnored = promAPI.Labels{
+		"namespace": "e2e-event-mesh", // e2e test pod
+	}
 	var timeoutMessage string
 	for {
 		select {
@@ -149,9 +152,13 @@ func testTargetsAreHealthy() {
 			allTargetsAreHealthy := true
 			timeoutMessage = ""
 			for _, target := range activeTargets {
+				// Ignoring the targets with certain labels
+				if hasLabels(target.Labels, labelsToBeIgnored) {
+					continue
+				}
 				if target.Health != "up" {
 					allTargetsAreHealthy = false
-					timeoutMessage += fmt.Sprintf("Target with job=%s and instance=%s is not healthy\n", target.Labels.Job, target.Labels.Instance)
+					timeoutMessage += fmt.Sprintf("Target with job=%s and instance=%s is not healthy\n", target.Labels["job"], target.Labels["instance"])
 				}
 			}
 			if allTargetsAreHealthy {
@@ -161,6 +168,15 @@ func testTargetsAreHealthy() {
 		}
 	}
 
+}
+
+func hasLabels(targetLabels promAPI.Labels, labelsToBeIgnored promAPI.Labels) bool {
+	for l, _ := range targetLabels {
+		if labelsToBeIgnored[l] == targetLabels[l] {
+			return true
+		}
+	}
+	return false
 }
 
 func testRulesAreHealthy() {

--- a/tests/integration/monitoring/test-monitoring.go
+++ b/tests/integration/monitoring/test-monitoring.go
@@ -153,7 +153,7 @@ func testTargetsAreHealthy() {
 			timeoutMessage = ""
 			for _, target := range activeTargets {
 				// Ignoring the targets with certain labels
-				if hasLabels(target.Labels, labelsToBeIgnored) {
+				if hasAnyLabels(target.Labels, labelsToBeIgnored) {
 					continue
 				}
 				if target.Health != "up" {
@@ -170,9 +170,9 @@ func testTargetsAreHealthy() {
 
 }
 
-func hasLabels(targetLabels, labelsToBeIgnored promAPI.Labels) bool {
-	for l, _ := range targetLabels {
-		if labelsToBeIgnored[l] == targetLabels[l] {
+func hasAnyLabels(target, anyOf promAPI.Labels) bool {
+	for l, _ := range target {
+		if target[l] == anyOf[l] {
 			return true
 		}
 	}


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/master/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- It is found that while running the tests(`monitoring` and `core-test-external-solution-event-mesh`) in parallel, the targets created in `core-test-external-solution-event-mesh` were getting ready while the `monitoring` test was checking the targets. Hence, those targets were not ready causing the monitoring test to fail.
- The solution is to exclude the targets created by the test. 

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
See https://github.com/kyma-project/kyma/issues/8408
