### PR TITLE
Adding missing helm delete policy hooks for kyma helm charts

### DIFF
--- a/resources/istio-kyma-patch/templates/job.yaml
+++ b/resources/istio-kyma-patch/templates/job.yaml
@@ -4,7 +4,7 @@ metadata:
   name: istio-kyma-patch
   annotations: 
     helm.sh/hook: post-install,post-upgrade
-    helm.sh/hook-delete-policy: hook-succeeded
+    helm.sh/hook-delete-policy: "before-hook-creation, hook-succeeded"
 spec:
   backoffLimit: 1
   template:

--- a/resources/monitoring/templates/kyma-additions/aks-kubelet-monitoring-patch-pre-upgrade-cleanup.yaml
+++ b/resources/monitoring/templates/kyma-additions/aks-kubelet-monitoring-patch-pre-upgrade-cleanup.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: kyma-system
   annotations:
     helm.sh/hook: pre-install,pre-upgrade
-    helm.sh/hook-delete-policy: hook-succeeded
+    helm.sh/hook-delete-policy: "before-hook-creation, hook-succeeded"
     helm.sh/hook-weight: "0"
 data:
   akspatchcleanup.sh: |
@@ -25,7 +25,7 @@ metadata:
   name: aks-kubelet-monitoring-cleanup-patch
   annotations:
     helm.sh/hook: pre-install,pre-upgrade
-    helm.sh/hook-delete-policy: hook-succeeded
+    helm.sh/hook-delete-policy: "before-hook-creation, hook-succeeded"
     helm.sh/hook-weight: "0"
 ---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -34,7 +34,7 @@ metadata:
   name: aks-kubelet-monitoring-cleanup-patch
   annotations:
     helm.sh/hook: pre-install,pre-upgrade
-    helm.sh/hook-delete-policy: hook-succeeded
+    helm.sh/hook-delete-policy: "before-hook-creation, hook-succeeded"
     helm.sh/hook-weight: "0"
 rules:
   - apiGroups: [""]
@@ -59,7 +59,7 @@ metadata:
   name: aks-kubelet-monitoring-cleanup-patch
   annotations:
     helm.sh/hook: pre-install,pre-upgrade
-    helm.sh/hook-delete-policy: hook-succeeded
+    helm.sh/hook-delete-policy: "before-hook-creation, hook-succeeded"
     helm.sh/hook-weight: "0"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -77,7 +77,7 @@ metadata:
   namespace: kyma-system
   annotations:
     helm.sh/hook: pre-install,pre-upgrade
-    helm.sh/hook-delete-policy: hook-succeeded
+    helm.sh/hook-delete-policy: "before-hook-creation, hook-succeeded"
     sidecar.istio.io/inject: "false"
     helm.sh/hook-weight: "9"
 spec:

--- a/resources/monitoring/templates/kyma-additions/delete-dns-patch.yaml
+++ b/resources/monitoring/templates/kyma-additions/delete-dns-patch.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: kyma-system
   annotations:
     helm.sh/hook: pre-delete
-    helm.sh/hook-delete-policy: hook-succeeded
+    helm.sh/hook-delete-policy: "before-hook-creation, hook-succeeded"
     helm.sh/hook-weight: "0"
 data:
   dns-del-patch.sh: |
@@ -24,7 +24,7 @@ metadata:
   name: pre-delete-delete-monitoring-dns-patch
   annotations:
     helm.sh/hook: pre-delete
-    helm.sh/hook-delete-policy: hook-succeeded
+    helm.sh/hook-delete-policy: "before-hook-creation, hook-succeeded"
     helm.sh/hook-weight: "0"
     
 ---
@@ -34,7 +34,7 @@ metadata:
   name: pre-delete-delete-monitoring-dns-patch
   annotations:
     helm.sh/hook: pre-delete
-    helm.sh/hook-delete-policy: hook-succeeded
+    helm.sh/hook-delete-policy: "before-hook-creation, hook-succeeded"
     helm.sh/hook-weight: "0"
 rules:
   - apiGroups: [""]
