### PR TITLE
Force cleanup the created service instance and service binding in case of errors

### DIFF
--- a/resources/compass-runtime-agent/values.yaml
+++ b/resources/compass-runtime-agent/values.yaml
@@ -7,7 +7,7 @@ global:
     runtimeAgentTests:
       version: "1066324c"
     compassExternalSolutionTests:
-      version: "PR-8734"
+      version: "PR-9128"
   istio:
     gateway:
       name: kyma-gateway

--- a/tests/end-to-end/external-solution-integration/chart/external-solution/values.yaml
+++ b/tests/end-to-end/external-solution-integration/chart/external-solution/values.yaml
@@ -3,7 +3,7 @@ containerRegistry:
 
 image:
   dir:
-  version: PR-8734
+  version: PR-9128
   pullPolicy: "Always"
 
 testServiceImage:

--- a/tests/end-to-end/external-solution-integration/internal/scenario/event_mesh/scenario.go
+++ b/tests/end-to-end/external-solution-integration/internal/scenario/event_mesh/scenario.go
@@ -35,5 +35,8 @@ func (s *Scenario) AddFlags(set *pflag.FlagSet) {
 func (s *Scenario) RunnerOpts() []step.RunnerOption {
 	runnerOpts := s.prepare.RunnerOpts()
 	runnerOpts = append(runnerOpts, s.evaluate.RunnerOpts()...)
-	return append(runnerOpts, step.WithCleanupDefault(step.CleanupModeYes))
+	return append(runnerOpts,
+		step.WithCleanupDefault(step.CleanupModeYes),
+		step.WithCleanupBehavior(step.CleanupBehaviorAllSteps),
+	)
 }

--- a/tests/end-to-end/external-solution-integration/pkg/helpers/k8s.go
+++ b/tests/end-to-end/external-solution-integration/pkg/helpers/k8s.go
@@ -39,10 +39,10 @@ func InClusterEndpoint(name, namespace string, port int) string {
 // AwaitResourceDeleted retries until the resources cannot be found any more
 func AwaitResourceDeleted(check func() (interface{}, error)) error {
 	return retry.Do(func() error {
-		_, err := check()
+		t, err := check()
 
 		if err == nil {
-			return errors.New("resource still exists")
+			return errors.New(fmt.Sprintf("resource still exists: %T", t))
 		}
 
 		if !k8serrors.IsNotFound(err) {


### PR DESCRIPTION
**Description**

The external solution E2E test sometimes fails to cleanup the created test namespace then exits with failure. And when the test suite executes it for the second time, it also fails because the test namespace still exists. The namespace is not deleted because the service catalog controller fails to cleanup the created service instance and service binding leaving its finalizer in their finalizers list. This PR fixes this behaviour by cleaning-up the finalizers list of the two resources so they can be garbage collected.

**Related issue(s)**

- Fixes https://github.com/kyma-project/kyma/issues/8875.