### PR TITLE
Fix doc for triggers to use v1/svc in tutorials

### DIFF
--- a/docs/application-connector-compass-mode/08-06-trigger-lambda-with-event.md
+++ b/docs/application-connector-compass-mode/08-06-trigger-lambda-with-event.md
@@ -165,7 +165,6 @@ To create a simple Function and trigger it with an event, you must first registe
          apiVersion: v1
          kind: Service
          name: my-events-function
-         namespace: $NAMESPACE
    EOF
    ```
 

--- a/docs/application-connector-compass-mode/08-06-trigger-lambda-with-event.md
+++ b/docs/application-connector-compass-mode/08-06-trigger-lambda-with-event.md
@@ -162,7 +162,7 @@ To create a simple Function and trigger it with an event, you must first registe
          type: exampleevent
      subscriber:
        ref:
-         apiVersion: serving.knative.dev/v1
+         apiVersion: v1
          kind: Service
          name: my-events-function
          namespace: $NAMESPACE

--- a/docs/application-connector/08-06-trigger-lambda-with-event.md
+++ b/docs/application-connector/08-06-trigger-lambda-with-event.md
@@ -165,7 +165,6 @@ To create a simple Function and trigger it with an event, you must first registe
          apiVersion: v1
          kind: Service
          name: my-events-function
-         namespace: $NAMESPACE
    EOF
    ```
 

--- a/docs/application-connector/08-06-trigger-lambda-with-event.md
+++ b/docs/application-connector/08-06-trigger-lambda-with-event.md
@@ -162,7 +162,7 @@ To create a simple Function and trigger it with an event, you must first registe
          type: exampleevent
      subscriber:
        ref:
-         apiVersion: serving.knative.dev/v1
+         apiVersion: v1
          kind: Service
          name: my-events-function
          namespace: $NAMESPACE

--- a/docs/event-mesh/03-01-event-processing.md
+++ b/docs/event-mesh/03-01-event-processing.md
@@ -38,7 +38,7 @@ spec:
       source: mock # Application name
   subscriber:
     ref:
-      apiVersion: serving.knative.dev/v1
+      apiVersion: v1
       kind: Service
       name: test-function # Function name
 ```


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/master/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- Fix doc for triggers to use v1/svc in tutorials as Kyma functions are no longer using knative.serving.dev based services but pure k8s deployments and svcs.
