### PR TITLE
Add pre-install hook for natss

### DIFF
--- a/resources/nats-streaming/check-namespace.sh
+++ b/resources/nats-streaming/check-namespace.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-seconds=240    #seconds to wait till "knative-eventing namespace" will be created by another Helm 3 installer
+seconds=48    #wait 4mins till "knative-eventing" namespace will be created by another Helm3 installer. Helm3 default timeout 5mins
 counter=0
 until [ $counter -gt $seconds ]; do
   timestamp=`date`
@@ -9,6 +9,6 @@ until [ $counter -gt $seconds ]; do
   else
     echo "[$timestamp] knative-eventing not found"
   fi
-  sleep 1
+  sleep 5
   ((counter++))
 done

--- a/resources/nats-streaming/check-namespace.sh
+++ b/resources/nats-streaming/check-namespace.sh
@@ -1,14 +1,17 @@
 #!/usr/bin/env bash
-seconds=48    #wait 4mins till "knative-eventing" namespace will be created by another Helm3 installer. Helm3 default timeout 5mins
 counter=0
-until [ $counter -gt $seconds ]; do
+until [ $counter -gt 3 ]; do  # it tries 3 times to solve the "Terminating" status
   timestamp=`date`
-  if kubectl get ns | grep knative-eventing; then
-    echo "[$timestamp] knative-eventing found"
-    break
+  if errormessage=`kubectl create ns knative-eventing 2>&1`; then
+    echo "[$timestamp] OK: knative-eventing created"
+    exit 0
+  elif echo "$errormessage" | grep 'already exists'; then
+    echo "[$timestamp] OK: knative-eventing already exists"
+    exit 0
   else
-    echo "[$timestamp] knative-eventing not found"
+    echo "[$timestamp] ERROR: knative-eventing creation failed"
   fi
   sleep 5
   ((counter++))
 done
+exit 1

--- a/resources/nats-streaming/check-namespace.sh
+++ b/resources/nats-streaming/check-namespace.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+seconds=240    #seconds to wait till "knative-eventing namespace" will be created by another Helm 3 installer
+counter=0
+until [ $counter -gt $seconds ]; do
+  timestamp=`date`
+  if kubectl get ns | grep knative-eventing; then
+    echo "[$timestamp] knative-eventing found"
+    break
+  else
+    echo "[$timestamp] knative-eventing not found"
+  fi
+  sleep 1
+  ((counter++))
+done

--- a/resources/nats-streaming/templates/pre-install-hook.yaml
+++ b/resources/nats-streaming/templates/pre-install-hook.yaml
@@ -1,10 +1,10 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: {{ .Release.Namespace }}-ns-check
+  name: {{ .Release.Name }}-ns-check
   namespace: {{ .Release.Namespace }}
   labels:
-    app: {{ .Release.Namespace }}-ns-check
+    app: {{ .Release.Name }}-ns-check
   annotations:
     helm.sh/hook: pre-install
     helm.sh/hook-delete-policy: "hook-succeeded,before-hook-creation"
@@ -12,9 +12,9 @@ metadata:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: {{ .Release.Namespace }}-ns-check
+  name: {{ .Release.Name }}-ns-check
   labels:
-    app: {{ .Release.Namespace }}-ns-check
+    app: {{ .Release.Name }}-ns-check
   annotations:
     helm.sh/hook: pre-install
     helm.sh/hook-delete-policy: "hook-succeeded,before-hook-creation"
@@ -26,19 +26,19 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: {{ .Release.Namespace }}-ns-check
+  name: {{ .Release.Name }}-ns-check
   labels:
-    app: {{ .Release.Namespace }}-ns-check
+    app: {{ .Release.Name }}-ns-check
   annotations:
     helm.sh/hook: pre-install
     helm.sh/hook-delete-policy: "hook-succeeded,before-hook-creation"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: {{ .Release.Namespace }}-ns-check
+  name: {{ .Release.Name }}-ns-check
 subjects:
   - kind: ServiceAccount
-    name: {{ .Release.Namespace }}-ns-check
+    name: {{ .Release.Name }}-ns-check
     namespace: {{ .Release.Namespace }}
 ---
 apiVersion: batch/v1
