### PR TITLE
Set explicit increased memory resources for kyma-installer-container

### DIFF
--- a/installation/resources/installer.yaml
+++ b/installation/resources/installer.yaml
@@ -188,6 +188,11 @@ spec:
         args:
           - -overrideLogFile=/app/overrides.txt
           - -helmDebugMode=true
+        resources:
+          requests:
+            memory: 512Mi
+          limits:
+            memory: 2Gi
 ---
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1beta1

--- a/installation/resources/installer.yaml
+++ b/installation/resources/installer.yaml
@@ -17,7 +17,7 @@ metadata:
 spec:
   limits:
   - max:
-      memory: 1024Mi # Maximum memory that a container can request
+      memory: 2048Mi # Maximum memory that a container can request
     default:
       # If a container does not specify memory limit, this default value will be applied.
       # If a container tries to allocate more memory, container will be OOM killed.


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

Set explicit 2Gi memory limit for kyma-installer-container
