### PR TITLE
Upgrade golang.org/x/text

### DIFF
--- a/resources/knative-serving/values.yaml
+++ b/resources/knative-serving/values.yaml
@@ -65,8 +65,8 @@ global:
   containerRegistry:
     path: eu.gcr.io/kyma-project
   test_knative_serving_acceptance:
-    dir:
-    version: "7dd25b42"
+    dir: 
+    version: "PR-9045"
   ingress:
     domainName:
 

--- a/resources/serverless/values.yaml
+++ b/resources/serverless/values.yaml
@@ -36,7 +36,7 @@ tests:
 
   image:
     repository: "eu.gcr.io/kyma-project/function-controller-test"
-    tag: "7dd25b42"
+    tag: "PR-9045"
     pullPolicy: IfNotPresent
   disableConcurrency: false
   restartPolicy: Never

--- a/tests/function-controller/go.mod
+++ b/tests/function-controller/go.mod
@@ -32,6 +32,8 @@ require (
 	sigs.k8s.io/controller-runtime v0.5.2
 )
 
+replace golang.org/x/text => golang.org/x/text v0.3.3
+
 // mismatch among fun-controller, knative enevting and knative serving...
 // try to delete it after update of eventing/serving
 replace knative.dev/pkg => knative.dev/pkg v0.0.0-20200113182502-b8dc5fbc6d2f

--- a/tests/function-controller/go.sum
+++ b/tests/function-controller/go.sum
@@ -529,11 +529,8 @@ golang.org/x/sys v0.0.0-20191010194322-b09406accb47/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20200323222414-85ca7c5b95cd/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200413165638-669c56c373c4 h1:opSr2sbRXk5X5/givKrrKj9HXxFpW2sdCiP8MJSKLQY=
 golang.org/x/sys v0.0.0-20200413165638-669c56c373c4/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/text v0.0.0-20160726164857-2910a502d2bf/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
-golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
-golang.org/x/text v0.3.1-0.20180807135948-17ff2d5776d2/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
-golang.org/x/text v0.3.2 h1:tW2bmiBqwgJj/UpqtC8EpXEZVYOwU0yG4iWbprSVAcs=
-golang.org/x/text v0.3.2/go.mod h1:bEr9sfX3Q8Zfm5fL9x+3itogRgK3+ptLWKqgva+5dAk=
+golang.org/x/text v0.3.3 h1:cokOdA+Jmi5PJGXLlLllQSgYigAEfHXJAERHVMaCc2k=
+golang.org/x/text v0.3.3/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
 golang.org/x/time v0.0.0-20180412165947-fbb02b2291d2/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
 golang.org/x/time v0.0.0-20181108054448-85acf8d2951c/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
 golang.org/x/time v0.0.0-20190308202827-9d24e82272b4/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=

--- a/tests/knative-serving/Gopkg.lock
+++ b/tests/knative-serving/Gopkg.lock
@@ -255,7 +255,7 @@
   revision = "3421d5a6bb1c214d7aec16aac9fe24627beb5dfd"
 
 [[projects]]
-  digest = "1:8d8faad6b12a3a4c819a3f9618cb6ee1fa1cfc33253abeeea8b55336721e3405"
+  digest = "1:fa940333c48808b0d86ef21f412ffcfd0e5084a82f13905c028a404803b1908f"
   name = "golang.org/x/text"
   packages = [
     "collate",
@@ -276,8 +276,8 @@
     "unicode/rangetable",
   ]
   pruneopts = "UT"
-  revision = "342b2e1fbaa52c93f31447ad2c6abc048c63e475"
-  version = "v0.3.2"
+  revision = "23ae387dee1f90d29a23c0e87ee0b46038fbed0e"
+  version = "v0.3.3"
 
 [[projects]]
   branch = "master"

--- a/tests/knative-serving/Gopkg.toml
+++ b/tests/knative-serving/Gopkg.toml
@@ -26,3 +26,7 @@ required = ["github.com/kyma-project/kyma/common"]
 [[override]]
   name = "golang.org/x/crypto"
   revision = "69ecbb4d6d5dab05e49161c6e77ea40a030884e1"
+
+[[override]]
+  name = "golang.org/x/text"
+  version="v0.3.3"


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/master/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- Upgrade `golang.org/x/text` to version `v0.3.3` in tests of the `knative-serving` and the `function-controller` because of security vulnerability (`CVE-2020-14040`)
