### PR TITLE
Add duration to minikube installation

### DIFF
--- a/installation/scripts/prow/kyma-integration-on-debian/deploy-and-test-kyma.sh
+++ b/installation/scripts/prow/kyma-integration-on-debian/deploy-and-test-kyma.sh
@@ -12,6 +12,6 @@ START_TIME=$SECONDS
 sudo ${INSTALLATION_DIR}/cmd/run.sh --vm-driver "none"
 sudo ${INSTALLATION_DIR}/scripts/is-installed.sh --timeout 30m
 ELAPSED_TIME=$(($SECONDS - $START_TIME))
-echo "$(($ELAPSED_TIME / 60)) minutes and $(($ELAPSED_TIME % 60)) seconds elapsed."
+echo "Installation of Kyma took $(($ELAPSED_TIME / 60)) minutes and $(($ELAPSED_TIME % 60)) seconds."
 sudo ${INSTALLATION_DIR}/scripts/watch-pods.sh
 sudo ${INSTALLATION_DIR}/scripts/testing.sh

--- a/installation/scripts/prow/kyma-integration-on-debian/deploy-and-test-kyma.sh
+++ b/installation/scripts/prow/kyma-integration-on-debian/deploy-and-test-kyma.sh
@@ -8,10 +8,10 @@ set -o errexit
 
 CURRENT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 INSTALLATION_DIR=${CURRENT_DIR}/../../../
-SECONDS=0
+START_TIME=$SECONDS
 sudo ${INSTALLATION_DIR}/cmd/run.sh --vm-driver "none"
 sudo ${INSTALLATION_DIR}/scripts/is-installed.sh --timeout 30m
-duration=$SECONDS
-echo "$(($duration / 60)) minutes and $(($duration % 60)) seconds elapsed."
+ELAPSED_TIME=$(($SECONDS - $START_TIME))
+echo "$(($ELAPSED_TIME / 60)) minutes and $(($ELAPSED_TIME % 60)) seconds elapsed."
 sudo ${INSTALLATION_DIR}/scripts/watch-pods.sh
 sudo ${INSTALLATION_DIR}/scripts/testing.sh

--- a/installation/scripts/prow/kyma-integration-on-debian/deploy-and-test-kyma.sh
+++ b/installation/scripts/prow/kyma-integration-on-debian/deploy-and-test-kyma.sh
@@ -8,8 +8,10 @@ set -o errexit
 
 CURRENT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 INSTALLATION_DIR=${CURRENT_DIR}/../../../
-
+SECONDS=0
 sudo ${INSTALLATION_DIR}/cmd/run.sh --vm-driver "none"
 sudo ${INSTALLATION_DIR}/scripts/is-installed.sh --timeout 30m
+duration=$SECONDS
+echo "$(($duration / 60)) minutes and $(($duration % 60)) seconds elapsed."
 sudo ${INSTALLATION_DIR}/scripts/watch-pods.sh
 sudo ${INSTALLATION_DIR}/scripts/testing.sh


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/master/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- Add duration to the minikube installation as we need to monitor the time taken to install Kyma using Minikube. This will in turn will help in choosing the tool which takes the least possible time to install.

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
Related https://github.com/kyma-project/kyma/issues/8756