### PR TITLE
adding istio annotation to metris chart default values

### DIFF
--- a/resources/compass/charts/metris/values.yaml
+++ b/resources/compass/charts/metris/values.yaml
@@ -19,7 +19,8 @@ resources: {}
 securityContext:
   runAsUser: 1001
 
-podAnnotations: {}
+podAnnotations:
+  sidecar.istio.io/inject: "false"
 
 loglevel: info
 port: 8080


### PR DESCRIPTION
**Description**
Fix to allow prometheus to scrape metris metrics

Changes proposed in this pull request:
- adding the istio sidecar inject annotation to the metris chart default values

**Related issue(s)**