### PR TITLE
Allow grafana extra ports to be configurable through kyma-installer overrides

### DIFF
--- a/resources/monitoring/charts/grafana/templates/kyma-additions/auth-proxy-service.yaml
+++ b/resources/monitoring/charts/grafana/templates/kyma-additions/auth-proxy-service.yaml
@@ -45,7 +45,7 @@ spec:
       nodePort: {{.Values.service.nodePort}}
 {{ end }}
   {{- if .Values.extraExposePorts }}
-  {{- tpl (toYaml .Values.extraExposePorts) . | indent 4 }}
+  {{- tpl (.Values.extraExposePorts) . | indent 4 }}
   {{- end }}
   selector:
     app.kubernetes.io/instance: {{ .Release.Name }}

--- a/resources/monitoring/charts/grafana/templates/service.yaml
+++ b/resources/monitoring/charts/grafana/templates/service.yaml
@@ -43,7 +43,7 @@ spec:
       nodePort: {{.Values.service.nodePort}}
 {{ end }}
   {{- if .Values.extraExposePorts }}
-  {{- tpl (toYaml .Values.extraExposePorts) . | indent 4 }}
+  {{- tpl (.Values.extraExposePorts) . | indent 4 }}
   {{- end }}
   selector:
     {{- include "grafana.selectorLabels" . | nindent 4 }}

--- a/resources/monitoring/charts/grafana/values.yaml
+++ b/resources/monitoring/charts/grafana/values.yaml
@@ -119,7 +119,7 @@ service:
   labels: {}
   portName: http-service
 
-extraExposePorts: []
+extraExposePorts:
  # - name: keycloak
  #   port: 8080
  #   targetPort: 8080


### PR DESCRIPTION
**Description**
Currently it is not possible to provide helm value overrides via kyma-installer of type list.
The istio-proxy status port has to be added as an extra to be able to properly probe grafana and keycloak-gatekeeper health endpoints from within the cluster, as [Istio probe-rewrite](https://istio.io/v1.1/help/ops/setup/app-health-check/#probe-rewrite) is enabled. 


**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
