### PR TITLE
Increase crd-installer job deadline to accommodate clusters with high latency

### DIFF
--- a/resources/cluster-essentials/templates/crd-install-job.yaml
+++ b/resources/cluster-essentials/templates/crd-install-job.yaml
@@ -14,7 +14,7 @@ metadata:
     "helm.sh/hook": "pre-install, pre-upgrade"
     "helm.sh/hook-weight": "10"
 spec:
-  activeDeadlineSeconds: 60
+  activeDeadlineSeconds: 180
   template:
     metadata:
       annotations:


### PR DESCRIPTION
**Description**

In one Kyma cluster where the workers and API server is very distinct from each other (Japan vs. west Europe) we observed Kyma installation/upgrade failure as the crd-installer job could not complete within the configured 60 seconds deadline. 
```
  - lastProbeTime: "2020-08-13T13:09:10Z"
    lastTransitionTime: "2020-08-13T13:09:10Z"
    message: Job was active longer than specified deadline
    reason: DeadlineExceeded
    status: "True"
    type: Failed
```

It's safe to increase this deadline to 3 minutes as it won'T cause any harm and will allow successful completion on clusters with high latency and/or API server response duration. 
  
