### PR TITLE
[CVE-2020-14040] Bump x/text in tests/cbs

### DIFF
--- a/tests/console-backend-service/Gopkg.lock
+++ b/tests/console-backend-service/Gopkg.lock
@@ -334,7 +334,7 @@
   revision = "ce4227a45e2eb77e5c847278dcc6a626742e2945"
 
 [[projects]]
-  digest = "1:8d8faad6b12a3a4c819a3f9618cb6ee1fa1cfc33253abeeea8b55336721e3405"
+  digest = "1:fa940333c48808b0d86ef21f412ffcfd0e5084a82f13905c028a404803b1908f"
   name = "golang.org/x/text"
   packages = [
     "collate",
@@ -355,8 +355,8 @@
     "unicode/rangetable",
   ]
   pruneopts = "NUT"
-  revision = "342b2e1fbaa52c93f31447ad2c6abc048c63e475"
-  version = "v0.3.2"
+  revision = "23ae387dee1f90d29a23c0e87ee0b46038fbed0e"
+  version = "v0.3.3"
 
 [[projects]]
   branch = "master"

--- a/tests/console-backend-service/Gopkg.toml
+++ b/tests/console-backend-service/Gopkg.toml
@@ -60,6 +60,10 @@ required = [
   name = "k8s.io/client-go"
   version = "kubernetes-1.15.0"
 
+[[override]]
+  name = "golang.org/x/text"
+  version="v0.3.3"
+
 [prune]
   go-tests = true
   unused-packages = true


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Resolve security issue by updating `golang.org/x/text` to 0.3.3 in `tests/console-backend-service` project.
- In CBS itself, this dependency has been already bumped in [9049](https://github.com/kyma-project/kyma/pull/9049).

**Related issue(s)**
[1](https://github.tools.sap/kyma/security-scans/issues/1855) [2](https://github.tools.sap/kyma/security-scans/issues/1857) [3](https://github.tools.sap/kyma/security-scans/issues/1859)
