### PR TITLE
Prevent throw "watch closed before UntilWithoutRetry timeout" in Rafter test

### DIFF
--- a/resources/rafter/values.yaml
+++ b/resources/rafter/values.yaml
@@ -8,7 +8,7 @@ tests:
   enabled: true
   image:
     repository: "eu.gcr.io/kyma-project/rafter-test"
-    tag: 1088c1af
+    tag: PR-9434
     pullPolicy: IfNotPresent
   disableConcurrency: true
   restartPolicy: Never

--- a/tests/rafter/pkg/resource/resource.go
+++ b/tests/rafter/pkg/resource/resource.go
@@ -122,11 +122,8 @@ func (r *Resource) Delete(name string, timeout time.Duration, callbacks ...func(
 		return true, nil
 	}
 	_, err = watchtools.Until(ctx, initialResourceVersion, r.ResCli, condition)
-	if err.Error() == watchtools.ErrWatchClosed.Error() {
+	if err == nil || err.Error() == watchtools.ErrWatchClosed.Error() {
 		return nil
 	}
-	if err != nil {
-		return err
-	}
-	return nil
+	return err
 }

--- a/tests/rafter/pkg/resource/resource.go
+++ b/tests/rafter/pkg/resource/resource.go
@@ -122,6 +122,9 @@ func (r *Resource) Delete(name string, timeout time.Duration, callbacks ...func(
 		return true, nil
 	}
 	_, err = watchtools.Until(ctx, initialResourceVersion, r.ResCli, condition)
+	if err.Error() == watchtools.ErrWatchClosed.Error() {
+		return nil
+	}
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/master/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

Prevent throw `watch closed before UntilWithoutRetry timeout` in Rafter test. Context: in some environment like Gardener 
tests throw mentioned error while deleting resources, even though the resource was successfully deleted.