### PR TITLE
Remove 1.13-1.14 migration guide

### DIFF
--- a/docs/migration-guides/1.13-1.14.md
+++ b/docs/migration-guides/1.13-1.14.md
@@ -1,5 +1,0 @@
-# Migrate from v1.13 to v1.14
-
-## Upgrade
-
-The migration of Kyma components from Helm v2 to Helm v3 is done automatically. The kyma-installer init container migrates the Kyma components before the upgrade process starts. For more details, read about [migration to Helm v3](https://github.com/kyma-project/kyma/blob/release-1.14/docs/kyma/03-03-charts.md#migration-to-helm-v3). 


### PR DESCRIPTION
**Description**

As Kyma Release 1.14 Ulm is out, the migration guide for this release should be removed from the master branch. 

Changes proposed in this pull request:

- Remove the migration guide for migration from Kyma 1.13 to Kyma 1.14.
