### PR TITLE
Retry sending event on every status

### DIFF
--- a/resources/application-connector/values.yaml
+++ b/resources/application-connector/values.yaml
@@ -76,5 +76,5 @@ tests:
       central: false
     skipSslVerify: true
     image:
-      version: "5afd3227"
+      version: "PR-9123"
       pullPolicy: IfNotPresent

--- a/tests/application-connector-tests/test/applicationaccess/suite.go
+++ b/tests/application-connector-tests/test/applicationaccess/suite.go
@@ -231,7 +231,8 @@ func (ts *TestSuite) ShouldAccessApplication(t *testing.T, credentials connector
 			return false, nil
 		}
 
-		if errorResponse.Code == http.StatusServiceUnavailable || errorResponse.Code == http.StatusNotFound {
+		// Event Service returns 500 when Event Mesh is not ready, therefore retry on any error status
+		if errorResponse.Code != http.StatusOK {
 			t.Logf("Event Service not ready, received %d status", errorResponse.Code)
 			return true, nil
 		}


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/master/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Due to Event Service returning `500` status code even if Event Mesh is not yet ready, we need to retry sending the event despite `500` response status.
This should stabilize `application-connector-tests`.

Changes proposed in this pull request:

- Retry sending Events on every status

**Related issue(s)**
#8019