### PR TITLE
Add isLocalEnv to istio chart

### DIFF
--- a/resources/istio/values.yaml
+++ b/resources/istio/values.yaml
@@ -1,4 +1,6 @@
 ---
+global:
+  isLocalEnv: false
 kyma:
   namespaces2Label:
     - istio-system


### PR DESCRIPTION
**Description**

Helm can't resolve the .Values.global.isLocalEnv when it is not provided.

Changes proposed in this pull request:

- Add global.isLocalEnv equal to false to istio chart
