### PR TITLE
iam-kubeconfig-service: switch to latest fsnotify version

### DIFF
--- a/components/iam-kubeconfig-service/Gopkg.lock
+++ b/components/iam-kubeconfig-service/Gopkg.lock
@@ -18,6 +18,14 @@
   version = "v1.1.1"
 
 [[projects]]
+  digest = "1:80057945464ffb5b0da1f026beb8df0e8dbd098eaf771a349291bed2cd29a83e"
+  name = "github.com/fsnotify/fsnotify"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "45d7d09e39ef4ac08d493309fa031790c15bfe8a"
+  version = "v1.4.9"
+
+[[projects]]
   digest = "1:573ca21d3669500ff845bdebee890eb7fc7f0f50c59f2132f2a0c6b03d85086a"
   name = "github.com/golang/protobuf"
   packages = ["proto"]
@@ -32,14 +40,6 @@
   pruneopts = "UT"
   revision = "00bdffe0f3c77e27d2cf6f5c70232a2d3e4d9c15"
   version = "v1.7.3"
-
-[[projects]]
-  digest = "1:7159b4af2aae0c37b088cea9cb5932b8801a289616c5b789e4669558521cff0c"
-  name = "github.com/howeyc/fsnotify"
-  packages = ["."]
-  pruneopts = "UT"
-  revision = "441bbc86b167f3c1f4786afae9931403b99fdacf"
-  version = "v0.9.0"
 
 [[projects]]
   digest = "1:31e761d97c76151dde79e9d28964a812c46efc5baee4085b86f68f0c654450de"
