### PR TITLE
Upgrade base image for nats init

### DIFF
--- a/components/nats-init/Dockerfile
+++ b/components/nats-init/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.11
+FROM alpine:3.12
 LABEL source=git@github.com:kyma-project/kyma.git
 
 WORKDIR /nats-streaming/

--- a/resources/nats-streaming/values.yaml
+++ b/resources/nats-streaming/values.yaml
@@ -17,7 +17,7 @@ global:
     path: eu.gcr.io/kyma-project
   natsInit:
     dir: ""
-    version: fe4fd6b3
+    version: PR-8848
   namespace: natss
   natsStreaming:
     fullname: nats-streaming


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/master/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- Upgrade base image as openssl 1.1.1d-r3 has `high` vulnerability
