### PR TITLE
Make loki and jaeger datasource configurable

### DIFF
--- a/resources/monitoring/templates/grafana/configmaps-datasources.yaml
+++ b/resources/monitoring/templates/grafana/configmaps-datasources.yaml
@@ -32,7 +32,10 @@ data:
 {{- end }}
 {{- end }}
 {{- end }}
-{{- if .Values.grafana.additionalDataSources }}
-{{ toYaml .Values.grafana.additionalDataSources | indent 4}}
+{{- if .Values.grafana.additionalDataSources.LokiEnabled }}
+{{ toYaml .Values.grafana.additionalDataSources.LokiConfig | indent 4}}
+{{- end }}
+{{- if .Values.grafana.additionalDataSources.JaegerEnabled }}
+{{ toYaml .Values.grafana.additionalDataSources.JaegerConfig | indent 4}}
 {{- end }}
 {{- end }}

--- a/resources/monitoring/values.yaml
+++ b/resources/monitoring/values.yaml
@@ -516,18 +516,22 @@ grafana:
   ## Configure additional grafana datasources
   ## ref: https://grafana.com/docs/grafana/latest/features/datasources/
   additionalDataSources:
-    - name: Loki
-      type: loki
-      access: proxy
-      url: http://logging-loki.kyma-system:3100
-      editable: true
-      jsonData:
-        maxLines: 1000
-    - name: Jaeger
-      type: jaeger
-      access: proxy
-      url: http://tracing-jaeger-query.kyma-system:16686
-      editable: true
+    LokiEnabled: true
+    LokiConfig:
+      - name: Loki
+        type: loki
+        access: proxy
+        url: http://logging-loki.kyma-system:3100
+        editable: true
+        jsonData:
+          maxLines: 1000
+    JaegerEnabled: true
+    JaegerConfig: 
+      - name: Jaeger
+        type: jaeger
+        access: proxy
+        url: http://tracing-jaeger-query.kyma-system:16686
+        editable: true
   # - name: prometheus-sample
   #   access: proxy
   #   basicAuth: true


### PR DESCRIPTION


<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/master/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- We should keep additional datasource in for grafana and loki configurable.
   So that we can control them via overrides if on of the component is not present

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