@@ -270,8 +270,8 @@
   analyzer-name = "dep"
   analyzer-version = 1
   input-imports = [
+    "github.com/fsnotify/fsnotify",
     "github.com/gorilla/mux",
-    "github.com/howeyc/fsnotify",
     "github.com/pkg/errors",
     "github.com/sirupsen/logrus",
     "github.com/stretchr/testify/assert",

--- a/components/iam-kubeconfig-service/Gopkg.toml
+++ b/components/iam-kubeconfig-service/Gopkg.toml
@@ -50,8 +50,8 @@ required = [
   version = "1.2.1"
 
 [[constraint]]
-  name = "github.com/howeyc/fsnotify"
-  version = "0.9.0"
+  name = "github.com/fsnotify/fsnotify"
+  version = "1.4.9"
 
 [prune]
   go-tests = true

--- a/components/iam-kubeconfig-service/README.md
+++ b/components/iam-kubeconfig-service/README.md
@@ -34,6 +34,7 @@ Use the following arguments to configure the application:
 | oidc-groups-claim | No | `groups` | Identifier of groups in JWT claim. |
 | oidc-username-prefix | No | None | If provided, all users will be prefixed with this value to prevent conflicts with other authentication strategies. |
 | oidc-groups-prefix | No | None | If provided, all groups will be prefixed with this value to prevent conflicts with other authentication strategies. |
+| log-level | No | info | Configures logging level. Allowed values: trace, debug, info, warn, error, fatal, panic |
 
 ### Run a local version
 

--- a/components/iam-kubeconfig-service/cmd/generator/main.go
+++ b/components/iam-kubeconfig-service/cmd/generator/main.go
@@ -105,9 +105,7 @@ func readAppConfig() *appConfig {
 	oidcUsernamePrefixArg := flag.String("oidc-username-prefix", "", "OIDC: If provided, all users will be prefixed with this value to prevent conflicts with other authentication strategies")
 	oidcGroupsPrefixArg := flag.String("oidc-groups-prefix", "", "OIDC: If provided, all groups will be prefixed with this value to prevent conflicts with other authentication strategies")
 	oidcCAFileArg := flag.String(oidcCAFileFlag, "", "File with Certificate Authority of the Kubernetes cluster, also used for OIDC authentication")
-	logLevelArg := flag.String(logLevelFlag, "Info", "Log level (Trace, Debug, Info, Warning, Error, Fatal and Panic)")
-
-	log.SetLevel(logLevelArg)
+	logLevelArg := flag.String(logLevelFlag, "info", "Log level (trace, debug, info, warning, error, fatal and panic)")
 
 	var oidcSupportedSigningAlgsArg multiValFlag = []string{}
 	flag.Var(&oidcSupportedSigningAlgsArg, "oidc-supported-signing-algs", "OIDC supported signing algorithms")
@@ -144,6 +142,14 @@ func readAppConfig() *appConfig {
 	if errors {
 		flag.Usage()
 		os.Exit(1)
+	}
+
+	logLevel, err := log.ParseLevel(*logLevelArg)
+	if err == nil {
+		log.SetLevel(logLevel)
+	} else {
+		log.Error(err, ". Defaulting to \"info\"")
+		log.SetLevel(log.InfoLevel)
 	}
 
 	if len(oidcSupportedSigningAlgsArg) == 0 {

--- a/components/iam-kubeconfig-service/cmd/generator/main.go
+++ b/components/iam-kubeconfig-service/cmd/generator/main.go
@@ -27,6 +27,7 @@ const (
 	apiserverURLFlag  = "kube-config-url"
 	clusterCAFileFlag = "kube-config-ca-file"
 	oidcCAFileFlag    = "oidc-ca-file"
+	logLevelFlag      = "log-level"
 )
 
 func main() {
@@ -104,6 +105,9 @@ func readAppConfig() *appConfig {
 	oidcUsernamePrefixArg := flag.String("oidc-username-prefix", "", "OIDC: If provided, all users will be prefixed with this value to prevent conflicts with other authentication strategies")
 	oidcGroupsPrefixArg := flag.String("oidc-groups-prefix", "", "OIDC: If provided, all groups will be prefixed with this value to prevent conflicts with other authentication strategies")
 	oidcCAFileArg := flag.String(oidcCAFileFlag, "", "File with Certificate Authority of the Kubernetes cluster, also used for OIDC authentication")
+	logLevelArg := flag.String(logLevelFlag, "Info", "Log level (Trace, Debug, Info, Warning, Error, Fatal and Panic)")
+
+	log.SetLevel(logLevelArg)
 
 	var oidcSupportedSigningAlgsArg multiValFlag = []string{}
 	flag.Var(&oidcSupportedSigningAlgsArg, "oidc-supported-signing-algs", "OIDC supported signing algorithms")

--- a/components/iam-kubeconfig-service/cmd/generator/reload/watch.go
+++ b/components/iam-kubeconfig-service/cmd/generator/reload/watch.go
@@ -73,7 +73,7 @@ func (w *watcher) watchFileEvents(ctx context.Context, wch <-chan fsnotify.Event
 	for {
 		select {
 		case ev := <-wch:
-			log.Infof("Watcher[%s]: watchFileEvents: %s", w.name, ev.String())
+			log.Debugf("Watcher[%s]: watchFileEvents: %s", w.name, ev.String())
 			if timer != nil {
 				//timer is already ticking. Once the timer is done, notification will be fired.
 				continue

--- a/components/iam-kubeconfig-service/cmd/generator/reload/watch.go
+++ b/components/iam-kubeconfig-service/cmd/generator/reload/watch.go
@@ -5,7 +5,7 @@ import (
 	"path/filepath"
 	"time"
 
-	"github.com/howeyc/fsnotify"
+	"github.com/fsnotify/fsnotify"
 
 	log "github.com/sirupsen/logrus"
 )
@@ -44,7 +44,7 @@ func NewWatcher(name string, filePaths []string, evBatchDelaySeconds uint8, noti
 func (w *watcher) Run(ctx context.Context) {
 	log.Infof("Watcher [%s] starts watching for files: %v", w.name, w.filePaths)
 
-	watchFileEventsFunc := func(fEventChan <-chan *fsnotify.FileEvent) {
+	watchFileEventsFunc := func(fEventChan <-chan fsnotify.Event) {
 		w.watchFileEvents(ctx, fEventChan)
 	}
 
@@ -63,7 +63,7 @@ func (w *watcher) Run(ctx context.Context) {
 // The function batches changes so that related changes are processed together in a single step.
 // The function ensures that notifyFn() is called no more than one time per eventBatchDelaySeconds.
 // The function does not return until the the context is canceled.
-func (w *watcher) watchFileEvents(ctx context.Context, wch <-chan *fsnotify.FileEvent) {
+func (w *watcher) watchFileEvents(ctx context.Context, wch <-chan fsnotify.Event) {
 	minDelay := time.Second * time.Duration(w.eventBatchDelaySeconds)
 
 	// timer and channel for managing minDelay.
@@ -75,6 +75,11 @@ func (w *watcher) watchFileEvents(ctx context.Context, wch <-chan *fsnotify.File
 		case ev := <-wch:
 			log.Infof("Watcher[%s]: watchFileEvents: %s", w.name, ev.String())
 			if timer != nil {
+				//timer is already ticking. Once the timer is done, notification will be fired.
+				continue
+			}
+			if ev.Op == fsnotify.Chmod {
+				//if the event is just chmod, DO NOT notify (there's no need to reload file)
 				continue
 			}
 			// create new timer
@@ -98,7 +103,7 @@ func (w *watcher) watchFileEvents(ctx context.Context, wch <-chan *fsnotify.File
 // watchForDirs configures a watch for every directory path in dirs.
 // It then invokes provided watchFunc with configured Watchers.
 // This function is blocking so it should be run in a goroutine.
-func (w *watcher) watchForDirs(dirs []string, watchFunc func(fEventChan <-chan *fsnotify.FileEvent)) {
+func (w *watcher) watchForDirs(dirs []string, watchFunc func(fEventChan <-chan fsnotify.Event)) {
 	fw, err := fsnotify.NewWatcher()
 	if err != nil {
 		log.Warningf("Watcher[%s]: failed to create a watcher for certificate files: %v", w.name, err)
@@ -111,14 +116,14 @@ func (w *watcher) watchForDirs(dirs []string, watchFunc func(fEventChan <-chan *
 	}()
 
 	for _, dir := range dirs {
-		if err := fw.Watch(dir); err != nil {
+		if err := fw.Add(dir); err != nil {
 			log.Warningf("Watcher[%s]: watching %s encountered an error %v", w.name, dir, err)
 			return
 		}
 		log.Infof("Watcher[%s]: watching %s for changes", w.name, dir)
 	}
 
-	watchFunc(fw.Event)
+	watchFunc(fw.Events)
 }
 
 //Extracts directory paths from provided filePaths list and returns a list of paths with duplicates removed.


### PR DESCRIPTION
**Description**

The file-watching mechanism we have at the moment re-loads files when only attributes are changing (ctime, mtime, permission bits).
This causes problems in some k8s scenarios where attributes may change frequently, although the data stays the same.

Changes proposed in this pull request:

- Bump fsnotify library to latest version (it's a new fork)
- Improve watching logic to skip only-attribute-changed scenarios
- Improved and extended tests for watch logic


**Related issue(s)**
See also #8868 