### PR TITLE
Fix apiVersion resources for helm 3 upgrade

### DIFF
--- a/resources/application-connector/charts/application-broker/templates/cluster-role-binding.yaml
+++ b/resources/application-connector/charts/application-broker/templates/cluster-role-binding.yaml
@@ -1,5 +1,5 @@
 kind: ClusterRoleBinding
-apiVersion: rbac.authorization.k8s.io/v1
+apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
   name: {{ .Chart.Name }}
   labels:

--- a/resources/application-connector/charts/application-broker/templates/cluster-role.yaml
+++ b/resources/application-connector/charts/application-broker/templates/cluster-role.yaml
@@ -1,5 +1,5 @@
 kind: ClusterRole
-apiVersion: rbac.authorization.k8s.io/v1
+apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
   name: {{ .Chart.Name }}
   labels:

--- a/resources/helm-broker/charts/etcd-stateful/templates/01-rbac.yaml
+++ b/resources/helm-broker/charts/etcd-stateful/templates/01-rbac.yaml
@@ -17,7 +17,7 @@ subjects:
   namespace: {{.Release.Namespace}}
 ---
 kind: ClusterRole
-apiVersion: rbac.authorization.k8s.io/v1
+apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
   name: {{ template "etcd-hb-fullname" . }}-etcd-certs
 rules:

--- a/resources/helm-broker/templates/rbac.yaml
+++ b/resources/helm-broker/templates/rbac.yaml
@@ -1,5 +1,5 @@
 kind: ClusterRole
-apiVersion: rbac.authorization.k8s.io/v1
+apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
   name: {{ template "fullname" . }}
   labels:
@@ -38,7 +38,7 @@ metadata:
 
 ---
 kind: ClusterRoleBinding
-apiVersion: rbac.authorization.k8s.io/v1
+apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
   name: {{ template "fullname" . }}
   labels:

--- a/resources/service-catalog-addons/charts/service-binding-usage-controller/templates/cluster-role-binding.yaml
+++ b/resources/service-catalog-addons/charts/service-binding-usage-controller/templates/cluster-role-binding.yaml
@@ -1,5 +1,5 @@
 kind: ClusterRoleBinding
-apiVersion: rbac.authorization.k8s.io/v1
+apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
   name: {{ template "fullname" . }}
   labels:

--- a/resources/service-catalog-addons/charts/service-binding-usage-controller/templates/cluster-role.yaml
+++ b/resources/service-catalog-addons/charts/service-binding-usage-controller/templates/cluster-role.yaml
@@ -1,5 +1,5 @@
 kind: ClusterRole
-apiVersion: rbac.authorization.k8s.io/v1
+apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
   name: {{ template "fullname" . }}
   labels:

--- a/resources/service-catalog/charts/catalog/templates/cleaner-job.yaml
+++ b/resources/service-catalog/charts/catalog/templates/cleaner-job.yaml
@@ -12,7 +12,7 @@ metadata:
 
 ---
 kind: ClusterRole
-apiVersion: rbac.authorization.k8s.io/v1
+apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
   name: clean-job-account
   labels:
@@ -45,7 +45,7 @@ rules:
 
 ---
 kind: ClusterRoleBinding
-apiVersion: rbac.authorization.k8s.io/v1
+apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
   name: clean-job-account
   labels:

--- a/resources/service-catalog/templates/tests/rbac.yaml
+++ b/resources/service-catalog/templates/tests/rbac.yaml
@@ -11,7 +11,7 @@ metadata:
     helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
 ---
 kind: ClusterRole
-apiVersion: rbac.authorization.k8s.io/v1
+apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
   name: {{ .Chart.Name }}-tests
   labels:
@@ -65,7 +65,7 @@ rules:
     verbs: ["create"]
 ---
 kind: ClusterRoleBinding
-apiVersion: rbac.authorization.k8s.io/v1
+apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
   name: {{ .Chart.Name }}-tests
   labels:


### PR DESCRIPTION
**Description**
When trying to update Kyma an issue occurs for all resources where `apiVersion` was changed. This only happens during the first upgrade for helm3 (Kyma 1.13 -> migration from helm2 to helm3 -> upgrade), during second and subsequent update (helm3) problem doesn't show up.
A similar issue can be find [here](https://github.com/helm/helm/issues/6850#issuecomment-559552700) or [here](https://github.com/helm/helm/pull/7649#issuecomment-644308903)

Changes proposed in this pull request:

- revert apiVersion for all RBAC resources to the previous one for the update process to run correctly.