### PR TITLE
Kyma docker images bump after merging PR-8417

### DIFF
--- a/resources/application-connector/values.yaml
+++ b/resources/application-connector/values.yaml
@@ -26,9 +26,9 @@ global:
   containerRegistry:
     path: eu.gcr.io/kyma-project
   application_operator:
-    version: PR-8417
+    version: "1066324c"
   application_operator_tests:
-    version: PR-8417
+    version: "1066324c"
   connector_service:
     version: "4e3576cd"
   connector_service_tests:
@@ -76,5 +76,5 @@ tests:
       central: false
     skipSslVerify: true
     image:
-      version: "PR-8417"
+      version: "1066324c"
       pullPolicy: IfNotPresent

--- a/resources/compass-runtime-agent/values.yaml
+++ b/resources/compass-runtime-agent/values.yaml
@@ -7,7 +7,7 @@ global:
       version: "PR-8273"
     runtimeAgentTests:
       dir:
-      version: "PR-8417"
+      version: "1066324c"
     compassExternalSolutionTests:
       dir:
       version: "PR-8581"

--- a/tests/application-operator-tests/go.mod
+++ b/tests/application-operator-tests/go.mod
@@ -5,7 +5,7 @@ go 1.13
 require (
 	github.com/docker/go-metrics v0.0.1 // indirect
 	github.com/kubernetes-sigs/service-catalog v0.2.2
-	github.com/kyma-project/kyma/components/application-operator v0.5.1
+	github.com/kyma-project/kyma/components/application-operator v0.0.0-20200610124020-b925f71c3209
 	github.com/sirupsen/logrus v1.4.2
 	github.com/stretchr/testify v1.5.1
 	helm.sh/helm/v3 v3.1.3
@@ -19,5 +19,3 @@ require (
 )
 
 replace golang.org/x/crypto => golang.org/x/crypto v0.0.0-20200604202706-70a84ac30bf9
-
-replace github.com/kyma-project/kyma/components/application-operator => github.com/koala7659/kyma/components/application-operator v0.0.0-20200529162005-1b73df3b6bac

--- a/tests/application-operator-tests/go.sum
+++ b/tests/application-operator-tests/go.sum
@@ -312,8 +312,6 @@ github.com/julienschmidt/httprouter v1.2.0/go.mod h1:SYymIcj16QtmaHHD7aYtjjsJG7V
 github.com/kisielk/errcheck v1.1.0/go.mod h1:EZBBE59ingxPouuu3KfxchcWSUPOHkagtvWXihfKN4Q=
 github.com/kisielk/errcheck v1.2.0/go.mod h1:/BMXB+zMLi60iA8Vv6Ksmxu/1UDYcXs4uQLJ+jE2L00=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
-github.com/koala7659/kyma/components/application-operator v0.0.0-20200529162005-1b73df3b6bac h1:XWBu7Znr5J/MOzFbvO9DJa+SlxMVjBv+EhJ1aJgXLMg=
-github.com/koala7659/kyma/components/application-operator v0.0.0-20200529162005-1b73df3b6bac/go.mod h1:k3dKHyJu8DBf1kEKVNFPx6rn6P7JhxAdPnhC6sAhjqM=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1 h1:mweAR1A6xJ3oS2pRaGiHgQ4OO8tzTaLawm8vnODuwDk=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/kr/logfmt v0.0.0-20140226030751-b84e30acd515/go.mod h1:+0opPa2QZZtGFBFZlji/RkVcI2GknAs/DXo4wKdlNEc=
@@ -325,6 +323,8 @@ github.com/kr/text v0.1.0 h1:45sCR5RtlFHMR4UwH9sdQ5TC8v0qDQCHnXt+kaKSTVE=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
 github.com/kubernetes-sigs/service-catalog v0.2.2 h1:V/NrjGRWD37hkyvIwiS1Ekz/n7k1Ro9kPj6efRXkqEw=
 github.com/kubernetes-sigs/service-catalog v0.2.2/go.mod h1:fmRsWJ38Od93DQ7cOXR9mMSSwmjyDS1EAomWxBlumuo=
+github.com/kyma-project/kyma/components/application-operator v0.0.0-20200610124020-b925f71c3209 h1:v91pO6W82Z9/mAFLj+tLqONgAeSYQC7pfcKXd4tmiNM=
+github.com/kyma-project/kyma/components/application-operator v0.0.0-20200610124020-b925f71c3209/go.mod h1:q7ktyGNNIJWy72jTW5nKGrPJch1aqFb4xlhpgPR3ZX0=
 github.com/liggitt/tabwriter v0.0.0-20181228230101-89fcab3d43de h1:9TO3cAIGXtEhnIaL+V+BEER86oLrvS+kWobKpbJuye0=
 github.com/liggitt/tabwriter v0.0.0-20181228230101-89fcab3d43de/go.mod h1:zAbeS9B/r2mtpb6U+EI2rYA5OAXxsYw6wTamcNW+zcE=
 github.com/lithammer/dedent v1.1.0/go.mod h1:jrXYCQtgg0nJiN+StA2KgR7w6CiQNv9Fd/Z9BP0jIOc=


### PR DESCRIPTION
This PR is about to bump version of images after after merging PR-8417. Following images are affected

/kyma-project/application-operator:1066324c
/kyma-project/application-operator-tests:1066324c
/kyma-project/compass-runtime-agent-tests:1066324c
/kyma-project/application-connector-tests:1066324c

Additionally the dependency to private repository is removed from go.mod file of  application-operator-tests and replaced with github.com/kyma-project/kyma/components/application-operator v0.0.0-20200610124020-b925f71c3209 (latest version)

