### PR TITLE
Fix the Application Connector tutorial for generating a CSR

### DIFF
--- a/docs/application-connector/08-02-get-client-certificate.md
+++ b/docs/application-connector/08-02-get-client-certificate.md
@@ -73,7 +73,7 @@ A successful call returns the following response:
         "certificatesUrl":  "https://connector-service.{CLUSTER_DOMAIN}/v1/applications/certificates",
     },
     "certificate":{
-        "subject": "OU=Test,O=TestOrg,L=Waldorf,ST=Waldorf,C=DE,CN={APP_NAME}",
+        "subject": "OU=OrgUnit,O=Organization,L=Waldorf,ST=Waldorf,C=DE,CN={APP_NAME}",
         "extensions": "",
         "key-algorithm": "rsa2048",
     }
@@ -88,7 +88,7 @@ Generate a CSR using the certificate subject data obtained in the previous step:
 
 ```bash
 openssl genrsa -out generated.key 2048
-openssl req -new -sha256 -out generated.csr -key generated.key -subj "/OU=Test/O=TestOrg/L=Waldorf/ST=Waldorf/C=DE/CN={APP_NAME}"
+openssl req -new -sha256 -out generated.csr -key generated.key -subj "/OU=OrgUnit/O=Organization/L=Waldorf/ST=Waldorf/C=DE/CN={APP_NAME}"
 openssl base64 -in generated.csr
 ```
 
@@ -139,7 +139,7 @@ A successful call returns the following response:
     "revokeCertUrl": "https://gateway.{CLUSTER_DOMAIN}/v1/applications/certificates/revocations"
   },
   "certificate": {
-    "subject": "OU=Test,O=Test,L=Blacksburg,ST=Virginia,C=US,CN={APP_NAME}",
+    "subject": "OU=OrgUnit,O=Organization,L=Blacksburg,ST=Virginia,C=US,CN={APP_NAME}",
     "extensions": "string",
     "key-algorithm": "rsa2048"
   }


### PR DESCRIPTION
**Description**

The values for Organization and Organization Unit in the tutorial are incorrect, which results in the call ending in an error. They need to be corrected. 

Changes proposed in this pull request:

- Correct the values for Organization to `O=Organization`
- Correct the values for Organization Unit to `OU=OrgUnit`

**Related issue**
See #9043 