### PR TITLE
Update Application Operator and Application Operator tests documentation

### DIFF
--- a/components/application-operator/README.md
+++ b/components/application-operator/README.md
@@ -39,7 +39,8 @@ The Application Operator has the following parameters:
  - **applicationConnectivityValidatorImage** is the Application Connectivity Validator image version to use in the Application chart.
  - **gatewayOncePerNamespace** is a flag that specifies whether Application Gateway should be deployed once per Namespace based on ServiceInstance or for every Application. The default value is `false`.
  - **strictMode** is a toggle used to enable or disable Istio authorization policy for validator and HTTP source adapter. The default value is `disabled`.
- - **healthPort** is a number of TCP port that is used to perform health checking of the Application Operator.
+ - **healthPort** is the number of the TCP port used to perform health checking of the Application Operator.
+ 
 ## Testing on a local deployment
 
 When you develop the Application Connector components, you can test the changes you introduced on a local Kyma deployment before you push them to a production cluster.

--- a/components/application-operator/README.md
+++ b/components/application-operator/README.md
@@ -29,10 +29,7 @@ The Application Operator has the following parameters:
  - **appName** is the name used in controller registration. The default value is `application-operator`.
  - **domainName** is the domain name of the cluster. The default domain name is `kyma.local`.
  - **namespace** is the Namespace where the AO deploys the charts of the Application. The default Namespace is `kyma-integration`.
- - **tillerUrl** is the Tiller release server URL. The default value is `tiller-deploy.kube-system.svc.cluster.local:44134`.
- - **helmTLSKeyFile** is the path to the TLS key used for secure communication with Tiller. The default value is `/etc/certs/tls.key`.
- - **helmTLSCertificateFile** is the path to the TLS certificate used for secure communication with Tiller. The default value is `/etc/certs/tls.crt`.
- - **tillerTLSSkipVerify** disables TLS verification in communication with Tiller. The default value is `true`.
+ - **helmDriver** is Helm3 backend storage driver setting. Only possible values are: `configmap`, `secret` and `memory`. The default value is `secret`.
  - **syncPeriod** is the time period between resyncing existing resources. The default value is `30` seconds.
  - **installationTimeout** is the time after which the release installation will time out. The default value is `240` seconds.
  - **applicationGatewayImage** is the Application Gateway image version to use in the Application chart.

--- a/components/application-operator/README.md
+++ b/components/application-operator/README.md
@@ -39,6 +39,7 @@ The Application Operator has the following parameters:
  - **applicationConnectivityValidatorImage** is the Application Connectivity Validator image version to use in the Application chart.
  - **gatewayOncePerNamespace** is a flag that specifies whether Application Gateway should be deployed once per Namespace based on ServiceInstance or for every Application. The default value is `false`.
  - **strictMode** is a toggle used to enable or disable Istio authorization policy for validator and HTTP source adapter. The default value is `disabled`.
+ - **healthPort** is a number of TCP port that is used to perform health checking of the Application Operator.
 ## Testing on a local deployment
 
 When you develop the Application Connector components, you can test the changes you introduced on a local Kyma deployment before you push them to a production cluster.

--- a/components/application-operator/cmd/manager/options.go
+++ b/components/application-operator/cmd/manager/options.go
@@ -30,7 +30,7 @@ func parseArgs() *options {
 	syncPeriod := flag.Int("syncPeriod", 30, "Time period between resyncing existing resources")
 	installationTimeout := flag.Int64("installationTimeout", 240, "Time after the release installation will time out")
 
-	helmDriver := flag.String("helmDriver", "secret", "Toggles Helm 3 configuration storage between configMap and secret")
+	helmDriver := flag.String("helmDriver", "secret", "Backend storage driver used by Helm 3 to store release data")
 	applicationGatewayImage := flag.String("applicationGatewayImage", "", "The image of the Application Gateway to use")
 	applicationGatewayTestsImage := flag.String("applicationGatewayTestsImage", "", "The image of the Application Gateway Tests to use")
 	eventServiceImage := flag.String("eventServiceImage", "", "The image of the Event Service to use")

--- a/docs/application-connector/05-01-application-operator.md
+++ b/docs/application-connector/05-01-application-operator.md
@@ -6,7 +6,6 @@ type: Configuration
 To configure the Application Operator (AO) sub-chart, override the default values of its `values.yaml` file. This document describes parameters that you can configure.
 
 >**TIP:** To learn more about how to use overrides in Kyma, see the following documents: 
->* [Helm overrides for Kyma installation](/root/kyma/#configuration-helm-overrides-for-kyma-installation)
 >* [Sub-charts overrides](/root/kyma/#configuration-helm-overrides-for-kyma-installation-sub-chart-overrides)
 
 ## Configurable parameters
@@ -16,5 +15,5 @@ This table lists the configurable parameters, their descriptions, and default va
 | Parameter | Description | Default value |
 |-----------|-------------|---------------|
 | **controller.args.installationTimeout** | Specifies a period of time provided for the Application Gateway, Application Connectivity Validator, and Event Service installation. The Application requires these services to be operational. The value is provided in seconds.| `240` |
-| **controller.args.tillerTLSSkipVerify** | Disables TLS verification in Tiller. | `true` 
-| **global.disableLegacyConnectivity** | Disables the default legacy [AO work mode](#architecture-application-connector-components-application-operator) and enables the Compass mode. | `false` 
+| **controller.args.helmDriver** | Specifies backend storage driver used by Helm 3 to store release data. Possible values are `configmap`, `secret` and `memory` | `secret` |
+| **global.disableLegacyConnectivity** | Disables the default legacy [AO work mode](#architecture-application-connector-components-application-operator) and enables the Compass mode. | `false` | 

--- a/tests/application-operator-tests/README.md
+++ b/tests/application-operator-tests/README.md
@@ -9,6 +9,15 @@ The tests are written in Go. Run them as standard Go tests.
 
 This section provides information on building and versioning the Docker image, as well as configuring Kyma.
 
+Environment parameters used by the tests:
+
+| Name | Required | Default | Description | Possible values |
+|------|----------|---------|-------------|-----------------|
+| **NAMESPACE** | Yes | `kyma-integration` | The Namespace in which the test Application will operate |  |
+| **HELM_DRIVER** | Yes | `secret` | Specifies backend storage driver used by Helm 3 to store release data | `configmap`, `secret`, `memory` |
+| **INSTALLATION_TIMEOUT_SECONDS** | No | 180 | Timeout in second for release installation |  |
+| **GATEWAY_DEPLOYED_PER_NAMESPACE** | No | `false` | Flag that specifies whether Application Gateway should be deployed once per Namespace based on ServiceInstance or for every Application | `true`, `false`
+
 ### Configuring Kyma
 
 After building and pushing the Docker image, set the proper tag in the `resources/core/charts/application-connector/charts/application-operator/values.yaml` file, in the`tests.image.tag` property.


### PR DESCRIPTION
For Readme.md for application-operator and application-operator-tests - provide updated parameters - removing all helm2 Tiller settings and adding helmDriver setting for helm3.

For options.go - Add more descriptive helmDriver parameter description

