### PR TITLE
Add missing alt texts to describe images and diagrams

### DIFF
--- a/docs/compass/02-03-detailed-workflow.md
+++ b/docs/compass/02-03-detailed-workflow.md
@@ -17,7 +17,7 @@ Connecting an Application consists of two phases: Application pairing and API re
 
 Application pairing phase is a process of creating a new Application and establishing a trusted connection between the Application and Compass. The workflow looks as follows:
 
-![](./assets/app-pairing.svg)
+![Application pairing](./assets/app-pairing.svg)
 
 1. Administrator sends a request to register a new Application in Compass.
 2. Director registers the Application.
@@ -31,7 +31,7 @@ Application pairing phase is a process of creating a new Application and establi
 
 API registration phase is a process of registering new API and Event Definitions, which consists of two steps:
 
-![](./assets/api-registration.svg)
+![API registration](./assets/api-registration.svg)
 
 1. Application sends a request to the Director to register an API or Event Definition.
 2. Director returns the operation result to the Application.
@@ -40,7 +40,7 @@ API registration phase is a process of registering new API and Event Definitions
 
 The process of registering a new Runtime looks as follows:
 
-![](./assets/runtime-creation.svg)
+![Runtime creation](./assets/runtime-creation.svg)
 
 1. Administrator sends a request to provision a new Runtime.
 2. Runtime Provisioner requests Runtime configuration from the Director.
@@ -66,11 +66,11 @@ There are two options for updating Application configuration:
 
 In the first case, the Application periodically pulls configuration details, such as **eventURL**, for connected Runtimes.
 
-![](./assets/app-configuration-update.svg)
+![Application configuration update](./assets/app-configuration-update.svg)
 
 In the second case, if configuration for any connected Runtime changes, Application Webhook API notifies an Application that new configuration details are available. The following diagram shows the interaction between the Runtime Agent, the Director, and an Application when a new Runtime is configured successfully:
 
-![](./assets/runtime-notification.svg)
+![Runtime notification](./assets/runtime-notification.svg)
 
 1. Runtime Agent sends a request to change Application configuration.
 2. Director notifies the Application about the request.
@@ -81,4 +81,4 @@ In the second case, if configuration for any connected Runtime changes, Applicat
 
 Runtime Agent gets Runtime configuration details from the Director and applies the configuration asynchronously. The configuration details include information such as the list of Applications and their credentials. Runtime Agent periodically checks for new configuration details and applies the changes.
 
-![](./assets/runtime-configuration-update.svg)
+![Runtime configuration update](./assets/runtime-configuration-update.svg)

--- a/docs/monitoring/01-01-monitoring.md
+++ b/docs/monitoring/01-01-monitoring.md
@@ -11,4 +11,4 @@ The whole installation package provides the end-to-end Kubernetes cluster monito
 - Manage the default alert rules and create new ones.
 - Set up channels for notifications informing of any detected alerts.
 
