### PR TITLE
Introduce HTTP Output for Fluent-Bit configuration

### DIFF
--- a/resources/logging/charts/fluentbit/templates/configmap.yaml
+++ b/resources/logging/charts/fluentbit/templates/configmap.yaml
@@ -43,6 +43,9 @@ data:
 {{- if .Values.conf.Output.forward.enabled }}
     @INCLUDE output-forward.conf
 {{- end }}
+{{- if .Values.conf.Output.http.enabled }}
+    @INCLUDE output-http.conf
+{{- end }}
 {{- if .Values.conf.Output.stdout.enabled }}
     @INCLUDE output-stdout.conf
 {{- end }}
@@ -207,6 +210,30 @@ data:
 {{- if and (.Values.backend.forward.tls.cert) (.Values.backend.forward.tls.key) }}
         tls.crt_file /secure/forward-tls.crt
         tls.key_file /secure/forward-tls.key
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{- if .Values.conf.Output.http.enabled }}
+  output-http.conf: |
+    [OUTPUT]
+        Name  http
+        Match {{ .Values.conf.Output.http.Match }}
+        Host  {{ .Values.backend.http.host }}
+        Port  {{ .Values.backend.http.port }}
+        URI  {{ .Values.backend.http.uri }}
+{{- if .Values.backend.http.format }}
+        Format {{ .Values.backend.http.format }}
+{{- end }}
+{{- if .Values.backend.http.http_user }}
+        HTTP_User {{ .Values.backend.http.http_user }}
+        HTTP_Passwd {{ .Values.backend.http.http_passwd }}
+{{- end }}
+{{- if (.Values.backend.http.tls)  }}
+        tls   {{ .Values.backend.http.tls }}
+        tls.verify {{ .Values.backend.http.tls_verify }}
+{{- if (.Values.backend.http.tls_debug)  }}
+        tls.debug {{ .Values.backend.http.tls_debug }}
 {{- end }}
 {{- end }}
 {{- end }}

--- a/resources/logging/charts/fluentbit/templates/configmap.yaml
+++ b/resources/logging/charts/fluentbit/templates/configmap.yaml
@@ -222,6 +222,15 @@ data:
         Host  {{ .Values.backend.http.host }}
         Port  {{ .Values.backend.http.port }}
         URI  {{ .Values.backend.http.uri }}
+{{- if .Values.backend.http.compress }}
+        compress {{ .Values.backend.http.compress }}
+{{- end }}
+{{- if .Values.backend.http.json_date_key }}
+        json_date_key {{ .Values.backend.http.json_date_key }}
+{{- end }}
+{{- if .Values.backend.http.json_date_format }}
+        json_date_format {{ .Values.backend.http.json_date_format }}
+{{- end }}
 {{- if .Values.backend.http.format }}
         Format {{ .Values.backend.http.format }}
 {{- end }}
@@ -232,8 +241,15 @@ data:
 {{- if (.Values.backend.http.tls)  }}
         tls   {{ .Values.backend.http.tls }}
         tls.verify {{ .Values.backend.http.tls_verify }}
+{{- if (.Values.backend.http.tls_ca)  }}
+        tls.ca_file /secure/http-tls-ca.crt
+{{- end }}
 {{- if (.Values.backend.http.tls_debug)  }}
         tls.debug {{ .Values.backend.http.tls_debug }}
+{{- end }}
+{{- if and (.Values.backend.http.tls_cert) (.Values.backend.http.tls_key) }}
+        tls.crt_file /secure/http-tls.crt
+        tls.key_file /secure/http-tls.key
 {{- end }}
 {{- end }}
 {{- end }}

--- a/resources/logging/charts/fluentbit/templates/daemonset.yaml
+++ b/resources/logging/charts/fluentbit/templates/daemonset.yaml
@@ -77,10 +77,23 @@ spec:
           mountPath: /secure/forward-tls.key
           subPath: tls.key
 {{- end }}
