### PR TITLE
Increase the time to wait for Kafka trigger/subscription to be stable

### DIFF
--- a/resources/core/templates/tests/test-external-solution.yaml
+++ b/resources/core/templates/tests/test-external-solution.yaml
@@ -46,6 +46,7 @@ spec:
               /e2e {{ $val.testsuite }} \
               --domain {{ $.Values.global.ingress.domainName }} \
               --testID {{ $val.testsuite }} \
+              --waitTime 20s \
               --skipSSLVerify
               {{- if $.Values.tests.application_connector_tests.connector_service.central }} --applicationTenant=tenant --applicationGroup=group {{- end }}
               exit_code=$?

--- a/resources/core/values.yaml
+++ b/resources/core/values.yaml
@@ -46,7 +46,7 @@ global:
     version: 0e322dac
   e2e_external_solution:
     dir:
-    version: PR-8489
+    version: PR-8541
   disableLegacyConnectivity: false
 
 tests:


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/master/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- Increase in "e2e-test" the time to wait for Knative to be stable after adding a new trigger/subscription (from the default 10s to 20s) 

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
