### PR TITLE
Move the restore troubleshooting guide to Rafter

### DIFF
--- a/docs/rafter/10-01-rafter-troubleshooting.md
+++ b/docs/rafter/10-01-rafter-troubleshooting.md
@@ -3,7 +3,7 @@ title: AssetGroup processing fails due to duplicated default buckets
 type: Troubleshooting
 ---
 
-It may happen that processing of a (Cluster)AssetGroup CR fails due to too many buckets with the `rafter.kyma-project.io/access:public` label.
+It may happen that the processing of a (Cluster)AssetGroup CR fails due to too many buckets with the `rafter.kyma-project.io/access:public` label.
 
 To fix this issue, manually remove all default buckets with the `rafter.kyma-project.io/access:public` label:  
 
@@ -12,7 +12,6 @@ To fix this issue, manually remove all default buckets with the `rafter.kyma-pro
    ```bash
    kubectl delete clusterbuckets.rafter.kyma-project.io --selector='rafter.kyma-project.io/access=public'
    ```
-
 2. Remove buckets from the Namespaces where you use them:
 
    ```bash

--- a/docs/rafter/10-01-rafter-troubleshooting.md
+++ b/docs/rafter/10-01-rafter-troubleshooting.md
@@ -1,0 +1,22 @@
+---
+title: AssetGroup restore fails due to duplicated default buckets
+type: Troubleshooting
+---
+
+[Velero restores Kyma resources asynchronously](/root/kyma/#tutorials-restore-with-velero), following the alphabetical `kind` object order. This creates issues for Rafter as Velero first restores (Cluster)AssetGroups and then buckets. When the (Cluster)AssetGroup controller notices there are no default buckets available, it automatically tries to create them. If Velero restores the default buckets in the meantime, (Cluster)AssetGroups restoration will fail due to too many buckets with the `rafter.kyma-project.io/access:public` label.
+
+To fix this issue, manually remove all default buckets with the `rafter.kyma-project.io/access:public` label right after restoring Kyma:  
+
+1. Remove the cluster-wide default bucket:
+
+   ```bash
+   kubectl delete clusterbuckets.rafter.kyma-project.io --selector='rafter.kyma-project.io/access=public'
+   ```
+
+2. Remove buckets from the Namespaces where you use them:
+
+   ```bash
+   kubectl delete buckets.rafter.kyma-project.io --selector='rafter.kyma-project.io/access=public' --namespace=default
+   ```
+
+This allows the (Cluster)AssetGroup controller to recreate the default buckets successfully.

--- a/docs/rafter/10-01-rafter-troubleshooting.md
+++ b/docs/rafter/10-01-rafter-troubleshooting.md
@@ -1,11 +1,11 @@
 ---
-title: AssetGroup restore fails due to duplicated default buckets
+title: AssetGroup processing fails due to duplicated default buckets
 type: Troubleshooting
 ---
 
-[Velero restores Kyma resources asynchronously](/root/kyma/#tutorials-restore-with-velero), following the alphabetical `kind` object order. This creates issues for Rafter as Velero first restores (Cluster)AssetGroups and then buckets. When the (Cluster)AssetGroup controller notices there are no default buckets available, it automatically tries to create them. If Velero restores the default buckets in the meantime, (Cluster)AssetGroups restoration will fail due to too many buckets with the `rafter.kyma-project.io/access:public` label.
+It may happen that processing of a (Cluster)AssetGroup CR fails due to too many buckets with the `rafter.kyma-project.io/access:public` label.
 
-To fix this issue, manually remove all default buckets with the `rafter.kyma-project.io/access:public` label right after restoring Kyma:  
+To fix this issue, manually remove all default buckets with the `rafter.kyma-project.io/access:public` label:  
 
 1. Remove the cluster-wide default bucket:
 
@@ -18,5 +18,4 @@ To fix this issue, manually remove all default buckets with the `rafter.kyma-pro
    ```bash
    kubectl delete buckets.rafter.kyma-project.io --selector='rafter.kyma-project.io/access=public' --namespace=default
    ```
-
 This allows the (Cluster)AssetGroup controller to recreate the default buckets successfully.


### PR DESCRIPTION

**Description**

Changes proposed in this pull request:

- Moved the omitted troubleshooting guide from the old Backup docs to Rafter documentation
- Added links to Velero restore guide

