### PR TITLE
Configurable pod-preset webhook timeout

### DIFF
--- a/resources/cluster-essentials/charts/pod-preset/templates/webhook/webhook.yaml
+++ b/resources/cluster-essentials/charts/pod-preset/templates/webhook/webhook.yaml
@@ -32,7 +32,7 @@ webhooks:
       operator: NotIn
       values:
       - kube-system
-  timeoutSeconds: 10
+  timeoutSeconds: {{ .Values.webhook.timeout }}
 ---
 apiVersion: v1
 kind: Secret

--- a/resources/cluster-essentials/charts/pod-preset/values.yaml
+++ b/resources/cluster-essentials/charts/pod-preset/values.yaml
@@ -9,6 +9,7 @@ webhook:
     runAsUser: 2000
   pdb:
     enabled: false
+  timeout: 10
 
 controller:
   enabled: false


### PR DESCRIPTION
**Description**

On non-supported Gardener region clusters, we observe regular 10 seconds timeout for pod-preset webhook after it has been configured in 1.14.0. This PR allows tuning of the timeout parameter.

