### PR TITLE
send_resolved parameter is configurable in alertmanger config

### DIFF
--- a/docs/monitoring/05-01-alertmanager.md
+++ b/docs/monitoring/05-01-alertmanager.md
@@ -18,10 +18,10 @@ This table lists the configurable parameters, their descriptions, and default va
 | **global.alertTools.credentials.slack.apiurl** | Specifies the URL endpoint which sends alerts triggered by Prometheus rules.  | None |
 | **global.alertTools.credentials.slack.channel** | Refers to the Slack channel which receives notifications on new alerts. | None |
 | **global.alertTools.credentials.slack.matchExpression** | Notifications will be sent only for those alerts whose labels match the specified expression.  | "severity: critical" |
-| **global.alertTools.credentials.slack.sendresolved** | Specifies whether or not to notify about resolved alerts.  | true |
+| **global.alertTools.credentials.slack.sendResolved** | Specifies whether or not to notify about resolved alerts.  | true |
 | **global.alertTools.credentials.victorOps.routingkey** | Defines the team routing key in [VictorOps](https://help.victorops.com/). | None |
 | **global.alertTools.credentials.victorOps.apikey** | Defines the team API key in VictorOps. | None |
 | **global.alertTools.credentials.victorOps.matchExpression** | Notifications will be sent only for those alerts whose labels match the specified expression.  | "severity: critical" |
-| **global.alertTools.credentials.victorOps.sendresolved** | Specifies whether or not to notify about resolved alerts.  | true |
+| **global.alertTools.credentials.victorOps.sendResolved** | Specifies whether or not to notify about resolved alerts.  | true |
 
 >**NOTE:** Override all configurable values for the Alertmanager sub-chart using Secrets (`kind: Secret`).

--- a/docs/monitoring/05-01-alertmanager.md
+++ b/docs/monitoring/05-01-alertmanager.md
@@ -18,8 +18,10 @@ This table lists the configurable parameters, their descriptions, and default va
 | **global.alertTools.credentials.slack.apiurl** | Specifies the URL endpoint which sends alerts triggered by Prometheus rules.  | None |
 | **global.alertTools.credentials.slack.channel** | Refers to the Slack channel which receives notifications on new alerts. | None |
 | **global.alertTools.credentials.slack.matchExpression** | Notifications will be sent only for those alerts whose labels match the specified expression.  | "severity: critical" |
+| **global.alertTools.credentials.slack.sendresolved** | Specifies whether or not to notify about resolved alerts.  | true |
 | **global.alertTools.credentials.victorOps.routingkey** | Defines the team routing key in [VictorOps](https://help.victorops.com/). | None |
 | **global.alertTools.credentials.victorOps.apikey** | Defines the team API key in VictorOps. | None |
 | **global.alertTools.credentials.victorOps.matchExpression** | Notifications will be sent only for those alerts whose labels match the specified expression.  | "severity: critical" |
+| **global.alertTools.credentials.victorOps.sendresolved** | Specifies whether or not to notify about resolved alerts.  | true |
 
 >**NOTE:** Override all configurable values for the Alertmanager sub-chart using Secrets (`kind: Secret`).

--- a/resources/monitoring/templates/kyma-additions/alertmanager.config.yaml
+++ b/resources/monitoring/templates/kyma-additions/alertmanager.config.yaml
@@ -47,7 +47,11 @@ receivers:
 - name: "victorOps"
   victorops_configs:
   - api_key: {{ .Values.global.alertTools.credentials.victorOps.apikey | quote }}
-    send_resolved: {{ .Values.global.alertTools.credentials.victorOps.sendResolved }}
+    {{- if .Values.global.alertTools.credentials.victorOps.sendResolved }}
+    send_resolved: true
+    {{- else }}
+    send_resolved: false
+    {{- end }}
     api_url: https://alert.victorops.com/integrations/generic/20131114/alert/
     routing_key: {{ .Values.global.alertTools.credentials.victorOps.routingkey | quote }}
     state_message: 'Alert: {{`{{ .CommonLabels.alertname }}`}}. Summary:{{`{{ .CommonAnnotations.message }}`}}. RawData: {{`{{ .CommonLabels }}`}}'
@@ -59,7 +63,11 @@ receivers:
 - name: "slack"
   slack_configs:
   - channel: {{ .Values.global.alertTools.credentials.slack.channel | quote }}
-    send_resolved: {{ .Values.global.alertTools.credentials.slack.sendResolved }}
+    {{- if .Values.global.alertTools.credentials.slack.sendResolved }}
+    send_resolved: true
+    {{- else }}
+    send_resolved: false
+    {{- end }}
     api_url: {{ .Values.global.alertTools.credentials.slack.apiurl | quote }}
     icon_emoji: ":ghost:"
     title: '{{`{{ template "__subject" . }}`}} ({{ .Values.global.ingress.domainName }})'

--- a/resources/monitoring/templates/kyma-additions/alertmanager.config.yaml
+++ b/resources/monitoring/templates/kyma-additions/alertmanager.config.yaml
@@ -47,11 +47,7 @@ receivers:
 - name: "victorOps"
   victorops_configs:
   - api_key: {{ .Values.global.alertTools.credentials.victorOps.apikey | quote }}
-    {{- if .Values.global.alertTools.credentials.victorOps.sendResolved }}
-    send_resolved: true
-    {{- else }}
-    send_resolved: false
-    {{- end }}
+    send_resolved: {{ .Values.global.alertTools.credentials.victorOps.sendResolved }}
     api_url: https://alert.victorops.com/integrations/generic/20131114/alert/
     routing_key: {{ .Values.global.alertTools.credentials.victorOps.routingkey | quote }}
     state_message: 'Alert: {{`{{ .CommonLabels.alertname }}`}}. Summary:{{`{{ .CommonAnnotations.message }}`}}. RawData: {{`{{ .CommonLabels }}`}}'
@@ -63,11 +59,7 @@ receivers:
 - name: "slack"
   slack_configs:
   - channel: {{ .Values.global.alertTools.credentials.slack.channel | quote }}
-    {{- if .Values.global.alertTools.credentials.slack.sendResolved }}
-    send_resolved: true
-    {{- else }}
-    send_resolved: false
-    {{- end }}
+    send_resolved: {{ .Values.global.alertTools.credentials.slack.sendResolved }}
     api_url: {{ .Values.global.alertTools.credentials.slack.apiurl | quote }}
     icon_emoji: ":ghost:"
     title: '{{`{{ template "__subject" . }}`}} ({{ .Values.global.ingress.domainName }})'

--- a/resources/monitoring/templates/kyma-additions/alertmanager.config.yaml
+++ b/resources/monitoring/templates/kyma-additions/alertmanager.config.yaml
@@ -47,7 +47,7 @@ receivers:
 - name: "victorOps"
   victorops_configs:
   - api_key: {{ .Values.global.alertTools.credentials.victorOps.apikey | quote }}
-    send_resolved: {{ .Values.global.alertTools.credentials.victorOps.sendResolved | quote }}
+    send_resolved: {{ .Values.global.alertTools.credentials.victorOps.sendResolved }}
     api_url: https://alert.victorops.com/integrations/generic/20131114/alert/
     routing_key: {{ .Values.global.alertTools.credentials.victorOps.routingkey | quote }}
     state_message: 'Alert: {{`{{ .CommonLabels.alertname }}`}}. Summary:{{`{{ .CommonAnnotations.message }}`}}. RawData: {{`{{ .CommonLabels }}`}}'
@@ -59,7 +59,7 @@ receivers:
 - name: "slack"
   slack_configs:
   - channel: {{ .Values.global.alertTools.credentials.slack.channel | quote }}
-    send_resolved: {{ .Values.global.alertTools.credentials.slack.sendResolved | quote }}
+    send_resolved: {{ .Values.global.alertTools.credentials.slack.sendResolved }}
     api_url: {{ .Values.global.alertTools.credentials.slack.apiurl | quote }}
     icon_emoji: ":ghost:"
     title: '{{`{{ template "__subject" . }}`}} ({{ .Values.global.ingress.domainName }})'

--- a/resources/monitoring/templates/kyma-additions/alertmanager.config.yaml
+++ b/resources/monitoring/templates/kyma-additions/alertmanager.config.yaml
@@ -47,7 +47,7 @@ receivers:
 - name: "victorOps"
   victorops_configs:
   - api_key: {{ .Values.global.alertTools.credentials.victorOps.apikey | quote }}
-    send_resolved: true
+    send_resolved: {{ .Values.global.alertTools.credentials.victorOps.sendresolved }}
     api_url: https://alert.victorops.com/integrations/generic/20131114/alert/
     routing_key: {{ .Values.global.alertTools.credentials.victorOps.routingkey | quote }}
     state_message: 'Alert: {{`{{ .CommonLabels.alertname }}`}}. Summary:{{`{{ .CommonAnnotations.message }}`}}. RawData: {{`{{ .CommonLabels }}`}}'
@@ -59,7 +59,7 @@ receivers:
 - name: "slack"
   slack_configs:
   - channel: {{ .Values.global.alertTools.credentials.slack.channel | quote }}
-    send_resolved: true
+    send_resolved: {{ .Values.global.alertTools.credentials.slack.sendresolved }}
     api_url: {{ .Values.global.alertTools.credentials.slack.apiurl | quote }}
     icon_emoji: ":ghost:"
     title: '{{`{{ template "__subject" . }}`}} ({{ .Values.global.ingress.domainName }})'

--- a/resources/monitoring/templates/kyma-additions/alertmanager.config.yaml
+++ b/resources/monitoring/templates/kyma-additions/alertmanager.config.yaml
@@ -47,7 +47,7 @@ receivers:
 - name: "victorOps"
   victorops_configs:
   - api_key: {{ .Values.global.alertTools.credentials.victorOps.apikey | quote }}
-    send_resolved: {{ .Values.global.alertTools.credentials.victorOps.sendresolved }}
+    send_resolved: '{{ .Values.global.alertTools.credentials.victorOps.sendresolved }}'
     api_url: https://alert.victorops.com/integrations/generic/20131114/alert/
     routing_key: {{ .Values.global.alertTools.credentials.victorOps.routingkey | quote }}
     state_message: 'Alert: {{`{{ .CommonLabels.alertname }}`}}. Summary:{{`{{ .CommonAnnotations.message }}`}}. RawData: {{`{{ .CommonLabels }}`}}'
@@ -59,7 +59,7 @@ receivers:
 - name: "slack"
   slack_configs:
   - channel: {{ .Values.global.alertTools.credentials.slack.channel | quote }}
-    send_resolved: {{ .Values.global.alertTools.credentials.slack.sendresolved }}
+    send_resolved: '{{ .Values.global.alertTools.credentials.slack.sendresolved }}'
     api_url: {{ .Values.global.alertTools.credentials.slack.apiurl | quote }}
     icon_emoji: ":ghost:"
     title: '{{`{{ template "__subject" . }}`}} ({{ .Values.global.ingress.domainName }})'

--- a/resources/monitoring/templates/kyma-additions/alertmanager.config.yaml
+++ b/resources/monitoring/templates/kyma-additions/alertmanager.config.yaml
@@ -47,11 +47,7 @@ receivers:
 - name: "victorOps"
   victorops_configs:
   - api_key: {{ .Values.global.alertTools.credentials.victorOps.apikey | quote }}
-    {{- if .Values.global.alertTools.credentials.victorOps.sendresolved }}
-    send_resolved: {{ .Values.global.alertTools.credentials.victorOps.sendresolved }}
-    {{ else }}
-    send_resolved: false
-    {{- end }}
+    send_resolved: {{ .Values.global.alertTools.credentials.victorOps.sendResolved | quote }}
     api_url: https://alert.victorops.com/integrations/generic/20131114/alert/
     routing_key: {{ .Values.global.alertTools.credentials.victorOps.routingkey | quote }}
     state_message: 'Alert: {{`{{ .CommonLabels.alertname }}`}}. Summary:{{`{{ .CommonAnnotations.message }}`}}. RawData: {{`{{ .CommonLabels }}`}}'
@@ -63,11 +59,7 @@ receivers:
 - name: "slack"
   slack_configs:
   - channel: {{ .Values.global.alertTools.credentials.slack.channel | quote }}
-    {{- if .Values.global.alertTools.credentials.slack.sendresolved }}
-    send_resolved: {{ .Values.global.alertTools.credentials.slack.sendresolved }}
-    {{ else }}
-    send_resolved: false
-    {{- end }}
+    send_resolved: {{ .Values.global.alertTools.credentials.slack.sendResolved | quote }}
     api_url: {{ .Values.global.alertTools.credentials.slack.apiurl | quote }}
     icon_emoji: ":ghost:"
     title: '{{`{{ template "__subject" . }}`}} ({{ .Values.global.ingress.domainName }})'

--- a/resources/monitoring/templates/kyma-additions/alertmanager.config.yaml
+++ b/resources/monitoring/templates/kyma-additions/alertmanager.config.yaml
@@ -47,7 +47,11 @@ receivers:
 - name: "victorOps"
   victorops_configs:
   - api_key: {{ .Values.global.alertTools.credentials.victorOps.apikey | quote }}
-    send_resolved: '{{ .Values.global.alertTools.credentials.victorOps.sendresolved }}'
+    {{- if .Values.global.alertTools.credentials.victorOps.sendresolved }}
+    send_resolved: {{ .Values.global.alertTools.credentials.victorOps.sendresolved }}
+    {{ else }}
+    send_resolved: false
+    {{- end }}
     api_url: https://alert.victorops.com/integrations/generic/20131114/alert/
     routing_key: {{ .Values.global.alertTools.credentials.victorOps.routingkey | quote }}
     state_message: 'Alert: {{`{{ .CommonLabels.alertname }}`}}. Summary:{{`{{ .CommonAnnotations.message }}`}}. RawData: {{`{{ .CommonLabels }}`}}'
@@ -59,7 +63,11 @@ receivers:
 - name: "slack"
   slack_configs:
   - channel: {{ .Values.global.alertTools.credentials.slack.channel | quote }}
-    send_resolved: '{{ .Values.global.alertTools.credentials.slack.sendresolved }}'
+    {{- if .Values.global.alertTools.credentials.slack.sendresolved }}
+    send_resolved: {{ .Values.global.alertTools.credentials.slack.sendresolved }}
+    {{ else }}
+    send_resolved: false
+    {{- end }}
     api_url: {{ .Values.global.alertTools.credentials.slack.apiurl | quote }}
     icon_emoji: ":ghost:"
     title: '{{`{{ template "__subject" . }}`}} ({{ .Values.global.ingress.domainName }})'

--- a/resources/monitoring/values.yaml
+++ b/resources/monitoring/values.yaml
@@ -23,14 +23,14 @@ global:
   alertTools:
     credentials:
       slack:
-        sendresolved: true
+        sendResolved: true
         apiurl: ""
         channel: ""
         matchExpression:
           severity: critical
         routes: |-
       victorOps:
-        sendresolved: true
+        sendResolved: true
         routingkey: ""
         apikey: ""
         matchExpression:

--- a/resources/monitoring/values.yaml
+++ b/resources/monitoring/values.yaml
@@ -23,12 +23,14 @@ global:
   alertTools:
     credentials:
       slack:
+        sendresolved: true
         apiurl: ""
         channel: ""
         matchExpression:
           severity: critical
         routes: |-
       victorOps:
+        sendresolved: true
         routingkey: ""
         apikey: ""
         matchExpression:


### PR DESCRIPTION
Problem:
We met the alert issue is that first alert is firing, and the second alert is firing which is not trigger the VictorOps incident. Note that second alert is same kind of the first one but have more labels.

Expected:
We expected each alert will trigger the VictorOps incident.

Suggestion:
According to[ send_resolved definition](https://prometheus.io/docs/alerting/latest/configuration/#victorops_config), we hope to set send_resolved=false in our local environment.