-{{- if and (.Values.backend.forward.tls.verify) (.Values.backend.forward.tls.ca) }}
-        - name: forward-ca-secret
-          mountPath: /secure/forward-tls-ca.crt
-          subPath: forward-tls-ca.crt
+{{- if and (.Values.backend.http.tls_verify) (.Values.backend.http.tls_ca) }}
+        - name: http-ca-secret
+          mountPath: /secure/http-tls-ca.crt
+          subPath: http-tls-ca.crt
+{{- end }}
+{{- if and (.Values.backend.http.tls_cert) (.Values.backend.http.tls_key) }}
+        - name: http-tls-secret
+          mountPath: /secure/http-tls.crt
+          subPath: tls.crt
+        - name: http-tls-secret
+          mountPath: /secure/http-tls.key
+          subPath: tls.key
+{{- end }}
+{{- if and (.Values.backend.http.tls_verify) (.Values.backend.http.tls_ca) }}
+        - name: http-ca-secret
+          mountPath: /secure/http-tls-ca.crt
+          subPath: http-tls-ca.crt
 {{- end }}
 {{- with .Values.extraVolumeMounts }}
         {{- tpl . $ | nindent 8}}

--- a/resources/logging/charts/fluentbit/templates/daemonset.yaml
+++ b/resources/logging/charts/fluentbit/templates/daemonset.yaml
@@ -77,10 +77,10 @@ spec:
           mountPath: /secure/forward-tls.key
           subPath: tls.key
 {{- end }}
-{{- if and (.Values.backend.http.tls_verify) (.Values.backend.http.tls_ca) }}
-        - name: http-ca-secret
-          mountPath: /secure/http-tls-ca.crt
-          subPath: http-tls-ca.crt
+{{- if and (.Values.backend.forward.tls.verify) (.Values.backend.forward.tls.ca) }}
+        - name: forward-ca-secret
+          mountPath: /secure/forward-tls-ca.crt
+          subPath: forward-tls-ca.crt
 {{- end }}
 {{- if and (.Values.backend.http.tls_cert) (.Values.backend.http.tls_key) }}
         - name: http-tls-secret

--- a/resources/logging/charts/fluentbit/templates/daemonset.yaml
+++ b/resources/logging/charts/fluentbit/templates/daemonset.yaml
@@ -168,6 +168,16 @@ spec:
         secret:
           secretName: "{{ template "fluent-bit.fullname" . }}-forward-tls-secret"
 {{- end }}
+{{- if and (.Values.backend.http.tls_verify) (.Values.backend.http.tls_ca) }}
+      - name: http-ca-secret
+        secret:
+          secretName: "{{ template "fluent-bit.fullname" . }}-http-ca-secret"
+{{- end }}
+{{- if (.Values.backend.http.tls) }}
+      - name: http-tls-secret
+        secret:
+          secretName: "{{ template "fluent-bit.fullname" . }}-http-tls-secret"
+{{- end }}
 {{- if .Values.prometheusPushGateway.tls.caCertificate }}
       - name: pg-ca-secret
         secret:

--- a/resources/logging/charts/fluentbit/templates/secrets.yaml
+++ b/resources/logging/charts/fluentbit/templates/secrets.yaml
@@ -99,8 +99,8 @@ metadata:
     {{- end }}
 type: kubernetes.io/tls
 data:
-  tls.crt: {{ .Values.backend.http.tls_cert }}
-  tls.key: {{ .Values.backend.http.tls_key }}
+  tls.crt: {{ .Values.backend.http.tls_cert | default "" | quote }}
+  tls.key: {{ .Values.backend.http.tls_key | default "" | quote }}
 {{- end }}
 {{- if and (.Values.enabled) (.Values.prometheusPushGateway.enabled) (.Values.prometheusPushGateway.tls.enabled) (or (.Values.prometheusPushGateway.tls.verify) (.Values.prometheusPushGateway.tls.auth)) }}
 ---

--- a/resources/logging/charts/fluentbit/templates/secrets.yaml
+++ b/resources/logging/charts/fluentbit/templates/secrets.yaml
@@ -72,6 +72,41 @@ data:
 apiVersion: v1
 kind: Secret
 metadata:
