### PR TITLE
Change labels to helm3 recommended

### DIFF
--- a/resources/logging/Chart.yaml
+++ b/resources/logging/Chart.yaml
@@ -1,7 +1,7 @@
+apiVersion: v1
 name: logging
 version: 0.3.0
 description: "Helm Chart for Kyma logging"
-apiVersion: v1
 keywords:
   - logging
   - loki

--- a/resources/logging/charts/fluentbit/Chart.yaml
+++ b/resources/logging/charts/fluentbit/Chart.yaml
@@ -1,6 +1,6 @@
+apiVersion: v1
 name: fluent-bit
 version: 0.17.0
-appVersion: 1.3.4
 description: Fast and Lightweight Log/Data Forwarder for Linux, BSD and OSX
 keywords:
 - logging
@@ -11,4 +11,4 @@ home: http://fluentbit.io
 icon: http://fluentbit.io/assets/img/logo1-default.png
 sources:
 - https://github.com/fluent/fluent-bit
-apiVersion: v1
+appVersion: 1.3.4

--- a/resources/logging/charts/fluentbit/templates/_helpers.tpl
+++ b/resources/logging/charts/fluentbit/templates/_helpers.tpl
@@ -60,15 +60,35 @@ Create the name of the service account to use
 Create meta labels
 */}}
 {{- define "fluent-bit.metaLabels" -}}
-{{- $labelChart := include "fluent-bit.chart" $ -}}
 {{- $labelApp := include "fluent-bit.name" $ -}}
 {{- if .Values.helmLabels.enabled -}}
-  {{- $labels := dict "chart" $labelChart "release" .Release.Name -}}
-  {{ merge $labels .Values.extraLabels (default (dict "app" $labelApp) .Values.defaultLabels) | toYaml }}
+  {{ merge .Values.extraLabels (default (dict "app" $labelApp) .Values.defaultLabels) | toYaml }}
 {{- else -}}
   {{ merge .Values.extraLabels (default (dict "app" $labelApp) .Values.defaultLabels) | toYaml }}
 {{- end -}}
+{{- printf "\n" -}}
+{{ include "fluent-bit.labels" . -}}
 {{- end -}}
+
+{{/*
+Common labels
+*/}}
+{{- define "fluent-bit.labels" -}}
+helm.sh/chart: {{ include "fluent-bit.chart" . }}
+{{ include "fluent-bit.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "fluent-bit.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "fluent-bit.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
 
 {{/*
 Create match labels

--- a/resources/logging/charts/logui/Chart.yaml
+++ b/resources/logging/charts/logui/Chart.yaml
@@ -1,7 +1,7 @@
+apiVersion: v1
 name: logui
 version: 0.3.0
 description: "Helm Chart for Kyma logging UI"
-apiVersion: v1
 keywords:
   - logging
   - loki

--- a/resources/logging/charts/logui/templates/_helpers.tpl
+++ b/resources/logging/charts/logui/templates/_helpers.tpl
@@ -7,6 +7,26 @@ Expand the name of the chart.
 {{- end -}}
 
 {{/*
+Common labels
+*/}}
+{{- define "logui.labels" -}}
+helm.sh/chart: {{ include "logui.chart" . }}
+{{ include "logui.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "logui.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "logui.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
 Create a default fully qualified app name.
 We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
 */}}

--- a/resources/logging/charts/logui/templates/clustermicrofrontend.yaml
+++ b/resources/logging/charts/logui/templates/clustermicrofrontend.yaml
@@ -3,9 +3,7 @@ kind: ClusterMicroFrontend
 metadata:
   name: {{ template "logui.fullname" . }}
   labels:
-    app: {{ template "logui.name" . }}
-    chart: {{ template "logui.chart" . }}
-    release: {{ .Release.Name }}
+    {{- include "logui.labels" . | nindent 4 }}
 spec:
   category: Diagnostics
   viewBaseUrl: https://log-ui.{{ .Values.global.ingress.domainName }}

--- a/resources/logging/charts/logui/templates/configmap.yaml
+++ b/resources/logging/charts/logui/templates/configmap.yaml
@@ -3,9 +3,7 @@ kind: ConfigMap
 metadata:
   name: {{ template "logui.fullname" . }}
   labels:
-    app: {{ template "logui.name" . }}
-    chart: {{ template "logui.chart" . }}
-    release: {{ .Release.Name }}
+    {{- include "logui.labels" . | nindent 4 }}
 data:
   config.js: |
     window.clusterConfig = {

--- a/resources/logging/charts/logui/templates/deployment.yaml
+++ b/resources/logging/charts/logui/templates/deployment.yaml
@@ -3,9 +3,7 @@ kind: Deployment
 metadata:
   name: {{ template "logui.fullname" . }}
   labels:
-    app: {{ template "logui.name" . }}
-    chart: {{ template "logui.chart" . }}
-    release: {{ .Release.Name }}
+    {{- include "logui.labels" . | nindent 4 }}
 spec:
   selector:
     matchLabels:

--- a/resources/logging/charts/logui/templates/destinationrule.yaml
+++ b/resources/logging/charts/logui/templates/destinationrule.yaml
@@ -3,9 +3,7 @@ kind: "DestinationRule"
 metadata:
   name: {{ template "logui.fullname" . }}
   labels:
-    app: {{ template "logui.name" . }}
-    chart: {{ template "logui.chart" . }}
-    release: {{ .Release.Name }}
+    {{- include "logui.labels" . | nindent 4 }}
 spec:
   host: {{ template "logui.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local
   trafficPolicy:

--- a/resources/logging/charts/logui/templates/service.yaml
+++ b/resources/logging/charts/logui/templates/service.yaml
@@ -3,9 +3,7 @@ kind: Service
 metadata:
   name: {{ template "logui.fullname" . }}
   labels:
-    app: {{ template "logui.name" . }}
-    chart: {{ template "logui.chart" . }}
-    release: {{ .Release.Name }}
+    {{- include "logui.labels" . | nindent 4 }}
 spec:
   ports:
     - port: {{ .Values.service.externalPort }}

--- a/resources/logging/charts/logui/templates/virtualservice.yaml
+++ b/resources/logging/charts/logui/templates/virtualservice.yaml
@@ -3,9 +3,7 @@ kind: VirtualService
 metadata:
   name: {{ template "logui.fullname" . }}
   labels:
-    app: {{ template "logui.name" . }}
-    chart: {{ template "logui.chart" . }}
-    release: {{ .Release.Name }}
+    {{- include "logui.labels" . | nindent 4 }}
 spec:
   hosts:
   - log-ui.{{ .Values.global.ingress.domainName }}


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Change labels for `Fluent-bit` and `Logui` to Helm 3 recommended.
- `Loki` labels not migrated due to too many changes on a third party chart. It is best to wait for the official loki chart to be updated.

**Related issue(s)**
#8601
