### PR TITLE
Fix the upgrade of knative-eventing-kafka chart with Helm 3 operator 

### DIFF
--- a/resources/knative-eventing-kafka/pre-upgrade.sh
+++ b/resources/knative-eventing-kafka/pre-upgrade.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+set -eux -o pipefail
+
+kubectl delete deployment -n knative-eventing -lapp.kubernetes.io/instance=knative-eventing-kafka --ignore-not-found

--- a/resources/knative-eventing-kafka/templates/pre-upgrade.yaml
+++ b/resources/knative-eventing-kafka/templates/pre-upgrade.yaml
@@ -1,0 +1,88 @@
+# About:
+# This pre-upgrade job delete the deployment knative-kafka-channel-controller
+
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ .Release.Name }}-pre-upgrade
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: {{ .Release.Name }}-pre-upgrade
+  annotations:
+    helm.sh/hook: "pre-upgrade"
+    helm.sh/hook-delete-policy: "hook-succeeded,before-hook-creation"
+    helm.sh/hook-weight: "0"
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ .Release.Name }}-pre-upgrade
+  labels:
+    app: {{ .Release.Name }}-pre-upgrade
+  annotations:
+    helm.sh/hook: "pre-upgrade"
+    helm.sh/hook-delete-policy: "hook-succeeded,before-hook-creation"
+    helm.sh/hook-weight: "0"
+rules:
+- apiGroups: ["apps", "extensions"]
+  resources: ["deployments"]
+  verbs: ["list", "delete"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ .Release.Name }}-pre-upgrade
+  labels:
+    app: {{ .Release.Name }}-pre-upgrade
+  annotations:
+    helm.sh/hook: "pre-upgrade"
+    helm.sh/hook-delete-policy: "hook-succeeded,before-hook-creation"
+    helm.sh/hook-weight: "1"
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ .Release.Name }}-pre-upgrade
+subjects:
+  - kind: ServiceAccount
+    name: {{ .Release.Name }}-pre-upgrade
+    namespace: {{ .Release.Namespace }}
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ .Release.Name }}-pre-upgrade
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: {{ .Release.Name }}-pre-upgrade
+  annotations:
+    helm.sh/hook: "pre-upgrade"
+    helm.sh/hook-delete-policy: "hook-succeeded,before-hook-creation"
+    helm.sh/hook-weight: "2"
+    sidecar.istio.io/inject: "false"
+spec:
+  backoffLimit: 1
+  template:
+    metadata:
+      annotations:
+        sidecar.istio.io/inject: "false"
+      name: {{ .Release.Name }}-pre-upgrade
+    spec:
+      serviceAccountName: {{ .Release.Name }}-pre-upgrade
+      restartPolicy: Never
+      containers:
+        - name: {{ .Release.Name }}-pre-upgrade
+          image: eu.gcr.io/kyma-project/test-infra/alpine-kubectl:v20200507-070ff576
+          command:
+            - "/bin/bash"
+          args:
+            - "-c"
+            - |
+{{ .Files.Get "pre-upgrade.sh" | indent 14 }}
+          terminationMessagePolicy: "FallbackToLogsOnError"
+          resources:
+            requests:
+              cpu: 200m
+              memory: 128Mi
+            limits:
+              cpu: 200m
+              memory: 128Mi


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/master/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- Fix the upgrade of knative-eventing-kafka chart with Helm 3 operator

Reason:
With the [change](https://github.com/kyma-project/kyma/pull/8713/files#diff-d848376d40fe767413ce5973e2e2d333R2) in chart name, the `matchLabel` `app.kubernetes.io/name` changed as well. As this field is immutable, the upgrade process failed. Hence it is imperative to delete the deployment before the Helm upgrade.
