### PR TITLE
Fix installation tutorial

### DIFF
--- a/docs/kyma/08-02-sample-service-deployment-to-cluster.md
+++ b/docs/kyma/08-02-sample-service-deployment-to-cluster.md
@@ -84,7 +84,7 @@ Follow these steps:
 Run the following command:
 
    ```bash
-   curl -k https://raw.githubusercontent.com/kyma-project/examples/master/gateway/service/api-with-auth.yaml |  sed "s/.kyma.local/.$yourClusterDomain/" | kubectl apply -n stage -f -
+   curl -k https://raw.githubusercontent.com/kyma-project/examples/master/gateway/service/api-with-oauth2.yaml |  sed "s/.kyma.local/.$yourClusterDomain/" | kubectl apply -n stage -f -
    ```
 
 After you apply this update, you must include a valid bearer ID token in the Authorization header to access the service.

--- a/docs/kyma/08-03-local-develop-no-docker.md
+++ b/docs/kyma/08-03-local-develop-no-docker.md
@@ -42,7 +42,7 @@ For this step, you need a running local Kyma instance. Read the [installation do
 
    ```shell
    # Use the following pattern:
-   minikube mount {LOCAL_DIR_PATH}:{CLUSTER_DIR_PATH}`
+   minikube mount {LOCAL_DIR_PATH}:{CLUSTER_DIR_PATH}
    # To follow this guide, call:
    minikube mount ~/go/src/github.com/kyma-project/examples/http-db-service:/go/src/github.com/kyma-project/examples/http-db-service
    ```


### PR DESCRIPTION

**Description**

Changes proposed in this pull request:

- Fix the deadlink in: https://kyma-project.io/docs/#tutorials-sample-service-deployment-on-a-cluster
- Remove the redundant quote in https://kyma-project.io/docs/#tutorials-develop-a-service-locally-without-using-docker
