### PR TITLE
Update KEB chart Avs tester tag config parsing

### DIFF
--- a/resources/compass/charts/kyma-environment-broker/templates/_helpers.tpl
+++ b/resources/compass/charts/kyma-environment-broker/templates/_helpers.tpl
@@ -49,9 +49,10 @@ Utility function for joining Avs tag list into string.
 */}}
 {{- define "avs.utils.joinTags" -}}
 {{- $local := dict "first" true -}}
-{{- range $k, $v := . -}}
+{{- $data := (printf "%s:\n%s" "tags" .) | fromYaml -}}
+{{- range $tag := $data.tags -}}
 {{- if not $local.first -}},{{- end -}}
-{{ printf "{%q,%v,%q}" $v.content $v.tag_id $v.tag_name }}
+{{ printf "{%q,%v,%q}" $tag.content $tag.tag_id $tag.tag_name }}
 {{- $_ := set $local "first" false -}}
 {{- end -}}
 {{- end -}}

--- a/resources/compass/charts/kyma-environment-broker/values.yaml
+++ b/resources/compass/charts/kyma-environment-broker/values.yaml
@@ -96,14 +96,15 @@ avs:
   externalTesterService: ""
   # List of tags to bind to testers.
   # Example: 
-  #  - content: tag-A
-  #    tag_id: 1
-  #    tag_name: value-A
-  #  - content: tag-B
-  #    tag_id: 2
-  #    tag_name: value-B
-  internalTesterTags: {}
-  externalTesterTags: {}
+  # internalTesterTags: |-
+  #   - content: tag-A
+  #     tag_id: 1
+  #     tag_name: value-A
+  #   - content: tag-B
+  #     tag_id: 2
+  #     tag_name: value-B
+  internalTesterTags: ""
+  externalTesterTags: ""
 
 lms:
   secretName: "lms-creds"


### PR DESCRIPTION

**Description**

Changes the way how Avs configuration is being defined and parsed within KEB chart. This was changed due to Kyma Operator inability to override objects. 

Now, KEB Avs configuration uses multiline string which is possible to override.

**Related PRs**
* [kyma-incubator/compass/pull/PR#1470](https://github.com/kyma-incubator/compass/pull/1470)