### PR TITLE
Fix broken links to Gardener documentation

### DIFF
--- a/docs/kyma/04-04-cluster-installation.md
+++ b/docs/kyma/04-04-cluster-installation.md
@@ -170,7 +170,7 @@ This installation guide explains how you can quickly deploy Kyma on a cluster wi
 
     * For GCP:
       * Create a project in Gardener.
-      * Add a [new service account and roles](https://gardener.cloud/050-tutorials/content/howto/gardener_gcp/#create-a-new-serviceaccount-and-assign-roles).
+      * Add a [new service account and roles](https://gardener.cloud/documentation/050-tutorials/content/howto/gardener_gcp/#create-a-new-serviceaccount-and-assign-roles).
       * Add the GCP Secret under **Secrets** in the Gardener dashboard.
       * Add the service account and download Gardener's `kubeconfig` file.
 

--- a/docs/security/10-03-certificates-gardener.md
+++ b/docs/security/10-03-certificates-gardener.md
@@ -3,7 +3,7 @@ title: Issues with certificates on Gardener
 type: Troubleshooting
 ---
 
-During installation on Gardener, Kyma requests domain SSL certificates using the Gardener's [`Certificate`](https://gardener.cloud/050-tutorials/content/howto/x509_certificates/#request-a-certificate-via-certificate) custom resource to ensure secure communication through both Kyma UI and Kubernetes CLI. 
+During installation on Gardener, Kyma requests domain SSL certificates using the Gardener's [`Certificate`](https://gardener.cloud/documentation/050-tutorials/content/howto/x509_certificates/#request-a-certificate-via-certificate) custom resource to ensure secure communication through both Kyma UI and Kubernetes CLI. 
 
 This process can result in the following issues:
 


### PR DESCRIPTION
**Description**

Since the location of the Gardener documentation changed, the links had to be updated. 

Changes proposed in this pull request:

- Fix broken links to the Gardener documentation.