->**NOTE:** The monitoring component is available by default in the cluster installation, but disabled in the **Kyma Lite** local installation on Minikube.[Enable the component](/root/kyma/#configuration-custom-component-installation-add-a-component) to install it with the [local profile](/components/monitoring/#configuration-monitoring-profiles-local-profile).
+>**NOTE:** The monitoring component is available by default in the cluster installation, but disabled in the **Kyma Lite** local installation on Minikube. [Enable the component](/root/kyma/#configuration-custom-component-installation-add-a-component) to install it with the [local profile](/components/monitoring/#configuration-monitoring-profiles-local-profile).

--- a/docs/monitoring/02-01-monitoring.md
+++ b/docs/monitoring/02-01-monitoring.md
@@ -7,7 +7,7 @@ Before you go into component details, find out more about the end-to-end monitor
 
 The complete monitoring flow in Kyma comes down to these components and steps:
 
-![](./assets/monitoring-flow.svg)
+![End-to-end monitoring flow](./assets/monitoring-flow.svg)
 
 1. Upon Kyma installation on a cluster, Prometheus Operator creates a Prometheus instance with the default configuration.
 2. The Prometheus server periodically polls all metrics exposed on `/metrics` endpoints of ports specified in ServiceMonitor CRDs. Prometheus stores these metrics in a time-series database.
@@ -19,7 +19,7 @@ The complete monitoring flow in Kyma comes down to these components and steps:
 
 The diagram presents monitoring components and the way they interact with one another.
 
-![](./assets/monitoring-architecture.svg)
+![Monitoring components](./assets/monitoring-architecture.svg)
 
 
 1. [**Prometheus Operator**](https://github.com/coreos/prometheus-operator) creates a Prometheus instance, manages its deployment, and provides configuration for it. It also deploys Alertmanager and operates ServiceMonitor custom resources that specify monitoring definitions for groups of services.
@@ -27,12 +27,10 @@ The diagram presents monitoring components and the way they interact with one an
 2. [**Prometheus**](https://prometheus.io/docs/introduction) collects metrics from Pods. Metrics are the time-stamped data that provide information on the running jobs, workload, CPU consumption, memory usage, and more. To obtain such metrics, Prometheus uses the [**kube-state-metrics**](https://github.com/kubernetes/kube-state-metrics) service. It generates the metrics from Kubernetes API objects and exposes them on the `/metrics` HTTP endpoint.  
 Pods can also contain applications with custom metrics, such as the total storage space available in the MinIO server. Prometheus stores this polled data in a time-series database (TSDB) and runs rules over them to generate alerts if it detects any metric anomalies. It also scrapes metrics provided by [**Node Exporter**](https://github.com/mindprince/nvidia_gpu_prometheus_exporter) which exposes existing hardware metrics from external systems as Prometheus metrics.
 
-3. **ServiceMonitors** monitor services and specify the endpoints from which Prometheus should poll the metrics. Even if you expose a handful of metrics in your application, Prometheus polls only those from the `/metrics` endpoints of ports specified in ServiceMonitor CRDs. 
+3. **ServiceMonitors** monitor services and specify the endpoints from which Prometheus should poll the metrics. Even if you expose a handful of metrics in your application, Prometheus polls only those from the `/metrics` endpoints of ports specified in ServiceMonitor CRDs.
 
-4. [**Alertmanager**](https://prometheus.io/docs/alerting/alertmanager/) receives alerts from Prometheus and forwards this data to configured Slack or Victor Ops channels.  You can use **PrometheusRules** to define alert conditions for metrics. Kyma provides a set of out-of-the-box alerting rules that are passed from Prometheus to Alertmanager. The definitions of such rules specify the alert logic, the value at which alerts are triggered, the alerts' severity, and more. 
+4. [**Alertmanager**](https://prometheus.io/docs/alerting/alertmanager/) receives alerts from Prometheus and forwards this data to configured Slack or Victor Ops channels.  You can use **PrometheusRules** to define alert conditions for metrics. Kyma provides a set of out-of-the-box alerting rules that are passed from Prometheus to Alertmanager. The definitions of such rules specify the alert logic, the value at which alerts are triggered, the alerts' severity, and more.
 
     >**NOTE:** There are no notification channels configured in the default monitoring installation. The current configuration allows you to add either Slack or Victor Ops channels.
 
 5. [**Grafana**](https://grafana.com/docs/guides/getting_started/) provides a dashboard and a graph editor to visualize metrics collected from the Prometheus API. Grafana uses the query language called [PromQL](https://prometheus.io/docs/prometheus/latest/querying/basics/) to select and aggregate metrics data from the Prometheus database. To access the Grafana UI, use the `https://grafana.{DOMAIN}` address, where `{DOMAIN}` is the domain of your Kyma cluster.
-
-

--- a/docs/monitoring/08-04-define-alerting-rules.md
+++ b/docs/monitoring/08-04-define-alerting-rules.md
@@ -68,8 +68,8 @@ Follow these steps to create an alerting rule:
 
 4. Go to [`http://localhost:9090/rules`](http://localhost:9090/rules) to view the rule in the dashboard.
 
-   ![](./assets/rules-dashboard.png)
+   ![Rule on the dashboard](./assets/rules-dashboard.png)
 
 5. Go to [`http://localhost:9090/alerts`](http://localhost:9090/alerts) to see if the alert fires appropriately.
 
-   ![](./assets/fired-alert.png)
+   ![Alert on the dashboard](./assets/fired-alert.png)

--- a/docs/rafter/02-01-basic-asset-flow.md
+++ b/docs/rafter/02-01-basic-asset-flow.md
@@ -7,7 +7,7 @@ This diagram shows a high-level overview of how Rafter works:
 
 >**NOTE:** This flow also applies to the cluster-wide counterparts of all CRs.
 
-![](./assets/basic-architecture.svg)
+![Basic architecture](./assets/basic-architecture.svg)
 
 1. The user creates a Bucket CR. This propagates the creation of buckets in MinIO Gateway where assets will be stored.
 2. The user creates an Asset CR that contains the reference to assets.

--- a/docs/rafter/02-02-assetgroup.md
+++ b/docs/rafter/02-02-assetgroup.md
@@ -7,7 +7,7 @@ This diagram provides more details of the AssetGroup CR flow, the controller tha
 
 >**NOTE:** This flow also applies to the ClusterAssetGroup CR.
 
-![](./assets/rafter-architecture-1.svg)
+![AssetGroup CR flow](./assets/rafter-architecture-1.svg)
 
 1. The user creates an AssetGroup CR in a given Namespace.
 2. The AssetGroup Controller (AGC) reads the AssetGroup CR definition.

--- a/docs/rafter/02-03-asset-and-bucket.md
+++ b/docs/rafter/02-03-asset-and-bucket.md
@@ -5,7 +5,7 @@ type: Architecture
 
 This diagram provides an overview of the basic Asset and Bucket CRs flow and the role of particular components in this process:
 
-![](./assets/rafter-architecture-2.svg)
+![Rafter's architecture](./assets/rafter-architecture-2.svg)
 
 1. The user creates a bucket through a Bucket CR.
 2. The Bucket Controller (BC) listens for new events and acts upon receiving the Bucket CR creation event.

--- a/docs/rafter/03-01-asset-cr-lifecycle.md
+++ b/docs/rafter/03-01-asset-cr-lifecycle.md
@@ -11,13 +11,13 @@ Learn about the lifecycle of the Asset custom resource (CR) and how its creation
 
 When you create an Asset CR, the Asset Controller (AC) receives a CR creation Event, reads the CR definition, verifies if the bucket exists, downloads the asset, unpacks it, and stores it in MinIO Gateway.
 
-![](./assets/create-asset.svg)
+![Create an asset](./assets/create-asset.svg)
 
 ## Remove an Asset CR
 
 When you remove the Asset CR, the AC receives a CR deletion Event and deletes the CR from MinIO Gateway.
 
-![](./assets/delete-asset.svg)
+![Delete and asset](./assets/delete-asset.svg)
 
 ## Change the bucket reference
 
@@ -25,10 +25,10 @@ When you modify an Asset CR by updating the bucket reference in the Asset CR to 
 
 Unfortunately, this causes duplication of data as the assets from the previous bucket storage are not cleaned up by default. Thus, to avoid multiplication of assets, first remove one Bucket CR and then modify the existing Asset CR with a new bucket reference.
 
-![](./assets/modify-bucket-ref-asset.svg)
+![Change the bucket reference](./assets/modify-bucket-ref-asset.svg)
 
 ## Change the Asset CR specification
 
 When you modify the Asset CR specification, the lifecycle starts again. The previous asset content is removed and no longer available.
 
-![](./assets/modify-asset.svg)
+![Change the Asset CR specification](./assets/modify-asset.svg)

--- a/docs/rafter/03-01-asset-cr-lifecycle.md
+++ b/docs/rafter/03-01-asset-cr-lifecycle.md
@@ -17,7 +17,7 @@ When you create an Asset CR, the Asset Controller (AC) receives a CR creation Ev
 
 When you remove the Asset CR, the AC receives a CR deletion Event and deletes the CR from MinIO Gateway.
 
-![Delete and asset](./assets/delete-asset.svg)
+![Delete an asset](./assets/delete-asset.svg)
 
 ## Change the bucket reference
 

--- a/docs/rafter/03-02-bucket-cr-lifecycle.md
+++ b/docs/rafter/03-02-bucket-cr-lifecycle.md
@@ -11,7 +11,7 @@ Learn about the lifecycle of the Bucket custom resource (CR) and how its creatio
 
 When you create a Bucket CR, the Bucket Controller (BC) receives a CR creation Event and creates a bucket with the name specified in the CR. It is created in the MinIO Gateway storage under the `{CR_name}-{ID}` location, such as `test-bucket-1b19rnbuc6ir8`, where `{CR_name}` is the **name** field from the Bucket CR and `{ID}` is a randomly generated string. The status of the CR contains a reference URL to the created bucket.
 
-![](./assets/create-bucket.svg)
+![Create a bucket](./assets/create-bucket.svg)
 
 ## Remove a Bucket CR
 
@@ -19,4 +19,4 @@ When you remove the Bucket CR, the BC receives a CR deletion Event and removes t
 
 The Asset Controller (AC) also monitors the status of the referenced bucket. The AC checks the Bucket CR status to make sure the bucket exists. If you delete the bucket, the AC receives information that the files are no longer accessible and the bucket was removed. The AC updates the status of the Asset CR to `ready: False` and removes the asset storage reference. The Asset CR is still available and you can use it later for a new bucket.
 
-![](./assets/delete-bucket.svg)
+![Delete a bucket](./assets/delete-bucket.svg)

--- a/docs/rafter/03-04-minio-gateway.md
+++ b/docs/rafter/03-04-minio-gateway.md
@@ -18,7 +18,7 @@ MinIO is an open-source asset storage server with Amazon S3-compatible API. You 
 
 In the context of Rafter, the Asset Controller stores all assets in MinIO, in dedicated storage space.
 
-![](./assets/minio.svg)
+![MinIO](./assets/minio.svg)
 
 ## Production storage
 
@@ -28,9 +28,9 @@ For the production purposes, Rafter uses MinIO Gateway which:
 - Allows you to use various cloud providers that support the data replication and CDN configuration.
 - Is compatible with Amazon S3 APIs.
 
-![](./assets/minio-gateway.svg)
+![MinIO Gateway](./assets/minio-gateway.svg)
 
->**TIP:** Using Gateway mode may generate additional costs for storing buckets, assets, or traffic in general. To avoid them, verify the payment policy with the given cloud provider before you switch to Gateway mode. 
+>**TIP:** Using Gateway mode may generate additional costs for storing buckets, assets, or traffic in general. To avoid them, verify the payment policy with the given cloud provider before you switch to Gateway mode.
 
 See [this tutorial](#tutorials-set-minio-to-gateway-mode) to learn how to set MinIO to Google Cloud Storage Gateway mode.
 

--- a/docs/rafter/03-06-upload-service.md
+++ b/docs/rafter/03-06-upload-service.md
@@ -18,7 +18,7 @@ Once you upload the files, system buckets store them permanently. There is no po
 
 The diagram describes the Upload Service flow:
 
-![](./assets/upload-service.svg)
+![Upload Service](./assets/upload-service.svg)
 
 ## Use the service outside the Kyma cluster
 

--- a/docs/rafter/08-01-add-new-documentation-to-console.md
+++ b/docs/rafter/08-01-add-new-documentation-to-console.md
@@ -167,7 +167,7 @@ This tutorial shows how you can customize the Documentation view that is availab
 
 3. Open the Console UI and navigate to the Documentation view. The new **Prometheus** section with **Concepts** and **Guides** topic groups and alphabetically ordered Markdown documents appears at the bottom of the documentation panel:
 
-   ![](./assets/prometheus.png)
+   ![Overview of the Prometheus section](./assets/prometheus.png)
 
    >**NOTE:** Since the source Markdown documents are prepared for different UIs and can contain custom tags, there can be issues with rendering their full content. If you prepare your own input, use our [content guidelines](https://github.com/kyma-project/community/tree/master/guidelines/content-guidelines) to make sure the documents render properly in the Console UI.
 

--- a/docs/rafter/08-01-add-new-documentation-to-console.md
+++ b/docs/rafter/08-01-add-new-documentation-to-console.md
@@ -167,7 +167,7 @@ This tutorial shows how you can customize the Documentation view that is availab
 
 3. Open the Console UI and navigate to the Documentation view. The new **Prometheus** section with **Concepts** and **Guides** topic groups and alphabetically ordered Markdown documents appears at the bottom of the documentation panel:
 
-   ![Overview of the Prometheus section](./assets/prometheus.png)
+   ![Prometheus section in navigation](./assets/prometheus.png)
 
    >**NOTE:** Since the source Markdown documents are prepared for different UIs and can contain custom tags, there can be issues with rendering their full content. If you prepare your own input, use our [content guidelines](https://github.com/kyma-project/community/tree/master/guidelines/content-guidelines) to make sure the documents render properly in the Console UI.
 

--- a/docs/service-catalog/15-04-specifications-in-console-ui.md
+++ b/docs/service-catalog/15-04-specifications-in-console-ui.md
@@ -96,11 +96,11 @@ type: Details
   Service Catalog UI preview
   </summary>
 
-![](./assets/catalog-ui-docs.png)
+![Documentation tab](./assets/catalog-ui-docs.png)
   </details>
 </div>
 
->**NOTE:** A document with the **Overview** `title` always displays as the first tab. Markdown files with `title` other than **Overview** appear in alphanumeric order.
+>**NOTE:** A document with the **Overview** `title` always displays as the first tab. Markdown files with `title` other than **Overview** appear in an alphanumeric order.
 
 ### Content
 
@@ -162,7 +162,7 @@ In Kyma, to make documentation more reader-friendly, some Markdown features are 
       Preview
       </summary>
 
-    ![](./assets/docs-toggle.png)
+    ![Documentation toggle](./assets/docs-toggle.png)
       </details>
     </div>
 
@@ -183,7 +183,7 @@ In Kyma, to make documentation more reader-friendly, some Markdown features are 
       Preview
       </summary>
 
-    ![](./assets/tip-panel.png)
+    ![TIP panel](./assets/tip-panel.png)
       </details>
     </div>
 


### PR DESCRIPTION

**Description**

Changes proposed in this pull request:

- Added missing alt texts to describe images and diagrams

**Related issue(s)**
See also #8464 