@@ -53,7 +53,7 @@ metadata:
   name: pre-delete-delete-monitoring-dns-patch
   annotations:
     helm.sh/hook: pre-delete
-    helm.sh/hook-delete-policy: hook-succeeded
+    helm.sh/hook-delete-policy: "before-hook-creation, hook-succeeded"
     helm.sh/hook-weight: "0"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -71,7 +71,7 @@ metadata:
   namespace: kyma-system
   annotations:
     helm.sh/hook: pre-delete
-    helm.sh/hook-delete-policy: hook-succeeded
+    helm.sh/hook-delete-policy: "before-hook-creation, hook-succeeded"
     sidecar.istio.io/inject: "false"
     helm.sh/hook-weight: "9"
 spec:

--- a/resources/monitoring/templates/kyma-additions/monitoring-dns-patch.yaml
+++ b/resources/monitoring/templates/kyma-additions/monitoring-dns-patch.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: kyma-system
   annotations:
     helm.sh/hook: post-install,post-upgrade
-    helm.sh/hook-delete-policy: hook-succeeded
+    helm.sh/hook-delete-policy: "before-hook-creation, hook-succeeded"
     helm.sh/hook-weight: "0"
 data:
   dnspatch.sh: |
@@ -30,7 +30,7 @@ metadata:
   name: monitoring-dns-patch
   annotations:
     helm.sh/hook: post-install,post-upgrade
-    helm.sh/hook-delete-policy: hook-succeeded
+    helm.sh/hook-delete-policy: "before-hook-creation, hook-succeeded"
     helm.sh/hook-weight: "0"
 ---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -39,7 +39,7 @@ metadata:
   name: monitoring-dns-patch
   annotations:
     helm.sh/hook: post-install,post-upgrade
-    helm.sh/hook-delete-policy: hook-succeeded
+    helm.sh/hook-delete-policy: "before-hook-creation, hook-succeeded"
     helm.sh/hook-weight: "0"
 rules:
   - apiGroups: [""]
@@ -58,7 +58,7 @@ metadata:
   name: monitoring-dns-patch
   annotations:
     helm.sh/hook: post-install,post-upgrade
-    helm.sh/hook-delete-policy: hook-succeeded
+    helm.sh/hook-delete-policy: "before-hook-creation, hook-succeeded"
     helm.sh/hook-weight: "0"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -76,7 +76,7 @@ metadata:
   namespace: kyma-system
   annotations:
     helm.sh/hook: post-install,post-upgrade
-    helm.sh/hook-delete-policy: hook-succeeded
+    helm.sh/hook-delete-policy: "before-hook-creation, hook-succeeded"
     sidecar.istio.io/inject: "false"
     helm.sh/hook-weight: "9"
 spec:

--- a/resources/monitoring/templates/prometheus-operator/cleanup-crds.yaml
+++ b/resources/monitoring/templates/prometheus-operator/cleanup-crds.yaml
@@ -7,7 +7,7 @@ metadata:
   annotations:
     "helm.sh/hook": pre-delete
     "helm.sh/hook-weight": "3"
-    "helm.sh/hook-delete-policy": hook-succeeded
+    "helm.sh/hook-delete-policy": "before-hook-creation, hook-succeeded"
   labels:
     app: {{ template "prometheus-operator.name" . }}-operator
 {{ include "prometheus-operator.labels" . | indent 4 }}

--- a/resources/rafter/charts/controller-manager/charts/minio/templates/post-install-create-bucket-job.yaml
+++ b/resources/rafter/charts/controller-manager/charts/minio/templates/post-install-create-bucket-job.yaml
@@ -10,7 +10,7 @@ metadata:
     heritage: {{ .Release.Service }}
   annotations:
     "helm.sh/hook": post-install,post-upgrade
-    "helm.sh/hook-delete-policy": hook-succeeded
+    "helm.sh/hook-delete-policy": "before-hook-creation, hook-succeeded"
 spec:
   template:
     metadata:

