### PR TITLE
Fix eventing uninstall rbac

### DIFF
--- a/resources/event-sources/templates/uninstall.yaml
+++ b/resources/event-sources/templates/uninstall.yaml
@@ -5,7 +5,7 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: {{ .Release.Name }}-rc-delete
+  name: {{ .Release.Name }}-cr-delete
   namespace: {{ .Release.Namespace }}
   labels:
     app: {{ .Release.Name }}-cr-delete
@@ -18,7 +18,7 @@ metadata:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: {{ .Release.Name }}-rc-delete
+  name: {{ .Release.Name }}-cr-delete
   labels:
     app: {{ .Release.Name }}-cr-delete
   annotations:
@@ -36,7 +36,7 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: {{ .Release.Name }}-rc-delete
+  name: {{ .Release.Name }}-cr-delete
   labels:
     app: {{ .Release.Name }}-cr-delete
   annotations:
@@ -46,16 +46,16 @@ metadata:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: {{ .Release.Name }}-rc-delete
+  name: {{ .Release.Name }}-cr-delete
 subjects:
   - kind: ServiceAccount
-    name: {{ .Release.Name }}-rc-delete
+    name: {{ .Release.Name }}-cr-delete
     namespace: {{ .Release.Namespace }}
 ---
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: {{ .Release.Name }}-rc-delete
+  name: {{ .Release.Name }}-cr-delete
   namespace: {{ .Release.Namespace }}
   labels:
     app: {{ .Release.Name }}-cr-delete
@@ -72,14 +72,14 @@ spec:
     metadata:
       annotations:
         sidecar.istio.io/inject: "false"
-      name: {{ .Release.Name }}-rc-delete
+      name: {{ .Release.Name }}-cr-delete
       labels:
         kyma-project.io/app: "eventing-uninstall"
     spec:
-      serviceAccountName: {{ .Release.Name }}-rc-delete
+      serviceAccountName: {{ .Release.Name }}-cr-delete
       restartPolicy: Never
       containers:
-        - name: {{ .Release.Name }}-rc-delete
+        - name: {{ .Release.Name }}-cr-delete
           image: eu.gcr.io/kyma-project/test-infra/alpine-kubectl:v20200507-070ff576
           command:
             - "/bin/bash"

--- a/resources/event-sources/templates/uninstall.yaml
+++ b/resources/event-sources/templates/uninstall.yaml
@@ -79,7 +79,7 @@ spec:
       serviceAccountName: {{ .Release.Name }}-cr-delete
       restartPolicy: Never
       containers:
-        - name: {{ .Release.Name }}-rc-delete
+        - name: {{ .Release.Name }}-cr-delete
           image: eu.gcr.io/kyma-project/test-infra/alpine-kubectl:v20200617-32c1f3ff
           command:
             - "/bin/bash"

--- a/resources/event-sources/templates/uninstall.yaml
+++ b/resources/event-sources/templates/uninstall.yaml
@@ -74,7 +74,7 @@ spec:
         sidecar.istio.io/inject: "false"
       name: {{ .Release.Name }}-rc-delete
       labels:
-        app: "event-sources-delete"
+        kyma-project.io/app: "eventing-uninstall"
     spec:
       serviceAccountName: {{ .Release.Name }}-rc-delete
       restartPolicy: Never

--- a/resources/event-sources/templates/uninstall.yaml
+++ b/resources/event-sources/templates/uninstall.yaml
@@ -31,7 +31,7 @@ rules:
     verbs: ["list", "delete"]
   - apiGroups: ["apiextensions.k8s.io"]
     resources: ["customresourcedefinitions"]
