### PR TITLE
Lower Prometheus query timeout

### DIFF
--- a/resources/monitoring/values.yaml
+++ b/resources/monitoring/values.yaml
@@ -1552,7 +1552,7 @@ prometheus:
     ##
     query:
       maxConcurrency: 100
-      timeout: 1m
+      timeout: 30s
 
     ## Namespaces to be selected for PrometheusRules discovery.
     ## If nil, select own namespace. Namespaces to be selected for ServiceMonitor discovery.


### PR DESCRIPTION
**Description**
Current query time out is too high, this PR reduce query time out to 30 seconds.

New value testet on weekly cluster to ensure prometheus has enough data collected and few complex queries fired on this data.

Queries executed in parallel and repeated every 5 seconds over 2 hours. In this time Prometheus query execution time measured max 2.5 seconds.

Following screenshoot show engine query duration in seconds, with following query ```prometheus_engine_query_duration_seconds{quantile="0.99"}```

![query_timeout](https://user-images.githubusercontent.com/6337703/92088595-5c400700-edcd-11ea-9c7e-40dae21a577d.png)
