### PR TITLE
Add a section on configuring the Runtime to Runtime Agent docs

### DIFF
--- a/docs/runtime-agent/01-01-runtime-agent.md
+++ b/docs/runtime-agent/01-01-runtime-agent.md
@@ -2,7 +2,7 @@
 title: Overview
 ---
 
-Runtime Agent is a Kyma component that connects to [Compass](https://github.com/kyma-incubator/compass). It is an integral part of every Kyma Runtime and it fetches the latest configuration from Compass. It also provides Runtime-specific information that is displayed in the Compass UI, such as Runtime UI URL, and it provides Compass with Runtime configuration, such as Event Gateway URL, that should be passed to an Application.
+Runtime Agent is a Kyma component that connects to [Compass](https://github.com/kyma-incubator/compass). It is an integral part of every Kyma Runtime and it fetches the latest configuration from Compass. It also provides Runtime-specific information that is displayed in the Compass UI, such as Runtime UI URL, and it provides Compass with Runtime configuration, such as Event Gateway URL, that should be passed to an Application. To learn more, read the section on [configuring the Runtime](#details-configuring-the-runtime).
 
 The main responsibilities of the component are:
 - Establishing a trusted connection between the Kyma Runtime and Compass

--- a/docs/runtime-agent/03-02-configuring-runtime.md
+++ b/docs/runtime-agent/03-02-configuring-runtime.md
@@ -5,11 +5,17 @@ type: Details
 
 > **NOTE:** To represent API and Event Definitions of the connected Applications on Runtime, Open Service Broker API usage is recommended.
 
-In Kyma Runtime, during Runtime configuration, Application's Packages are integrated into the [Service Catalog](components/service-catalog) using [Application](components/application-connector#custom-resource-application) custom resources and [Application Broker](components/application-connector#architecture-application-broker). By default, a single Application is represented as a [ServiceClass](components/service-catalog/#architecture-resources), and a single Package is represented as a [ServicePlan](components/service-catalog/#architecture-resources) in the Service Catalog. Read more about [API Packages](https://github.com/kyma-incubator/compass/blob/master/docs/compass/03-packages-api.md) document.
+In Kyma Runtime, during Runtime configuration, Application's Packages are integrated into the [Service Catalog](components/service-catalog) using [Application](components/application-connector#custom-resource-application) custom resources and [Application Broker](components/application-connector#architecture-application-broker).
+By default, a single Application is represented as a [ServiceClass](components/service-catalog/#architecture-resources), and a single Package is represented as a [ServicePlan](components/service-catalog/#architecture-resources) in the Service Catalog.
+Read more about [API Packages](https://github.com/kyma-incubator/compass/blob/master/docs/compass/03-packages-api.md) document.
 
-Runtime Agent periodically requests for the configuration of its Runtime from Compass. Changes in the configuration for the Runtime are applied by the Runtime Agent on the Runtime.
+Runtime Agent periodically requests for the configuration of its Runtime from Compass.
+Changes in the configuration for the Runtime are applied by the Runtime Agent on the Runtime.
 
-To fetch the Runtime configuration, Runtime Agent calls the [`applicationsForRuntime`](https://github.com/kyma-incubator/compass/blob/master/components/director/pkg/graphql/schema.graphql) query offered by the Compass component called Director. The response for the query contains a page with the list of Applications assigned for the Runtime and info about the next page. Each Application will contain only credentials that are valid for the Runtime that called the query. Each Runtime Agent can fetch the configurations for Runtimes that belong to its tenant, there is no validation if the Runtime Agent is fetching the configuration for the Runtime on which it runs.
+To fetch the Runtime configuration, Runtime Agent calls the [`applicationsForRuntime`](https://github.com/kyma-incubator/compass/blob/master/components/director/pkg/graphql/schema.graphql) query offered by the Compass component called Director.
+The response for the query contains Applications assigned for the Runtime.
+Each Application contains only credentials that are valid for the Runtime that called the query.
+Each Runtime Agent can fetch the configurations for Runtimes that belong to its tenant.
 
 Runtime Agent reports back to the Director the Runtime-specific [LabelDefinitions](https://github.com/kyma-incubator/compass/blob/master/docs/compass/03-02-labels.md#labeldefinitions) that represent Runtime configuration together with their values.
 

--- a/docs/runtime-agent/03-02-configuring-runtime.md
+++ b/docs/runtime-agent/03-02-configuring-runtime.md
@@ -3,11 +3,11 @@ title: Configuring the Runtime
 type: Details
 ---
 
-> **NOTE:** To represent API and Event Definitions of the connected Applications on Runtime, Open Service Broker API usage is recommended.
+> **NOTE:** To represent API and Event Definitions of the Applications connected to a Runtime, Open Service Broker API usage is recommended.
 
-In Kyma Runtime, during Runtime configuration, Application's Packages are integrated into the [Service Catalog](components/service-catalog) using [Application](components/application-connector#custom-resource-application) custom resources and [Application Broker](components/application-connector#architecture-application-broker).
-By default, a single Application is represented as a [ServiceClass](components/service-catalog/#architecture-resources), and a single Package is represented as a [ServicePlan](components/service-catalog/#architecture-resources) in the Service Catalog.
-Read more about [API Packages](https://github.com/kyma-incubator/compass/blob/master/docs/compass/03-packages-api.md) document.
+In a Kyma Runtime, during Runtime configuration, Application's Packages are integrated into [Service Catalog](components/service-catalog) using [Application](components/application-connector#custom-resource-application) custom resources and [Application Broker](components/application-connector#architecture-application-broker).
+By default, a single Application is represented as a [ServiceClass](components/service-catalog/#architecture-resources), and a single Package is represented as a [ServicePlan](components/service-catalog/#architecture-resources) in Service Catalog.
+Refer to the documentation to learn more about [API Packages](https://github.com/kyma-incubator/compass/blob/master/docs/compass/03-packages-api.md).
 
 Runtime Agent periodically requests for the configuration of its Runtime from Compass.
 Changes in the configuration for the Runtime are applied by the Runtime Agent on the Runtime.
@@ -17,9 +17,5 @@ The response for the query contains Applications assigned for the Runtime.
 Each Application contains only credentials that are valid for the Runtime that called the query.
 Each Runtime Agent can fetch the configurations for Runtimes that belong to its tenant.
 
-Runtime Agent reports back to the Director the Runtime-specific [LabelDefinitions](https://github.com/kyma-incubator/compass/blob/master/docs/compass/03-02-labels.md#labeldefinitions) that represent Runtime configuration together with their values.
-
-Runtime-specific LabelDefinitions:
-
-- Events Gateway URL
-- Runtime Console URL
+Runtime Agent reports back to the Director the Runtime-specific [LabelDefinitions](https://github.com/kyma-incubator/compass/blob/master/docs/compass/03-02-labels.md#labeldefinitions), which represent Runtime configuration, together with their values.
+Runtime-specific LabelDefinitions are Events Gateway URL and Runtime Console URL.

--- a/docs/runtime-agent/03-02-configuring-runtime.md
+++ b/docs/runtime-agent/03-02-configuring-runtime.md
@@ -5,7 +5,7 @@ type: Details
 
 > **NOTE:** To represent API and Event Definitions of the connected Applications on Runtime, Open Service Broker API usage is recommended.
 
-In Kyma Runtime, during Runtime configuration, Application's Packages are integrated into the [Service Catalog](components/service-catalog) using [Application](components/application-connector#custom-resource-application) custom resources and [Application Broker](components/application-connector#architecture-application-broker). By default, a single Application is represented as a [ServiceClass](components/service-catalog/#architecture-resources), and a single Package is represented as a [ServicePlan](components/service-catalog/#architecture-resources) in the Service Catalog. Read more about [API Packages](https://github.com/kyma-incubator/compass/docs/compass/03-packages-api.md) document.
+In Kyma Runtime, during Runtime configuration, Application's Packages are integrated into the [Service Catalog](components/service-catalog) using [Application](components/application-connector#custom-resource-application) custom resources and [Application Broker](components/application-connector#architecture-application-broker). By default, a single Application is represented as a [ServiceClass](components/service-catalog/#architecture-resources), and a single Package is represented as a [ServicePlan](components/service-catalog/#architecture-resources) in the Service Catalog. Read more about [API Packages](https://github.com/kyma-incubator/compass/blob/master/docs/compass/03-packages-api.md) document.
 
 Runtime Agent periodically requests for the configuration of its Runtime from Compass. Changes in the configuration for the Runtime are applied by the Runtime Agent on the Runtime.
 

--- a/docs/runtime-agent/03-02-configuring-runtime.md
+++ b/docs/runtime-agent/03-02-configuring-runtime.md
@@ -1,0 +1,19 @@
+---
+title: Configuring the Runtime
+type: Details
+---
+
+> **NOTE:** To represent API and Event Definitions of the connected Applications on Runtime, Open Service Broker API usage is recommended.
+
+In Kyma Runtime, during Runtime configuration, Application's Packages are integrated into the [Service Catalog](components/service-catalog) using [Application](components/application-connector#custom-resource-application) custom resources and [Application Broker](components/application-connector#architecture-application-broker). By default, a single Application is represented as a [ServiceClass](components/service-catalog/#architecture-resources), and a single Package is represented as a [ServicePlan](components/service-catalog/#architecture-resources) in the Service Catalog. Read more about [API Packages](https://github.com/kyma-incubator/compass/docs/compass/03-packages-api.md) document.
+
+Runtime Agent periodically requests for the configuration of its Runtime from Compass. Changes in the configuration for the Runtime are applied by the Runtime Agent on the Runtime.
+
+To fetch the Runtime configuration, Runtime Agent calls the [`applicationsForRuntime`](https://github.com/kyma-incubator/compass/blob/master/components/director/pkg/graphql/schema.graphql) query offered by the Compass component called Director. The response for the query contains a page with the list of Applications assigned for the Runtime and info about the next page. Each Application will contain only credentials that are valid for the Runtime that called the query. Each Runtime Agent can fetch the configurations for Runtimes that belong to its tenant, there is no validation if the Runtime Agent is fetching the configuration for the Runtime on which it runs.
+
+Runtime Agent reports back to the Director the Runtime-specific [LabelDefinitions](https://github.com/kyma-incubator/compass/blob/master/docs/compass/03-02-labels.md#labeldefinitions) that represent Runtime configuration together with their values.
+
+Runtime-specific LabelDefinitions:
+
+- Events Gateway URL
+- Runtime Console URL


### PR DESCRIPTION
**Description**

We previously had a bit on configuring the Runtime documented in Runtime Agent contract with Compass. However, this was not the right place for it. As we did not want to get rid of that information altogether, we decided to create such a section in the Runtime Agent documentation on the website.

Changes proposed in this pull request:

- Add a section on configuring the Runtime to the Runtime Agent documentation.

**Related PR**
kyma-incubator/compass#1494