--- a/resources/rafter/charts/upload-service/templates/migrator-job.yaml
+++ b/resources/rafter/charts/upload-service/templates/migrator-job.yaml
@@ -12,7 +12,7 @@ metadata:
   annotations:
     helm.sh/hook: pre-upgrade,post-upgrade
     helm.sh/hook-weight: "-1"
-    helm.sh/hook-delete-policy: hook-succeeded
+    helm.sh/hook-delete-policy: "before-hook-creation, hook-succeeded"
 data:
   initialize: |-
   {{ include (print $.Template.BasePath "/_helper_migrate_buckets.txt") . | indent 4 }}
@@ -42,7 +42,7 @@ metadata:
   name: {{ include "rafterUploadService.fullname" . }}-migrator
   annotations:
     helm.sh/hook: pre-upgrade
-    helm.sh/hook-delete-policy: hook-succeeded
+    helm.sh/hook-delete-policy: "before-hook-creation, hook-succeeded"
     helm.sh/hook-weight: "1"
 subjects:
   - kind: ServiceAccount
@@ -59,7 +59,7 @@ metadata:
   name: {{ include "rafterUploadService.fullname" . }}-migrator
   annotations:
     helm.sh/hook: pre-upgrade
-    helm.sh/hook-delete-policy: hook-succeeded
+    helm.sh/hook-delete-policy: "before-hook-creation, hook-succeeded"
     helm.sh/hook-weight: "1"
 rules:
   - apiGroups: ["apps"]
@@ -73,7 +73,7 @@ metadata:
   namespace: {{ .Release.Namespace }}
   annotations:
     helm.sh/hook: pre-upgrade
-    helm.sh/hook-delete-policy: hook-succeeded
+    helm.sh/hook-delete-policy: "before-hook-creation, hook-succeeded"
     helm.sh/hook-weight: "1"
 ---
 apiVersion: batch/v1
@@ -88,7 +88,7 @@ metadata:
   annotations:
     helm.sh/hook: pre-upgrade
     helm.sh/hook-weight: "2"
-    helm.sh/hook-delete-policy: hook-succeeded
+    helm.sh/hook-delete-policy: "before-hook-creation, hook-succeeded"
 spec:
   template:
     metadata:
@@ -166,7 +166,7 @@ metadata:
   annotations:
     helm.sh/hook: post-upgrade
     helm.sh/hook-weight: "0"
-    helm.sh/hook-delete-policy: hook-succeeded
+    helm.sh/hook-delete-policy: "before-hook-creation, hook-succeeded"
 spec:
   template:
     metadata:
@@ -222,7 +222,7 @@ metadata:
   name: {{ include "rafterUploadService.fullname" . }}-migrator-delete-pvc
   annotations:
     helm.sh/hook: post-upgrade
-    helm.sh/hook-delete-policy: hook-succeeded
+    helm.sh/hook-delete-policy: "before-hook-creation, hook-succeeded"
     helm.sh/hook-weight: "1"
 subjects:
   - kind: ServiceAccount
@@ -239,7 +239,7 @@ metadata:
   name: {{ include "rafterUploadService.fullname" . }}-migrator-delete-pvc
   annotations:
     helm.sh/hook: post-upgrade
-    helm.sh/hook-delete-policy: hook-succeeded
+    helm.sh/hook-delete-policy: "before-hook-creation, hook-succeeded"
     helm.sh/hook-weight: "1"
 rules:
   - apiGroups: [""]
@@ -253,7 +253,7 @@ metadata:
   namespace: {{ .Release.Namespace }}
   annotations:
     helm.sh/hook: post-upgrade
-    helm.sh/hook-delete-policy: hook-succeeded
+    helm.sh/hook-delete-policy: "before-hook-creation, hook-succeeded"
     helm.sh/hook-weight: "1"
 ---
 apiVersion: batch/v1
@@ -268,7 +268,7 @@ metadata:
   annotations:
     helm.sh/hook: post-upgrade
     helm.sh/hook-weight: "2"
