### PR TITLE
Fix rafter & serverless tutorials

### DIFF
--- a/docs/rafter/08-02-set-minio-to-gateway-mode.md
+++ b/docs/rafter/08-02-set-minio-to-gateway-mode.md
@@ -279,7 +279,7 @@ metadata:
     kyma-project.io/installation: ""
 type: Opaque
 data:
-  controller-manager.minio.accessKey: "$(echo "${AZ_ACCOUNT_NAME}" | base64)"
+  controller-manager.minio.accessKey: "$(echo -n "${AZ_ACCOUNT_NAME}" | base64)"
   controller-manager.minio.secretKey: "${AZ_ACCOUNT_KEY}"
 ---
 apiVersion: v1
@@ -330,8 +330,8 @@ metadata:
     kyma-project.io/installation: ""
 type: Opaque
 data:
-  controller-manager.minio.accessKey: "$(echo "${AWS_ACCESS_KEY}" | base64)"
-  controller-manager.minio.secretKey: "$(echo "${AWS_SECRET_KEY}" | base64)"
+  controller-manager.minio.accessKey: "$(echo -n "${AWS_ACCESS_KEY}" | base64)"
+  controller-manager.minio.secretKey: "$(echo -n "${AWS_SECRET_KEY}" | base64)"
 ---
 apiVersion: v1
 kind: ConfigMap
@@ -382,8 +382,8 @@ metadata:
     kyma-project.io/installation: ""
 type: Opaque
 data:
-  controller-manager.minio.accessKey: "$(echo "${ALIBABA_ACCESS_KEY}" | base64)"
-  controller-manager.minio.secretKey: "$(echo "${ALIBABA_SECRET_KEY}" | base64)"
+  controller-manager.minio.accessKey: "$(echo -n "${ALIBABA_ACCESS_KEY}" | base64)"
+  controller-manager.minio.secretKey: "$(echo -n "${ALIBABA_SECRET_KEY}" | base64)"
 ---
 apiVersion: v1
 kind: ConfigMap

--- a/docs/serverless/08-06-set-external-docker-registry.md
+++ b/docs/serverless/08-06-set-external-docker-registry.md
@@ -224,11 +224,11 @@ metadata:
     component: serverless
     kyma-project.io/installation: ""
 data:
-  dockerRegistry.enableInternal: $(echo "false" | base64)
-  dockerRegistry.username: $(echo "${USERNAME}" | base64)
-  dockerRegistry.password: $(echo "${PASSWORD}" | base64)
-  dockerRegistry.serverAddress: $(echo "${SERVER_ADDRESS}" | base64)
-  dockerRegistry.registryAddress: $(echo "${REGISTRY_ADDRESS}" | base64)
+  dockerRegistry.enableInternal: $(echo -n "false" | base64)
+  dockerRegistry.username: $(echo -n "${USERNAME}" | base64)
+  dockerRegistry.password: $(echo -n "${PASSWORD}" | base64)
+  dockerRegistry.serverAddress: $(echo -n "${SERVER_ADDRESS}" | base64)
+  dockerRegistry.registryAddress: $(echo -n "${REGISTRY_ADDRESS}" | base64)
 EOF
 ```
 
@@ -250,11 +250,11 @@ metadata:
     component: serverless
     kyma-project.io/installation: ""
 data:
-  dockerRegistry.enableInternal: $(echo "false" | base64)
-  dockerRegistry.username: $(echo "_json_key" | base64)
+  dockerRegistry.enableInternal: $(echo -n "false" | base64)
+  dockerRegistry.username: $(echo -n "_json_key" | base64)
   dockerRegistry.password: "${GCS_KEY_JSON}"
-  dockerRegistry.serverAddress: $(echo "${SERVER_ADDRESS}" | base64)
-  dockerRegistry.registryAddress: $(echo "${SERVER_ADDRESS}/${PROJECT}" | base64)
+  dockerRegistry.serverAddress: $(echo -n "${SERVER_ADDRESS}" | base64)
+  dockerRegistry.registryAddress: $(echo -n "${SERVER_ADDRESS}/${PROJECT}" | base64)
 EOF
 ```
 
@@ -276,11 +276,11 @@ metadata:
     component: serverless
     kyma-project.io/installation: ""
 data:
-  dockerRegistry.enableInternal: $(echo "false" | base64)
-  dockerRegistry.username: $(echo "${SP_APP_ID}" | base64)
-  dockerRegistry.password: $(echo "${SP_PASSWORD}" | base64)
-  dockerRegistry.serverAddress: $(echo "${AZ_REGISTRY_NAME}.${SERVER_ADDRESS}" | base64)
-  dockerRegistry.registryAddress: $(echo "${AZ_REGISTRY_NAME}.${SERVER_ADDRESS}" | base64)
+  dockerRegistry.enableInternal: $(echo -n "false" | base64)
+  dockerRegistry.username: $(echo -n "${SP_APP_ID}" | base64)
+  dockerRegistry.password: $(echo -n "${SP_PASSWORD}" | base64)
+  dockerRegistry.serverAddress: $(echo -n "${AZ_REGISTRY_NAME}.${SERVER_ADDRESS}" | base64)
+  dockerRegistry.registryAddress: $(echo -n "${AZ_REGISTRY_NAME}.${SERVER_ADDRESS}" | base64)
 EOF
 ```
 


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/master/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

As in title: Fix serverless & rafter tutorials -> remove newline from echo commands.

Context: in some enviroments echo add newline to output, so Kyma upgrade phase with enabled external docker registry in serverless or gateway mode in rafter will crash.
