### PR TITLE
Adapt management components to Helm 3

### DIFF
--- a/resources/service-catalog-addons/charts/service-binding-usage-controller/templates/deployment.yaml
+++ b/resources/service-catalog-addons/charts/service-binding-usage-controller/templates/deployment.yaml
@@ -8,10 +8,6 @@ metadata:
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
 spec:
-  {{- with .Values.securityContext }}
-  securityContext:
-{{ toYaml . | indent 8 }}
-  {{- end }}
   replicas: {{ .Values.replicaCount }}
   selector:
     matchLabels:
@@ -29,6 +25,10 @@ spec:
         release: {{ .Release.Name }}
     spec:
       serviceAccountName: {{ template "fullname" . }}
+      {{- with .Values.securityContext }}
+      securityContext:
+        {{ toYaml . }}
+      {{- end }}
       containers:
         - name: {{ .Chart.Name }}
           image: "{{ .Values.global.containerRegistry.path }}/{{ .Values.global.service_binding_usage_controller.dir }}service-binding-usage-controller:{{ .Values.global.service_binding_usage_controller.version }}"


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Adapt management components to work with Helm 3
- From all management components, ServiceBindingUsage (inside `service-catalog-addons`) needs fix

**Related issue(s)**
#8563 
