### PR TITLE
Increase timeout for instance provisioning

### DIFF
--- a/resources/compass-runtime-agent/values.yaml
+++ b/resources/compass-runtime-agent/values.yaml
@@ -10,7 +10,7 @@ global:
       version: "PR-8473"
     compassExternalSolutionTests:
       dir:
-      version: PR-8398
+      version: "PR-8473"
   istio:
     gateway:
       name: kyma-gateway

--- a/resources/compass-runtime-agent/values.yaml
+++ b/resources/compass-runtime-agent/values.yaml
@@ -7,7 +7,7 @@ global:
       version: "PR-8273"
     runtimeAgentTests:
       dir:
-      version: "PR-8050"
+      version: "PR-8473"
     compassExternalSolutionTests:
       dir:
       version: PR-8398

--- a/tests/compass-runtime-agent/test/testkit/kymaconfig/configurator.go
+++ b/tests/compass-runtime-agent/test/testkit/kymaconfig/configurator.go
@@ -33,9 +33,9 @@ const (
 
 	defaultCheckInterval         = 3 * time.Second
 	serviceInstanceCheckInterval = 2 * time.Second
-	serviceInstanceWait          = 2 * time.Minute
+	serviceInstanceWait          = 3 * time.Minute
 
-	serviceInstanceDeletionWaitTime = 30 * time.Second
+	serviceInstanceDeletionWaitTime = time.Minute
 )
 
 // KymaConfigurator configures Compass Applications to be usable from Kyma

--- a/tests/compass-runtime-agent/test/testkit/kymaconfig/configurator.go
+++ b/tests/compass-runtime-agent/test/testkit/kymaconfig/configurator.go
@@ -33,7 +33,7 @@ const (
 
 	defaultCheckInterval         = 3 * time.Second
 	serviceInstanceCheckInterval = 2 * time.Second
-	serviceInstanceWait          = 60 * time.Second
+	serviceInstanceWait          = 2 * time.Minute
 
 	serviceInstanceDeletionWaitTime = 30 * time.Second
 )

--- a/tests/end-to-end/external-solution-integration/pkg/testsuite/create_service_instance.go
+++ b/tests/end-to-end/external-solution-integration/pkg/testsuite/create_service_instance.go
@@ -2,6 +2,9 @@ package testsuite
 
 import (
 	"fmt"
+	"time"
+
+	retrygo "github.com/avast/retry-go"
 
 	servicecatalogclientset "github.com/kubernetes-incubator/service-catalog/pkg/client/clientset_generated/clientset/typed/servicecatalog/v1beta1"
 	scv1beta1 "github.com/kubernetes-sigs/service-catalog/pkg/apis/servicecatalog/v1beta1"
@@ -74,7 +77,8 @@ func (s *CreateServiceInstance) Run() error {
 	if err != nil {
 		return err
 	}
-	return retry.Do(s.isServiceInstanceCreated)
+
+	return retry.Do(s.isServiceInstanceCreated, retrygo.Attempts(180), retrygo.Delay(time.Second))
 }
 
 func (s *CreateServiceInstance) findServiceClassExternalName(serviceClassID string) (string, error) {


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/master/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- Increased timeout for instance provisioning to `2min`, for example we have `5min` timeout for the same action in [upgrade test](https://github.com/kyma-project/kyma/blob/master/tests/end-to-end/upgrade/pkg/tests/service-catalog/base_flow.go#L255).

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
