### PR TITLE
Refine ClusterRoles for Kyma-Eventing

### DIFF
--- a/resources/cluster-users/templates/clusterroles-knative-eventing.yaml
+++ b/resources/cluster-users/templates/clusterroles-knative-eventing.yaml
@@ -12,7 +12,7 @@ metadata:
     helm.sh/hook-weight: "0"
 rules:
 - apiGroups:
-    - "eventing.knative.dev"
+{{ toYaml .Values.clusterRoles.apiGroups.kymaEventing | indent 4 }}
   resources:
     - "*"
   verbs:
@@ -31,7 +31,7 @@ metadata:
     helm.sh/hook-weight: "0"
 rules:
 - apiGroups:
-    - "eventing.knative.dev"
+{{ toYaml .Values.clusterRoles.apiGroups.kymaEventing | indent 4 }}
   resources:
     - "*"
   verbs:
@@ -50,7 +50,7 @@ metadata:
     helm.sh/hook-weight: "0"
 rules:
 - apiGroups:
-    - "eventing.knative.dev"
+{{ toYaml .Values.clusterRoles.apiGroups.kymaEventing | indent 4 }}
   resources:
     - "*"
   verbs:

--- a/resources/cluster-users/values.schema.json
+++ b/resources/cluster-users/values.schema.json
@@ -337,6 +337,12 @@
               "autoscaling.internal.knative.dev",
               "serving.knative.dev"
             ],
+            "kymaEventing": [
+              "knativekafka.kyma-project.io",
+              "sources.kyma-project.io",
+              "messaging.knative.dev",
+              "eventing.knative.dev"
+            ],
             "addons": [
               "addons.kyma-project.io"
             ],
@@ -396,6 +402,12 @@
                 "caching.internal.knative.dev",
                 "autoscaling.internal.knative.dev",
                 "serving.knative.dev"
+              ],
+              "kymaEventing": [
+                "knativekafka.kyma-project.io",
+                "sources.kyma-project.io",
+                "messaging.knative.dev",
+                "eventing.knative.dev"
               ],
               "addons": [
                 "addons.kyma-project.io"
@@ -682,6 +694,35 @@
                   "networking.internal.knative.dev",
                   "caching.internal.knative.dev",
                   "autoscaling.internal.knative.dev"
+                ]
+              }
+            },
+            "kymaEventing": {
+              "$id": "#/properties/clusterRoles/properties/apiGroups/properties/kymaEventing",
+              "type": "array",
+              "title": "The kymaEventing Schema",
+              "description": "",
+              "default": [],
+              "examples": [
+                [
+                  "knativekafka.kyma-project.io",
+                  "sources.kyma-project.io",
+                  "messaging.knative.dev",
+                  "eventing.knative.dev"
+                ]
+              ],
+              "additionalItems": true,
+              "items": {
+                "$id": "#/properties/clusterRoles/properties/apiGroups/properties/kymaEventing/items",
+                "type": "string",
+                "title": "The Items Schema",
+                "description": "",
+                "default": "",
+                "examples": [
+                  "knativekafka.kyma-project.io",
+                  "sources.kyma-project.io",
+                  "messaging.knative.dev",
+                  "eventing.knative.dev"
                 ]
               }
             }

--- a/resources/cluster-users/values.yaml
+++ b/resources/cluster-users/values.yaml
@@ -57,6 +57,11 @@ clusterRoles:
       - "caching.internal.knative.dev"
       - "autoscaling.internal.knative.dev"
       - "serving.knative.dev"
+    kymaEventing:
+      - "knativekafka.kyma-project.io"
+      - "sources.kyma-project.io"
+      - "messaging.knative.dev"
+      - "eventing.knative.dev"
   verbs:
     edit:
       - "create"


### PR DESCRIPTION
Certain Resources for kyma eventing were not aggregated into the eventing clsuter roles, as a consequence it was impossible to debug state of eventing unless a user was granted a cluster-admin role.

with this change, eventing resources are added into relevant kyma-roles.