### PR TITLE
Make extraVolumeMounts and extraVolumes consumable via kyma operator

### DIFF
--- a/resources/logging/charts/fluentbit/templates/daemonset.yaml
+++ b/resources/logging/charts/fluentbit/templates/daemonset.yaml
@@ -82,8 +82,8 @@ spec:
           mountPath: /secure/forward-tls-ca.crt
           subPath: forward-tls-ca.crt
 {{- end }}
-{{- if .Values.extraVolumeMounts }}
-        {{- toYaml .Values.extraVolumeMounts | trim | nindent 8 }}
+{{- with .Values.extraVolumeMounts }}
+        {{- tpl . $ | nindent 8}}
 {{- end }}
 {{- if .Values.prometheusPushGateway.enabled }}
       - name: metrics-collector
@@ -175,8 +175,8 @@ spec:
           items:
           - key: cron
             path: metrics
-{{- end }}
-{{- if .Values.extraVolumes }}
-      {{- toYaml .Values.extraVolumes | trim | nindent 6 }}
+{{- end }} 
+{{- with .Values.extraVolumes }}
+      {{- tpl . $ | nindent 6}}
 {{- end }}
 {{- end }}

--- a/resources/logging/charts/fluentbit/values.yaml
+++ b/resources/logging/charts/fluentbit/values.yaml
@@ -279,14 +279,14 @@ existingConfigMap: ""
 
 # Extra volume mounts for the fluent-bit pod.
 # Ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-volume-storage/
-extraVolumeMounts: []
+extraVolumeMounts: ""
 # - name: volume
 #   mountPath: /var/tmp
 
 # Extra volumes containing additional files required for fluent-bit to work
 # (eg. CA certificates)
 # Ref: https://kubernetes.io/docs/concepts/storage/volumes/
-extraVolumes: []
+extraVolumes: ""
 # - name: volume
 #   configMap:
 #     name: config

--- a/resources/logging/charts/fluentbit/values.yaml
+++ b/resources/logging/charts/fluentbit/values.yaml
@@ -280,16 +280,18 @@ existingConfigMap: ""
 # Extra volume mounts for the fluent-bit pod.
 # Ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-volume-storage/
 extraVolumeMounts: ""
-# - name: volume
-#   mountPath: /var/tmp
+# extraVolumeMounts: |
+#   - name: volume
+#     mountPath: /var/tmp
 
 # Extra volumes containing additional files required for fluent-bit to work
 # (eg. CA certificates)
 # Ref: https://kubernetes.io/docs/concepts/storage/volumes/
 extraVolumes: ""
-# - name: volume
-#   configMap:
-#     name: config
+# extraVolumes: |
+#   - name: volume
+#     configMap:
+#       name: config
 
 # fluent-bit container resources
 resources:


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/master/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- Existing logging overrides cannot be set properly using kyma-installation overrides because complex yaml structures are not allowed by kyma-operator
- Default both values to string

** How to Test**
- Set these values in `https://github.com/kyma-project/kyma/blob/9ec03fed78870cd37ed091c0c7dc16dd7b18a9d6/resources/logging/charts/fluentbit/values.yaml#L283`

```yaml
extraVolumeMounts: |
  - mountPath: /etc/gcp-sa-stackdriver/
    name: gcp-sa-stackdriver

extraVolumes: |
  - name: gcp-sa-stackdriver
    secret:
      defaultMode: "420"
      secretName: gcp-sa-stackdriver
```

Run these commands:

```bash
cd resources/logging
helm template logging . \
        --debug \
        -n kyma-system \
        --set-string global.ingress.domainName=35.233.94.18.xip.io ; echo $?
```


Result with defaults from above in values.yaml:
```yaml
...
       volumeMounts:
        - name: varlog
          mountPath: /var/log
        - name: varlibdockercontainers
          mountPath: /var/lib/docker/containers
          readOnly: true
        - name: config
          mountPath: /fluent-bit/etc/
        - mountPath: /etc/gcp-sa-stackdriver/
          name: gcp-sa-stackdriver

      terminationGracePeriodSeconds: 10
      tolerations:
        - effect: NoSchedule
          key: node-role.kubernetes.io/master
          operator: Exists
      volumes:
      - name: varlog
        hostPath:
          path: /var/log
      - name: varlibdockercontainers
        hostPath:
          path: /var/lib/docker/containers
      - name: config
        configMap:
          name: logging-fluent-bit-config
      - name: gcp-sa-stackdriver
        secret:
          defaultMode: "420"
          secretName: gcp-sa-stackdriver
```

Result with unmodified values.yaml:
```yaml
...
        volumeMounts:
        - name: varlog
          mountPath: /var/log
        - name: varlibdockercontainers
          mountPath: /var/lib/docker/containers
          readOnly: true
        - name: config
          mountPath: /fluent-bit/etc/
      terminationGracePeriodSeconds: 10
      tolerations:
        - effect: NoSchedule
          key: node-role.kubernetes.io/master
          operator: Exists
      volumes:
      - name: varlog
        hostPath:
          path: /var/log
      - name: varlibdockercontainers
        hostPath:
          path: /var/lib/docker/containers
      - name: config
        configMap:
          name: logging-fluent-bit-config
```

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
https://github.com/kyma-project/kyma/issues/8783