### PR TITLE
Improving monitoring test error message

### DIFF
--- a/resources/monitoring/values.yaml
+++ b/resources/monitoring/values.yaml
@@ -11,7 +11,7 @@ global:
   monitoring_integration_tests:
     name: monitoring-integration-tests
     dir:
-    version: 7e73540b
+    version: PR-8656
     tests:
       enabled: true
 

--- a/tests/end-to-end/upgrade/chart/upgrade/values.yaml
+++ b/tests/end-to-end/upgrade/chart/upgrade/values.yaml
@@ -3,7 +3,7 @@ containerRegistry:
 
 image:
   dir:
-  version: PR-8540
+  version: PR-8656
   pullPolicy: "IfNotPresent"
 
 dex:

--- a/tests/end-to-end/upgrade/pkg/tests/monitoring/prom/targets.go
+++ b/tests/end-to-end/upgrade/pkg/tests/monitoring/prom/targets.go
@@ -18,7 +18,4 @@ type ActiveTarget struct {
 	Health    string `json:"health"`
 }
 
-type Labels struct {
-	Instance string `json:"instance"`
-	Job      string `json:"job"`
-}
+type Labels map[string]string

--- a/tests/end-to-end/upgrade/pkg/tests/monitoring/targets_rules.go
+++ b/tests/end-to-end/upgrade/pkg/tests/monitoring/targets_rules.go
@@ -178,7 +178,11 @@ func (t TargetsAndRulesTest) testTargetsAreHealthy() error {
 			for _, target := range activeTargets {
 				if target.Health != "up" && target.Labels.Job != "istio-ingressgateway" {
 					allTargetsAreHealthy = false
-					timeoutMessage += fmt.Sprintf("Target with job=%s and instance=%s is not healthy\n", target.Labels.Job, target.Labels.Instance)
+					timeoutMessage += "The following target is not healthy:\n"
+					for label, value := range target.Labels {
+						timeoutMessage += fmt.Sprintf("- %s=%s\n", label, value)
+					}
+					timeoutMessage += fmt.Sprintf("- errorMessage: %s", target.LastError)
 				}
 			}
 			if allTargetsAreHealthy {

--- a/tests/end-to-end/upgrade/pkg/tests/monitoring/targets_rules.go
+++ b/tests/end-to-end/upgrade/pkg/tests/monitoring/targets_rules.go
@@ -176,7 +176,7 @@ func (t TargetsAndRulesTest) testTargetsAreHealthy() error {
 			allTargetsAreHealthy := true
 			timeoutMessage = ""
 			for _, target := range activeTargets {
-				if target.Health != "up" && target.Labels.Job != "istio-ingressgateway" {
+				if target.Health != "up" {
 					allTargetsAreHealthy = false
 					timeoutMessage += "The following target is not healthy:\n"
 					for label, value := range target.Labels {

--- a/tests/integration/monitoring/prom/rules.go
+++ b/tests/integration/monitoring/prom/rules.go
@@ -1,4 +1,4 @@
-package promAPI
+package prom
 
 // To parse JSON response from http://monitoring-prometheus.kyma-system:9090/api/v1/rules
 type AlertResponse struct {

--- a/tests/integration/monitoring/prom/targets.go
+++ b/tests/integration/monitoring/prom/targets.go
@@ -1,4 +1,4 @@
-package promAPI
+package prom
 
 // To parse JSON response from http://monitoring-prometheus.kyma-system:9090/api/v1/targets
 type TargetsResponse struct {

--- a/tests/integration/monitoring/test-monitoring.go
+++ b/tests/integration/monitoring/test-monitoring.go
@@ -155,7 +155,11 @@ func testTargetsAreHealthy() {
 				}
 				if target.Health != "up" {
 					allTargetsAreHealthy = false
-					timeoutMessage += fmt.Sprintf("Target with job=%s and instance=%s is not healthy, with labels=%v\n", target.Labels["job"], target.Labels["instance"], target.Labels)
+					timeoutMessage += "The following target is not healthy:\n"
+					for label, value := range target.Labels {
+						timeoutMessage += fmt.Sprintf("- %s=%s\n", label, value)
+					}
+					timeoutMessage += fmt.Sprintf("- errorMessage: %s", target.LastError)
 				}
 			}
 			if allTargetsAreHealthy {

--- a/tests/integration/monitoring/test-monitoring.go
+++ b/tests/integration/monitoring/test-monitoring.go
@@ -127,7 +127,7 @@ func testPodsAreReady() {
 
 func testTargetsAreHealthy() {
 	timeout := time.After(3 * time.Minute)
-	tick := time.NewTicker(30 * time.Second)
+	tick := time.NewTicker(5 * time.Second)
 
 	var timeoutMessage string
 	for {
@@ -188,7 +188,7 @@ func shouldIgnoreTarget(target promAPI.Labels) bool {
 
 func testRulesAreHealthy() {
 	timeout := time.After(3 * time.Minute)
-	tick := time.NewTicker(30 * time.Second)
+	tick := time.NewTicker(5 * time.Second)
 	var timeoutMessage string
 	for {
 		select {

--- a/tests/integration/monitoring/test-monitoring.go
+++ b/tests/integration/monitoring/test-monitoring.go
@@ -18,7 +18,7 @@ import (
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 
-	"github.com/kyma-project/kyma/tests/integration/monitoring/promAPI"
+	"github.com/kyma-project/kyma/tests/integration/monitoring/prom"
 )
 
 const prometheusURL = "http://monitoring-prometheus.kyma-system:9090"
@@ -136,11 +136,10 @@ func testTargetsAreHealthy() {
 			tick.Stop()
 			log.Fatal(timeoutMessage)
 		case <-tick.C:
-			var resp promAPI.TargetsResponse
+			var resp prom.TargetsResponse
 			url := fmt.Sprintf("%s/api/v1/targets", prometheusURL)
 			respBody, statusCode := doGet(url)
-			err := json.Unmarshal([]byte(respBody), &resp)
-			if err != nil {
+			if err := json.Unmarshal([]byte(respBody), &resp); err != nil {
 				log.Fatalf("Error unmarshalling response: %v.\nResponse body: %s", err, respBody)
 			}
 			if statusCode != 200 || resp.Status != "success" {
@@ -171,7 +170,7 @@ func testTargetsAreHealthy() {
 
 }
 
-func shouldIgnoreTarget(target promAPI.Labels) bool {
+func shouldIgnoreTarget(target prom.Labels) bool {
 	var jobsToBeIgnored = []string{
 		// Note: These targets will be tested here: https://github.com/kyma-project/kyma/issues/6457
 		"knative-eventing/knative-eventing-event-mesh-dashboard-broker",
@@ -196,11 +195,10 @@ func testRulesAreHealthy() {
 			tick.Stop()
 			log.Fatal(timeoutMessage)
 		case <-tick.C:
-			var resp promAPI.AlertResponse
+			var resp prom.AlertResponse
 			url := fmt.Sprintf("%s/api/v1/rules", prometheusURL)
 			respBody, statusCode := doGet(url)
-			err := json.Unmarshal([]byte(respBody), &resp)
-			if err != nil {
+			if err := json.Unmarshal([]byte(respBody), &resp); err != nil {
 				log.Fatalf("Error unmarshalling response: %v.\nResponse body: %s", err, respBody)
 			}
 			if statusCode != 200 || resp.Status != "success" {


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/master/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- improving monitoring test error message by including all the labels for the failing target
- No need anymore to exclude `istio-ingressgateway` from monitoring upgrade test, since its service monitor is disabled here: https://github.com/kyma-project/kyma/pull/7904
- reduce ticking interval in monitoring integration test
- rename promAPI package to prom in monitoring integration test to be consistent with the naming used in the upgrade test

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
#8656 