### PR TITLE
Fix nodeSelector for api-gateway chart

### DIFF
--- a/resources/api-gateway/templates/deployment.yaml
+++ b/resources/api-gateway/templates/deployment.yaml
@@ -56,7 +56,7 @@ spec:
             name: metrics
       serviceAccountName: {{ include "api-gateway.name" . }}-account
       nodeSelector:
-      {{- with .Values.deployment.nodeSelector }}
+      {{- with .Values.config.nodeSelector }}
         {{- toYaml . | nindent 8 }}
       {{- end }}
     {{- with .Values.affinity }}


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Fix nodeSelector configuration path for api-gateway template. There is no Values.deployment.nodeSelector in values.yaml but there is Values.config.nodeSelector