-    verbs: ["list"]
+    verbs: ["get", "list"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/resources/event-sources/templates/uninstall.yaml
+++ b/resources/event-sources/templates/uninstall.yaml
@@ -74,7 +74,7 @@ spec:
         sidecar.istio.io/inject: "false"
       name: {{ .Release.Name }}-cr-delete
       labels:
-        kyma-project.io/app: "eventing-uninstall"
+        kyma-project.io/uninstall: eventing
     spec:
       serviceAccountName: {{ .Release.Name }}-cr-delete
       restartPolicy: Never

--- a/resources/knative-eventing-kafka/templates/uninstall.yaml
+++ b/resources/knative-eventing-kafka/templates/uninstall.yaml
@@ -58,7 +58,7 @@ metadata:
   name: {{ .Release.Name }}-cr-delete
   namespace: {{ .Release.Namespace }}
   labels:
-    kyma-project.io/app: "eventing-uninstall"
+    kyma-project.io/uninstall: eventing
   annotations:
     helm.sh/hook: pre-delete
     helm.sh/hook-delete-policy: "hook-succeeded,before-hook-creation"
@@ -73,7 +73,7 @@ spec:
       annotations:
         sidecar.istio.io/inject: "false"
       labels:
-        kyma-project.io/app: "eventing-uninstall"
+        kyma-project.io/uninstall: eventing
       name: {{ .Release.Name }}-cr-delete
     spec:
       serviceAccountName: {{ .Release.Name }}-cr-delete

--- a/resources/knative-eventing-kafka/templates/uninstall.yaml
+++ b/resources/knative-eventing-kafka/templates/uninstall.yaml
@@ -58,7 +58,7 @@ metadata:
   name: {{ .Release.Name }}-cr-delete
   namespace: {{ .Release.Namespace }}
   labels:
-    app: {{ .Release.Name }}-cr-delete
+    kyma-project.io/app: "eventing-uninstall"
   annotations:
     helm.sh/hook: pre-delete
     helm.sh/hook-delete-policy: "hook-succeeded,before-hook-creation"
@@ -72,6 +72,8 @@ spec:
     metadata:
       annotations:
         sidecar.istio.io/inject: "false"
+      labels:
+        kyma-project.io/app: "eventing-uninstall"
       name: {{ .Release.Name }}-cr-delete
     spec:
       serviceAccountName: {{ .Release.Name }}-cr-delete

--- a/resources/knative-eventing-kafka/templates/uninstall.yaml
+++ b/resources/knative-eventing-kafka/templates/uninstall.yaml
@@ -31,7 +31,7 @@ rules:
   verbs: ["list", "delete"]
 - apiGroups: ["apiextensions.k8s.io"]
   resources: ["customresourcedefinitions"]
-  verbs: ["list"]
+  verbs: ["get", "list"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/resources/knative-eventing/charts/knative-eventing/templates/uninstall-eventing.yaml
+++ b/resources/knative-eventing/charts/knative-eventing/templates/uninstall-eventing.yaml
@@ -37,7 +37,7 @@ rules:
     verbs: ["list", "delete"]
   - apiGroups: ["apiextensions.k8s.io"]
     resources: ["customresourcedefinitions"]
-    verbs: ["list"]
+    verbs: ["get", "list"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/resources/knative-eventing/charts/knative-eventing/templates/uninstall-eventing.yaml
+++ b/resources/knative-eventing/charts/knative-eventing/templates/uninstall-eventing.yaml
@@ -64,7 +64,7 @@ metadata:
   name: {{ .Release.Name }}-cr-delete
   namespace: {{ .Release.Namespace }}
   labels:
-    kyma-project.io/app: "eventing-uninstall"
+    kyma-project.io/uninstall: eventing
   annotations:
     helm.sh/hook: pre-delete
     helm.sh/hook-delete-policy: "hook-succeeded,before-hook-creation"
@@ -79,7 +79,7 @@ spec:
       annotations:
         sidecar.istio.io/inject: "false"
       labels:
-        kyma-project.io/app: "eventing-uninstall"
+        kyma-project.io/uninstall: eventing
       name: {{ .Release.Name }}-cr-delete
     spec:
       serviceAccountName: {{ .Release.Name }}-cr-delete

--- a/resources/knative-eventing/charts/knative-eventing/templates/uninstall-eventing.yaml
+++ b/resources/knative-eventing/charts/knative-eventing/templates/uninstall-eventing.yaml
@@ -64,7 +64,7 @@ metadata:
   name: {{ .Release.Name }}-cr-delete
   namespace: {{ .Release.Namespace }}
   labels:
-    app: {{ .Release.Name }}-cr-delete
+    kyma-project.io/app: "eventing-uninstall"
   annotations:
     helm.sh/hook: pre-delete
     helm.sh/hook-delete-policy: "hook-succeeded,before-hook-creation"
@@ -78,6 +78,8 @@ spec:
     metadata:
       annotations:
         sidecar.istio.io/inject: "false"
+      labels:
+        kyma-project.io/app: "eventing-uninstall"
       name: {{ .Release.Name }}-cr-delete
     spec:
       serviceAccountName: {{ .Release.Name }}-cr-delete

--- a/resources/knative-provisioner-natss/charts/knative-provisioner-natss/templates/uninstall.yaml
+++ b/resources/knative-provisioner-natss/charts/knative-provisioner-natss/templates/uninstall.yaml
@@ -58,7 +58,7 @@ metadata:
   name: {{ .Release.Name }}-cr-delete
   namespace: {{ .Release.Namespace }}
   labels:
-    kyma-project.io/app: "eventing-uninstall"
+    kyma-project.io/uninstall: eventing
   annotations:
     helm.sh/hook: pre-delete
     helm.sh/hook-delete-policy: "hook-succeeded,before-hook-creation"
@@ -73,7 +73,7 @@ spec:
       annotations:
         sidecar.istio.io/inject: "false"
       labels:
-        kyma-project.io/app: "eventing-uninstall"
+        kyma-project.io/uninstall: eventing
       name: {{ .Release.Name }}-cr-delete
     spec:
       serviceAccountName: {{ .Release.Name }}-cr-delete

--- a/resources/knative-provisioner-natss/charts/knative-provisioner-natss/templates/uninstall.yaml
+++ b/resources/knative-provisioner-natss/charts/knative-provisioner-natss/templates/uninstall.yaml
@@ -31,7 +31,7 @@ rules:
     verbs: ["list", "delete"]
   - apiGroups: ["apiextensions.k8s.io"]
     resources: ["customresourcedefinitions"]
-    verbs: ["list"]
+    verbs: ["get", "list"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/resources/knative-provisioner-natss/charts/knative-provisioner-natss/templates/uninstall.yaml
+++ b/resources/knative-provisioner-natss/charts/knative-provisioner-natss/templates/uninstall.yaml
@@ -58,7 +58,7 @@ metadata:
   name: {{ .Release.Name }}-cr-delete
   namespace: {{ .Release.Namespace }}
   labels:
-    app: {{ .Release.Name }}-cr-delete
+    kyma-project.io/app: "eventing-uninstall"
   annotations:
     helm.sh/hook: pre-delete
     helm.sh/hook-delete-policy: "hook-succeeded,before-hook-creation"
@@ -72,6 +72,8 @@ spec:
     metadata:
       annotations:
         sidecar.istio.io/inject: "false"
+      labels:
+        kyma-project.io/app: "eventing-uninstall"
       name: {{ .Release.Name }}-cr-delete
     spec:
       serviceAccountName: {{ .Release.Name }}-cr-delete


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/master/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- pre-delete hooks didn't have rbac get permission. The consequence was that the script thought the API server doesn't know the CRD, hence CRs have not been deleted by the job
- Use static label  `kyma-project.io/uninstall: eventing` => easier watching of pre-delete job e.g. via `stern -l  kyma-project.io/uninstall: eventing --all-namespaces
`

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
#8526