### PR TITLE
Have Merge_Log_Key unset by default to have parsed JSON structure at the root level

### DIFF
--- a/resources/logging/charts/fluentbit/templates/configmap.yaml
+++ b/resources/logging/charts/fluentbit/templates/configmap.yaml
@@ -115,7 +115,9 @@ data:
         Kube_URL            https://kubernetes.default.svc:443
         Merge_Log           {{ .Values.conf.Filter.Kubernetes.Merge_Log }}
         Keep_Log            {{ .Values.conf.Filter.Kubernetes.Keep_Log }}
+{{- if .Values.conf.Filter.Kubernetes.Merge_Log_Key }}
         Merge_Log_Key       {{ .Values.conf.Filter.Kubernetes.Merge_Log_Key }}
+{{- end }}
         K8S-Logging.Parser  On
         K8S-Logging.Exclude On
 {{- if .Values.conf.Filter.custom_parser.enabled }}

--- a/resources/logging/charts/fluentbit/values.yaml
+++ b/resources/logging/charts/fluentbit/values.yaml
@@ -173,7 +173,7 @@ conf:
       Keep_Log: "On"
       Match: "*"
       # When Merge_Log is enabled, the filter tries to assume the log field from the incoming message is a JSON string message and make a structured representation of it at the same level of the log field in the map. Now if Merge_Log_Key is set (a string name), all the new structured fields taken from the original log content are inserted under the new key.
-      Merge_Log_Key: "logs"
+      Merge_Log_Key: ""
     custom_parser:
       enabled: false
       name:


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/master/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Default settings of kyma logging chart have Merge_Log of kubernetes filter in fluent-bit enabled and configured with "logs" record. So the filter tries to parse a log as JSON and puts the structure into the "logs" record.
We missed the fact that the default value of the key setting is empty, meaning that the structure is directly placed on the root level, so all parsed JSON attributes get an own record. With that Grafana will interpret them as own fields nicely and also a custom labelling can be done easily.

This PR proposes to unset the key setting by default to exactly have this nice effect.


**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
