### PR TITLE
increase limits/requests.memory in */serverless/values.yaml

### DIFF
--- a/resources/serverless/values.yaml
+++ b/resources/serverless/values.yaml
@@ -93,10 +93,10 @@ containers:
     resources:
       limits:
         cpu: 100m
-        memory: 126Mi #This is temporary. helm3 is using secrets as storage by default. I talked already with michalhudy to exclude secrets with helm labels from watching.
+        memory: 256Mi #This is temporary. helm3 is using secrets as storage by default. I talked already with michalhudy to exclude secrets with helm labels from watching.
       requests:
-        cpu: 10m
-        memory: 32Mi
+        cpu: 50m
+        memory: 128Mi
     extraProperties: {}
     envs:
       runtimeConfigMapName:


### PR DESCRIPTION
**Description**
serverless pod sometimes reported OOMKilled alert, want to fix it by increasing tis limits/requests.memory and cpu.