### PR TITLE
Add missing Serverless info to docs

### DIFF
--- a/docs/serverless/03-01-api-rules.md
+++ b/docs/serverless/03-01-api-rules.md
@@ -13,7 +13,7 @@ To expose a Function outside the cluster, you must create an [APIRule custom res
 
 1. Create the APIRule CR where you specify the Function to expose, define a [Oathkeeper Access Rule](/components/api-gateway/#details-available-security-options) to secure it, and list which HTTP request methods you want to enable for it.
 
-> **CAUTION:** If you decide to expose your Function on an unsecured endpoint, use the `noop` **handler** for the **accessStrategy** you define in the APIRule CR. The `allow` value for the **handler** is not supported in the current Serverless implementation.
+> **CAUTION:** If you decide to expose your Function through an unsecured endpoint, use the `noop` **handler** for the **accessStrategy** you define in the APIRule CR. The `allow` value for the **handler** is not supported in the current Serverless implementation.
 
 2. The API Gateway Controller detects a new APIRule CR and reads its definition.
 

--- a/docs/serverless/03-01-api-rules.md
+++ b/docs/serverless/03-01-api-rules.md
@@ -13,6 +13,8 @@ To expose a Function outside the cluster, you must create an [APIRule custom res
 
 1. Create the APIRule CR where you specify the Function to expose, define a [Oathkeeper Access Rule](/components/api-gateway/#details-available-security-options) to secure it, and list which HTTP request methods you want to enable for it.
 
+> **CAUTION:** If you decide to expose your Function on an unsecured endpoint, use the `noop` **handler** for the **accessStrategy** you define in the APIRule CR. The `allow` value for the **handler** is not supported in the current Serverless implementation.
+
 2. The API Gateway Controller detects a new APIRule CR and reads its definition.
 
 3. The API Gateway Controller creates an Istio Virtual Service and Access Rules according to details specified in the CR. Such a Function service is available under the `{host-name}.{domain}` endpoint, such as `my-function.kyma.local`.

--- a/docs/serverless/06-01-function-cr.md
+++ b/docs/serverless/06-01-function-cr.md
@@ -69,7 +69,7 @@ spec:
         type: ConfigurationReady
 ```
 
-> **CATION:** When you create a Function, the exported object in the Function's body must have `main` as the handler name.
+> **CAUTION:** When you create a Function, the exported object in the Function's body must have `main` as the handler name.
 
 ## Custom resource properties
 

--- a/docs/serverless/06-01-function-cr.md
+++ b/docs/serverless/06-01-function-cr.md
@@ -69,6 +69,8 @@ spec:
         type: ConfigurationReady
 ```
 
+> **CATION:** When you create a Function, the exported object in the Function's body must have `main` as a handler name.
+
 ## Custom resource properties
 
 This table lists all the possible properties of a given resource together with their descriptions:

--- a/docs/serverless/06-01-function-cr.md
+++ b/docs/serverless/06-01-function-cr.md
@@ -69,7 +69,7 @@ spec:
         type: ConfigurationReady
 ```
 
-> **CATION:** When you create a Function, the exported object in the Function's body must have `main` as a handler name.
+> **CATION:** When you create a Function, the exported object in the Function's body must have `main` as the handler name.
 
 ## Custom resource properties
 


### PR DESCRIPTION

**Description**

Changes proposed in this pull request:

- Clearly stated that the `allow` handler is not supported in access strategies for Functions.
- Added info that the Function's body must have `main` as a handler name.

