### PR TITLE
Ignore dynamic targets for monitoring test

### DIFF
--- a/resources/monitoring/values.yaml
+++ b/resources/monitoring/values.yaml
@@ -11,7 +11,7 @@ global:
   monitoring_integration_tests:
     name: monitoring-integration-tests
     dir:
-    version: 6bf39e9f
+    version: PR-8505
     tests:
       enabled: true
 

--- a/tests/integration/monitoring/test-monitoring.go
+++ b/tests/integration/monitoring/test-monitoring.go
@@ -169,7 +169,7 @@ func testTargetsAreHealthy() {
 
 func shouldIgnoreTarget(target promAPI.Labels) bool {
 	var jobsToBeIgnored = []string{
-		// TODO [sayanh]: These targets will be tested here: https://github.com/kyma-project/kyma/issues/6457
+		// Note: These targets will be tested here: https://github.com/kyma-project/kyma/issues/6457
 		"knative-eventing/knative-eventing-event-mesh-dashboard-broker",
 		"knative-eventing/knative-eventing-event-mesh-dashboard-httpsource",
 	}

--- a/tests/integration/monitoring/test-monitoring.go
+++ b/tests/integration/monitoring/test-monitoring.go
@@ -128,9 +128,7 @@ func testPodsAreReady() {
 func testTargetsAreHealthy() {
 	timeout := time.After(3 * time.Minute)
 	tick := time.NewTicker(30 * time.Second)
-	var labelsToBeIgnored = promAPI.Labels{
-		"namespace": "e2e-event-mesh", // e2e test pod
-	}
+
 	var timeoutMessage string
 	for {
 		select {
@@ -152,13 +150,12 @@ func testTargetsAreHealthy() {
 			allTargetsAreHealthy := true
 			timeoutMessage = ""
 			for _, target := range activeTargets {
-				// Ignoring the targets with certain labels
-				if hasAnyLabel(target.Labels, labelsToBeIgnored) {
+				if shouldIgnoreTarget(target.Labels) {
 					continue
 				}
 				if target.Health != "up" {
 					allTargetsAreHealthy = false
-					timeoutMessage += fmt.Sprintf("Target with job=%s and instance=%s is not healthy\n", target.Labels["job"], target.Labels["instance"])
+					timeoutMessage += fmt.Sprintf("Target with job=%s and instance=%s is not healthy, with labels=%v\n", target.Labels["job"], target.Labels["instance"], target.Labels)
 				}
 			}
 			if allTargetsAreHealthy {
@@ -170,9 +167,15 @@ func testTargetsAreHealthy() {
 
 }
 
-func hasAnyLabel(target, anyOf promAPI.Labels) bool {
-	for l, _ := range target {
-		if target[l] == anyOf[l] {
+func shouldIgnoreTarget(target promAPI.Labels) bool {
+	var jobsToBeIgnored = []string{
+		// TODO [sayanh]: These targets will be tested here: https://github.com/kyma-project/kyma/issues/6457
+		"knative-eventing/knative-eventing-event-mesh-dashboard-broker",
+		"knative-eventing/knative-eventing-event-mesh-dashboard-httpsource",
+	}
+
+	for _, j := range jobsToBeIgnored {
+		if target["job"] == j {
 			return true
 		}
 	}


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/master/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- Following targets are only`up` when an application is created along with binding an event-service to a ns:
  - knative-eventing/knative-eventing-event-mesh-dashboard-broker
  - knative-eventing/knative-eventing-event-mesh-dashboard-httpsource
- When monitoring tests are executed in parallel to e2e tests, it does not make sense to check whether these targets are up or not cause there is no deterministic approach to that.
- These targets will eventually be tested here: https://github.com/kyma-project/kyma/issues/6457


**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
See https://github.com/kyma-project/kyma/issues/8498