### PR TITLE
Make management components uninstallationable

### DIFF
--- a/resources/application-connector/values.yaml
+++ b/resources/application-connector/values.yaml
@@ -9,6 +9,12 @@ global:
   isLocalEnv: false
   namespace: kyma-integration
   strictMode: disabled
+  ingress:
+    domainName: "TBD"
+  helm:
+    tls:
+      crt: "TBD"
+      key: "TBD"
   istio:
     namespace: istio-system
     tls:

--- a/resources/helm-broker/templates/clear-cr-job.yaml
+++ b/resources/helm-broker/templates/clear-cr-job.yaml
@@ -1,0 +1,51 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ template "fullname" . }}-cleanup
+  labels:
+    app: {{ template "fullname" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+  annotations:
+    "helm.sh/hook": pre-delete
+    "helm.sh/hook-weight": "1"
+    "helm.sh/hook-delete-policy": before-hook-creation, hook-succeeded
+spec:
+  backoffLimit: 1
+  template:
+    metadata:
+      annotations:
+        sidecar.istio.io/inject: "false"
+    spec:
+      serviceAccountName: {{ template "fullname" . }}
+      restartPolicy: Never
+      containers:
+        - name: job
+          image: "eu.gcr.io/kyma-project/test-infra/alpine-kubectl:v20200310-5f52f407"
+          command:
+            - bash
+            - -c
+            - |-
+              MAX_RETRIES=60
+              cnt=0
+
+              kubectl delete clusteraddonsconfigurations.addons.kyma-project.io helm-repos-urls > /dev/null 2>&1
+
+              while :
+                do
+                  kubectl get clusteraddonsconfigurations.addons.kyma-project.io helm-repos-urls -o=jsonpath='{.metadata.name}' > /dev/null 2>&1
+                  if [[ $? -eq "helm-repos-urls" ]]; then
+                    ((cnt++))
+                    if (( cnt > $MAX_RETRIES )); then
+                    echo "Max retries has been reached (retries $MAX_RETRIES). Exit."
+                    exit 1
+                  fi
+
+                  echo "Removing clusteraddonsconfigurations helm-repos-urls..."
+                  sleep 1
+                  else
+                    echo "clusteraddonsconfigurations helm-repos-urls has been removed"
+                    break
+                  fi
+              done

--- a/resources/helm-broker/values.yaml
+++ b/resources/helm-broker/values.yaml
@@ -70,3 +70,10 @@ global:
       - "bitbucket.org/"
     additionalDevelopMode:
       - "http://"
+
+  ingress:
+    domainName: "TBD"
+  helm:
+    tls:
+      crt: "TBD"
+      key: "TBD"

--- a/resources/service-catalog-addons/charts/service-binding-usage-controller/templates/clear-cr-job.yaml
+++ b/resources/service-catalog-addons/charts/service-binding-usage-controller/templates/clear-cr-job.yaml
@@ -1,0 +1,51 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ template "fullname" . }}-cleanup
+  labels:
+    app: {{ template "fullname" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+  annotations:
+    "helm.sh/hook": pre-delete
+    "helm.sh/hook-weight": "1"
+    "helm.sh/hook-delete-policy": before-hook-creation, hook-succeeded
+spec:
+  backoffLimit: 1
+  template:
+    metadata:
+      annotations:
+        sidecar.istio.io/inject: "false"
+    spec:
+      serviceAccountName: {{ template "fullname" . }}
+      restartPolicy: Never
+      containers:
+        - name: job
+          image: "eu.gcr.io/kyma-project/test-infra/alpine-kubectl:v20200310-5f52f407"
+          command:
+            - bash
+            - -c
+            - |-
+              MAX_RETRIES=60
+              cnt=0
+
+              kubectl delete usagekinds.servicecatalog.kyma-project.io deployment > /dev/null 2>&1
+
+              while :
+                do
+                  kubectl get usagekinds.servicecatalog.kyma-project.io deployment -o=jsonpath='{.metadata.name}' > /dev/null 2>&1
+                  if [[ $? -eq "deployment" ]]; then
+                    ((cnt++))
+                    if (( cnt > $MAX_RETRIES )); then
+                    echo "Max retries has been reached (retries $MAX_RETRIES). Exit."
+                    exit 1
+                  fi
+
+                  echo "Removing usagekinds deployment..."
+                  sleep 1
+                  else
+                    echo "usagekinds deployment has been removed"
+                    break
+                  fi
+              done

--- a/resources/service-catalog-addons/requirements.yaml
+++ b/resources/service-catalog-addons/requirements.yaml
@@ -1,9 +1,5 @@
 dependencies:
 - name: service-binding-usage-controller
   condition: service-binding-usage-controller.enabled
-- name: broker-ui
-  condition: broker-ui.enabled
-- name: catalog-ui
+- name: service-catalog-ui
   condition: catalog-ui.enabled
-- name: instances-ui
-  condition: instances-ui.enabled

--- a/resources/service-catalog-addons/values.yaml
+++ b/resources/service-catalog-addons/values.yaml
@@ -7,3 +7,5 @@ global:
   service_binding_usage_controller:
     dir:
     version: 7a244165
+  ingress:
+    domainName: "TBD"


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

Proposed changes allow to install and uninstall management components repeatedly.
The management components consists of 4 elements:
1. ServiceCatalog
  This component did not require any modifications, installation and uninstallation work correctly.
2. ServiceBindingUsage
  The component is one of the sub chart of `service-catalog-addons` chart. The component required the following modifications:
  - add default value for key `global.ingress.domainName` in `values.yaml`
  - requirements correction (removes old dependencies, adding new ones)
  - adding pre-delete job which removes CR `usagekinds` "deployment" before removing SBU controller.
    Remove controller before CR, resulted in the finalizer `servicecatalog.kyma-project.io/usage-kind-protection` not being removed from the CR and CR was not removed at all.
3. HelmBroker
  The component required the following modifications:
  - add default value for keys `global.ingress.domainName`, `global.helm.tls.crt` and `global.helm.tls.key` in `values.yaml`
  - adding pre-delete job which removes CR `clusteraddonsconfigurations` "helm-repos-urls" before removing addons controller.
    Remove controller before CR, resulted in the finalizer `addons.kyma-project.io` not being removed from the CR and CR was not removed at all.
4. ApplicationBroker
  The component is one of the sub chart of `application-connector` chart. The component required the following modifications:
  - add default value for keys `global.ingress.domainName`, `global.helm.tls.crt` and `global.helm.tls.key` in `values.yaml`

  after reinstalling `application-connector` chart, pod `connection-token-handler` restarts with error:
  ```
  > if kind is a CRD, it should be installed before calling Start: no matches for kind "TokenRequest" in version "applicationconnector.kyma-project.io/v1alpha1"
  > unable to register the tokenrequest controller to the manager: no matches for kind "TokenRequest" in version "applicationconnector.kyma-project.io/v1alpha1"
  ```
  the chart itself is installed correctly with status `DEPLOYED`


**Related issue(s)**
#8562 
