### PR TITLE
Update production profile for prometheus with required memory

### DIFF
--- a/installation/resources/installer-config-production.yaml.tpl
+++ b/installation/resources/installer-config-production.yaml.tpl
@@ -50,7 +50,7 @@ data:
   prometheus.prometheusSpec.retentionSize: "15GB"
   prometheus.prometheusSpec.retention: "30d"
   prometheus.prometheusSpec.storageSpec.volumeClaimTemplate.spec.resources.requests.storage: "20Gi"
-  prometheus.prometheusSpec.resources.limits.cpu: "600m"
+  prometheus.prometheusSpec.resources.limits.cpu: "1"
   prometheus.prometheusSpec.resources.limits.memory: "3Gi"
   prometheus.prometheusSpec.resources.requests.cpu: "300m"
   prometheus.prometheusSpec.resources.requests.memory: "1Gi"

--- a/installation/resources/installer-config-production.yaml.tpl
+++ b/installation/resources/installer-config-production.yaml.tpl
@@ -51,7 +51,7 @@ data:
   prometheus.prometheusSpec.retention: "30d"
   prometheus.prometheusSpec.storageSpec.volumeClaimTemplate.spec.resources.requests.storage: "20Gi"
   prometheus.prometheusSpec.resources.limits.cpu: "600m"
-  prometheus.prometheusSpec.resources.limits.memory: "2Gi"
+  prometheus.prometheusSpec.resources.limits.memory: "3Gi"
   prometheus.prometheusSpec.resources.requests.cpu: "300m"
   prometheus.prometheusSpec.resources.requests.memory: "1Gi"
   alertmanager.alertmanagerSpec.retention: "240h"


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/master/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- Prometheus needs more memory that 2Gi for a long running cluster. So adjust the production profile to have 3Gi of memory.
- Currently the  `apiserver` and `kubelet` are generating lots of metrics and top metrics being `container_memory_cache`. `container_memory_cache` has high cardinality as it accepts labels with `name` which is dynamic and would increase with the number of pods. We cannot avoid this since we still need pod names to be displayed in dashboards  to properly identify them.
