### PR TITLE
Add verification of function response in upgrade tests

### DIFF
--- a/tests/end-to-end/upgrade/chart/upgrade/values.yaml
+++ b/tests/end-to-end/upgrade/chart/upgrade/values.yaml
@@ -7,7 +7,7 @@ subscriberimage:
 
 image:
   dir:
-  version: PR-8777
+  version: PR-8810
   pullPolicy: "IfNotPresent"
 
 dex:

--- a/tests/end-to-end/upgrade/pkg/tests/serverless/serverless.go
+++ b/tests/end-to-end/upgrade/pkg/tests/serverless/serverless.go
@@ -103,6 +103,7 @@ func (ut *serverlessUpgradeTest) TestResources(stop <-chan struct{}, log logrus.
 	logger.Info("Deleting function...")
 	if err := ut.client.Delete(namespace, functionName); err != nil {
 		logger.Errorf("Deleting function failed, because: %v", err)
+		return err
 	}
 	logger.Info("Function deleted")
 

--- a/tests/end-to-end/upgrade/pkg/tests/serverless/serverless.go
+++ b/tests/end-to-end/upgrade/pkg/tests/serverless/serverless.go
@@ -77,14 +77,6 @@ func (ut *serverlessUpgradeTest) TestResources(stop <-chan struct{}, log logrus.
 	logger := log.WithField("name", functionName).
 		WithField("namespace", namespace)
 
-	defer func() {
-		logger.Info("Deleting function...")
-		if err := ut.client.Delete(namespace, functionName); err != nil {
-			logger.Errorf("Deleting function failed, because: %v", err)
-		}
-		logger.Info("Function deleted")
-	}()
-
 	function := v1alpha1.Function{}
 	logger.Info("Waiting for function to be running...")
 	if err := ut.waitForRunning(ctx, logger, namespace, functionName, &function); err != nil {
@@ -107,6 +99,12 @@ func (ut *serverlessUpgradeTest) TestResources(stop <-chan struct{}, log logrus.
 		return err
 	}
 	logger.Info("Function is responding")
+
+	logger.Info("Deleting function...")
+	if err := ut.client.Delete(namespace, functionName); err != nil {
+		logger.Errorf("Deleting function failed, because: %v", err)
+	}
+	logger.Info("Function deleted")
 
 	return nil
 }
@@ -156,19 +154,19 @@ func (ut *serverlessUpgradeTest) compareFunctions(log logrus.FieldLogger, expect
 		log.Errorf("MinReplicas field is not equal, expected: %d, actual: %d", *expected.Spec.MinReplicas, *actual.Spec.MinReplicas)
 		result = false
 	}
-	if expected.Spec.Resources.Limits.Cpu().Equal(*actual.Spec.Resources.Limits.Cpu()) {
+	if !expected.Spec.Resources.Limits.Cpu().Equal(*actual.Spec.Resources.Limits.Cpu()) {
 		log.Errorf("CPU limit field is not equal, expected: %v, actual: %v", expected.Spec.Resources.Limits.Cpu(), actual.Spec.Resources.Limits.Cpu())
 		result = false
 	}
-	if expected.Spec.Resources.Limits.Memory().Equal(*actual.Spec.Resources.Limits.Memory()) {
+	if !expected.Spec.Resources.Limits.Memory().Equal(*actual.Spec.Resources.Limits.Memory()) {
 		log.Errorf("Memory limit field is not equal, expected: %v, actual: %v", expected.Spec.Resources.Limits.Memory(), actual.Spec.Resources.Limits.Memory())
 		result = false
 	}
-	if expected.Spec.Resources.Requests.Cpu().Equal(*actual.Spec.Resources.Requests.Cpu()) {
+	if !expected.Spec.Resources.Requests.Cpu().Equal(*actual.Spec.Resources.Requests.Cpu()) {
 		log.Errorf("CPU request field is not equal, expected: %v, actual: %v", expected.Spec.Resources.Requests.Cpu(), actual.Spec.Resources.Requests.Cpu())
 		result = false
 	}
-	if expected.Spec.Resources.Requests.Memory().Equal(*actual.Spec.Resources.Requests.Memory()) {
+	if !expected.Spec.Resources.Requests.Memory().Equal(*actual.Spec.Resources.Requests.Memory()) {
 		log.Errorf("Memory request field is not equal, expected: %v, actual: %v", expected.Spec.Resources.Requests.Memory(), actual.Spec.Resources.Requests.Memory())
 		result = false
 	}


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/master/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- Added verification of function's response

@magicmatatjahu I didn't add verification of envs from different types than literal. That verification should be rather added to e2e tests, not upgrade. Also, function cannot be deleted in defer, because when the test is restarted, the function will not exist.

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
Closes #8729