### PR TITLE
Image bump

### DIFF
--- a/components/dex-static-user-configurer/Dockerfile
+++ b/components/dex-static-user-configurer/Dockerfile
@@ -1,4 +1,4 @@
-FROM eu.gcr.io/kyma-project/test-infra/alpine-kubectl:v20200309-9a88ce97
+FROM eu.gcr.io/kyma-project/test-infra/alpine-kubectl:v20200507-070ff576
 
 RUN apk add --no-cache jq apache2-utils
 

--- a/components/etcd-tls-setup-job/Dockerfile
+++ b/components/etcd-tls-setup-job/Dockerfile
@@ -1,4 +1,4 @@
-FROM eu.gcr.io/kyma-project/test-infra/alpine-kubectl:v20200309-9a88ce97
+FROM eu.gcr.io/kyma-project/test-infra/alpine-kubectl:v20200507-070ff576
 
 LABEL source=git@github.com:kyma-project/kyma.git
 

--- a/components/istio-installer/Dockerfile
+++ b/components/istio-installer/Dockerfile
@@ -1,4 +1,4 @@
-FROM eu.gcr.io/kyma-project/test-infra/alpine-kubectl:v20200309-9a88ce97
+FROM eu.gcr.io/kyma-project/test-infra/alpine-kubectl:v20200507-070ff576
 
 LABEL source=git@github.com:kyma-project/kyma.git
 

--- a/components/istio-installer/README.md
+++ b/components/istio-installer/README.md
@@ -1,10 +1,10 @@
 # Istio installer
 
 ## Overview
-Base image used: `eu.gcr.io/kyma-project/test-infra/alpine-kubectl:v20200121-4f3202bd`
+Base image used: `eu.gcr.io/kyma-project/test-infra/alpine-kubectl:v20200507-070ff576`
 
 Alpine based docker image with additional software:
 - bash
-- kubectl 
+- kubectl
 - istioctl
 - [yq](https://github.com/mikefarah/yq)

--- a/components/istio-kyma-patch/Dockerfile
+++ b/components/istio-kyma-patch/Dockerfile
@@ -1,4 +1,4 @@
-FROM eu.gcr.io/kyma-project/test-infra/alpine-kubectl:v20200309-9a88ce97
+FROM eu.gcr.io/kyma-project/test-infra/alpine-kubectl:v20200507-070ff576
 
 LABEL source=git@github.com:kyma-project/kyma.git
 

--- a/components/xip-patch/Dockerfile
+++ b/components/xip-patch/Dockerfile
@@ -1,4 +1,4 @@
-FROM eu.gcr.io/kyma-project/test-infra/alpine-kubectl:v20200309-9a88ce97
+FROM eu.gcr.io/kyma-project/test-infra/alpine-kubectl:v20200507-070ff576
 
 LABEL source=git@github.com:kyma-project/kyma.git
 

--- a/resources/api-gateway/values.yaml
+++ b/resources/api-gateway/values.yaml
@@ -79,7 +79,7 @@ tests:
   enabled: true
   image:
     registry: "eu.gcr.io/kyma-project"
-    version: "8256adfe"
+    version: "PR-8619"
   env:
     testUser: "admin-user"
     timeout: 120

--- a/resources/apiserver-proxy/values.yaml
+++ b/resources/apiserver-proxy/values.yaml
@@ -43,4 +43,4 @@ global:
     path: eu.gcr.io/kyma-project
   xip_patch:
     dir:
-    version: 0e322dac
+    version: PR-8619

--- a/resources/core/values.yaml
+++ b/resources/core/values.yaml
@@ -42,7 +42,7 @@ global:
     version: "d4ff1c8c"
   xip_patch:
     dir:
-    version: 0e322dac
+    version: PR-8619
   e2e_external_solution:
     dir:
     version: e1bc4644

--- a/resources/dex/values.yaml
+++ b/resources/dex/values.yaml
@@ -83,7 +83,7 @@ global:
       namespace: kyma-system
   dex_static_user_configurer:
     dir:
-    version: 3b88aaaf
+    version: PR-8619
   containerRegistry:
     path: eu.gcr.io/kyma-project
   dex_integration_tests:

--- a/resources/istio-kyma-patch/values.yaml
+++ b/resources/istio-kyma-patch/values.yaml
@@ -7,5 +7,5 @@ global:
     version: 84219cbc
   istio_kyma_patch:
     dir:
-    version: 3b88aaaf
+    version: PR-8619
   required_istio_version: 1.4.7-distroless

--- a/resources/istio/values.yaml
+++ b/resources/istio/values.yaml
@@ -10,4 +10,4 @@ kyma:
 istio:
   installer:
     image: eu.gcr.io/kyma-project/istio-installer
-    tag: "ce7e3510"
+    tag: "PR-8619"

--- a/resources/xip-patch/values.yaml
+++ b/resources/xip-patch/values.yaml
@@ -2,7 +2,7 @@ containerRegistry:
   path: eu.gcr.io/kyma-project
 xip_patch:
   dir:
-  version: 0e322dac
+  version: PR-8619
 tls:
   secretName: "kyma-gateway-certs"
 global:

--- a/tests/integration/api-gateway/Dockerfile
+++ b/tests/integration/api-gateway/Dockerfile
@@ -20,7 +20,7 @@ RUN mkdir /test &&\
 	mv ${BASE_DIR}/app.test /test/app.test  &&\
 	mv ${BASE_DIR}/licenses /test/licenses
 
-FROM eu.gcr.io/kyma-project/test-infra/alpine-kubectl:v20200310-5f52f407
+FROM eu.gcr.io/kyma-project/test-infra/alpine-kubectl:v20200507-070ff576
 LABEL source=git@github.com:kyma-project/kyma.git
 WORKDIR /test
 


### PR DESCRIPTION
**Description**

Bump alpine-kubectl image to latest version: eu.gcr.io/kyma-project/test-infra/alpine-kubectl:v20200507-070ff576 (security fixes)

Changes proposed in this pull request:

- Bump all 'alpine-kubectl' images used in Dockerfiles of Kyma components to the latest version