+  name: "{{ template "fluent-bit.fullname" . }}-http-ca-secret"
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "fluent-bit.metaLabels" . | trim | nindent 4 }}
+  annotations:
+    {{- if .Values.globalAnnotations }}
+    {{- toYaml .Values.globalAnnotations | trim | nindent 4 }}
+    {{- end }}
+type: Opaque
+data:
+  http-tls-ca.crt: {{ .Values.backend.http.tls_ca }}
+{{- end }}
+{{- if and (.Values.enabled) (.Values.backend.http.tls) }}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: "{{ template "fluent-bit.fullname" . }}-http-tls-secret"
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "fluent-bit.metaLabels" . | trim | nindent 4 }}
+  annotations:
+    {{- if .Values.globalAnnotations }}
+    {{- toYaml .Values.globalAnnotations | trim | nindent 4 }}
+    {{- end }}
+type: kubernetes.io/tls
+data:
+  tls.crt: {{ .Values.backend.http.tls_cert }}
+  tls.key: {{ .Values.backend.http.tls_key }}
+{{- end }}
+{{- if and (.Values.enabled) (.Values.prometheusPushGateway.enabled) (.Values.prometheusPushGateway.tls.enabled) (or (.Values.prometheusPushGateway.tls.verify) (.Values.prometheusPushGateway.tls.auth)) }}
+---
+apiVersion: v1
+kind: Secret
+metadata:
   name: "{{ template "fluent-bit.fullname" . }}-pg-ca-secret"
   namespace: {{ .Release.Namespace }}
   labels:

--- a/resources/logging/charts/fluentbit/templates/secrets.yaml
+++ b/resources/logging/charts/fluentbit/templates/secrets.yaml
@@ -67,7 +67,7 @@ data:
   tls.crt: {{ .Values.backend.forward.tls.cert }}
   tls.key: {{ .Values.backend.forward.tls.key }}
 {{- end }}
-{{- if and (.Values.enabled) (.Values.prometheusPushGateway.enabled) (.Values.prometheusPushGateway.tls.enabled) (or (.Values.prometheusPushGateway.tls.verify) (.Values.prometheusPushGateway.tls.auth)) }}
+{{- if (.Values.backend.http.tls) }}
 ---
 apiVersion: v1
 kind: Secret

--- a/resources/logging/charts/fluentbit/templates/secrets.yaml
+++ b/resources/logging/charts/fluentbit/templates/secrets.yaml
@@ -82,7 +82,7 @@ metadata:
     {{- end }}
 type: Opaque
 data:
-  http-tls-ca.crt: {{ .Values.backend.http.tls_ca }}
+  http-tls-ca.crt: {{ .Values.backend.http.tls_ca | default "" | quote }}
 {{- end }}
 {{- if and (.Values.enabled) (.Values.backend.http.tls) }}
 ---

--- a/resources/logging/charts/fluentbit/values.yaml
+++ b/resources/logging/charts/fluentbit/values.yaml
@@ -241,11 +241,16 @@ backend:
     http_passwd: ""
     tls: "off"
     tls_verify: on
+    tls_ca: ""
+    tls_cert: ""
+    tls_key: ""
     tls_debug: 1
     ## Specify the data format to be used in the HTTP request body
     ## Can be either 'msgpack' or 'json'
     format: msgpack
-    # json_date_format: double or iso8601
+    compress: ""
+    json_date_key: ""
+    json_date_format: ""
     headers: []
 
 # Enable this if you're using https://github.com/coreos/prometheus-operator

--- a/resources/logging/charts/fluentbit/values.yaml
+++ b/resources/logging/charts/fluentbit/values.yaml
@@ -160,6 +160,9 @@ conf:
     forward:
       enabled: false
       Match: "*"
+    http:
+      enabled: false
+      Match: "*"
     stdout:
       enabled: false
       Match: "*"
@@ -230,6 +233,20 @@ backend:
       key: ""
       # TLS debugging levels = 1-5
       debug: 1
+  http:
+    host: "127.0.0.1"
+    port: 80
+    uri: "/"
+    http_user: ""
+    http_passwd: ""
+    tls: "off"
+    tls_verify: on
+    tls_debug: 1
+    ## Specify the data format to be used in the HTTP request body
+    ## Can be either 'msgpack' or 'json'
+    format: msgpack
+    # json_date_format: double or iso8601
+    headers: []
 
 # Enable this if you're using https://github.com/coreos/prometheus-operator
 serviceMonitor:


### PR DESCRIPTION
**Description**

This change introduces HTTP Output plugin configuration as an option to set-up the Fluent-Bit deployment: see [Fluent Bit: Official Manual]() and [Fluent Bit Configuration parameters](https://github.com/helm/charts/tree/master/stable/fluent-bit#configuration)

The HTTP Output plugin allows to flush your records into a HTTP endpoint. For now the functionality is pretty basic and it issues a POST request with the data records in MessagePack (or JSON) format.
