### PR TITLE
Update 06-01-apirule.md

### DIFF
--- a/docs/api-gateway/06-01-apirule.md
+++ b/docs/api-gateway/06-01-apirule.md
@@ -6,7 +6,7 @@ type: Custom Resource
 The `apirule.gateway.kyma-project.io` CustomResourceDefinition (CRD) is a detailed description of the kind of data and the format the API Gateway Controller listens for. To get the up-to-date CRD and show the output in the `yaml` format, run this command:
 
 ```shell
-kubectl get crd apirule.gateway.kyma-project.io -o yaml
+kubectl get crd apirules.gateway.kyma-project.io -o yaml
 ```
 
 ## Sample custom resource


### PR DESCRIPTION
Corrected the `kubectl get crd` command to inspect the CRD structure of API rules.
Btw.: Is the API version really still in alpha state? See: `apiVersion: gateway.kyma-project.io/v1alpha1`

**Description**

Changes proposed in this pull request:

- Corrected the `kubectl get crd` command to inspect the CRD structure of API rules.
