### PR TITLE
Fix additional prometheus rule template

### DIFF
--- a/resources/monitoring/templates/prometheus/additionalPrometheusRules.yaml
+++ b/resources/monitoring/templates/prometheus/additionalPrometheusRules.yaml
@@ -1,40 +1,18 @@
-{{- if or .Values.additionalPrometheusRules .Values.additionalPrometheusRulesMap}}
-apiVersion: v1
-kind: List
-items:
-{{- if .Values.additionalPrometheusRulesMap }}
-{{- range $prometheusRuleName, $prometheusRule := .Values.additionalPrometheusRulesMap }}
-  - apiVersion: monitoring.coreos.com/v1
-    kind: PrometheusRule
-    metadata:
-      name: {{ template "prometheus-operator.name" $ }}-{{ $prometheusRuleName }}
-      namespace: {{ $.Release.Namespace }}
-      labels:
-        app: {{ template "prometheus-operator.name" $ }}
-{{ include "prometheus-operator.labels" $ | indent 8 }}
-    {{- if $prometheusRule.additionalLabels }}
-{{ toYaml $prometheusRule.additionalLabels | indent 8 }}
-    {{- end }}
-    spec:
-      groups:
-{{ toYaml $prometheusRule.groups| indent 8 }}
-{{- end }}
-{{- else }}
-{{- range .Values.additionalPrometheusRules }}
-  - apiVersion: monitoring.coreos.com/v1
-    kind: PrometheusRule
-    metadata:
-      name: {{ template "prometheus-operator.name" $ }}-{{ .name }}
-      namespace: {{ $.Release.Namespace }}
-      labels:
-        app: {{ template "prometheus-operator.name" $ }}
-{{ include "prometheus-operator.labels" $ | indent 8 }}
-    {{- if .additionalLabels }}
-{{ toYaml .additionalLabels | indent 8 }}
-    {{- end }}
-    spec:
-      groups:
-{{ toYaml .groups| indent 8 }}
-{{- end }}
-{{- end }}
-{{- end }}
+{{- if .Values.additionalPrometheusRules }}
+  {{- range $name, $config := .Values.additionalPrometheusRules | fromYaml }}
+- apiVersion: monitoring.coreos.com/v1
+  kind: PrometheusRule
+  metadata:
+    name: {{ template "prometheus-operator.name" $ }}-{{$name}}
+    namespace: {{ $.Release.Namespace }}
+    labels:
+      app: {{ template "prometheus-operator.name" $ -}}
+  {{ include "prometheus-operator.labels" $ | indent 8 -}}
+  {{ if $config.additionalLabels }}
+  {{ toYaml $config.additionalLabels | trim | indent 8 }}
+  {{- end }}
+  spec:
+    groups:
+  {{ toYaml $config.groups | indent 8 -}}
+  {{- end }}
+  {{- end }}

--- a/resources/monitoring/values.yaml
+++ b/resources/monitoring/values.yaml
@@ -103,8 +103,10 @@ defaultRules:
 
 ## Provide custom recording or alerting rules to be deployed into the cluster.
 ##
-additionalPrometheusRules: []
-#  - name: my-rule-file
+additionalPrometheusRules: |-
+#  custom_rule:
+#    additionalLabels:
+#      some: label
 #    groups:
 #      - name: my_group
 #        rules:


### PR DESCRIPTION
Additional prometheus rules cannot be specified via kyma-installer, as it only accepts strings. Modify template to parse multiline strings and work with kyma-installer.