### PR TITLE
Adapt pod preset webhook to gardener system

### DIFF
--- a/resources/cluster-essentials/charts/pod-preset/templates/webhook/deploy.yaml
+++ b/resources/cluster-essentials/charts/pod-preset/templates/webhook/deploy.yaml
@@ -54,3 +54,13 @@ spec:
             path: webhook.crt
           - key: tls.key
             path: webhook.key
+---
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ template "pod-preset.fullname" . }}-pdb
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      app: {{ template "pod-preset.name" . }}-webhook

--- a/resources/cluster-essentials/charts/pod-preset/templates/webhook/webhook.yaml
+++ b/resources/cluster-essentials/charts/pod-preset/templates/webhook/webhook.yaml
@@ -26,6 +26,13 @@ webhooks:
     - CREATE
     resources:
     - pods
+  namespaceSelector:
+    matchExpressions:
+    - key: gardener.cloud/purpose
+      operator: NotIn
+      values:
+      - kube-system
+  timeoutSeconds: 10
 ---
 apiVersion: v1
 kind: Secret


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- change of the default timeout for MutatingWebhookConfiguration in version `admissionregistration.k8s.io/v1beta1` from 30sec to 10sec
- add `namespaceSelector` to MutatingWebhookConfiguration to exclude resources from `kube-system` namespace on Gardner system (on Gardner `namespace` resource gets `gardener.cloud/purpose: kube-sytem` flag)
- add `PodDisruptionBudget` to webhook Pod with `minAvailable` set to 1, to provide at least one Pod webhook in running condition.
