### PR TITLE
Change timeout for function creation in long running tests

### DIFF
--- a/resources/serverless/templates/tests/long-test.yaml
+++ b/resources/serverless/templates/tests/long-test.yaml
@@ -50,7 +50,8 @@ spec:
               ---
               EOF
               ) \
-              && kubectl wait --for=condition=Running functions.serverless.kyma-project.io/{{ .Values.tests.long.name }} -n {{ .Values.tests.long.namespace }}
+              && kubectl wait --for=condition=Running functions.serverless.kyma-project.io/{{ .Values.tests.long.name }} -n {{ .Values.tests.long.namespace }} --timeout={{ .Values.tests.long.initTimeout }} \
+              || ( kubectl -n {{ .Values.tests.long.namespace }} describe functions.serverless.kyma-project.io {{ .Values.tests.long.name }}; exit 1 ) 
       containers:
         - name: {{ include "tests.name" . }}
           image: "{{ .Values.tests.long.image.repository  }}:{{ .Values.tests.long.image.tag }}"

--- a/resources/serverless/values.yaml
+++ b/resources/serverless/values.yaml
@@ -19,6 +19,7 @@ knativeMigration:
 tests:
   enabled: true
   long:
+    initTimeout: 120s
     resources:
       requests:
         memory: 128Mi


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/master/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**
Change timeout for function creation in long running tests

Changes proposed in this pull request:

- the timeout for creating function in init container was changed from 30s to 120s

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->

See also: https://github.com/kyma-project/kyma/issues/8730