### PR TITLE
switched kiali test to alpine-kubectl image

### DIFF
--- a/resources/kiali/templates/tests/test.yaml
+++ b/resources/kiali/templates/tests/test.yaml
@@ -29,9 +29,3 @@ spec:
 
 {{- end}}
 {{- end}}
-
-tests:
-  enabled: true
-  image:
-    name: eu.gcr.io/kyma-project/test-infra/alpine-kubectl
-    version: v20200617-32c1f3ff

--- a/resources/kiali/templates/tests/test.yaml
+++ b/resources/kiali/templates/tests/test.yaml
@@ -22,10 +22,16 @@ spec:
       restartPolicy: Never
       containers:
       - name: tests
-        image: {{ .Values.global.containerRegistry.path }}/{{ .Values.global.alpine_net.dir }}{{ .Values.global.alpine_net.name }}:{{ .Values.global.alpine_net.version }}
+        image: {{ .Values.tests.image.name }}:{{ .Values.tests.image.version }}
         imagePullPolicy: "{{ .Values.global.imagePullPolicy }}"
         command: ['curl']
         args: ['-k', 'https://kiali.{{ .Values.global.ingress.domainName }}']
 
 {{- end}}
 {{- end}}
+
+tests:
+  enabled: true
+  image:
+    name: eu.gcr.io/kyma-project/test-infra/alpine-kubectl
+    version: v20200617-32c1f3ff

--- a/resources/kiali/values.yaml
+++ b/resources/kiali/values.yaml
@@ -1,7 +1,9 @@
 
 tests:
   enabled: true
-
+  image:
+    name: eu.gcr.io/kyma-project/test-infra/alpine-kubectl
+    version: v20200703-d5c97fa6
 nodeSelector: {}
 
 global:
@@ -12,10 +14,6 @@ global:
       namespace: kyma-system
   containerRegistry:
     path: eu.gcr.io/kyma-project
-  alpine_net:
-    name: alpine-net
-    dir:
-    version: "fab13c7c"
 
 kcproxy:
   replicaCount: 1


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/master/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- The alpine-net image is outdated. As it will be the only usage left, I switched it to the alpine-kubectl image.
- ...
- ...

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
