### PR TITLE
Update kubectl to v20200617-32c1f3ff - leftovers

### DIFF
--- a/installation/resources/installer-local.yaml
+++ b/installation/resources/installer-local.yaml
@@ -201,7 +201,7 @@ spec:
             name: helm-certs
             readOnly: true
       - name: 2to3
-        image: eu.gcr.io/kyma-project/test-infra/alpine-kubectl:v20200529-34b39bd3
+        image: eu.gcr.io/kyma-project/test-infra/alpine-kubectl:v20200617-32c1f3ff
         terminationMessagePolicy: "FallbackToLogsOnError"
         command:
         - /bin/bash

--- a/installation/resources/installer.yaml
+++ b/installation/resources/installer.yaml
@@ -199,7 +199,7 @@ spec:
             name: helm-certs
             readOnly: true
       - name: 2to3
-        image: eu.gcr.io/kyma-project/test-infra/alpine-kubectl:v20200529-34b39bd3
+        image: eu.gcr.io/kyma-project/test-infra/alpine-kubectl:v20200617-32c1f3ff
         terminationMessagePolicy: "FallbackToLogsOnError"
         command:
         - /bin/bash

--- a/resources/api-gateway/values.yaml
+++ b/resources/api-gateway/values.yaml
@@ -3,7 +3,7 @@ replicaCount: 1
 rbacJob:
   image:
     repository: eu.gcr.io/kyma-project/test-infra/alpine-kubectl
-    tag: "v20200507-070ff576"
+    tag: "v20200617-32c1f3ff"
 
 image:
   repository: eu.gcr.io/kyma-project/incubator/develop/api-gateway-controller

--- a/resources/application-connector/charts/application-operator/templates/controller.yaml
+++ b/resources/application-connector/charts/application-operator/templates/controller.yaml
@@ -33,7 +33,7 @@ spec:
       serviceAccountName: {{ .Chart.Name }}
       initContainers:
         - name: helm-release-migrator
-          image: eu.gcr.io/kyma-project/test-infra/alpine-kubectl:v20200529-34b39bd3
+          image: eu.gcr.io/kyma-project/test-infra/alpine-kubectl:v20200617-32c1f3ff
           command:
             - /bin/bash
             - -c

--- a/resources/cluster-users/values.yaml
+++ b/resources/cluster-users/values.yaml
@@ -2,7 +2,7 @@ tests:
   enabled: true
   image:
     name: eu.gcr.io/kyma-project/test-infra/alpine-kubectl
-    version: v20200507-070ff576
+    version: v20200617-32c1f3ff
   env:
     namespace: default
 

--- a/resources/event-sources/templates/uninstall.yaml
+++ b/resources/event-sources/templates/uninstall.yaml
@@ -80,7 +80,7 @@ spec:
       restartPolicy: Never
       containers:
         - name: {{ .Release.Name }}-rc-delete
-          image: eu.gcr.io/kyma-project/test-infra/alpine-kubectl:v20200507-070ff576
+          image: eu.gcr.io/kyma-project/test-infra/alpine-kubectl:v20200617-32c1f3ff
           command:
             - "/bin/bash"
           args:

--- a/resources/istio/values.yaml
+++ b/resources/istio/values.yaml
@@ -5,7 +5,7 @@ kyma:
     - kube-system
   labelJob:
     image: eu.gcr.io/kyma-project/test-infra/alpine-kubectl
-    tag: "v20200507-070ff576"
+    tag: "v20200617-32c1f3ff"
 
 istio:
   installer:

--- a/resources/kiali/templates/kyma-additions/pre-delete-job.yaml
+++ b/resources/kiali/templates/kyma-additions/pre-delete-job.yaml
@@ -93,7 +93,7 @@ spec:
       restartPolicy: Never
       containers:
       - name: kiali-pre-delete-job
-        image: eu.gcr.io/kyma-project/test-infra/alpine-kubectl:v20200507-070ff576
+        image: eu.gcr.io/kyma-project/test-infra/alpine-kubectl:v20200617-32c1f3ff
         command: ["/scripts/kiali-delete.sh"]
         volumeMounts:
             - name: kiali-delete

--- a/resources/knative-eventing-kafka/templates/uninstall.yaml
+++ b/resources/knative-eventing-kafka/templates/uninstall.yaml
@@ -78,7 +78,7 @@ spec:
       restartPolicy: Never
       containers:
         - name: {{ .Release.Name }}-cr-delete
-          image: eu.gcr.io/kyma-project/test-infra/alpine-kubectl:v20200507-070ff576
+          image: eu.gcr.io/kyma-project/test-infra/alpine-kubectl:v20200617-32c1f3ff
           command:
             - "/bin/bash"
           args:

--- a/resources/knative-eventing/charts/knative-eventing/templates/uninstall-eventing.yaml
+++ b/resources/knative-eventing/charts/knative-eventing/templates/uninstall-eventing.yaml
@@ -84,7 +84,7 @@ spec:
       restartPolicy: Never
       containers:
         - name: {{ .Release.Name }}-cr-delete
