### PR TITLE
Configure liveness probe for dex

### DIFF
--- a/resources/dex/Chart.yaml
+++ b/resources/dex/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-appVersion: "59c6ec8f"
+appVersion: "7d6c1cb1"
 description: Kyma component 'dex'
 name: dex
 version: 1.0.0

--- a/resources/dex/templates/dex-deployment.yaml
+++ b/resources/dex/templates/dex-deployment.yaml
@@ -42,6 +42,7 @@ spec:
         {{- with .Values.volumeMountsExtra }}
         {{- tpl . $ | nindent 8 }}
         {{- end }}
+        {{- if .Values.livenessProbe.enabled }}
         livenessProbe:
           httpGet:
             path: /healthz
@@ -50,6 +51,7 @@ spec:
           timeoutSeconds: {{ .Values.livenessProbe.timeoutSeconds }}
           initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds }}
           failureThreshold: {{ .Values.livenessProbe.failureThreshold }}
+        {{- end -}}
       {{ if .Values.dex.useStaticConnector }}
       initContainers:
       - name: dex-users-configurator

--- a/resources/dex/templates/dex-deployment.yaml
+++ b/resources/dex/templates/dex-deployment.yaml
@@ -25,7 +25,7 @@ spec:
       serviceAccountName: dex-account
       securityContext:
         runAsUser: 2000
-      nodeSelector: 
+      nodeSelector:
         {{- toYaml .Values.nodeSelector | nindent 8 }}
       containers:
       - image: {{ .Values.imageRegistry }}/dex:{{ .Chart.AppVersion }}
@@ -42,6 +42,14 @@ spec:
         {{- with .Values.volumeMountsExtra }}
         {{- tpl . $ | nindent 8 }}
         {{- end }}
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: {{ .Values.containerPort }}
+          periodSeconds: {{ .Values.livenessProbe.periodSeconds }}
+          timeoutSeconds: {{ .Values.livenessProbe.timeoutSeconds }}
+          initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds }}
+          failureThreshold: {{ .Values.livenessProbe.failureThreshold }}
       {{ if .Values.dex.useStaticConnector }}
       initContainers:
       - name: dex-users-configurator
@@ -73,4 +81,3 @@ spec:
       {{- with .Values.volumesExtra }}
       {{- tpl . $ | nindent 6 }}
       {{- end }}
-

--- a/resources/dex/values.yaml
+++ b/resources/dex/values.yaml
@@ -92,3 +92,9 @@ global:
     version: 47b606f6
 
 nodeSelector: {}
+
+livenessProbe:
+  initialDelaySeconds: 60
+  periodSeconds: 30
+  timeoutSeconds: 5
+  failureThreshold: 4

--- a/resources/dex/values.yaml
+++ b/resources/dex/values.yaml
@@ -94,6 +94,7 @@ global:
 nodeSelector: {}
 
 livenessProbe:
+  enabled: false
   initialDelaySeconds: 60
   periodSeconds: 30
   timeoutSeconds: 5


### PR DESCRIPTION
**Description**
Liveness probe is configured to mitigate the broken connectivity (through istio-proxy and through the Gardener VPN) issue of the HTTP client in dex [which is kept in open state](https://github.com/kyma-incubator/dex/blob/kyma-master/storage/kubernetes/client.go#L152-L157).

The default settings are tuned in accordance with the dex async health check params (15 seconds period, http.Client.Timeout = 15 seconds)