### PR TITLE
fixed cluster role setup for kiali-operator

### DIFF
--- a/resources/kiali/templates/operator/clusterrole.yaml
+++ b/resources/kiali/templates/operator/clusterrole.yaml
@@ -226,7 +226,7 @@ rules:
   - security.istio.io
   resources: ["*"]
   verbs:
-{{- if .Values.kiali.spec.deployment.view_only_mode }}
+{{- if not .Values.kiali.spec.deployment.view_only_mode }}
   - create
   - delete
   - patch
@@ -238,7 +238,7 @@ rules:
   resources:
   - servicemeshpolicies
   verbs:
-{{- if .Values.kiali.spec.deployment.view_only_mode }}
+{{- if not .Values.kiali.spec.deployment.view_only_mode }}
   - create
   - delete
   - patch
@@ -250,7 +250,7 @@ rules:
   resources:
   - servicemeshrbacconfigs
   verbs:
-{{- if .Values.kiali.spec.deployment.view_only_mode }}
+{{- if not .Values.kiali.spec.deployment.view_only_mode }}
   - create
   - delete
   - patch
@@ -285,7 +285,7 @@ rules:
   resources:
   - experiments
   verbs:
-{{- if .Values.kiali.spec.deployment.view_only_mode }}
+{{- if not .Values.kiali.spec.deployment.view_only_mode }}
   - create
   - delete
   - patch


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/master/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**
The modifying rights for the kiali-operator clusterrole were applied wrongly in the view-only mode.

Changes proposed in this pull request:

- Fixed if clause to add modifying rights in edit mode only
- ...
- ...

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
