### PR TITLE
bump alpine-kubectl image to latest version

### DIFF
--- a/installation/resources/installer-local.yaml
+++ b/installation/resources/installer-local.yaml
@@ -117,7 +117,7 @@ spec:
       serviceAccountName: kyma-installer
       initContainers:
       - name: certhelper
-        image: eu.gcr.io/kyma-project/test-infra/alpine-kubectl:v20200310-5f52f407
+        image: eu.gcr.io/kyma-project/test-infra/alpine-kubectl:v20200507-070ff576
         command:
           - bash
           - -c

--- a/installation/resources/installer.yaml
+++ b/installation/resources/installer.yaml
@@ -115,7 +115,7 @@ spec:
       serviceAccountName: kyma-installer
       initContainers:
       - name: certhelper
-        image: eu.gcr.io/kyma-project/test-infra/alpine-kubectl:v20200310-5f52f407
+        image: eu.gcr.io/kyma-project/test-infra/alpine-kubectl:v20200507-070ff576
         command:
           - bash
           - -c

--- a/installation/resources/tiller.yaml
+++ b/installation/resources/tiller.yaml
@@ -52,7 +52,7 @@ spec:
         imagePullPolicy: IfNotPresent
         command: ['sh', '-c', 'until nc -zv kube-dns.kube-system.svc.cluster.local 53; do echo waiting for k8s readiness; sleep 2; done;']
       - name: tiller-certhelper
-        image: eu.gcr.io/kyma-project/test-infra/alpine-kubectl:v20200310-5f52f407
+        image: eu.gcr.io/kyma-project/test-infra/alpine-kubectl:v20200507-070ff576
         command:
           - bash
           - -c

--- a/resources/api-gateway/values.yaml
+++ b/resources/api-gateway/values.yaml
@@ -3,7 +3,7 @@ replicaCount: 1
 rbacJob:
   image:
     repository: eu.gcr.io/kyma-project/test-infra/alpine-kubectl
-    tag: "v20200310-5f52f407"
+    tag: "v20200507-070ff576"
 
 image:
   repository: eu.gcr.io/kyma-project/incubator/develop/api-gateway-controller

--- a/resources/apiserver-proxy/templates/job.yaml
+++ b/resources/apiserver-proxy/templates/job.yaml
@@ -78,7 +78,7 @@ spec:
               done
               echo "Maximum retries exceeded"
               exit 1
-          image: eu.gcr.io/kyma-project/test-infra/alpine-kubectl:v20200310-5f52f407
+          image: eu.gcr.io/kyma-project/test-infra/alpine-kubectl:v20200507-070ff576
           name: gardener-annotate
       restartPolicy: Never
       serviceAccountName: {{ template "name" . }}-ssl-helper-service-account

--- a/resources/application-connector/charts/application-broker/templates/subscription-migration.yaml
+++ b/resources/application-connector/charts/application-broker/templates/subscription-migration.yaml
@@ -63,7 +63,7 @@ spec:
       restartPolicy: Never
       containers:
         - name: job
-          image: eu.gcr.io/kyma-project/test-infra/alpine-kubectl:v20200312-fc2a4147
+          image: eu.gcr.io/kyma-project/test-infra/alpine-kubectl:v20200507-070ff576
           env:
             - name: API_PACKAGES_SUPPORT
               value: "{{ .Values.global.disableLegacyConnectivity }}"

--- a/resources/cluster-essentials/templates/crd-init-compass-runtime-agent.yaml
+++ b/resources/cluster-essentials/templates/crd-init-compass-runtime-agent.yaml
@@ -36,7 +36,7 @@ spec:
       restartPolicy: Never
       containers:
       - name: job
-        image: eu.gcr.io/kyma-project/test-infra/alpine-kubectl:v20200310-5f52f407
+        image: eu.gcr.io/kyma-project/test-infra/alpine-kubectl:v20200507-070ff576
         terminationMessagePolicy: "FallbackToLogsOnError"
         volumeMounts:
         - name: crd-compass-rt