-    helm.sh/hook-delete-policy: hook-succeeded
+    helm.sh/hook-delete-policy: "before-hook-creation, hook-succeeded"
 spec:
   template:
     metadata:

--- a/resources/rafter/templates/pre-upgrade-delete-vs-job.yaml
+++ b/resources/rafter/templates/pre-upgrade-delete-vs-job.yaml
@@ -5,7 +5,7 @@ metadata:
   annotations:
     helm.sh/hook: "pre-upgrade"
     helm.sh/hook-weight: "0"
-    helm.sh/hook-delete-policy: hook-succeeded
+    helm.sh/hook-delete-policy: "before-hook-creation, hook-succeeded"
   labels:
     job: pre-upgrade-delete-vs-rafter-minio
 ---
@@ -19,7 +19,7 @@ metadata:
   annotations:
     helm.sh/hook: "pre-upgrade"
     helm.sh/hook-weight: "0"
-    helm.sh/hook-delete-policy: hook-succeeded
+    helm.sh/hook-delete-policy: "before-hook-creation, hook-succeeded"
 rules:
 - apiGroups:
   - networking.istio.io
@@ -37,7 +37,7 @@ metadata:
   annotations:
     helm.sh/hook: "pre-upgrade"
     helm.sh/hook-weight: "0"
-    helm.sh/hook-delete-policy: hook-succeeded
+    helm.sh/hook-delete-policy: "before-hook-creation, hook-succeeded"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -62,7 +62,7 @@ metadata:
   annotations:
     helm.sh/hook: "pre-upgrade"
     helm.sh/hook-weight: "1"
-    helm.sh/hook-delete-policy: hook-succeeded
+    helm.sh/hook-delete-policy: "before-hook-creation, hook-succeeded"
   labels:
     job: pre-upgrade-delete-vs-rafter-minio
   name: pre-upgrade-delete-vs-rafter-minio
@@ -73,7 +73,7 @@ metadata:
   annotations:
     helm.sh/hook: "pre-upgrade"
     helm.sh/hook-weight: "2"
-    helm.sh/hook-delete-policy: hook-succeeded
+    helm.sh/hook-delete-policy: "before-hook-creation, hook-succeeded"
   labels:
     job: pre-upgrade-delete-vs-rafter-minio
   name: pre-upgrade-delete-vs-rafter-minio

--- a/resources/serverless/templates/daemonset-delete-job.yaml
+++ b/resources/serverless/templates/daemonset-delete-job.yaml
@@ -9,7 +9,7 @@ metadata:
   annotations:
     helm.sh/hook: post-upgrade
     helm.sh/hook-weight: "0"
-    helm.sh/hook-delete-policy: hook-succeeded
+    helm.sh/hook-delete-policy: "before-hook-creation, hook-succeeded"
 data:
   daemonset-delete: |-
     #!/usr/bin/env bash
@@ -35,7 +35,7 @@ metadata:
     {{- include "tplValue" ( dict "value" .Values.global.commonLabels "context" . ) | nindent 4 }}
   annotations:
     helm.sh/hook: post-upgrade
-    helm.sh/hook-delete-policy: hook-succeeded
+    helm.sh/hook-delete-policy: "before-hook-creation, hook-succeeded"
     helm.sh/hook-weight: "0"
 ---
 kind: ClusterRole
@@ -46,7 +46,7 @@ metadata:
     {{- include "tplValue" ( dict "value" .Values.global.commonLabels "context" . ) | nindent 4 }}
   annotations:
     helm.sh/hook: post-upgrade
-    helm.sh/hook-delete-policy: hook-succeeded
+    helm.sh/hook-delete-policy: "before-hook-creation, hook-succeeded"
     helm.sh/hook-weight: "0"
 rules:
 - apiGroups: ["apps", "extensions"]
@@ -61,7 +61,7 @@ metadata:
     {{- include "tplValue" ( dict "value" .Values.global.commonLabels "context" . ) | nindent 4 }}
   annotations:
     helm.sh/hook: post-upgrade
