### PR TITLE
Update the Kyma environment broker image to enforce lowercase Azure resource names

### DIFF
--- a/resources/compass/values.yaml
+++ b/resources/compass/values.yaml
@@ -43,7 +43,7 @@ global:
       version: "0a651695"
     kyma_environment_broker:
       dir:
-      version: "a9b7becf"
+      version: "341946c1"
     external_services_mock:
       dir:
       version: "e2837b23"


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Update the Kyma environment broker image to enforce lowercase Azure resource names.

For more info see: https://github.com/kyma-incubator/compass/issues/1359#issuecomment-631328399.

**Related issue(s)**

- https://github.com/kyma-incubator/compass/issues/1359.