--- a/resources/compass/templates/agent-configuration-job.yaml
+++ b/resources/compass/templates/agent-configuration-job.yaml
@@ -54,7 +54,7 @@ spec:
       restartPolicy: Never
       containers:
         - name: compass-agent-configuration
-          image: "eu.gcr.io/kyma-project/test-infra/alpine-kubectl:v20200310-5f52f407"
+          image: "eu.gcr.io/kyma-project/test-infra/alpine-kubectl:v20200507-070ff576"
           command:
             - bash
             - -c
@@ -63,7 +63,7 @@ spec:
               DIRECTOR_URL=http://compass-director.{{ .Release.Namespace }}.svc.cluster.local:{{ .Values.global.director.port }}/graphql
               DIRECTOR_HEALTHZ_URL=http://compass-director.{{ .Release.Namespace }}.svc.cluster.local:{{ .Values.global.director.port }}/healthz
               CONNECTOR_EXTERNAL_URL=https://{{ .Values.global.gateway.tls.host }}.{{ .Values.global.ingress.domainName }}/connector/graphql
-              
+
               TOKEN_PAYLOAD_TENANT=""
               ENCODED_TOKEN_PAYLOAD_TENANT=""
               INTERNAL_TOKEN_TENANT=""
@@ -71,7 +71,7 @@ spec:
               TOKEN_PAYLOAD_NO_TENANT='{"scopes":"tenant:read","externalTenant":"","tenant":""}'
               ENCODED_TOKEN_PAYLOAD_NO_TENANT=$(echo -e ${TOKEN_PAYLOAD_NO_TENANT} | base64 | tr -d \\n)
               INTERNAL_TOKEN_NO_TENANT="eyJhbGciOiJub25lIiwidHlwIjoiSldUIn0.${ENCODED_TOKEN_PAYLOAD_NO_TENANT//=}."
