### PR TITLE
Improve application broker upgrade e2e test

### DIFF
--- a/tests/end-to-end/upgrade/Gopkg.lock
+++ b/tests/end-to-end/upgrade/Gopkg.lock
@@ -1041,15 +1041,7 @@
   version = "kubernetes-1.15.3"
 
 [[projects]]
-  branch = "release-1.12"
-  digest = "1:9d15b3b19ff07702451e28152bde999bbf216a3fc22cf0760ac8a78bf8e568a6"
-  name = "k8s.io/cli-runtime"
-  packages = ["pkg/genericclioptions/printers"]
-  pruneopts = "UT"
-  revision = "1d4f3e836fd24e95c1457ce8d096f5ab5107054a"
-
-[[projects]]
-  digest = "1:d8d3801b555decd0041471264a979c30e95d02540f16fd1694784e3bee4a9ed5"
+  digest = "1:f6ef044c98ccd05be6cf7a130383ee0d9bb84886b49d13150145025f25a95960"
   name = "k8s.io/client-go"
   packages = [
     "discovery",
@@ -1183,7 +1175,6 @@
     "rest",
     "rest/watch",
     "restmapper",
-    "third_party/forked/golang/template",
     "tools/auth",
     "tools/cache",
     "tools/clientcmd",
@@ -1200,7 +1191,6 @@
     "util/connrotation",
     "util/flowcontrol",
     "util/homedir",
-    "util/jsonpath",
     "util/keyutil",
     "util/retry",
     "util/workqueue",
@@ -1382,7 +1372,6 @@
     "k8s.io/apimachinery/pkg/runtime/schema",
     "k8s.io/apimachinery/pkg/util/intstr",
     "k8s.io/apimachinery/pkg/util/wait",
-    "k8s.io/cli-runtime/pkg/genericclioptions/printers",
     "k8s.io/client-go/dynamic",
     "k8s.io/client-go/kubernetes",
     "k8s.io/client-go/kubernetes/scheme",

--- a/tests/end-to-end/upgrade/chart/upgrade/templates/pod.yaml
+++ b/tests/end-to-end/upgrade/chart/upgrade/templates/pod.yaml
@@ -47,7 +47,7 @@ spec:
     - name: APP_DEX_USER_SECRET
       value: "{{ .Values.dex.userSecret }}"
     - name: APP_TESTING_ADDONS_URL
-      value: "https://github.com/kyma-project/addons/releases/download/0.11.0/index-testing.yaml"
+      value: "https://github.com/kyma-project/addons/releases/download/0.13.0/index-testing.yaml"
     - name: APP_EVENT_SUBSCRIBER_IMAGE
       value: "{{ .Values.containerRegistry.path }}/{{ .Values.subscriberimage.dir}}event-subscriber-tools:{{ .Values.subscriberimage.version }}"
 

--- a/tests/end-to-end/upgrade/chart/upgrade/values.yaml
+++ b/tests/end-to-end/upgrade/chart/upgrade/values.yaml
@@ -7,7 +7,7 @@ subscriberimage:
 
 image:
   dir:
-  version: PR-9386
+  version: PR-9413
   pullPolicy: "IfNotPresent"
 
 dex:

--- a/tests/end-to-end/upgrade/pkg/tests/service-catalog/app_broker.go
+++ b/tests/end-to-end/upgrade/pkg/tests/service-catalog/app_broker.go
@@ -1,23 +1,25 @@
 package servicecatalog
 
 import (
+	"bufio"
 	"time"
 
-	"github.com/kubernetes-incubator/service-catalog/pkg/apis/servicecatalog/v1beta1"
-	"github.com/kubernetes-incubator/service-catalog/pkg/client/clientset_generated/clientset"
 	appConnectorApi "github.com/kyma-project/kyma/components/application-broker/pkg/apis/applicationconnector/v1alpha1"
 	appBroker "github.com/kyma-project/kyma/components/application-broker/pkg/client/clientset/versioned"
 	"github.com/kyma-project/kyma/components/application-operator/pkg/apis/applicationconnector/v1alpha1"
 	appConnector "github.com/kyma-project/kyma/components/application-operator/pkg/client/clientset/versioned"
 	bu "github.com/kyma-project/kyma/components/service-binding-usage-controller/pkg/client/clientset/versioned"
+
+	"github.com/kubernetes-incubator/service-catalog/pkg/apis/servicecatalog/v1beta1"
+	"github.com/kubernetes-incubator/service-catalog/pkg/client/clientset_generated/clientset"
+	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
+	k8sCoreTypes "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/kubernetes"
-	k8sCoreTypes "k8s.io/api/core/v1"
 	messagingv1alpha1 "knative.dev/eventing/pkg/apis/messaging/v1alpha1"
 	messagingclientv1alpha1 "knative.dev/eventing/pkg/client/clientset/versioned/typed/messaging/v1alpha1"
-	"bufio"
 )
 
 const (
@@ -139,6 +141,7 @@ func (f *appBrokerFlow) TestResources() error {
 		f.deleteApplication,
 		f.deleteChannel,
 		f.waitForClassesRemoved,
+		f.undeployEnvTester,
 	} {
 		err := fn()
 		if err != nil {
@@ -151,10 +154,15 @@ func (f *appBrokerFlow) TestResources() error {
 }
 
 func (f *appBrokerFlow) logReport() {
-	f.logK8SReport()
-	f.logServiceCatalogAndBindingUsageReport()
-	f.logApplicationReport()
-	f.reportLogs()
+	report := NewReport(f.namespace, f.log)
+
+	f.logK8SReport(report)
+	f.logServiceCatalogAndBindingUsageReport(report)
+	f.logApplicationReport(report)
+	f.logChannels(report)
+	f.reportLogs(report)
+
+	report.Print()
 }
 
 func (f *appBrokerFlow) deleteApplication() error {
@@ -317,12 +325,12 @@ func (f *appBrokerFlow) verifyEventActivation() error {
 
 func (f *appBrokerFlow) verifyEnvTesterHasGatewayInjected() error {
 	f.log.Info("Waiting for GATEWAY_URL env injected")
-	return f.waitForEnvInjected(appEnvTester, "GATEWAY_URL", gatewayURL)
+	return f.waitForEnvInjected(appEnvTester, gatewayURL)
 }
 
 func (f *appBrokerFlow) verifyDeploymentDoesNotContainGatewayEnvs() error {
 	f.log.Info("Verify deployment does not contain GATEWAY_URL environment variable")
-	return f.waitForEnvNotInjected(appEnvTester, "GATEWAY_URL")
+	return f.waitForEnvNotInjected(appEnvTester)
 }
 
 func (f *appBrokerFlow) deleteAPIServiceBindingUsage() error {
@@ -445,63 +453,82 @@ func (f *appBrokerFlow) waitForEnvTester() error {
 	return f.waitForDeployment(appEnvTester)
 }
 
-func (f *appBrokerFlow) logApplicationReport() {
-	appMappings, err := f.appBrokerInterface.ApplicationconnectorV1alpha1().ApplicationMappings(f.namespace).List(metav1.ListOptions{})
-	f.report("ApplicationMappings", appMappings, err)
-
-	eventActivations, err := f.appBrokerInterface.ApplicationconnectorV1alpha1().EventActivations(f.namespace).List(metav1.ListOptions{})
-	f.report("EventActivations", eventActivations, err)
-
-	applications, err := f.appConnectorInterface.ApplicationconnectorV1alpha1().Applications().List(metav1.ListOptions{})
-	f.report("Applications", applications, err)
+func (f *appBrokerFlow) undeployEnvTester() error {
+	f.log.Info("Removing deployment environment variable tester")
+	return f.deleteDeployment(appEnvTester)
 }
 
-func (f *appBrokerFlow) logFromPod(namespace, labelSelector, container string) {
+func (f *appBrokerFlow) logApplicationReport(report *Report) {
+	appMappings, err := f.appBrokerInterface.ApplicationconnectorV1alpha1().ApplicationMappings(f.namespace).List(metav1.ListOptions{})
+	report.AddApplicationMappings(appMappings, err)
+
+	eventActivations, err := f.appBrokerInterface.ApplicationconnectorV1alpha1().EventActivations(f.namespace).List(metav1.ListOptions{})
+	report.AddEventActivations(eventActivations, err)
+
+	applications, err := f.appConnectorInterface.ApplicationconnectorV1alpha1().Applications().List(metav1.ListOptions{})
+	report.AddApplications(applications, err)
+}
+
+func (f *appBrokerFlow) logChannels(report *Report) {
+	channels, err := f.messagingInterface.Channels(integrationNamespace).List(metav1.ListOptions{})
+	report.AddChannels(channels, err)
+}
+
+func (f *appBrokerFlow) logFromPod(namespace, labelSelector, container string) ([]string, error) {
+	logs := make([]string, 0)
+
 	pods, err := f.k8sInterface.CoreV1().Pods(namespace).List(metav1.ListOptions{
 		LabelSelector: labelSelector,
 	})
 	if err != nil {
-		f.log.Errorf("unable to fetch %s logs: %s", labelSelector, err.Error())
-		return
+		return logs, errors.Wrapf(err, "unable to fetch logs for label %s", labelSelector)
 	}
 	if len(pods.Items) == 0 {
-		f.log.Errorf("could not find %s pod", labelSelector)
-		return
+		return logs, errors.Wrapf(err, "could not find pod for label %s", labelSelector)
 	}
 
-	var tailLines int64 = 512
 	for _, p := range pods.Items {
 		func() {
 			req := f.k8sInterface.CoreV1().Pods(namespace).
 				GetLogs(p.Name, &k8sCoreTypes.PodLogOptions{
-				Container: container,
-				TailLines: &tailLines,
-			})
+					Container: container,
+				})
 			readCloser, err := req.Stream()
 			if err != nil {
+				f.log.Warnf("cannot get stream for pod %s: %s", p.Name, err)
 				return
 			}
-			defer readCloser.Close()
+			defer func() {
+				err = readCloser.Close()
+				if err != nil {
+					f.log.Warnf("cannot close stream for pod %s: %s", p.Name, err)
+				}
+			}()
 
 			rd := bufio.NewReader(readCloser)
+			lineCounter := 0
 			for {
+				lineCounter++
 				line, _, err := rd.ReadLine()
 				if err != nil {
-					f.log.Warnf("error while reading logs: %s", err.Error())
+					f.log.Warnf("cannot read line %d from stream for pod %s: %s", lineCounter, p.Name, err)
 					return
 				}
-				f.log.Infof(string(line))
+				logs = append(logs, string(line))
 			}
-			return
 		}()
-
 	}
+
+	return logs, nil
 }
 
-func (f *appBrokerFlow) reportLogs() {
-	f.log.Infof("Application Broker logs:")
-	f.logFromPod(integrationNamespace, "app=application-broker", "ctrl")
-	f.log.Infof("Service Binding Usage Controller logs:")
-	f.logFromPod("kyma-system", "app=service-catalog-addons-service-binding-usage-controller", "service-binding-usage-controller")
-}
+func (f *appBrokerFlow) reportLogs(report *Report) {
+	logs, err := f.logFromPod(integrationNamespace, "app=application-broker", "ctrl")
+	report.AddLogs("ApplicationBroker", logs, []string{apiServiceID, eventsServiceID, applicationName}, err)
 
+	logs, err = f.logFromPod("kyma-system", "app=service-catalog-addons-service-binding-usage-controller", "service-binding-usage-controller")
+	report.AddLogs("ServiceBindingUsageController", logs, []string{apiBindingUsageName}, err)
+
+	logs, err = f.logFromPod("kyma-system", "app=service-catalog-catalog-controller-manager", "controller-manager")
+	report.AddLogs("ServiceCatalog", logs, []string{apiServiceID, eventsServiceID, apiBindingName}, err)
+}

--- a/tests/end-to-end/upgrade/pkg/tests/service-catalog/base_flow.go
+++ b/tests/end-to-end/upgrade/pkg/tests/service-catalog/base_flow.go
@@ -15,10 +15,7 @@ import (
 	k8sCoreTypes "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/wait"
-	"k8s.io/cli-runtime/pkg/genericclioptions/printers"
 	"k8s.io/client-go/kubernetes"
 )
 
@@ -67,7 +64,7 @@ func (f *baseFlow) envTesterDeployment(name string, labels map[string]string, te
 					Containers: []k8sCoreTypes.Container{
 						{
 							Name:    "app",
-							Image:   "alpine:3.8",
+							Image:   "alpine:3.12",
 							Command: []string{"/bin/sh", "-c", "--"},
 							Args:    []string{fmt.Sprintf("echo \"value=$%s\"; echo \"done\"; while true; do sleep 30; done;", testedEnv)},
 						},
@@ -182,15 +179,15 @@ func (f *baseFlow) wait(timeout time.Duration, conditionFunc wait.ConditionFunc)
 	return wait.PollUntil(time.Second, conditionFunc, stopCh)
 }
 
-func (f *baseFlow) waitForEnvInjected(svc, expectedEnvName, expectedEnvValue string) error {
-	return f.waitForEnvTesterValue(svc, expectedEnvName, expectedEnvValue)
+func (f *baseFlow) waitForEnvInjected(svc, expectedEnvValue string) error {
+	return f.waitForEnvTesterValue(svc, expectedEnvValue)
 }
 
-func (f *baseFlow) waitForEnvNotInjected(svc, expectedEnvName string) error {
-	return f.waitForEnvTesterValue(svc, expectedEnvName, "")
+func (f *baseFlow) waitForEnvNotInjected(svc string) error {
+	return f.waitForEnvTesterValue(svc, "")
 }
 
-func (f *baseFlow) waitForEnvTesterValue(svc, expectedEnvName, expectedEnvValue string) error {
+func (f *baseFlow) waitForEnvTesterValue(svc, expectedEnvValue string) error {
 	return f.wait(time.Minute, func() (bool, error) {
 		var podName string
 
@@ -306,63 +303,36 @@ func (f *baseFlow) waitForDeployment(name string) error {
 	})
 }
 
-func (f *baseFlow) logK8SReport() {
+func (f *baseFlow) logK8SReport(report *Report) {
 	deployments, err := f.k8sInterface.AppsV1().Deployments(f.namespace).List(metav1.ListOptions{})
-	f.report("Deployments", deployments, err)
+	report.AddDeployments(deployments, err)
 
 	pods, err := f.k8sInterface.CoreV1().Pods(f.namespace).List(metav1.ListOptions{})
-	f.report("Pods", pods, err)
+	report.AddPods(pods, err)
 
 	secrets, err := f.k8sInterface.CoreV1().Secrets(f.namespace).List(metav1.ListOptions{})
-	f.report("Secrets", secrets, err)
+	report.AddSecrets(secrets, err)
 }
 
-func (f *baseFlow) logServiceCatalogAndBindingUsageReport() {
+func (f *baseFlow) logServiceCatalogAndBindingUsageReport(report *Report) {
 	clusterServiceBrokers, err := f.scInterface.ServicecatalogV1beta1().ClusterServiceBrokers().List(metav1.ListOptions{})
-	f.report("ClusterServiceBrokers", clusterServiceBrokers, err)
+	report.AddClusterServiceBrokers(clusterServiceBrokers, err)
 
 	serviceBrokers, err := f.scInterface.ServicecatalogV1beta1().ServiceBrokers(f.namespace).List(metav1.ListOptions{})
-	f.report("ServiceBrokers", serviceBrokers, err)
+	report.AddServiceBrokers(serviceBrokers, err)
 
 	clusterServiceClass, err := f.scInterface.ServicecatalogV1beta1().ClusterServiceClasses().List(metav1.ListOptions{})
-	f.report("ClusterServiceClasses", clusterServiceClass, err)
+	report.AddClusterServiceClasses(clusterServiceClass, err)
 
 	serviceClass, err := f.scInterface.ServicecatalogV1beta1().ServiceClasses(f.namespace).List(metav1.ListOptions{})
-	f.report("ServiceClasses", serviceClass, err)
+	report.AddServiceClasses(serviceClass, err)
 
 	serviceInstances, err := f.scInterface.ServicecatalogV1beta1().ServiceInstances(f.namespace).List(metav1.ListOptions{})
-	f.report("ServiceInstances", serviceInstances, err)
+	report.AddServiceInstances(serviceInstances, err)
 
 	serviceBindings, err := f.scInterface.ServicecatalogV1beta1().ServiceBindings(f.namespace).List(metav1.ListOptions{})
-	f.report("ServiceBindings", serviceBindings, err)
+	report.AddServiceBindings(serviceBindings, err)
 
 	serviceBindingUsages, err := f.buInterface.ServicecatalogV1alpha1().ServiceBindingUsages(f.namespace).List(metav1.ListOptions{})
-	f.report("ServiceBindingUsages", serviceBindingUsages, err)
-}
-
-func (f *baseFlow) report(kind string, obj runtime.Object, err error) {
-	printer := &printers.JSONPrinter{}
-	logger := &logWriter{log: f.log}
-	obj.(printerObject).SetGroupVersionKind(schema.GroupVersionKind{Kind: kind})
-	if err != nil {
-		f.log.Errorf("Could not fetch resources: %v", err)
-		return
-	}
-	err = printer.PrintObj(obj, logger)
-	if err != nil {
-		f.log.Errorf("Could not print objects: %v", err)
-	}
-}
-
-type logWriter struct {
-	log logrus.FieldLogger
-}
-
-func (w *logWriter) Write(p []byte) (n int, err error) {
-	w.log.Infof(string(p))
-	return len(p), nil
-}
-
-type printerObject interface {
-	SetGroupVersionKind(gvk schema.GroupVersionKind)
+	report.AddServiceBindingUsages(serviceBindingUsages, err)
 }

--- a/tests/end-to-end/upgrade/pkg/tests/service-catalog/helm_broker.go
+++ b/tests/end-to-end/upgrade/pkg/tests/service-catalog/helm_broker.go
@@ -134,8 +134,12 @@ func (f *helmBrokerFlow) TestResources() error {
 }
 
 func (f *helmBrokerFlow) logReport() {
-	f.logK8SReport()
-	f.logServiceCatalogAndBindingUsageReport()
+	report := NewReport(f.namespace, f.log)
+
+	f.logK8SReport(report)
+	f.logServiceCatalogAndBindingUsageReport(report)
+
+	report.Print()
 }
 
 func (f *helmBrokerFlow) deployEnvTester() error {
@@ -222,7 +226,7 @@ func (f *helmBrokerFlow) verifyDeploymentContainsRedisEvns() error {
 		return errors.Wrap(err, "while getting redis credentials")
 	}
 
-	return f.waitForEnvInjected(envTesterName, "REDIS_PASSWORD", creds.password)
+	return f.waitForEnvInjected(envTesterName, creds.password)
 }
 
 func (f *helmBrokerFlow) verifyKeyInRedisExists() error {
@@ -296,7 +300,7 @@ func (f *helmBrokerFlow) deleteRedisBindingUsage() error {
 
 func (f *helmBrokerFlow) verifyDeploymentDoesNotContainRedisEnvs() error {
 	f.log.Info("Verify deployment does not contain redis environments")
-	return f.waitForEnvNotInjected(envTesterName, "REDIS_PASSWORD")
+	return f.waitForEnvNotInjected(envTesterName)
 }
 
 func (f *helmBrokerFlow) deleteRedisBinding() error {

--- a/tests/end-to-end/upgrade/pkg/tests/service-catalog/helm_broker_conflict.go
+++ b/tests/end-to-end/upgrade/pkg/tests/service-catalog/helm_broker_conflict.go
@@ -118,8 +118,12 @@ func (f *helmBrokerConflictFlow) TestResources() error {
 }
 
 func (f *helmBrokerConflictFlow) logReport() {
-	f.logK8SReport()
-	f.logServiceCatalogAndBindingUsageReport()
+	report := NewReport(f.namespace, f.log)
+
+	f.logK8SReport(report)
+	f.logServiceCatalogAndBindingUsageReport(report)
+
+	report.Print()
 }
 
 func (f *helmBrokerConflictFlow) createFirstRedisInstance() error {

--- a/tests/end-to-end/upgrade/pkg/tests/service-catalog/report.go
+++ b/tests/end-to-end/upgrade/pkg/tests/service-catalog/report.go
@@ -1,0 +1,437 @@
+package servicecatalog
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	sc "github.com/kubernetes-incubator/service-catalog/pkg/apis/servicecatalog/v1beta1"
+	appBrk "github.com/kyma-project/kyma/components/application-broker/pkg/apis/applicationconnector/v1alpha1"
+	appOpr "github.com/kyma-project/kyma/components/application-operator/pkg/apis/applicationconnector/v1alpha1"
+	sbu "github.com/kyma-project/kyma/components/service-binding-usage-controller/pkg/apis/servicecatalog/v1alpha1"
+	appsV1 "k8s.io/api/apps/v1"
+	coreV1 "k8s.io/api/core/v1"
+	ch "knative.dev/eventing/pkg/apis/messaging/v1alpha1"
+
+	"github.com/sirupsen/logrus"
+)
+
+type (
+	Deployment struct {
+		Status     map[string]int32             `json:"status"`
+		Conditions []appsV1.DeploymentCondition `json:"conditions"`
+	}
+
+	Pod struct {
+		ContainersStatus map[string]string
+		Conditions       []coreV1.PodCondition
+	}
+
+	Secret struct {
+		Keys map[string]string
+	}
+)
+
+type (
+	ServiceBroker struct {
+		Conditions []sc.ServiceBrokerCondition
+	}
+
+	ServiceClass struct {
+		ClassName string
+		Owners    []string `json:"owners,omitempty"`
+	}
+
+	ServiceInstance struct {
+		LastOperation              string `json:"last_operation,omitempty"`
+		ProvisionStatus            string
+		DeprovisionStatus          string
+		OrphanMitigationInProgress string
+		Conditions                 []sc.ServiceInstanceCondition
+	}
+
+	ServiceBinding struct {
+		LastOperation              string `json:"last_operation,omitempty"`
+		OrphanMitigationInProgress string
+		Conditions                 []sc.ServiceBindingCondition
+	}
+
+	ServiceBindingUsage struct {
+		Conditions []sbu.ServiceBindingUsageCondition
+	}
+)
+
+type (
+	Application struct {
+		Status appOpr.ApplicationStatus
+	}
+)
+
+type (
+	Channel struct {
+		Status ch.ChannelStatus
+	}
+)
+
+type (
+	Log struct {
+		Message string
+	}
+
+	PodLog struct {
+		Level string
+		Log   Log
+	}
+)
+
+type Report struct {
+	Namespace string
+	log       logrus.FieldLogger
+
+	Details  map[string]string   `json:"details"`
+	Warnings map[string]string   `json:"warnings"`
+	Logs     map[string][]string `json:"logs"`
+
+	Deployments map[string]Deployment `json:"deployments"`
+	Pods        map[string]Pod        `json:"pods"`
+	Secrets     map[string]Secret     `json:"secrets"`
+
+	ClusterServiceBrokers map[string]ServiceBroker       `json:"cluster_service_brokers"`
+	ServiceBrokers        map[string]ServiceBroker       `json:"service_brokers"`
+	ClusterServiceClasses map[string]ServiceClass        `json:"cluster_service_classes"`
+	ServiceClasses        map[string]ServiceClass        `json:"service_classes"`
+	ServiceInstances      map[string]ServiceInstance     `json:"service_instances"`
+	ServiceBindings       map[string]ServiceBinding      `json:"service_bindings"`
+	ServiceBindingUsages  map[string]ServiceBindingUsage `json:"service_binding_usages"`
+
+	Applications map[string]Application `json:"applications"`
+
+	Channels map[string]Channel `json:"channels"`
+}
+
+func NewReport(namespace string, log logrus.FieldLogger) *Report {
+	return &Report{
+		Namespace:             namespace,
+		log:                   log,
+		Details:               make(map[string]string, 0),
+		Warnings:              make(map[string]string, 0),
+		Logs:                  make(map[string][]string, 0),
+		Deployments:           make(map[string]Deployment, 0),
+		Pods:                  make(map[string]Pod, 0),
+		Secrets:               make(map[string]Secret, 0),
+		ClusterServiceBrokers: make(map[string]ServiceBroker, 0),
+		ServiceBrokers:        make(map[string]ServiceBroker, 0),
+		ClusterServiceClasses: make(map[string]ServiceClass, 0),
+		ServiceClasses:        make(map[string]ServiceClass, 0),
+		ServiceInstances:      make(map[string]ServiceInstance, 0),
+		ServiceBindings:       make(map[string]ServiceBinding, 0),
+		ServiceBindingUsages:  make(map[string]ServiceBindingUsage, 0),
+		Applications:          make(map[string]Application, 0),
+		Channels:              make(map[string]Channel, 0),
+	}
+}
+
+func (r *Report) AddDeployments(deployments *appsV1.DeploymentList, err error) {
+	if err != nil {
+		r.Warnings["Deployments"] = fmt.Sprintf("cannot fetch Deployments list from %s namespace: %s", r.Namespace, err)
+		return
+	}
+
+	r.Details["Deployments"] = fmt.Sprintf("report found %d Deployments in %s namespace", len(deployments.Items), r.Namespace)
+	names := make([]string, 0)
+	for _, deployment := range deployments.Items {
+		status := make(map[string]int32, 0)
+		status["AvailableReplicas"] = deployment.Status.AvailableReplicas
+		status["ReadyReplicas"] = deployment.Status.ReadyReplicas
+		status["UpdatedReplicas"] = deployment.Status.UpdatedReplicas
+
+		names = append(names, deployment.Name)
+		r.Deployments[deployment.Name] = Deployment{
+			Status:     status,
+			Conditions: deployment.Status.Conditions,
+		}
+	}
+	r.Details["Deployments"] = fmt.Sprintf("%s (%s)", r.Details["Deployments"], strings.Join(names, ", "))
+}
+
+func (r *Report) AddPods(pods *coreV1.PodList, err error) {
+	if err != nil {
+		r.Warnings["Pods"] = fmt.Sprintf("cannot fetch Pods list from %s namespace: %s", r.Namespace, err)
+		return
+	}
+
+	r.Details["Pods"] = fmt.Sprintf("report found %d Pods in %s namespace", len(pods.Items), r.Namespace)
+	for _, pod := range pods.Items {
+		containersStatus := make(map[string]string, 0)
+		for _, cs := range pod.Status.ContainerStatuses {
+			containersStatus[cs.Name] = fmt.Sprintf("ready: %t, restartCount: %d, state: %v", cs.Ready, cs.RestartCount, cs.State)
+		}
+		r.Pods[pod.Name] = Pod{
+			ContainersStatus: containersStatus,
+			Conditions:       pod.Status.Conditions,
+		}
+	}
+}
+
+func (r *Report) AddSecrets(secrets *coreV1.SecretList, err error) {
+	if err != nil {
+		r.Warnings["Secrets"] = fmt.Sprintf("cannot fetch Secrets list from %s namespace: %s", r.Namespace, err)
+		return
+	}
+
+	r.Details["Secrets"] = fmt.Sprintf("report found %d Secrets in %s namespace", len(secrets.Items), r.Namespace)
+	for _, secret := range secrets.Items {
+		keys := make(map[string]string)
+		for key, value := range secret.Data {
+			isEmpty := "isEmpty"
+			if len(value) != 0 {
+				isEmpty = "isNotEmpty"
+			}
+			keys[key] = isEmpty
+		}
+		r.Secrets[secret.Name] = Secret{Keys: keys}
+	}
+}
+
+func (r *Report) AddClusterServiceBrokers(clusterServiceBrokers *sc.ClusterServiceBrokerList, err error) {
+	if err != nil {
+		r.Warnings["ClusterServiceBroker"] = fmt.Sprintf("cannot fetch ClusterServiceBroker list: %s", err)
+		return
+	}
+
+	r.Details["ClusterServiceBroker"] = fmt.Sprintf("report found %d ClusterServiceBrokers", len(clusterServiceBrokers.Items))
+	for _, csb := range clusterServiceBrokers.Items {
+		r.ClusterServiceBrokers[csb.Name] = ServiceBroker{
+			Conditions: csb.Status.Conditions,
+		}
+	}
+}
+
+func (r *Report) AddServiceBrokers(serviceBrokers *sc.ServiceBrokerList, err error) {
+	if err != nil {
+		r.Warnings["ServiceBroker"] = fmt.Sprintf("cannot fetch ServiceBroker list from %s namespace: %s", r.Namespace, err)
+		return
+	}
+
+	r.Details["ServiceBroker"] = fmt.Sprintf("report found %d ServiceBrokers in %s namespace", len(serviceBrokers.Items), r.Namespace)
+	for _, sb := range serviceBrokers.Items {
+		r.ServiceBrokers[sb.Name] = ServiceBroker{
+			Conditions: sb.Status.Conditions,
+		}
+	}
+}
+
+func (r *Report) AddClusterServiceClasses(clusterServiceClasses *sc.ClusterServiceClassList, err error) {
+	if err != nil {
+		r.Warnings["ClusterServiceClass"] = fmt.Sprintf("cannot fetch ClusterServiceClass list: %s", err)
+		return
+	}
+
+	r.Details["ClusterServiceClass"] = fmt.Sprintf("report found %d ClusterServiceClasses", len(clusterServiceClasses.Items))
+	for _, csc := range clusterServiceClasses.Items {
+		var owners []string
+		for _, owner := range csc.OwnerReferences {
+			owners = append(owners, fmt.Sprintf("%s - %s", owner.Kind, owner.Name))
+		}
+		r.ClusterServiceClasses[csc.Spec.ExternalName] = ServiceClass{
+			ClassName: csc.Name,
+			Owners:    owners,
+		}
+	}
+}
+
+func (r *Report) AddServiceClasses(serviceClasses *sc.ServiceClassList, err error) {
+	if err != nil {
+		r.Warnings["ServiceClass"] = fmt.Sprintf("cannot fetch ServiceClass list from %s namespace: %s", r.Namespace, err)
+		return
+	}
+
+	r.Details["ServiceClass"] = fmt.Sprintf("report found %d ServiceClasses in %s namespace", len(serviceClasses.Items), r.Namespace)
+	for _, sco := range serviceClasses.Items {
+		var owners []string
+		for _, owner := range sco.OwnerReferences {
+			owners = append(owners, fmt.Sprintf("%s - %s", owner.Kind, owner.Name))
+		}
+		r.ServiceClasses[sco.Spec.ExternalName] = ServiceClass{
+			ClassName: sco.Name,
+			Owners:    owners,
+		}
+	}
+}
+
+func (r *Report) AddServiceInstances(serviceInstances *sc.ServiceInstanceList, err error) {
+	if err != nil {
+		r.Warnings["ServiceInstance"] = fmt.Sprintf("cannot fetch ServiceInstance list from %s namespace: %s", r.Namespace, err)
+		return
+	}
+
+	r.Details["ServiceInstance"] = fmt.Sprintf("report found %d ServiceInstances in %s namespace", len(serviceInstances.Items), r.Namespace)
+	names := make([]string, 0)
+	for _, si := range serviceInstances.Items {
+		var lo string
+		if si.Status.LastOperation != nil {
+			lo = *si.Status.LastOperation
+		}
+		r.ServiceInstances[si.Name] = ServiceInstance{
+			LastOperation:              lo,
+			ProvisionStatus:            string(si.Status.ProvisionStatus),
+			DeprovisionStatus:          string(si.Status.DeprovisionStatus),
+			OrphanMitigationInProgress: fmt.Sprintf("%t", si.Status.OrphanMitigationInProgress),
+			Conditions:                 si.Status.Conditions,
+		}
+		names = append(names, si.Name)
+	}
+
+	r.Details["ServiceInstance"] = fmt.Sprintf("%s (%s)", r.Details["ServiceInstance"], strings.Join(names, ", "))
+}
+
+func (r *Report) AddServiceBindings(serviceBindings *sc.ServiceBindingList, err error) {
+	if err != nil {
+		r.Warnings["ServiceBinding"] = fmt.Sprintf("cannot fetch ServiceBinding list from %s namespace: %s", r.Namespace, err)
+		return
+	}
+
+	r.Details["ServiceBinding"] = fmt.Sprintf("report found %d ServiceBindings in %s namespace", len(serviceBindings.Items), r.Namespace)
+	for _, sb := range serviceBindings.Items {
+		var lo string
+		if sb.Status.LastOperation != nil {
+			lo = *sb.Status.LastOperation
+		}
+		r.ServiceBindings[sb.Name] = ServiceBinding{
+			LastOperation:              lo,
+			OrphanMitigationInProgress: fmt.Sprintf("%t", sb.Status.OrphanMitigationInProgress),
+			Conditions:                 sb.Status.Conditions,
+		}
+	}
+}
+
+func (r *Report) AddServiceBindingUsages(serviceBindingUsages *sbu.ServiceBindingUsageList, err error) {
+	if err != nil {
+		r.Warnings["ServiceBindingUsage"] = fmt.Sprintf("cannot fetch ServiceBindingUsage list from %s namespace: %s", r.Namespace, err)
+		return
+	}
+
+	r.Details["ServiceBindingUsage"] = fmt.Sprintf("report found %d ServiceBindingUsages in %s namespace", len(serviceBindingUsages.Items), r.Namespace)
+	for _, sbuo := range serviceBindingUsages.Items {
+		r.ServiceBindingUsages[sbuo.Name] = ServiceBindingUsage{
+			Conditions: sbuo.Status.Conditions,
+		}
+	}
+}
+
+func (r *Report) AddApplicationMappings(applicationMappings *appBrk.ApplicationMappingList, err error) {
+	if err != nil {
+		r.Warnings["ApplicationMapping"] = fmt.Sprintf("cannot fetch ApplicationMapping list from %s namespace: %s", r.Namespace, err)
+		return
+	}
+
+	r.Details["ApplicationMapping"] = fmt.Sprintf("report found %d ApplicationMappings in %s namespace", len(applicationMappings.Items), r.Namespace)
+	names := make([]string, 0)
+	for _, am := range applicationMappings.Items {
+		names = append(names, am.Name)
+	}
+	r.Details["ApplicationMapping"] = fmt.Sprintf("%s (%s)", r.Details["ApplicationMapping"], strings.Join(names, ", "))
+}
+
+func (r *Report) AddEventActivations(eventActivations *appBrk.EventActivationList, err error) {
+	if err != nil {
+		r.Warnings["EventActivation"] = fmt.Sprintf("cannot fetch EventActivation list from %s namespace: %s", r.Namespace, err)
+		return
+	}
+
+	r.Details["EventActivation"] = fmt.Sprintf("report found %d EventActivations in %s namespace", len(eventActivations.Items), r.Namespace)
+	names := make([]string, 0)
+	for _, ea := range eventActivations.Items {
+		names = append(names, ea.Name)
+	}
+	r.Details["EventActivation"] = fmt.Sprintf("%s (%s)", r.Details["EventActivation"], strings.Join(names, ", "))
+}
+
+func (r *Report) AddApplications(applications *appOpr.ApplicationList, err error) {
+	if err != nil {
+		r.Warnings["Application"] = fmt.Sprintf("cannot fetch Application list: %s", err)
+		return
+	}
+
+	r.Details["Application"] = fmt.Sprintf("report found %d Applications", len(applications.Items))
+	names := make([]string, 0)
+	for _, a := range applications.Items {
+		names = append(names, a.Name)
+		r.Applications[a.Name] = Application{
+			Status: a.Status,
+		}
+	}
+	r.Details["Application"] = fmt.Sprintf("%s (%s)", r.Details["Application"], strings.Join(names, ", "))
+}
+
+func (r *Report) AddChannels(channels *ch.ChannelList, err error) {
+	if err != nil {
+		r.Warnings["Channel"] = fmt.Sprintf("cannot fetch Channels list: %s", err)
+		return
+	}
+
+	r.Details["Channel"] = fmt.Sprintf("report found %d Channels", len(channels.Items))
+	names := make([]string, 0)
+	for _, channel := range channels.Items {
+		names = append(names, channel.Name)
+		r.Channels[channel.Name] = Channel{
+			Status: channel.Status,
+		}
+	}
+	r.Details["Channel"] = fmt.Sprintf("%s (%s)", r.Details["Channel"], strings.Join(names, ", "))
+}
+
+func (r *Report) AddLogs(name string, logs []string, grepWords []string, err error) {
+	if err != nil {
+		r.Warnings[fmt.Sprintf("Logs:%s", name)] = fmt.Sprintf("cannot fetch logs: %s", err)
+		return
+	}
+	var grep bool
+	if len(grepWords) > 0 {
+		grep = true
+	}
+
+	for _, singleLog := range logs {
+		podLog := &PodLog{}
+		err := json.Unmarshal([]byte(singleLog), podLog)
+		if err != nil {
+			// if log is not in `{"level":"", "log":{"message":""}}` schema then report cannot unmarshal them
+			// log will be save only if contains grep words
+			if log := r.grep(singleLog, grepWords); log != "" {
+				r.Logs[name] = append(r.Logs[name], fmt.Sprintf("[unsupportedSchema] %s", log))
+			}
+			continue
+		}
+		if grep {
+			// if grepWords are not empty, save only logs which contains grep words + all with 'error' word
+			if log := r.grep(podLog.Log.Message, grepWords); log != "" {
+				r.Logs[name] = append(r.Logs[name], fmt.Sprintf("[%s] %s", podLog.Level, log))
+			}
+			if log := r.grep(podLog.Log.Message, []string{"error"}); log != "" {
+				r.Logs[name] = append(r.Logs[name], fmt.Sprintf("[%s] %s", podLog.Level, log))
+			}
+		} else {
+			// if grepWords are empty, save all logs
+			r.Logs[name] = append(r.Logs[name], fmt.Sprintf("[%s] %s", podLog.Level, podLog.Log.Message))
+		}
+	}
+}
+
+func (r *Report) grep(log string, greps []string) string {
+	for _, word := range greps {
+		if strings.Contains(log, word) {
+			return log
+		}
+	}
+
+	return ""
+}
+
+func (r *Report) Print() {
+	jsonReport, err := json.MarshalIndent(r, "", "\t")
+	if err != nil {
+		r.log.Errorf("cannot marshal Report: %s", err)
+		return
+	}
+	r.log.Info(string(jsonReport))
+}

--- a/tests/end-to-end/upgrade/pkg/tests/service-catalog/report.go
+++ b/tests/end-to-end/upgrade/pkg/tests/service-catalog/report.go
@@ -397,7 +397,11 @@ func (r *Report) AddLogs(name string, logs []string, grepWords []string, err err
 		if err != nil {
 			// if log is not in `{"level":"", "log":{"message":""}}` schema then report cannot unmarshal them
 			// log will be save only if contains grep words
+			var logWithGrepWord string
 			if log := r.grep(singleLog, grepWords); log != "" {
+				logWithGrepWord = strings.ToLower(log)
+			}
+			if log := r.grep(logWithGrepWord, []string{"error"}); log != "" {
 				r.Logs[name] = append(r.Logs[name], fmt.Sprintf("[unsupportedSchema] %s", log))
 			}
 			continue

--- a/tests/end-to-end/upgrade/pkg/tests/service-catalog/report.go
+++ b/tests/end-to-end/upgrade/pkg/tests/service-catalog/report.go
@@ -433,5 +433,5 @@ func (r *Report) Print() {
 		r.log.Errorf("cannot marshal Report: %s", err)
 		return
 	}
-	r.log.Warn(string(jsonReport))
+	r.log.Info(string(jsonReport))
 }

--- a/tests/end-to-end/upgrade/pkg/tests/service-catalog/report.go
+++ b/tests/end-to-end/upgrade/pkg/tests/service-catalog/report.go
@@ -433,5 +433,5 @@ func (r *Report) Print() {
 		r.log.Errorf("cannot marshal Report: %s", err)
 		return
 	}
-	r.log.Info(string(jsonReport))
+	r.log.Warn(string(jsonReport))
 }


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- changing the log display (the logs are more compressed). New logs (report) schema:
```json
{
	"Namespace": "test-namespace",
	"details": {
		"Application": "report found 1 Applications (application-for-testing)",
		"ApplicationMapping": "report found 1 ApplicationMappings in applicationbrokerupgradetest namespace (application-for-testing)",
		"ClusterServiceBroker": "report found 1 ClusterServiceBrokers",
                  (...)
	},
	"warnings": {},
	"logs": {
		"ApplicationBroker": [
			"[info] Application \"application-for-testing\" was added into storage (replaced: false)",
			"[info] Relist requested after successful processing of the \"application-for-testing\"",
                          (...)
		],
		"ServiceBindingUsageController": [
	          (...)
		],
		"ServiceCatalog": [
		  (...)
		]
	},
	"deployments": {
		"deployment-name": {
			"status": {
				"AvailableReplicas": 1,
				"ReadyReplicas": 1,
				"UpdatedReplicas": 1
			},
			"conditions": [
				{
					"type": "Available",
					"status": "True",
					"lastUpdateTime": "2020-09-09T06:05:41Z",
					"lastTransitionTime": "2020-09-09T06:05:41Z",
					"reason": "MinimumReplicasAvailable",
					"message": "Deployment has minimum availability."
				},
				{
					"type": "Progressing",
					"status": "True",
					"lastUpdateTime": "2020-09-09T06:05:59Z",
					"lastTransitionTime": "2020-09-09T06:05:32Z",
					"reason": "NewReplicaSetAvailable",
					"message": "ReplicaSet \"app-env-tester-574878748c\" has successfully progressed."
				}
			]
		},
		(...)
	},
	"pods": {
		"pod-name": {
		 (...)
		},
	},
	"secrets": {
	  (...)
	},
	(...)
}
```
- add logs from ServiceCatalog `controller-manager`
- small fixes (e.g. bump addons image, remove unuse variable)

**Related issue(s)**
#8731 
