### PR TITLE
xip-patch not detecting a gardener environment on apiserver problems

### DIFF
--- a/components/xip-patch/xip-patch.sh
+++ b/components/xip-patch/xip-patch.sh
@@ -144,7 +144,8 @@ echo "Checking if running on Gardener"
 
 GARDENER_ENVIRONMENT=false
 
-if [ -n "$(kubectl -n kube-system get configmap shoot-info --ignore-not-found)" ]; then
+SHOOT_INFO="$(kubectl -n kube-system get configmap shoot-info --ignore-not-found)"
+if [ -n "$SHOOT_INFO" ]; then
   requestGardenerCerts
   INGRESS_DOMAIN=${DOMAIN}
   INGRESS_TLS_CERT=${TLS_CERT}


### PR DESCRIPTION

<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/master/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

I had several clusters running on gardener having an xip domain assigned. Expected behaviour is to have a gardener managed domain assigned.
On the cluster there was no xip-patch job listed anymore (so assuming it finished successful), there was no certificate resource generated, the shoot-info configmap was created before the installation resource got created and the net-global-overrides configmap stated:
`global.environment.gardener: "false"`

So I looked into the xip-patch logic and the decision if running on gardener or not is done only by one if statement containing a kubectl function. Looking at the documentation of the `-e` option for bash reveals that it will exit for errors except for the last statement in an if condition. A small test of that confirmed the suspicion.

If there is a problem at that single apiserver call, kubectl will not print anything to stdout (only stderr). So the if condition is not true and the flow will just continue assuming that we are not running on gardener.

What we want is that the script just exit on failure so that the job will retry at a later time.

Changes proposed in this pull request:

- move kubectl command outside of if-block
- ...
- ...

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
