### PR TITLE
Exlude unnecessary namespaces from knative-eventing webhook

### DIFF
--- a/resources/knative-eventing/values.yaml
+++ b/resources/knative-eventing/values.yaml
@@ -22,6 +22,9 @@ knative-eventing:
         operator: NotIn
         values:
           - kube-system
+          - kyma-system
+          - kyma-installer
+          - istio-system
 
 
 # PodMonitorSelector is configured here: resources/monitoring/templates/prometheus/prometheus.yaml


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/master/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

# Problem statement 
This PR is intended to fix the following problem:

```log:time="2020-07-28T15:57:33Z" level=warning msg="installation error occurred: installation error occurred: install component service-catalog"

description: install component service-catalog
    errorLog:
    - component: Kyma Operator
      log: 'Helm error: context deadline exceeded'
      occurrences: 8
    - component: service-catalog
      log: "Helm install error: rpc error: code = Unknown desc = release service-catalog
        failed: Internal error occurred: failed calling webhook \"legacysinkbindings.webhook.sources.knative.dev\":
        Post https://eventing-webhook.knative-eventing.svc:443/legacysinkbindings?timeout=30s:
        read tcp 192.168.123.6:49426->100.96.2.16:8443: read: network is unreachable
        \n Helm delete of service-catalog failed with an error: rpc error: code =
        Unknown desc = Job failed: BackoffLimitExceeded \n"
      occurrences: 1
    - component: service-catalog
      log: "Helm install error: rpc error: code = Unknown desc = a release named service-catalog
        already exists.\nRun: helm ls --all service-catalog; to check the status of
        the release\nOr run: helm del --purge service-catalog; to delete it \n Helm
        delete of service-catalog failed with an error: rpc error: code = Unknown
        desc = Job failed: BackoffLimitExceeded \n"
      occurrences: 5
    state: Error
    url: ""
    version: ""
```

# Options

- This is a quick-fix for problems where knative-webhooks, especially the sinkbindings ones, make the installation fail (because for every v1 resource the webhook is asked and the operation is failed if the webhook is not reachable, e.g. network error)
- A more polite way of fixing this is to use a whitelist/blacklist approach and specify the namespaces which should be included/excluded for sinkbinding webhook. It was [introduced](https://github.com/knative/eventing/pull/2662/files) after knative 0.12. We can do this as soon as we upgrade knative-eventing.

**Related issue(s)**
- k3d: https://github.com/kyma-incubator/local-kyma-k3d/issues/8
- minikube: https://github.com/kyma-project/cli/issues/455