### PR TITLE
Update serverless to forbid scale-to-zero

### DIFF
--- a/components/function-controller/README.md
+++ b/components/function-controller/README.md
@@ -53,7 +53,7 @@ To develop the component, use the formulae declared in the [generic](/common/mak
 | **WEBHOOK_PORT**                          | Port on which the webhook server are exposed                                                    | `8443`               |
 | **WEBHOOK_VALIDATION_MIN_REQUEST_CPU**    | Minimum amount of requested the limits and requests CPU to pass through the validation          | `10m`                |
 | **WEBHOOK_VALIDATION_MIN_REQUEST_MEMORY** | Minimum amount of requested the limits and requests memory to pass through the validation       | `16Mi`               |
-| **WEBHOOK_VALIDATION_MIN_REPLICAS_VALUE** | Minimum amount of replicas to pass through the validation                                       | `0`                  |
+| **WEBHOOK_VALIDATION_MIN_REPLICAS_VALUE** | Minimum amount of replicas to pass through the validation                                       | `1`                  |
 | **WEBHOOK_VALIDATION_RESERVED_ENVS**      | List of reserved envs                                                                           | `{}`                 |
 | **WEBHOOK_DEFAULTING_REQUEST_CPU**        | Value of the request CPU which webhook should set if origin equals null                         | `50m`                |
 | **WEBHOOK_DEFAULTING_REQUEST_MEMORY**     | Value of the request memory which webhook should set if origin equals null                      | `64Mi`               |

--- a/components/function-controller/pkg/apis/serverless/v1alpha1/function_validation.go
+++ b/components/function-controller/pkg/apis/serverless/v1alpha1/function_validation.go
@@ -19,7 +19,7 @@ const ValidationConfigKey = "validation-config"
 type ValidationConfig struct {
 	MinRequestCpu    string   `envconfig:"default=10m"`
 	MinRequestMemory string   `envconfig:"default=16Mi"`
-	MinReplicasValue int32    `envconfig:"default=0"`
+	MinReplicasValue int32    `envconfig:"default=1"`
 	ReservedEnvs     []string `envconfig:"default={}"`
 }
 

--- a/components/function-controller/pkg/apis/serverless/v1alpha1/function_validation_test.go
+++ b/components/function-controller/pkg/apis/serverless/v1alpha1/function_validation_test.go
@@ -170,6 +170,22 @@ func TestFunctionSpec_validateResources(t *testing.T) {
 				),
 			),
 		},
+		"Should return error on replicas validation on 0 minReplicas set": {
+			givenFunc: Function{
+				ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "test"},
+				Spec: FunctionSpec{
+					Source:      "test-source",
+					MinReplicas: &zero, // HPA needs this value to be greater then 0
+					MaxReplicas: &one,
+				},
+			},
+			expectedError: gomega.HaveOccurred(),
+			specifiedExpectedError: gomega.And(
+				gomega.ContainSubstring(
+					"spec.minReplicas",
+				),
+			),
+		},
 		"Should return error on resources validation": {
 			givenFunc: Function{
 				ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "test"},

--- a/resources/core/charts/console/templates/configmap.yaml
+++ b/resources/core/charts/console/templates/configmap.yaml
@@ -40,9 +40,6 @@ data:
       serverless: {
         functionUsageKind: "serverless-function",
         restrictedVariables: [
-          'K_REVISION',
-          'K_CONFIGURATION',
-          'K_SERVICE',
           'FUNC_RUNTIME',
           'FUNC_HANDLER',
           'FUNC_TIMEOUT',
@@ -50,6 +47,8 @@ data:
           'PORT',
           'MOD_NAME',
           'NODE_PATH',
+          'REQ_MB_LIMIT',
+          'FUNC_MEMORY_LIMIT'
         ],
         resources: {
           min: {

--- a/resources/core/charts/console/values.yaml
+++ b/resources/core/charts/console/values.yaml
@@ -37,7 +37,7 @@ console:
 core_ui:
   image:
     pullPolicy: IfNotPresent
-    tag: 4725d3c8
+    tag: dd00031e
   service:
     externalPort: 80
     internalPort: 80

--- a/resources/serverless/charts/webhook/values.yaml
+++ b/resources/serverless/charts/webhook/values.yaml
@@ -61,9 +61,9 @@ container:
     minRequestMemory:
       value: "16Mi"
     minReplicasValue:
-      value: "0"
+      value: "1"
     reservedEnvs:
-      value: "K_REVISION,K_CONFIGURATION,K_SERVICE,FUNC_RUNTIME,FUNC_HANDLER,FUNC_TIMEOUT,FUNC_PORT,PORT,MOD_NAME,NODE_PATH"
+      value: "FUNC_RUNTIME,FUNC_HANDLER,FUNC_TIMEOUT,FUNC_PORT,PORT,MOD_NAME,NODE_PATH,REQ_MB_LIMIT,FUNC_MEMORY_LIMIT" # https://github.com/kubeless/runtimes/blob/master/stable/nodejs/kubeless.js
     requestCpu:
       value: "50m"
     requestMemory:

--- a/resources/serverless/charts/webhook/values.yaml
+++ b/resources/serverless/charts/webhook/values.yaml
@@ -7,7 +7,7 @@ fullnameOverride:
 
 image:
   repository: "eu.gcr.io/kyma-project/function-webhook"
-  tag: "PR-8513"
+  tag: "PR-8710"
   pullPolicy: IfNotPresent
 
 commonLabels:


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/master/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- HPA doesn't allow to have minReplicas set to 0:
```bash
"error":"HorizontalPodAutoscaler.autoscaling \"upbeat-bleah-5vntg\" is invalid: spec.minReplicas: Invalid value: 0: must be greater than 0"
```
so we need to disable that option entirely
- update envs which are forbidden
- update core-ui img with changes from https://github.com/kyma-project/console/pull/1829

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
https://github.com/kyma-project/kyma/issues/8650