### PR TITLE
Enable logging upgrade test

### DIFF
--- a/tests/end-to-end/upgrade/chart/upgrade/values.yaml
+++ b/tests/end-to-end/upgrade/chart/upgrade/values.yaml
@@ -3,7 +3,7 @@ containerRegistry:
 
 image:
   dir:
-  version: PR-8315
+  version: PR-8540
   pullPolicy: "IfNotPresent"
 
 dex:

--- a/tests/end-to-end/upgrade/main.go
+++ b/tests/end-to-end/upgrade/main.go
@@ -35,6 +35,7 @@ import (
 	apigateway "github.com/kyma-project/kyma/tests/end-to-end/upgrade/pkg/tests/api-gateway"
 	applicationoperator "github.com/kyma-project/kyma/tests/end-to-end/upgrade/pkg/tests/application-operator"
 	"github.com/kyma-project/kyma/tests/end-to-end/upgrade/pkg/tests/eventmesh"
+	"github.com/kyma-project/kyma/tests/end-to-end/upgrade/pkg/tests/logging"
 	"github.com/kyma-project/kyma/tests/end-to-end/upgrade/pkg/tests/monitoring"
 	"github.com/kyma-project/kyma/tests/end-to-end/upgrade/pkg/tests/rafter"
 	servicecatalog "github.com/kyma-project/kyma/tests/end-to-end/upgrade/pkg/tests/service-catalog"
@@ -144,7 +145,7 @@ func main() {
 		"ApplicationOperatorUpgradeTest":  applicationoperator.NewApplicationOperatorUpgradeTest(appConnectorCli, *k8sCli),
 		"RafterUpgradeTest":               rafter.NewRafterUpgradeTest(dynamicCli),
 		"EventMeshUpgradeTest":            eventmesh.NewEventMeshUpgradeTest(appConnectorCli, k8sCli, messagingCli, servingCli, appBrokerCli, scCli, eventingCli),
-		//"LoggingUpgradeTest":            logging.NewLoggingTest(k8sCli, domainName, dexConfig.IdProviderConfig()),
+		"LoggingUpgradeTest":              logging.NewLoggingTest(k8sCli, domainName, dexConfig.IdProviderConfig()),
 	}
 	tRegistry, err := runner.NewConfigMapTestRegistry(k8sCli, cfg.WorkingNamespace, cfg.TestsInfoConfigMapName)
 	fatalOnError(err, "while creating Test Registry")

--- a/tests/end-to-end/upgrade/pkg/tests/logging/logging.go
+++ b/tests/end-to-end/upgrade/pkg/tests/logging/logging.go
@@ -50,7 +50,6 @@ func (t LoggingTest) CreateResources(stop <-chan struct{}, log logrus.FieldLogge
 	log.Println("Test if logs from test-counter-pod are streamed by Loki before upgrade")
 	err = t.testLogStream(namespace)
 	if err != nil {
-		logstream.Cleanup(namespace, t.coreInterface)
 		return err
 	}
 	return nil
@@ -61,7 +60,6 @@ func (t LoggingTest) TestResources(stop <-chan struct{}, log logrus.FieldLogger,
 	log.Println("Test if new logs from test-counter-pod are streamed by Loki after upgrade")
 	err := t.testLogStream(namespace)
 	if err != nil {
-		logstream.Cleanup(namespace, t.coreInterface)
 		return err
 	}
 	log.Println("Deleting test-counter-pod")

--- a/tests/end-to-end/upgrade/pkg/tests/logging/logging.go
+++ b/tests/end-to-end/upgrade/pkg/tests/logging/logging.go
@@ -33,23 +33,19 @@ func NewLoggingTest(coreInterface kubernetes.Interface, domainName string, dexCo
 // CreateResources creates resources for logging upgrade test
 func (t LoggingTest) CreateResources(stop <-chan struct{}, log logrus.FieldLogger, namespace string) error {
 	log.Println("Cleaning up before creating resources")
-	err := logstream.Cleanup(namespace, t.coreInterface)
-	if err != nil {
+	if err := logstream.Cleanup(namespace, t.coreInterface); err != nil {
 		return err
 	}
 	log.Println("Deploying test-counter-pod")
-	err = logstream.DeployDummyPod(namespace, t.coreInterface)
-	if err != nil {
+	if err := logstream.DeployDummyPod(namespace, t.coreInterface); err != nil {
 		return err
 	}
 	log.Println("Waiting for test-counter-pod to run...")
-	err = logstream.WaitForDummyPodToRun(namespace, t.coreInterface)
-	if err != nil {
+	if err := logstream.WaitForDummyPodToRun(namespace, t.coreInterface); err != nil {
 		return err
 	}
 	log.Println("Test if logs from test-counter-pod are streamed by Loki before upgrade")
-	err = t.testLogStream(namespace)
-	if err != nil {
+	if err := t.testLogStream(namespace); err != nil {
 		return err
 	}
 	return nil
@@ -58,13 +54,11 @@ func (t LoggingTest) CreateResources(stop <-chan struct{}, log logrus.FieldLogge
 // TestResources checks if resources are working properly after upgrade
 func (t LoggingTest) TestResources(stop <-chan struct{}, log logrus.FieldLogger, namespace string) error {
 	log.Println("Test if new logs from test-counter-pod are streamed by Loki after upgrade")
-	err := t.testLogStream(namespace)
-	if err != nil {
+	if err := t.testLogStream(namespace); err != nil {
 		return err
 	}
 	log.Println("Deleting test-counter-pod")
-	err = logstream.Cleanup(namespace, t.coreInterface)
-	if err != nil {
+	if err := logstream.Cleanup(namespace, t.coreInterface); err != nil {
 		return err
 	}
 	return nil
@@ -76,16 +70,13 @@ func (t LoggingTest) testLogStream(namespace string) error {
 		return errors.Wrap(err, "cannot fetch dex token")
 	}
 	authHeader := jwt.SetAuthHeader(token)
-	err = logstream.Test("container", "count", authHeader, t.httpClient)
-	if err != nil {
+	if err := logstream.Test("container", "count", authHeader, t.httpClient); err != nil {
 		return err
 	}
-	err = logstream.Test("app", "test-counter-pod", authHeader, t.httpClient)
-	if err != nil {
+	if err := logstream.Test("app", "test-counter-pod", authHeader, t.httpClient); err != nil {
 		return err
 	}
-	err = logstream.Test("namespace", namespace, authHeader, t.httpClient)
-	if err != nil {
+	if err := logstream.Test("namespace", namespace, authHeader, t.httpClient); err != nil {
 		return err
 	}
 	return nil

--- a/tests/end-to-end/upgrade/pkg/tests/logging/pkg/logstream/logstream.go
+++ b/tests/end-to-end/upgrade/pkg/tests/logging/pkg/logstream/logstream.go
@@ -97,8 +97,7 @@ func Cleanup(namespace string, coreInterface kubernetes.Interface) error {
 	gracePeriod := int64(0)
 	deleteOptions := metav1.DeleteOptions{GracePeriodSeconds: &gracePeriod}
 	listOptions := metav1.ListOptions{LabelSelector: "app=test-counter-pod"}
-	err := coreInterface.CoreV1().Pods(namespace).DeleteCollection(&deleteOptions, listOptions)
-	if err != nil {
+	if err := coreInterface.CoreV1().Pods(namespace).DeleteCollection(&deleteOptions, listOptions); err != nil {
 		return errors.Wrap(err, "cannot delete test-counter-pod")
 	}
 	return nil


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/master/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- Enable back logging upgrade test. The reason for previous failure was due to fluent-bit pods being restarted during the upgrade process. Now, since the version of fluent-bit is not changed during the upgrade, fluent-bit pods will not restart and test succeeds.
- Avoid deleting test-counter-pod when upgrade test fail. The reason for this is that in the second trial of test execution, `CreateResources` will not be executed again, so the test-counter-pod will not be deployed and the test will definitely fail in the second trial of execution.
- Handling errors in one line instead of two lines

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
#8030