### PR TITLE
Disable pod-preset PDB by default

### DIFF
--- a/resources/cluster-essentials/charts/pod-preset/templates/webhook/deploy.yaml
+++ b/resources/cluster-essentials/charts/pod-preset/templates/webhook/deploy.yaml
@@ -54,6 +54,7 @@ spec:
             path: webhook.crt
           - key: tls.key
             path: webhook.key
+{{- if .Values.webhook.pdb.enabled }}
 ---
 apiVersion: policy/v1beta1
 kind: PodDisruptionBudget
@@ -64,3 +65,4 @@ spec:
   selector:
     matchLabels:
       app: {{ template "pod-preset.name" . }}-webhook
+{{- end -}}

--- a/resources/cluster-essentials/charts/pod-preset/values.yaml
+++ b/resources/cluster-essentials/charts/pod-preset/values.yaml
@@ -7,6 +7,8 @@ webhook:
   verbosity: 6
   securityContext:
     runAsUser: 2000
+  pdb:
+    enabled: false
 
 controller:
   enabled: false


### PR DESCRIPTION
**Description**
The default webhook replica count is 1, which means the PDB with `minAvailable: 1` would cause K8S worker node operations to block since the webhook pod could not be evicted. Configuring PDB should be self-voluntary by explicitly specifying from configuration, and adjusting the replica count accordingly. 
