### PR TITLE
enable tls verification for openid provider by default

### DIFF
--- a/resources/kiali/templates/kyma-additions/kcproxy-deployment.yaml
+++ b/resources/kiali/templates/kyma-additions/kcproxy-deployment.yaml
@@ -32,7 +32,9 @@ spec:
         command: ["/keycloak-gatekeeper"]
         args:
         - --discovery-url=https://dex.{{ .Values.global.ingress.domainName }}
+        {{- if .Values.global.isLocalEnv }}
         - --skip-openid-provider-tls-verify=true
+        {{- end }}
         - --client-id={{ .Values.kcproxy.clientId }}
         - --client-secret={{ .Values.kcproxy.clientSecret }}
         - --resources=uri=/*|methods=GET,POST,PUT,DELETE

--- a/resources/tracing/templates/kyma-additions/kcproxy-deployment.yaml
+++ b/resources/tracing/templates/kyma-additions/kcproxy-deployment.yaml
@@ -31,7 +31,9 @@ spec:
         command: ["/keycloak-gatekeeper"]
         args:
         - --discovery-url=https://dex.{{ .Values.global.ingress.domainName }}
+        {{- if .Values.global.isLocalEnv }}
         - --skip-openid-provider-tls-verify=true
+        {{- end }}
         - --client-id={{ .Values.kcproxy.clientId }}
         - --client-secret={{ .Values.kcproxy.clientSecret }}
         - --resources=uri=/*|methods=GET,POST,PUT,DELETE


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/master/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**
The setup of the keycloak-gatekeeper proxy for kiali and jaeger has by default disabled the verification of TLS for the openId provider. 

Changes proposed in this pull request:

- Have it enabled by default
- Disable it only for the local setup as here a self-signed certificate is used
- ...

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
