### PR TITLE
Fix defaulting replicas for HPA in function-controller

### DIFF
--- a/components/function-controller/internal/controllers/serverless/function_controller_test.go
+++ b/components/function-controller/internal/controllers/serverless/function_controller_test.go
@@ -12,9 +12,9 @@ import (
 	serverlessv1alpha1 "github.com/kyma-project/kyma/components/function-controller/pkg/apis/serverless/v1alpha1"
 )
 
-func newFixFunction(namespace, name string) *serverlessv1alpha1.Function {
-	one := int32(1)
-	two := int32(2)
+func newFixFunction(namespace, name string, minReplicas, maxReplicas int) *serverlessv1alpha1.Function {
+	one := int32(minReplicas)
+	two := int32(maxReplicas)
 	suffix := rand.Int()
 
 	return &serverlessv1alpha1.Function{

--- a/components/function-controller/internal/controllers/serverless/function_reconcile_test.go
+++ b/components/function-controller/internal/controllers/serverless/function_reconcile_test.go
@@ -34,7 +34,7 @@ var _ = ginkgo.Describe("Function", func() {
 	)
 
 	ginkgo.BeforeEach(func() {
-		function := newFixFunction("tutaj", "ah-tak-przeciez")
+		function := newFixFunction("tutaj", "ah-tak-przeciez", 1, 2)
 		request = ctrl.Request{NamespacedName: types.NamespacedName{Namespace: function.GetNamespace(), Name: function.GetName()}}
 		gomega.Expect(resourceClient.Create(context.TODO(), function)).To(gomega.Succeed())
 

--- a/resources/serverless/values.yaml
+++ b/resources/serverless/values.yaml
@@ -60,7 +60,7 @@ global:
 images:
   manager:
     repository: "eu.gcr.io/kyma-project/function-controller"
-    tag: "PR-8651"
+    tag: "PR-8744"
     pullPolicy: IfNotPresent
   functionRuntimeNodejs12:
     repository: "eu.gcr.io/kyma-project/function-runtime-nodejs12"


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/master/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:
- As in title. When webhook doesn't work, then we try retrieve value from pointer (max replicas for HPA), and function-controller breaks with panic error.

**Related issue(s)**
https://github.com/kyma-project/kyma/issues/8641