### PR TITLE
Pod-preset webhook change failure policy

### DIFF
--- a/resources/cluster-essentials/charts/pod-preset/templates/webhook/webhook.yaml
+++ b/resources/cluster-essentials/charts/pod-preset/templates/webhook/webhook.yaml
@@ -15,7 +15,7 @@ webhooks:
       name: {{ template "pod-preset.fullname" . }}-webhook
       namespace: "{{ .Release.Namespace }}"
       path: /mutating-pods
-  failurePolicy: Ignore
+  failurePolicy: Fail
   name: podpresets.settings.svcat.k8s.io
   rules:
   - apiGroups:


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/master/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**
We detected multiple high API requests duration of 30-40 seconds (old 30 second timeout values on the webhook). After investigation it seems to point to pod-preset webhook which is creating POST requests to the API which times out. It seems like it's caused by a bad failure policy of `Ignore`, changing it to `Fail` See https://kubernetes.io/docs/reference/access-authn-authz/extensible-admission-controllers/#failure-policy

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
https://github.com/kyma-project/kyma/pull/8767