-              
+
               echo "Token without tenant: ${INTERNAL_TOKEN_NO_TENANT}"
 
               function kill_proxy_and_exit() {
@@ -152,7 +152,7 @@ spec:
                       echo "Max retries has been reached (retries $MAX_RETRIES). Exit."
                       exit 1
                     fi
-  
+
                     echo "Unable to fetch external tenant ID, waiting 15s..."
                     sleep 15
                   fi

--- a/resources/compass/templates/registration-job.yaml
+++ b/resources/compass/templates/registration-job.yaml
@@ -48,7 +48,7 @@ spec:
       restartPolicy: Never
       containers:
         - name: {{ template "fullname" . }}-registration
-          image: "eu.gcr.io/kyma-project/test-infra/alpine-kubectl:v20200310-5f52f407"
+          image: "eu.gcr.io/kyma-project/test-infra/alpine-kubectl:v20200507-070ff576"
           command:
             - bash
             - -c

--- a/resources/dex/templates/upgrade-job.yaml
+++ b/resources/dex/templates/upgrade-job.yaml
@@ -65,7 +65,7 @@ spec:
         runAsUser: 2000
       containers:
       - name: job
-        image: eu.gcr.io/kyma-project/test-infra/alpine-kubectl:v20200310-5f52f407
+        image: eu.gcr.io/kyma-project/test-infra/alpine-kubectl:v20200507-070ff576
         terminationMessagePolicy: "FallbackToLogsOnError"
         command:
           - /bin/bash

--- a/resources/istio/values.yaml
+++ b/resources/istio/values.yaml
@@ -5,7 +5,7 @@ kyma:
     - kube-system
   labelJob:
     image: eu.gcr.io/kyma-project/test-infra/alpine-kubectl
-    tag: "v20200310-5f52f407"
+    tag: "v20200507-070ff576"
 
 istio:
   installer:

--- a/resources/knative-serving-init/templates/delete-crd-job.yaml
+++ b/resources/knative-serving-init/templates/delete-crd-job.yaml
@@ -97,7 +97,7 @@ spec:
       restartPolicy: OnFailure
       containers:
       - name: delete-crd-knative-serving-crds
-        image: eu.gcr.io/kyma-project/test-infra/alpine-kubectl:v20200312-fc2a4147
+        image: eu.gcr.io/kyma-project/test-infra/alpine-kubectl:v20200507-070ff576
         imagePullPolicy: IfNotPresent
         command:
         - /bin/sh

--- a/resources/knative-serving/templates/pre-upgrade-job.yaml
+++ b/resources/knative-serving/templates/pre-upgrade-job.yaml
@@ -94,7 +94,7 @@ spec:
       restartPolicy: OnFailure
       containers:
       - command: ["sh", "/scripts/delete-resources.sh"]
-        image: eu.gcr.io/kyma-project/test-infra/alpine-kubectl:v20200310-5f52f407
+        image: eu.gcr.io/kyma-project/test-infra/alpine-kubectl:v20200507-070ff576
         imagePullPolicy: IfNotPresent
         name: pre-upgrade-delete-knative-serving-resources
         volumeMounts:

--- a/resources/monitoring/templates/kyma-additions/aks-kubelet-monitoring-patch.yaml
+++ b/resources/monitoring/templates/kyma-additions/aks-kubelet-monitoring-patch.yaml
@@ -125,7 +125,7 @@ spec:
       restartPolicy: Never
       containers:
         - name: aks-kubelet-monitoring-kyma-patch
-          image: eu.gcr.io/kyma-project/test-infra/alpine-kubectl:v20200310-5f52f407
+          image: eu.gcr.io/kyma-project/test-infra/alpine-kubectl:v20200507-070ff576
           command: ["/scripts/akspatch.sh"]
           volumeMounts:
             - name: aks-kubelet-monitoring-kyma-patch

--- a/resources/monitoring/templates/kyma-additions/monitoring-dns-patch.yaml
+++ b/resources/monitoring/templates/kyma-additions/monitoring-dns-patch.yaml
@@ -93,7 +93,7 @@ spec:
       restartPolicy: Never
       containers:
         - name: monitoring-dns-patch
-          image: eu.gcr.io/kyma-project/test-infra/alpine-kubectl:v20200310-5f52f407
+          image: eu.gcr.io/kyma-project/test-infra/alpine-kubectl:v20200507-070ff576
           command: ["/scripts/dnspatch.sh"]
           volumeMounts:
             - name: monitoring-dns-patch

--- a/resources/ory/charts/hydra/charts/hydra-maester/values.yaml
+++ b/resources/ory/charts/hydra/charts/hydra-maester/values.yaml
@@ -3,7 +3,7 @@ replicaCount: 1
 jobs:
   image:
     repository: eu.gcr.io/kyma-project/test-infra/alpine-kubectl
-    tag: "v20200310-5f52f407"
+    tag: "v20200507-070ff576"
 
 config:
   # SyncPeriod determines the minimum frequency at which watched resources are

--- a/resources/ory/charts/oathkeeper/charts/oathkeeper-master/templates/crd-job.yaml
+++ b/resources/ory/charts/oathkeeper/charts/oathkeeper-master/templates/crd-job.yaml
@@ -17,7 +17,7 @@ spec:
       serviceAccountName: {{ .Release.Name }}-crd-init
       containers:
       - name: {{ .Release.Name }}-crd-rules
-        image: "eu.gcr.io/kyma-project/test-infra/alpine-kubectl:v20200310-5f52f407"
+        image: "eu.gcr.io/kyma-project/test-infra/alpine-kubectl:v20200507-070ff576"
         volumeMounts:
         - name: crd-rules
           mountPath: /etc/ory/crd

--- a/resources/ory/values.yaml
+++ b/resources/ory/values.yaml
@@ -7,9 +7,9 @@ global:
     gateway:
       name: kyma-gateway
       namespace: kyma-system
-  ory:  
-    oathkeeper: 
-      maester:  
+  ory:
+    oathkeeper:
+      maester:
         mode: sidecar
     hydra:
       persistence:
@@ -49,7 +49,7 @@ hpa:
 maintenance:
   image:
     name: eu.gcr.io/kyma-project/test-infra/alpine-kubectl
-    tag: "v20200310-5f52f407"
+    tag: "v20200507-070ff576"
 
 # Overrides for the Hydra chart
 hydra:
@@ -93,7 +93,7 @@ hydra:
 # Overrides for the Oathkeeper chart
 oathkeeper:
   kubectlJob:
-    image: eu.gcr.io/kyma-project/test-infra/alpine-kubectl:v20200310-5f52f407
+    image: eu.gcr.io/kyma-project/test-infra/alpine-kubectl:v20200507-070ff576
   oathkeeper:
     config:
       authenticators:

--- a/resources/rafter/charts/upload-service/values.yaml
+++ b/resources/rafter/charts/upload-service/values.yaml
@@ -115,7 +115,7 @@ migrator:
   images:
     alpineKubectl:
       repository: eu.gcr.io/kyma-project/test-infra/alpine-kubectl
-      tag: 'v20200310-5f52f407'
+      tag: 'v20200507-070ff576'
       pullPolicy: IfNotPresent
     minioClient:
       repository: 'minio/mc'

--- a/resources/rafter/templates/pre-upgrade-delete-vs-job.yaml
+++ b/resources/rafter/templates/pre-upgrade-delete-vs-job.yaml
@@ -90,7 +90,7 @@ spec:
       restartPolicy: OnFailure
       containers:
       - command: ["sh", "/scripts/delete-resources.sh"]
-        image: eu.gcr.io/kyma-project/test-infra/alpine-kubectl:v20200310-5f52f407
+        image: eu.gcr.io/kyma-project/test-infra/alpine-kubectl:v20200507-070ff576
         imagePullPolicy: IfNotPresent
         name: pre-upgrade-delete-vs-rafter-minio
         volumeMounts:

--- a/resources/rafter/values.yaml
+++ b/resources/rafter/values.yaml
@@ -328,7 +328,7 @@ upload-service:
     images:
       alpineKubectl:
         repository: eu.gcr.io/kyma-project/test-infra/alpine-kubectl
-        tag: 'v20200310-5f52f407'
+        tag: 'v20200507-070ff576'
         pullPolicy: IfNotPresent
       minioClient:
         repository: eu.gcr.io/kyma-project/incubator/develop/minio/mc

--- a/resources/serverless/values.yaml
+++ b/resources/serverless/values.yaml
@@ -7,7 +7,7 @@ fullnameOverride: "serverless"
 bindingsMigration:
   image:
     repository: 'eu.gcr.io/kyma-project/test-infra/alpine-kubectl'
-    tag: 'v20200310-5f52f407'
+    tag: 'v20200507-070ff576'
     pullPolicy: IfNotPresent
 
 tests:
@@ -62,7 +62,7 @@ images:
     pullPolicy: IfNotPresent
   functionRuntimeNodejs12:
     repository: "eu.gcr.io/kyma-project/function-runtime-nodejs12"
-    tag: "a62f4a7f"  
+    tag: "a62f4a7f"
 
 deployment:
   replicas: 1
@@ -210,7 +210,7 @@ clusterMicroFrontend:
 grafanaDashboard:
   enabled: true
 
-usageKind: 
+usageKind:
   name: serverless-function
 
 docker-registry:

--- a/resources/service-catalog/charts/catalog/values.yaml
+++ b/resources/service-catalog/charts/catalog/values.yaml
@@ -128,4 +128,4 @@ securityContext: {}
 
 ## images for migration process
 migration:
-  alpineKcImage: eu.gcr.io/kyma-project/test-infra/alpine-kubectl:v20200310-5f52f407
+  alpineKcImage: eu.gcr.io/kyma-project/test-infra/alpine-kubectl:v20200507-070ff576


### PR DESCRIPTION
**Description**

Bump alpine-kubectl image to latest version: eu.gcr.io/kyma-project/test-infra/alpine-kubectl:v20200507-070ff576 (security fixes)

Changes proposed in this pull request:

- Bump all 'alpine-kubectl' images used directly in Kyma resources to the latest version