### PR TITLE
refactor the assignment of  global.alertTools.credentials.victorOps.sendResolved

### DIFF
--- a/resources/monitoring/templates/kyma-additions/alertmanager.config.yaml
+++ b/resources/monitoring/templates/kyma-additions/alertmanager.config.yaml
@@ -47,7 +47,11 @@ receivers:
 - name: "victorOps"
   victorops_configs:
   - api_key: {{ .Values.global.alertTools.credentials.victorOps.apikey | quote }}
-    send_resolved: {{ .Values.global.alertTools.credentials.victorOps.sendResolved }}
+    {{- if .Values.global.alertTools.credentials.victorOps.sendResolved }}
+    send_resolved: true
+    {{- else }}
+    send_resolved: false
+    {{- end }}
     api_url: https://alert.victorops.com/integrations/generic/20131114/alert/
     routing_key: {{ .Values.global.alertTools.credentials.victorOps.routingkey | quote }}
     state_message: 'Alert: {{`{{ .CommonLabels.alertname }}`}}. Summary:{{`{{ .CommonAnnotations.message }}`}}. RawData: {{`{{ .CommonLabels }}`}}'
@@ -59,7 +63,11 @@ receivers:
 - name: "slack"
   slack_configs:
   - channel: {{ .Values.global.alertTools.credentials.slack.channel | quote }}
-    send_resolved: {{ .Values.global.alertTools.credentials.slack.sendResolved }}
+    {{- if  .Values.global.alertTools.credentials.slack.sendResolved }}
+    send_resolved: true
+    {{- else }}
+    send_resolved: false
+    {{- end }}
     api_url: {{ .Values.global.alertTools.credentials.slack.apiurl | quote }}
     icon_emoji: ":ghost:"
     title: '{{`{{ template "__subject" . }}`}} ({{ .Values.global.ingress.domainName }})'


### PR DESCRIPTION
**Description**
Found the overrides of sendResolved that  _global.alertTools.credentials.victorOps.sendResolved: "false"_ is not work with the the sourcecode in _send_resolved: {{ .Values.global.alertTools.credentials.victorOps.sendResolved }}_  (see previous PR #9046 )

now trial to use another format:
```
    {{- if .Values.global.alertTools.credentials.victorOps.sendResolved }}
    send_resolved: true
    {{- else }}
    send_resolved: false
    {{- end }}
```
**Expected**
Hope the overrides of sendResolved that  _global.alertTools.credentials.victorOps.sendResolved: "false"_  works.