### PR TITLE
Remove labels from issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -1,7 +1,6 @@
 ---
 name: Bug report
 about: Report a bug in the project
-labels: bug
 ---
 
 <!-- Thank you for your contribution. Before you submit the issue:

--- a/.github/ISSUE_TEMPLATE/feature-request.md
+++ b/.github/ISSUE_TEMPLATE/feature-request.md
@@ -1,7 +1,6 @@
 ---
 name: Feature request
 about: Suggest an improvement to the project
-labels: enhancement
 ---
 
 <!-- Thank you for your contribution. Before you submit the issue:

--- a/.github/ISSUE_TEMPLATE/security-vulnerability.md
+++ b/.github/ISSUE_TEMPLATE/security-vulnerability.md
@@ -1,7 +1,6 @@
 ---
 name: Security Vulnerability
 about: Report vulnerability in the project
-labels: area/security
 ---
 
 <!-- Thank you for your contribution. Before you submit the issue:

--- a/.github/ISSUE_TEMPLATE/support-request.md
+++ b/.github/ISSUE_TEMPLATE/support-request.md
@@ -1,7 +1,6 @@
 ---
 name: Support request
 about: Request support or ask a question relating to Kyma
-labels: support-request
 ---
 
 <!-- Thank you for your contribution. Before you submit the issue:


### PR DESCRIPTION
**Description**

Remove labels from issue templates. The labels are added during the triage process by kyma developers. If the label is created automatically the issue is treated as already reviewed.

**Related issue(s)**
See also https://github.com/kyma-project/kyma/pull/8939
