### PR TITLE
Change the verbosity type to string

### DIFF
--- a/resources/service-catalog/charts/catalog/values.schema.json
+++ b/resources/service-catalog/charts/catalog/values.schema.json
@@ -47,8 +47,8 @@
                 },
                 "verbosity": {
                     "description": "Defines log severity level. The possible values range from 0-10.",
-                    "default": 10,
-                    "type": "number"
+                    "default": "10",
+                    "type": "string"
                 }
             }
         },
@@ -96,8 +96,8 @@
                 },
                 "verbosity": {
                     "description": "Defines log severity level. The possible values range from 0-10.",
-                    "default": 10,
-                    "type": "number"
+                    "default": "10",
+                    "type": "string"
                 },
                 "brokerRelistIntervalActivated": {
                     "description": "Specifies whether or not the controller supports a --broker-relist-interval flag. If this is set to true, brokerRelistInterval will be used as the value for that flag.",

--- a/resources/service-catalog/charts/catalog/values.yaml
+++ b/resources/service-catalog/charts/catalog/values.yaml
@@ -37,7 +37,7 @@ webhook:
       # The TLS-enabled endpoint will be exposed here
       securePort: 31443
   # Log level; valid values are in the range 0 - 10
-  verbosity: 10
+  verbosity: "10"
   serviceAccount: service-catalog-webhook
   # Webhook resource requests and limits
   # Ref: http://kubernetes.io/docs/user-guide/compute-resources/
@@ -65,7 +65,7 @@ controllerManager:
   healthcheck:
     enabled: false # in Kyma we are using svc-cat together with istio and default healtcheck is not supported
   # Log level; valid values are in the range 0 - 10
-  verbosity: 10
+  verbosity: "10"
   # Resync interval; format is a duration (`20m`, `1h`, etc)
   resyncInterval: 5m
   # Broker relist interval; format is a duration (`20m`, `1h`, etc)


### PR DESCRIPTION
**Description**
As kyma-installer doesn't support passing primitive values of number type (only string and bool), the following values of service-catalog chart should be adjusted:

- catalog.controllerManager.verbosity
- catalog.webhook.verbosity

This was not a blocker when Helm 2 was used, but Helm 3 validates (lints) against the schema.json and fails if the type of the supplied values doesn't match the expected type.