-          image: eu.gcr.io/kyma-project/test-infra/alpine-kubectl:v20200507-070ff576
+          image: eu.gcr.io/kyma-project/test-infra/alpine-kubectl:v20200617-32c1f3ff
           command:
             - "/bin/bash"
           args:

--- a/resources/knative-provisioner-natss/charts/knative-provisioner-natss/templates/uninstall.yaml
+++ b/resources/knative-provisioner-natss/charts/knative-provisioner-natss/templates/uninstall.yaml
@@ -78,7 +78,7 @@ spec:
       restartPolicy: Never
       containers:
         - name: {{ .Release.Name }}-cr-delete
-          image: eu.gcr.io/kyma-project/test-infra/alpine-kubectl:v20200507-070ff576
+          image: eu.gcr.io/kyma-project/test-infra/alpine-kubectl:v20200617-32c1f3ff
           command:
             - "/bin/bash"
           args:

--- a/resources/ory/charts/hydra/charts/hydra-maester/values.yaml
+++ b/resources/ory/charts/hydra/charts/hydra-maester/values.yaml
@@ -3,7 +3,7 @@ replicaCount: 1
 jobs:
   image:
     repository: eu.gcr.io/kyma-project/test-infra/alpine-kubectl
-    tag: "v20200507-070ff576"
+    tag: "v20200617-32c1f3ff"
 
 config:
   # SyncPeriod determines the minimum frequency at which watched resources are

--- a/resources/ory/values.yaml
+++ b/resources/ory/values.yaml
@@ -49,7 +49,7 @@ hpa:
 maintenance:
   image:
     name: eu.gcr.io/kyma-project/test-infra/alpine-kubectl
-    tag: "v20200507-070ff576"
+    tag: "v20200617-32c1f3ff"
 
 # Overrides for the Hydra chart
 hydra:

--- a/resources/rafter/charts/upload-service/values.yaml
+++ b/resources/rafter/charts/upload-service/values.yaml
@@ -116,7 +116,7 @@ migrator:
   images:
     alpineKubectl:
       repository: eu.gcr.io/kyma-project/test-infra/alpine-kubectl
-      tag: 'v20200507-070ff576'
+      tag: 'v20200617-32c1f3ff'
       pullPolicy: IfNotPresent
     minioClient:
       repository: 'minio/mc'

--- a/resources/rafter/values.yaml
+++ b/resources/rafter/values.yaml
@@ -334,7 +334,7 @@ upload-service:
     images:
       alpineKubectl:
         repository: eu.gcr.io/kyma-project/test-infra/alpine-kubectl
-        tag: 'v20200507-070ff576'
+        tag: 'v20200617-32c1f3ff'
         pullPolicy: IfNotPresent
       minioClient:
         repository: eu.gcr.io/kyma-project/incubator/develop/minio/mc

--- a/resources/serverless/values.yaml
+++ b/resources/serverless/values.yaml
@@ -7,7 +7,7 @@ fullnameOverride: "serverless"
 injectCerts:
   image:
     repository: 'eu.gcr.io/kyma-project/test-infra/alpine-kubectl'
-    tag: 'v20200507-070ff576'
+    tag: 'v20200617-32c1f3ff'
     pullPolicy: IfNotPresent
 
 knativeMigration:
@@ -29,7 +29,7 @@ tests:
         cpu: 200m
     image:
       repository: "eu.gcr.io/kyma-project/test-infra/alpine-kubectl"
-      tag: "v20200310-5f52f407"
+      tag: "v20200617-32c1f3ff"
       pullPolicy: IfNotPresent
     namespace: "long-running-function-test"
     name: longrun

--- a/resources/testing/charts/octopus/templates/crd-job.yaml
+++ b/resources/testing/charts/octopus/templates/crd-job.yaml
@@ -82,7 +82,7 @@ spec:
       restartPolicy: Never
       containers:
       - name: job
-        image: "eu.gcr.io/kyma-project/test-infra/alpine-kubectl:v20200310-5f52f407"
+        image: "eu.gcr.io/kyma-project/test-infra/alpine-kubectl:v20200617-32c1f3ff"
         terminationMessagePolicy: "FallbackToLogsOnError"
         volumeMounts:
         - name: crd-testing


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/master/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

We still have 4 **different** versions of kubectl in Kyma:
```
eu.gcr.io/kyma-project/test-infra/alpine-kubectl:v20200310-5f52f407
eu.gcr.io/kyma-project/test-infra/alpine-kubectl:v20200507-070ff576
eu.gcr.io/kyma-project/test-infra/alpine-kubectl:v20200529-34b39bd3
eu.gcr.io/kyma-project/test-infra/alpine-kubectl:v20200617-32c1f3ff
```

There can be only one.

Changes proposed in this pull request:

- another set of updates to kubectl images

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
