### PR TITLE
fixed resource settings for prometheus-operator and kube-state-mtrics

### DIFF
--- a/resources/monitoring/charts/kube-state-metrics/values.yaml
+++ b/resources/monitoring/charts/kube-state-metrics/values.yaml
@@ -129,7 +129,7 @@ collectors:
 ##
 namespaceOverride: ""
 
-resources: {}
+resources:
   # We usually recommend not to specify default resources and to leave this as a conscious
   # choice for the user. This also increases chances charts run on environments with little
   # resources, such as Minikube. If you do want to specify resources, uncomment the following

--- a/resources/monitoring/charts/kube-state-metrics/values.yaml
+++ b/resources/monitoring/charts/kube-state-metrics/values.yaml
@@ -128,3 +128,15 @@ collectors:
 ## Override the deployment namespace
 ##
 namespaceOverride: ""
+
+resources: {}
+  # We usually recommend not to specify default resources and to leave this as a conscious
+  # choice for the user. This also increases chances charts run on environments with little
+  # resources, such as Minikube. If you do want to specify resources, uncomment the following
+  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  limits:
+    cpu: 100m
+    memory: 126Mi
+  requests:
+    cpu: 10m
+    memory: 32Mi

--- a/resources/monitoring/values.yaml
+++ b/resources/monitoring/values.yaml
@@ -1188,13 +1188,13 @@ prometheusOperator:
 
   ## Resource limits & requests
   ##
-  resources: {}
-  # limits:
-  #   cpu: 200m
-  #   memory: 200Mi
-  # requests:
-  #   cpu: 100m
-  #   memory: 100Mi
+  resources:
+    limits:
+      cpu: 200m
+      memory: 200Mi
+    requests:
+      cpu: 10m
+      memory: 90Mi
 
   ## Define which Nodes the Pods are scheduled on.
   ## ref: https://kubernetes.io/docs/user-guide/node-selection/


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/master/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:
There were resource settings missing for the mentioned deployments, with that the default gets applied which is too restrictive
- applied settings for prometheus-operator
- applied settings for kube-state-metrics
- ...

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