@@ -56,11 +56,11 @@ spec:
       annotations:
         sidecar.istio.io/inject: "false"
     spec:
-      serviceAccountName: {{ .Release.Namespace }}-ns-check
+      serviceAccountName: {{ .Release.Name }}-ns-check
       restartPolicy: Never
       terminationGracePeriodSeconds: 0
       containers:
-        - name: {{ .Release.Namespace }}-pre-install
+        - name: {{ .Release.Name }}-pre-install
           image: eu.gcr.io/kyma-project/test-infra/alpine-kubectl:v20200507-070ff576
           imagePullPolicy: IfNotPresent
 

--- a/resources/nats-streaming/templates/pre-install-hook.yaml
+++ b/resources/nats-streaming/templates/pre-install-hook.yaml
@@ -1,0 +1,73 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ .Release.Namespace }}-ns-check
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: {{ .Release.Namespace }}-ns-check
+  annotations:
+    helm.sh/hook: pre-install
+    helm.sh/hook-delete-policy: "hook-succeeded,before-hook-creation"
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ .Release.Namespace }}-ns-check
+  labels:
+    app: {{ .Release.Namespace }}-ns-check
+  annotations:
+    helm.sh/hook: pre-install
+    helm.sh/hook-delete-policy: "hook-succeeded,before-hook-creation"
+rules:
+  - apiGroups: [""]
+    resources: ["namespaces"]
+    verbs: ["list"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ .Release.Namespace }}-ns-check
+  labels:
+    app: {{ .Release.Namespace }}-ns-check
+  annotations:
+    helm.sh/hook: pre-install
+    helm.sh/hook-delete-policy: "hook-succeeded,before-hook-creation"
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ .Release.Namespace }}-ns-check
+subjects:
+  - kind: ServiceAccount
+    name: {{ .Release.Namespace }}-ns-check
+    namespace: {{ .Release.Namespace }}
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: pre-install-job
+  annotations:
+    helm.sh/hook: "pre-install"
+    helm.sh/hook-delete-policy: "hook-succeeded,before-hook-creation"
+    sidecar.istio.io/inject: "false"
+spec:
+  backoffLimit: 1
+  template:
+    metadata:
+      annotations:
+        sidecar.istio.io/inject: "false"
+    spec:
+      serviceAccountName: {{ .Release.Namespace }}-ns-check
+      restartPolicy: Never
+      terminationGracePeriodSeconds: 0
+      containers:
+        - name: {{ .Release.Namespace }}-pre-install
+          image: eu.gcr.io/kyma-project/test-infra/alpine-kubectl:v20200507-070ff576
+          imagePullPolicy: IfNotPresent
+
+          command:
+            - "/bin/bash"
+          args:
+            - "-c"
+            - |
+{{ .Files.Get "check-namespace.sh" | indent 14 }}
+          terminationMessagePolicy: "FallbackToLogsOnError"

--- a/resources/nats-streaming/templates/pre-install-hook.yaml
+++ b/resources/nats-streaming/templates/pre-install-hook.yaml
@@ -21,7 +21,7 @@ metadata:
 rules:
   - apiGroups: [""]
     resources: ["namespaces"]
-    verbs: ["list"]
+    verbs: ["create","get","list"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/resources/nats-streaming/templates/pre-install-hook.yaml
+++ b/resources/nats-streaming/templates/pre-install-hook.yaml
@@ -55,13 +55,15 @@ spec:
     metadata:
       annotations:
         sidecar.istio.io/inject: "false"
+      labels:
+        kyma-project.io/install: eventing
     spec:
       serviceAccountName: {{ .Release.Name }}-ns-check
       restartPolicy: Never
       terminationGracePeriodSeconds: 0
       containers:
         - name: {{ .Release.Name }}-pre-install
-          image: eu.gcr.io/kyma-project/test-infra/alpine-kubectl:v20200507-070ff576
+          image: eu.gcr.io/kyma-project/test-infra/alpine-kubectl:v20200617-32c1f3ff
           imagePullPolicy: IfNotPresent
 
           command:


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/master/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- Adds a pre-install Helm 3 hook for waiting till the "knative-eventing" namespace was created by another parallel deployment. The timeout is 4 mins, under the default timeout of Helm 3 installer (5 mins)

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
See also #8527