-    helm.sh/hook-delete-policy: hook-succeeded
+    helm.sh/hook-delete-policy: "before-hook-creation, hook-succeeded"
     helm.sh/hook-weight: "0"
 subjects:
 - kind: ServiceAccount
@@ -82,7 +82,7 @@ metadata:
   annotations:
     helm.sh/hook: post-upgrade
     helm.sh/hook-weight: "1"
-    helm.sh/hook-delete-policy: hook-succeeded
+    helm.sh/hook-delete-policy: "before-hook-creation, hook-succeeded"
 spec:
   template:
     metadata:

--- a/resources/serverless/templates/knative-migrator-job-post.yaml
+++ b/resources/serverless/templates/knative-migrator-job-post.yaml
@@ -9,7 +9,7 @@ metadata:
   annotations:
     helm.sh/hook: post-upgrade
     helm.sh/hook-weight: "0"
-    helm.sh/hook-delete-policy: hook-succeeded
+    helm.sh/hook-delete-policy: "before-hook-creation, hook-succeeded"
 data:
   knative-migration: |-
 {{ include (print $.Template.BasePath "/_helper_knative_migration.txt") . | indent 4 }}
@@ -23,7 +23,7 @@ metadata:
     {{- include "tplValue" ( dict "value" .Values.global.commonLabels "context" . ) | nindent 4 }}
   annotations:
     helm.sh/hook: post-upgrade
-    helm.sh/hook-delete-policy: hook-succeeded
+    helm.sh/hook-delete-policy: "before-hook-creation, hook-succeeded"
     helm.sh/hook-weight: "0"
 ---
 kind: ClusterRole
@@ -34,7 +34,7 @@ metadata:
     {{- include "tplValue" ( dict "value" .Values.global.commonLabels "context" . ) | nindent 4 }}
   annotations:
     helm.sh/hook: post-upgrade
-    helm.sh/hook-delete-policy: hook-succeeded
+    helm.sh/hook-delete-policy: "before-hook-creation, hook-succeeded"
     helm.sh/hook-weight: "0"
 rules:
 - apiGroups: ["serving.knative.dev"]
@@ -58,7 +58,7 @@ metadata:
     {{- include "tplValue" ( dict "value" .Values.global.commonLabels "context" . ) | nindent 4 }}
   annotations:
     helm.sh/hook: post-upgrade
-    helm.sh/hook-delete-policy: hook-succeeded
+    helm.sh/hook-delete-policy: "before-hook-creation, hook-succeeded"
     helm.sh/hook-weight: "0"
 subjects:
 - kind: ServiceAccount
@@ -79,7 +79,7 @@ metadata:
   annotations:
     helm.sh/hook: post-upgrade
     helm.sh/hook-weight: "1"
-    helm.sh/hook-delete-policy: hook-succeeded
+    helm.sh/hook-delete-policy: "before-hook-creation, hook-succeeded"
 spec:
   template:
     metadata:

--- a/resources/xip-patch/templates/job.yaml
+++ b/resources/xip-patch/templates/job.yaml
@@ -4,7 +4,7 @@ metadata:
   name: {{ .Release.Name }}
   annotations:  
     helm.sh/hook: post-install,post-upgrade
-    helm.sh/hook-delete-policy: hook-succeeded
+    helm.sh/hook-delete-policy: "before-hook-creation, hook-succeeded"
 spec:
   template:
     metadata:


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:
This PR will fix installation re-try after failed components, a typical issue we facing is after API server connection error installing component not more possible because of some patch jobs are having only helm delete policy ```hook-succeeded```, such jobs can't be installed and execute in re-try because there will be some other resources from previous try like ```serviceaccounts``` etc.

This fix add all the kyma helm hook jobs an additional helm delete policy ```before-hook-creation``` to ensure resources cleaned-up before hook created in re-try. This also will ensure in case hook self failed, keep job for further investigation like debug and log analyses.

**Related issue(s)**
Fixes #9107 
