### PR TITLE
Remove hardcoded Istio Gateway in Logging component

### DIFF
--- a/resources/logging/charts/logui/templates/virtualservice.yaml
+++ b/resources/logging/charts/logui/templates/virtualservice.yaml
@@ -8,7 +8,7 @@ spec:
   hosts:
   - log-ui.{{ .Values.global.ingress.domainName }}
   gateways:
-  - kyma-gateway
+  - {{ .Values.global.istio.gateway.namespace }}/{{ .Values.global.istio.gateway.name }}
   http:
   - match:
     - uri:

--- a/resources/logging/templates/loki/virtualservice.yaml
+++ b/resources/logging/templates/loki/virtualservice.yaml
@@ -31,5 +31,5 @@ spec:
       - access-control-allow-origin
       - authorization
   gateways:
-  - kyma-gateway
+  - {{ .Values.global.istio.gateway.namespace }}/{{ .Values.global.istio.gateway.name }}
 {{- end }}

--- a/resources/logging/values.yaml
+++ b/resources/logging/values.yaml
@@ -230,3 +230,7 @@ global:
     enabled: true
     env:
       testUser: "admin-user"
+    istio:
+      gateway:
+        name: kyma-gateway
+        namespace: kyma-system

--- a/resources/logging/values.yaml
+++ b/resources/logging/values.yaml
@@ -230,7 +230,7 @@ global:
     enabled: true
     env:
       testUser: "admin-user"
-    istio:
-      gateway:
-        name: kyma-gateway
-        namespace: kyma-system
+  istio:
+    gateway:
+      name: kyma-gateway
+      namespace: kyma-system


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Remove hardcoded Istio Gateway in Logging component

Previously, the gateway was hardcoded, which prevented using the component with different Istio Gateway, like `compass-gateway`. Now the gateway is configurable.