### PR TITLE
Categorize kyma components and provide some generic dashboards

### DIFF
--- a/resources/api-gateway/templates/deployment.yaml
+++ b/resources/api-gateway/templates/deployment.yaml
@@ -4,6 +4,7 @@ kind: Deployment
 metadata:
   name: {{ include "api-gateway.fullname" . }}
   labels:
+    kyma-project.io/component: controller
 {{ include "api-gateway.labels" . | indent 4 }}
 spec:
   replicas: {{ .Values.replicaCount }}
@@ -17,6 +18,7 @@ spec:
     metadata:
       labels:
         control-plane: controller-manager
+        kyma-project.io/component: controller
 {{ include "api-gateway.labels" . | indent 8 }}
       {{- with .Values.config.annotations }}
       annotations:

--- a/resources/apiserver-proxy/templates/deployment.yaml
+++ b/resources/apiserver-proxy/templates/deployment.yaml
@@ -3,6 +3,8 @@ kind: Deployment
 metadata:
   name: {{ template "name" . }}
   namespace: {{ .Release.Namespace }}
+  labels:
+    kyma-project.io/component: backend
 spec:
   selector:
     matchLabels:
@@ -24,6 +26,7 @@ spec:
       labels:
         app: {{ template "name" . }}
         tlsSecret: ingress-tls-cert
+        kyma-project.io/component: backend
     spec:
       serviceAccountName: {{ template "name" . }}
       {{ if .Values.global.isLocalEnv }}

--- a/resources/application-connector/charts/application-broker/templates/deployment.yaml
+++ b/resources/application-connector/charts/application-broker/templates/deployment.yaml
@@ -10,6 +10,7 @@ metadata:
     app.kubernetes.io/name: {{ template "name" . }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
     app.kubernetes.io/instance: {{ .Release.Name }}
+    kyma-project.io/component: controller
 spec:
   replicas: 1
   selector:
@@ -31,6 +32,7 @@ spec:
         app.kubernetes.io/name: {{ template "name" . }}
         app.kubernetes.io/managed-by: {{ .Release.Service }}
         app.kubernetes.io/instance: {{ .Release.Name }}
+        kyma-project.io/component: controller
     spec:
       serviceAccountName: {{ .Chart.Name }}
       containers:

--- a/resources/application-connector/charts/application-operator/templates/controller.yaml
+++ b/resources/application-connector/charts/application-operator/templates/controller.yaml
@@ -11,6 +11,7 @@ metadata:
     app.kubernetes.io/name: {{ template "name" . }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
     app.kubernetes.io/instance: {{ .Release.Name }}
+    kyma-project.io/component: controller
 spec:
   selector:
     matchLabels:
@@ -29,6 +30,7 @@ spec:
         app.kubernetes.io/name: {{ template "name" . }}
         app.kubernetes.io/managed-by: {{ .Release.Service }}
         app.kubernetes.io/instance: {{ .Release.Name }}
+        kyma-project.io/component: controller
     spec:
       serviceAccountName: {{ .Chart.Name }}
       initContainers:

--- a/resources/application-connector/charts/application-registry/templates/deployment.yaml
+++ b/resources/application-connector/charts/application-registry/templates/deployment.yaml
@@ -11,6 +11,7 @@ metadata:
     app.kubernetes.io/name: {{ template "name" . }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
     app.kubernetes.io/instance: {{ .Release.Name }}
+    kyma-project.io/component: backend
 spec:
   replicas: 1
   strategy:
@@ -32,6 +33,7 @@ spec:
         app.kubernetes.io/name: {{ template "name" . }}
         app.kubernetes.io/managed-by: {{ .Release.Service }}
         app.kubernetes.io/instance: {{ .Release.Name }}
+        kyma-project.io/component: backend
     spec:
       containers:
       - name: {{ .Chart.Name }}

--- a/resources/application-connector/charts/connection-token-handler/templates/deployment.yaml
+++ b/resources/application-connector/charts/connection-token-handler/templates/deployment.yaml
@@ -11,6 +11,7 @@ metadata:
     app.kubernetes.io/name: {{ template "name" . }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
     app.kubernetes.io/instance: {{ .Release.Name }}
+    kyma-project.io/component: controller
 spec:
   replicas: 1
   strategy:
@@ -30,6 +31,7 @@ spec:
         app.kubernetes.io/name: {{ template "name" . }}
         app.kubernetes.io/managed-by: {{ .Release.Service }}
         app.kubernetes.io/instance: {{ .Release.Name }}
+        kyma-project.io/component: controller
     spec:
       serviceAccount: {{ .Chart.Name }}
       containers:

--- a/resources/application-connector/charts/connector-service/templates/deployment.yaml
+++ b/resources/application-connector/charts/connector-service/templates/deployment.yaml
@@ -11,6 +11,7 @@ metadata:
     app.kubernetes.io/name: {{ template "name" . }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
     app.kubernetes.io/instance: {{ .Release.Name }}
+    kyma-project.io/component: backend
 spec:
   replicas: 1
   strategy:
@@ -32,6 +33,7 @@ spec:
         app.kubernetes.io/name: {{ template "name" . }}
         app.kubernetes.io/managed-by: {{ .Release.Service }}
         app.kubernetes.io/instance: {{ .Release.Name }}
+        kyma-project.io/component: backend
     spec:
       serviceAccountName: {{ .Chart.Name }}
       containers:

--- a/resources/cluster-essentials/charts/pod-preset/templates/controller-manager/stateful-set.yaml
+++ b/resources/cluster-essentials/charts/pod-preset/templates/controller-manager/stateful-set.yaml
@@ -9,6 +9,7 @@ metadata:
     chart: {{ template "pod-preset.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
+    kyma-project.io/component: controller
 spec:
   selector:
     matchLabels:
@@ -22,6 +23,7 @@ spec:
       labels:
         app: {{ template "pod-preset.name" . }}-controller
         release: {{ .Release.Name }}
+        kyma-project.io/component: controller
     spec:
       serviceAccountName: {{ template "pod-preset.fullname" . }}-controller
       terminationGracePeriodSeconds: 10

--- a/resources/console/charts/backend/templates/deployment.yaml
+++ b/resources/console/charts/backend/templates/deployment.yaml
@@ -7,6 +7,7 @@ metadata:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
+    kyma-project.io/component: backend
 spec:
   replicas: {{ .Values.replicaCount }}
   selector:
@@ -23,6 +24,7 @@ spec:
         chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
         release: "{{ .Release.Name }}"
         heritage: "{{ .Release.Service }}"
+        kyma-project.io/component: backend
     spec:
       serviceAccountName: {{ template "fullname" . }}
       {{ if .Values.global.isLocalEnv }}

--- a/resources/console/charts/web/templates/deployment.yaml
+++ b/resources/console/charts/web/templates/deployment.yaml
@@ -7,12 +7,14 @@ metadata:
     chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
+    kyma-project.io/component: frontend
 spec:
   replicas: {{ .Values.replicaCount }}
   selector:
     matchLabels:
       app: {{ template "fullname" . }}
       release: {{ .Release.Name }}
+      # not used anymore but need to stay as the selector is immutable 
       kyma-alerts: enabled
       kyma-component: ui
       kyma-grafana: enabled
@@ -21,6 +23,8 @@ spec:
       labels:
         app: {{ template "fullname" . }}
         release: {{ .Release.Name }}
+        kyma-project.io/component: frontend
+        # not used anymore but need to stay as it is used in the selector
         kyma-alerts: enabled
         kyma-component: ui
         kyma-grafana: enabled

--- a/resources/core/charts/docs/charts/content-ui/templates/deployment.yaml
+++ b/resources/core/charts/docs/charts/content-ui/templates/deployment.yaml
@@ -7,6 +7,7 @@ metadata:
     chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
+    kyma-project.io/component: frontend
 spec:
   selector:
     matchLabels:
@@ -20,6 +21,7 @@ spec:
       labels:
         app: {{ template "name" . }}
         release: {{ .Release.Name }}
+        kyma-project.io/component: frontend
     spec:
       containers:
         - name: {{ .Chart.Name }}

--- a/resources/helm-broker/charts/addons-ui/templates/deployment.yaml
+++ b/resources/helm-broker/charts/addons-ui/templates/deployment.yaml
@@ -7,6 +7,7 @@ metadata:
     chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
+    kyma-project.io/component: frontend
 spec:
   selector:
     matchLabels:
@@ -20,6 +21,7 @@ spec:
       labels:
         app: {{ template "addons-ui-name" . }}
         release: {{ .Release.Name }}
+        kyma-project.io/component: frontend
     spec:
       containers:
         - name: {{ .Chart.Name }}

--- a/resources/helm-broker/templates/deploy.yaml
+++ b/resources/helm-broker/templates/deploy.yaml
@@ -7,6 +7,7 @@ metadata:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
+    kyma-project.io/component: controller
 spec:
   replicas: 1
   selector:
@@ -23,6 +24,7 @@ spec:
         chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
         release: "{{ .Release.Name }}"
         heritage: "{{ .Release.Service }}"
+        kyma-project.io/component: controller
     spec:
       serviceAccountName: {{ template "fullname" . }}
       containers:

--- a/resources/iam-kubeconfig-service/templates/deployment.yaml
+++ b/resources/iam-kubeconfig-service/templates/deployment.yaml
@@ -8,6 +8,7 @@ metadata:
   labels:
     app: {{ template "name" . }}
     chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    kyma-project.io/component: backend
 spec:
   selector:
     matchLabels:
@@ -19,6 +20,7 @@ spec:
         app: {{ template "name" . }}
         tlsSecret: ingress-tls-cert
         chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+        kyma-project.io/component: backend
     spec:
       {{ if .Values.global.isLocalEnv }}
       hostAliases:

--- a/resources/logging/charts/logui/templates/deployment.yaml
+++ b/resources/logging/charts/logui/templates/deployment.yaml
@@ -3,6 +3,7 @@ kind: Deployment
 metadata:
   name: {{ template "logui.fullname" . }}
   labels:
+    kyma-project.io/component: frontend
     {{- include "logui.labels" . | nindent 4 }}
 spec:
   selector:
@@ -15,6 +16,7 @@ spec:
       labels:
         app: {{ template "logui.name" . }}
         release: {{ .Release.Name }}
+        kyma-project.io/component: frontend
       annotations:
         sidecar.istio.io/inject: "false"
     spec:

--- a/resources/monitoring/templates/grafana/kyma-dashboards/alertmanager.yaml
+++ b/resources/monitoring/templates/grafana/kyma-dashboards/alertmanager.yaml
@@ -699,7 +699,7 @@ data:
               "hide": false,
               "interval": "",
               "intervalFactor": 1,
-              "legendFormat": "Failed  {{ `{{ integration }}` }}` }}` }}",
+              "legendFormat": "Failed  {{ `{{ integration }}` }}",
               "refId": "A"
             }
           ],

--- a/resources/monitoring/templates/grafana/kyma-dashboards/kyma-backends.yaml
+++ b/resources/monitoring/templates/grafana/kyma-dashboards/kyma-backends.yaml
@@ -1,0 +1,1114 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: monitoring-kyma-backends-dashboard
+  labels:
+    grafana_dashboard: "1"
+    app: monitoring-grafana
+data:
+  kyma-backends-dashboard.json: |-
+    {
+      "annotations": {
+        "list": [
+          {
+            "builtIn": 1,
+            "datasource": "-- Grafana --",
+            "enable": true,
+            "hide": true,
+            "iconColor": "rgba(0, 211, 255, 1)",
+            "name": "Annotations & Alerts",
+            "type": "dashboard"
+          }
+        ]
+      },
+      "editable": false,
+      "gnetId": null,
+      "graphTooltip": 0,
+      "iteration": 1600801833171,
+      "links": [],
+      "panels": [
+        {
+          "content": "\nAll pods having label `kyma-project.io/component: backend`\n\n",
+          "datasource": null,
+          "fieldConfig": {
+            "defaults": {
+              "custom": {}
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 2,
+            "w": 12,
+            "x": 0,
+            "y": 0
+          },
+          "id": 19,
+          "mode": "markdown",
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "Note",
+          "type": "text"
+        },
+        {
+          "collapsed": false,
+          "datasource": null,
+          "gridPos": {
+            "h": 1,
+            "w": 24,
+            "x": 0,
+            "y": 2
+          },
+          "id": 4,
+          "panels": [],
+          "title": "Pod Metrics",
+          "type": "row"
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": null,
+          "fieldConfig": {
+            "defaults": {
+              "custom": {}
+            },
+            "overrides": []
+          },
+          "fill": 1,
+          "fillGradient": 0,
+          "gridPos": {
+            "h": 9,
+            "w": 12,
+            "x": 0,
+            "y": 3
+          },
+          "hiddenSeries": false,
+          "id": 2,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 2,
+          "nullPointMode": "null",
+          "options": {
+            "dataLinks": []
+          },
+          "percentage": false,
+          "pointradius": 2,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "sum by(container) (container_memory_usage_bytes{namespace=\"$namespace\", pod=\"$pod\", container_name!=\"POD\",container!=\"\"})",
+              "interval": "",
+              "legendFormat": "Current: {{`{{container_name}}`}}",
+              "refId": "A"
+            },
+            {
+              "expr": "sum by(container) (kube_pod_container_resource_requests{namespace=\"$namespace\", resource=\"memory\", pod=\"$pod\"})",
+              "interval": "",
+              "legendFormat": "Requests: {{`{{container}}`}}",
+              "refId": "B"
+            },
+            {
+              "expr": "sum by(container) (kube_pod_container_resource_limits{namespace=\"$namespace\", resource=\"memory\", pod=\"$pod\"})",
+              "interval": "",
+              "legendFormat": "Limit: {{`{{ container }}`}}",
+              "refId": "C"
+            },
+            {
+              "expr": "sum by(container) (container_memory_cache{ namespace=\"$namespace\", pod=~\"$pod\", container!=\"POD\"})",
+              "interval": "",
+              "legendFormat": "Cache: {{`{{ container }}`}}",
+              "refId": "D"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeRegions": [],
+          "timeShift": null,
+          "title": "Memory Usage",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "bytes",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": null,
+          "fieldConfig": {
+            "defaults": {
+              "custom": {}
+            },
+            "overrides": []
+          },
+          "fill": 1,
+          "fillGradient": 0,
+          "gridPos": {
+            "h": 9,
+            "w": 12,
+            "x": 12,
+            "y": 3
+          },
+          "hiddenSeries": false,
+          "id": 8,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "nullPointMode": "null",
+          "options": {
+            "dataLinks": []
+          },
+          "percentage": false,
+          "pointradius": 2,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "sum by (container) (irate(container_cpu_usage_seconds_total{namespace=\"$namespace\", image!=\"\", pod=\"$pod\", container!=\"POD\"}[4m]))",
+              "interval": "",
+              "legendFormat": "Current: {{`{{ container }}`}}",
+              "refId": "A"
+            },
+            {
+              "expr": "sum by(container) (kube_pod_container_resource_requests{namespace=\"$namespace\", resource=\"cpu\", pod=\"$pod\"})",
+              "interval": "",
+              "legendFormat": "Requested: {{`{{ container }}`}}",
+              "refId": "B"
+            },
+            {
+              "expr": "sum by(container) (kube_pod_container_resource_limits{namespace=\"$namespace\", resource=\"cpu\", pod=\"$pod\"})",
+              "interval": "",
+              "legendFormat": "Limit: {{`{{ container }}`}}",
+              "refId": "C"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeRegions": [],
+          "timeShift": null,
+          "title": "CPU Usage",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": "0",
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": "0",
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": null,
+          "fieldConfig": {
+            "defaults": {
+              "custom": {}
+            },
+            "overrides": []
+          },
+          "fill": 1,
+          "fillGradient": 0,
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 12
+          },
+          "hiddenSeries": false,
+          "id": 6,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "nullPointMode": "null",
+          "options": {
+            "dataLinks": []
+          },
+          "percentage": false,
+          "pointradius": 2,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "sort_desc(sum by (pod) (irate(container_network_receive_bytes_total{namespace=\"$namespace\", pod=\"$pod\"}[4m])))",
+              "interval": "",
+              "legendFormat": "RX: {{`{{ pod }}`}}",
+              "refId": "A"
+            },
+            {
+              "expr": "sort_desc(sum by (pod) (irate(container_network_transmit_bytes_total{namespace=\"$namespace\", pod=\"$pod\"}[4m])))",
+              "interval": "",
+              "legendFormat": "TX: {{`{{ pod }}`}}",
+              "refId": "B"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeRegions": [],
+          "timeShift": null,
+          "title": "Network I/O",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": null,
+          "fieldConfig": {
+            "defaults": {
+              "custom": {}
+            },
+            "overrides": []
+          },
+          "fill": 1,
+          "fillGradient": 0,
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 12
+          },
+          "hiddenSeries": false,
+          "id": 10,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "nullPointMode": "null",
+          "options": {
+            "dataLinks": []
+          },
+          "percentage": false,
+          "pointradius": 2,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "max by (container) (kube_pod_container_status_restarts_total{ namespace=\"$namespace\", pod=\"$pod\"})",
+              "interval": "",
+              "legendFormat": "Restarts: {{`{{ container }}`}}",
+              "refId": "A"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeRegions": [],
+          "timeShift": null,
+          "title": "Total Restarts Per Container",
+          "tooltip": {
+            "shared": false,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": "0",
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": "0",
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
+        },
+        {
+          "collapsed": false,
+          "datasource": null,
+          "gridPos": {
+            "h": 1,
+            "w": 24,
+            "x": 0,
+            "y": 20
+          },
+          "id": 21,
+          "panels": [],
+          "title": "Golang Metrics",
+          "type": "row"
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": null,
+          "fieldConfig": {
+            "defaults": {
+              "custom": {}
+            },
+            "overrides": []
+          },
+          "fill": 1,
+          "fillGradient": 0,
+          "gridPos": {
+            "h": 8,
+            "w": 8,
+            "x": 0,
+            "y": 21
+          },
+          "hiddenSeries": false,
+          "id": 23,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "nullPointMode": "null",
+          "options": {
+            "dataLinks": []
+          },
+          "percentage": false,
+          "pointradius": 2,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "go_gc_duration_seconds{namespace=\"$namespace\", pod=\"$pod\"}",
+              "interval": "",
+              "legendFormat": "{{`{{quantile}}`}}",
+              "refId": "A"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeRegions": [],
+          "timeShift": null,
+          "title": "GC duration [s]",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": null,
+          "fieldConfig": {
+            "defaults": {
+              "custom": {}
+            },
+            "overrides": []
+          },
+          "fill": 1,
+          "fillGradient": 0,
+          "gridPos": {
+            "h": 8,
+            "w": 8,
+            "x": 8,
+            "y": 21
+          },
+          "hiddenSeries": false,
+          "id": 25,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "nullPointMode": "null",
+          "options": {
+            "dataLinks": []
+          },
+          "percentage": false,
+          "pointradius": 2,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "process_open_fds{namespace=\"$namespace\", pod=\"$pod\"}",
+              "interval": "",
+              "legendFormat": "{{`{{pod}}`}}",
+              "refId": "A"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeRegions": [],
+          "timeShift": null,
+          "title": "open fds",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": null,
+          "fieldConfig": {
+            "defaults": {
+              "custom": {}
+            },
+            "overrides": []
+          },
+          "fill": 1,
+          "fillGradient": 0,
+          "gridPos": {
+            "h": 8,
+            "w": 8,
+            "x": 16,
+            "y": 21
+          },
+          "hiddenSeries": false,
+          "id": 27,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "nullPointMode": "null",
+          "options": {
+            "dataLinks": []
+          },
+          "percentage": false,
+          "pointradius": 2,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "go_threads{namespace=\"$namespace\", pod=\"$pod\"}",
+              "interval": "",
+              "legendFormat": "{{`{{pod}}`}}",
+              "refId": "A"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeRegions": [],
+          "timeShift": null,
+          "title": "Gothreads",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": null,
+          "fieldConfig": {
+            "defaults": {
+              "custom": {}
+            },
+            "overrides": []
+          },
+          "fill": 1,
+          "fillGradient": 0,
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 29
+          },
+          "hiddenSeries": false,
+          "id": 29,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "nullPointMode": "null",
+          "options": {
+            "dataLinks": []
+          },
+          "percentage": false,
+          "pointradius": 2,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "go_memstats_alloc_bytes{namespace=\"$namespace\", pod=\"$pod\"}",
+              "interval": "",
+              "legendFormat": "bytes allocated",
+              "refId": "A"
+            },
+            {
+              "expr": "rate(go_memstats_alloc_bytes_total{namespace=\"$namespace\", pod=\"$pod\"}[30s])",
+              "interval": "",
+              "legendFormat": "alloc rate",
+              "refId": "B"
+            },
+            {
+              "expr": "go_memstats_stack_inuse_bytes{namespace=\"$namespace\", pod=\"$pod\"}",
+              "interval": "",
+              "intervalFactor": 1,
+              "legendFormat": "stack inuse",
+              "refId": "C"
+            },
+            {
+              "expr": "go_memstats_heap_inuse_bytes{namespace=\"$namespace\", pod=\"$pod\"}",
+              "interval": "",
+              "intervalFactor": 1,
+              "legendFormat": "heap inuse",
+              "refId": "D"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeRegions": [],
+          "timeShift": null,
+          "title": "go memstats",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "bytes",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "Bps",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": null,
+          "fieldConfig": {
+            "defaults": {
+              "custom": {}
+            },
+            "overrides": []
+          },
+          "fill": 1,
+          "fillGradient": 0,
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 29
+          },
+          "hiddenSeries": false,
+          "id": 31,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "nullPointMode": "null",
+          "options": {
+            "dataLinks": []
+          },
+          "percentage": false,
+          "pointradius": 2,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "go_goroutines{namespace=\"$namespace\", pod=\"$pod\"}",
+              "interval": "",
+              "legendFormat": "{{`{{pod}}`}}",
+              "refId": "A"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeRegions": [],
+          "timeShift": null,
+          "title": "Goroutines",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
+        },
+        {
+          "collapsed": false,
+          "datasource": null,
+          "gridPos": {
+            "h": 1,
+            "w": 24,
+            "x": 0,
+            "y": 37
+          },
+          "id": 12,
+          "panels": [],
+          "title": "Logs",
+          "type": "row"
+        },
+        {
+          "datasource": "Loki",
+          "fieldConfig": {
+            "defaults": {
+              "custom": {}
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 24,
+            "x": 0,
+            "y": 38
+          },
+          "id": 14,
+          "options": {
+            "showLabels": false,
+            "showTime": true,
+            "sortOrder": "Descending",
+            "wrapLogMessage": true
+          },
+          "targets": [
+            {
+              "expr": "{namespace=\"$namespace\", instance=\"$pod\"}",
+              "refId": "A"
+            }
+          ],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "Logs",
+          "type": "logs"
+        }
+      ],
+      "refresh": "10s",
+      "schemaVersion": 25,
+      "style": "dark",
+      "tags": [
+        "kyma"
+      ],
+      "templating": {
+        "list": [
+          {
+            "allValue": null,
+            "current": {
+              "selected": false,
+              "text": "kyma-system",
+              "value": "kyma-system"
+            },
+            "datasource": "Prometheus",
+            "definition": "label_values(kube_pod_labels{label_kyma_project_io_component=\"backend\"},namespace)",
+            "hide": 0,
+            "includeAll": false,
+            "label": null,
+            "multi": false,
+            "name": "namespace",
+            "options": [],
+            "query": "label_values(kube_pod_labels{label_kyma_project_io_component=\"backend\"},namespace)",
+            "refresh": 1,
+            "regex": "",
+            "skipUrlSync": false,
+            "sort": 1,
+            "tagValuesQuery": "",
+            "tags": [],
+            "tagsQuery": "",
+            "type": "query",
+            "useTags": false
+          },
+          {
+            "allValue": null,
+            "current": {
+              "selected": true,
+              "text": "apiserver-proxy-669774b74c-wp9qj",
+              "value": "apiserver-proxy-669774b74c-wp9qj"
+            },
+            "datasource": "Prometheus",
+            "definition": "label_values(kube_pod_labels{label_kyma_project_io_component=\"backend\",namespace=\"$namespace\"},pod)",
+            "hide": 0,
+            "includeAll": false,
+            "label": null,
+            "multi": false,
+            "name": "pod",
+            "options": [],
+            "query": "label_values(kube_pod_labels{label_kyma_project_io_component=\"backend\",namespace=\"$namespace\"},pod)",
+            "refresh": 1,
+            "regex": "",
+            "skipUrlSync": false,
+            "sort": 1,
+            "tagValuesQuery": "",
+            "tags": [],
+            "tagsQuery": "",
+            "type": "query",
+            "useTags": false
+          }
+        ]
+      },
+      "time": {
+        "from": "now-1h",
+        "to": "now"
+      },
+      "timepicker": {
+        "hidden": false,
+        "refresh_intervals": [
+          "5s",
+          "10s",
+          "30s",
+          "1m",
+          "5m",
+          "15m",
+          "30m",
+          "1h",
+          "2h",
+          "1d"
+        ]
+      },
+      "timezone": "",
+      "title": "Kyma / Components / Backends",
+      "uid": "WK_q8xdMo",
+      "version": 2
+    }

--- a/resources/monitoring/templates/grafana/kyma-dashboards/kyma-controllers.yaml
+++ b/resources/monitoring/templates/grafana/kyma-dashboards/kyma-controllers.yaml
@@ -1,0 +1,1114 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: monitoring-kyma-controllers-dashboard
+  labels:
+    grafana_dashboard: "1"
+    app: monitoring-grafana
+data:
+  kyma-controllers-dashboard.json: |-
+    {
+      "annotations": {
+        "list": [
+          {
+            "builtIn": 1,
+            "datasource": "-- Grafana --",
+            "enable": true,
+            "hide": true,
+            "iconColor": "rgba(0, 211, 255, 1)",
+            "name": "Annotations & Alerts",
+            "type": "dashboard"
+          }
+        ]
+      },
+      "editable": false,
+      "gnetId": null,
+      "graphTooltip": 0,
+      "id": 58,
+      "iteration": 1600435026453,
+      "links": [],
+      "panels": [
+        {
+          "content": "\nAll pods having label `kyma-project.io/component: controller`\n\n",
+          "datasource": null,
+          "fieldConfig": {
+            "defaults": {
+              "custom": {}
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 2,
+            "w": 12,
+            "x": 0,
+            "y": 0
+          },
+          "id": 28,
+          "mode": "markdown",
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "Note",
+          "type": "text"
+        },
+        {
+          "collapsed": false,
+          "datasource": null,
+          "gridPos": {
+            "h": 1,
+            "w": 24,
+            "x": 0,
+            "y": 2
+          },
+          "id": 4,
+          "panels": [],
+          "title": "Pod Metrics",
+          "type": "row"
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": null,
+          "fieldConfig": {
+            "defaults": {
+              "custom": {}
+            },
+            "overrides": []
+          },
+          "fill": 1,
+          "fillGradient": 0,
+          "gridPos": {
+            "h": 9,
+            "w": 12,
+            "x": 0,
+            "y": 3
+          },
+          "hiddenSeries": false,
+          "id": 2,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 2,
+          "nullPointMode": "null",
+          "options": {
+            "dataLinks": []
+          },
+          "percentage": false,
+          "pointradius": 2,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "sum by(container) (container_memory_usage_bytes{namespace=\"$namespace\", pod=\"$pod\", container_name!=\"POD\",container!=\"\"})",
+              "interval": "",
+              "legendFormat": "Current: {{`{{container_name}}`}}",
+              "refId": "A"
+            },
+            {
+              "expr": "sum by(container) (kube_pod_container_resource_requests{namespace=\"$namespace\", resource=\"memory\", pod=\"$pod\"})",
+              "interval": "",
+              "legendFormat": "Requests: {{`{{container}}`}}",
+              "refId": "B"
+            },
+            {
+              "expr": "sum by(container) (kube_pod_container_resource_limits{namespace=\"$namespace\", resource=\"memory\", pod=\"$pod\"})",
+              "interval": "",
+              "legendFormat": "Limit: {{`{{ container }}`}}",
+              "refId": "C"
+            },
+            {
+              "expr": "sum by(container) (container_memory_cache{ namespace=\"$namespace\", pod=~\"$pod\", container!=\"POD\"})",
+              "interval": "",
+              "legendFormat": "Cache: {{`{{ container }}`}}",
+              "refId": "D"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeRegions": [],
+          "timeShift": null,
+          "title": "Memory Usage",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "bytes",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": null,
+          "fieldConfig": {
+            "defaults": {
+              "custom": {}
+            },
+            "overrides": []
+          },
+          "fill": 1,
+          "fillGradient": 0,
+          "gridPos": {
+            "h": 9,
+            "w": 12,
+            "x": 12,
+            "y": 3
+          },
+          "hiddenSeries": false,
+          "id": 8,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "nullPointMode": "null",
+          "options": {
+            "dataLinks": []
+          },
+          "percentage": false,
+          "pointradius": 2,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "sum by (container) (irate(container_cpu_usage_seconds_total{namespace=\"$namespace\", image!=\"\", pod=\"$pod\", container!=\"POD\"}[4m]))",
+              "interval": "",
+              "legendFormat": "Current: {{`{{ container }}`}}",
+              "refId": "A"
+            },
+            {
+              "expr": "sum by(container) (kube_pod_container_resource_requests{namespace=\"$namespace\", resource=\"cpu\", pod=\"$pod\"})",
+              "interval": "",
+              "legendFormat": "Requested: {{`{{ container }}`}}",
+              "refId": "B"
+            },
+            {
+              "expr": "sum by(container) (kube_pod_container_resource_limits{namespace=\"$namespace\", resource=\"cpu\", pod=\"$pod\"})",
+              "interval": "",
+              "legendFormat": "Limit: {{`{{ container }}`}}",
+              "refId": "C"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeRegions": [],
+          "timeShift": null,
+          "title": "CPU Usage",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": "0",
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": "0",
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": null,
+          "fieldConfig": {
+            "defaults": {
+              "custom": {}
+            },
+            "overrides": []
+          },
+          "fill": 1,
+          "fillGradient": 0,
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 12
+          },
+          "hiddenSeries": false,
+          "id": 6,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "nullPointMode": "null",
+          "options": {
+            "dataLinks": []
+          },
+          "percentage": false,
+          "pointradius": 2,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "sort_desc(sum by (pod) (irate(container_network_receive_bytes_total{namespace=\"$namespace\", pod=\"$pod\"}[4m])))",
+              "interval": "",
+              "legendFormat": "RX: {{`{{ pod }}`}}",
+              "refId": "A"
+            },
+            {
+              "expr": "sort_desc(sum by (pod) (irate(container_network_transmit_bytes_total{namespace=\"$namespace\", pod=\"$pod\"}[4m])))",
+              "interval": "",
+              "legendFormat": "TX: {{`{{ pod }}`}}",
+              "refId": "B"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeRegions": [],
+          "timeShift": null,
+          "title": "Network I/O",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": null,
+          "fieldConfig": {
+            "defaults": {
+              "custom": {}
+            },
+            "overrides": []
+          },
+          "fill": 1,
+          "fillGradient": 0,
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 12
+          },
+          "hiddenSeries": false,
+          "id": 10,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "nullPointMode": "null",
+          "options": {
+            "dataLinks": []
+          },
+          "percentage": false,
+          "pointradius": 2,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "max by (container) (kube_pod_container_status_restarts_total{ namespace=\"$namespace\", pod=\"$pod\"})",
+              "interval": "",
+              "legendFormat": "Restarts: {{`{{ container }}`}}",
+              "refId": "A"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeRegions": [],
+          "timeShift": null,
+          "title": "Total Restarts Per Container",
+          "tooltip": {
+            "shared": false,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": "0",
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": "0",
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
+        },
+        {
+          "collapsed": true,
+          "datasource": null,
+          "gridPos": {
+            "h": 1,
+            "w": 24,
+            "x": 0,
+            "y": 20
+          },
+          "id": 16,
+          "panels": [],
+          "title": "Golang Metrics",
+          "type": "row"
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": null,
+          "fieldConfig": {
+            "defaults": {
+              "custom": {}
+            },
+            "overrides": []
+          },
+          "fill": 1,
+          "fillGradient": 0,
+          "gridPos": {
+            "h": 8,
+            "w": 8,
+            "x": 0,
+            "y": 21
+          },
+          "hiddenSeries": false,
+          "id": 18,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "nullPointMode": "null",
+          "options": {
+            "dataLinks": []
+          },
+          "percentage": false,
+          "pointradius": 2,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "go_gc_duration_seconds{namespace=\"$namespace\", pod=\"$pod\"}",
+              "interval": "",
+              "legendFormat": "{{`{{quantile}}`}}",
+              "refId": "A"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeRegions": [],
+          "timeShift": null,
+          "title": "GC duration [s]",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": null,
+          "fieldConfig": {
+            "defaults": {
+              "custom": {}
+            },
+            "overrides": []
+          },
+          "fill": 1,
+          "fillGradient": 0,
+          "gridPos": {
+            "h": 8,
+            "w": 8,
+            "x": 8,
+            "y": 21
+          },
+          "hiddenSeries": false,
+          "id": 20,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "nullPointMode": "null",
+          "options": {
+            "dataLinks": []
+          },
+          "percentage": false,
+          "pointradius": 2,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "process_open_fds{namespace=\"$namespace\", pod=\"$pod\"}",
+              "interval": "",
+              "legendFormat": "{{`{{pod}}`}}",
+              "refId": "A"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeRegions": [],
+          "timeShift": null,
+          "title": "open fds",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": null,
+          "fieldConfig": {
+            "defaults": {
+              "custom": {}
+            },
+            "overrides": []
+          },
+          "fill": 1,
+          "fillGradient": 0,
+          "gridPos": {
+            "h": 8,
+            "w": 8,
+            "x": 16,
+            "y": 21
+          },
+          "hiddenSeries": false,
+          "id": 22,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "nullPointMode": "null",
+          "options": {
+            "dataLinks": []
+          },
+          "percentage": false,
+          "pointradius": 2,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "go_threads{namespace=\"$namespace\", pod=\"$pod\"}",
+              "interval": "",
+              "legendFormat": "{{`{{pod}}`}}",
+              "refId": "A"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeRegions": [],
+          "timeShift": null,
+          "title": "Gothreads",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": null,
+          "fieldConfig": {
+            "defaults": {
+              "custom": {}
+            },
+            "overrides": []
+          },
+          "fill": 1,
+          "fillGradient": 0,
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 29
+          },
+          "hiddenSeries": false,
+          "id": 25,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "nullPointMode": "null",
+          "options": {
+            "dataLinks": []
+          },
+          "percentage": false,
+          "pointradius": 2,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "go_memstats_alloc_bytes{namespace=\"$namespace\", pod=\"$pod\"}",
+              "interval": "",
+              "legendFormat": "bytes allocated",
+              "refId": "A"
+            },
+            {
+              "expr": "rate(go_memstats_alloc_bytes_total{namespace=\"$namespace\", pod=\"$pod\"}[30s])",
+              "interval": "",
+              "legendFormat": "alloc rate",
+              "refId": "B"
+            },
+            {
+              "expr": "go_memstats_stack_inuse_bytes{namespace=\"$namespace\", pod=\"$pod\"}",
+              "interval": "",
+              "intervalFactor": 1,
+              "legendFormat": "stack inuse",
+              "refId": "C"
+            },
+            {
+              "expr": "go_memstats_heap_inuse_bytes{namespace=\"$namespace\", pod=\"$pod\"}",
+              "interval": "",
+              "intervalFactor": 1,
+              "legendFormat": "heap inuse",
+              "refId": "D"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeRegions": [],
+          "timeShift": null,
+          "title": "go memstats",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "bytes",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "Bps",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": null,
+          "fieldConfig": {
+            "defaults": {
+              "custom": {}
+            },
+            "overrides": []
+          },
+          "fill": 1,
+          "fillGradient": 0,
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 29
+          },
+          "hiddenSeries": false,
+          "id": 26,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "nullPointMode": "null",
+          "options": {
+            "dataLinks": []
+          },
+          "percentage": false,
+          "pointradius": 2,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "go_goroutines{namespace=\"$namespace\", pod=\"$pod\"}",
+              "interval": "",
+              "legendFormat": "{{`{{pod}}`}}",
+              "refId": "A"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeRegions": [],
+          "timeShift": null,
+          "title": "Goroutines",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
+        },
+        {
+          "collapsed": false,
+          "datasource": null,
+          "gridPos": {
+            "h": 1,
+            "w": 24,
+            "x": 0,
+            "y": 37
+          },
+          "id": 12,
+          "panels": [],
+          "title": "Pod Logs",
+          "type": "row"
+        },
+        {
+          "datasource": "Loki",
+          "fieldConfig": {
+            "defaults": {
+              "custom": {}
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 24,
+            "x": 0,
+            "y": 38
+          },
+          "id": 14,
+          "options": {
+            "showLabels": false,
+            "showTime": true,
+            "sortOrder": "Descending",
+            "wrapLogMessage": true
+          },
+          "targets": [
+            {
+              "expr": "{namespace=\"$namespace\", instance=\"$pod\"}",
+              "refId": "A"
+            }
+          ],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "Logs",
+          "type": "logs"
+        }
+      ],
+      "refresh": "10s",
+      "schemaVersion": 25,
+      "tags": [
+        "kyma"
+      ],
+      "templating": {
+        "list": [
+          {
+            "allValue": null,
+            "current": {
+              "selected": false,
+              "text": "kyma-system",
+              "value": "kyma-system"
+            },
+            "datasource": "Prometheus",
+            "definition": "label_values(kube_pod_labels{label_kyma_project_io_component=\"controller\"},namespace)",
+            "hide": 0,
+            "includeAll": false,
+            "label": null,
+            "multi": false,
+            "name": "namespace",
+            "options": [],
+            "query": "label_values(kube_pod_labels{label_kyma_project_io_component=\"controller\"},namespace)",
+            "refresh": 1,
+            "regex": "",
+            "skipUrlSync": false,
+            "sort": 1,
+            "tagValuesQuery": "",
+            "tags": [],
+            "tagsQuery": "",
+            "type": "query",
+            "useTags": false
+          },
+          {
+            "allValue": null,
+            "current": {
+              "selected": true,
+              "text": "permission-controller-c5874b79c-8dsqs",
+              "value": "permission-controller-c5874b79c-8dsqs"
+            },
+            "datasource": "Prometheus",
+            "definition": "label_values(kube_pod_labels{label_kyma_project_io_component=\"controller\",namespace=\"$namespace\"},pod)",
+            "hide": 0,
+            "includeAll": false,
+            "label": null,
+            "multi": false,
+            "name": "pod",
+            "options": [],
+            "query": "label_values(kube_pod_labels{label_kyma_project_io_component=\"controller\",namespace=\"$namespace\"},pod)",
+            "refresh": 1,
+            "regex": "",
+            "skipUrlSync": false,
+            "sort": 1,
+            "tagValuesQuery": "",
+            "tags": [],
+            "tagsQuery": "",
+            "type": "query",
+            "useTags": false
+          }
+        ]
+      },
+      "time": {
+        "from": "now-1h",
+        "to": "now"
+      },
+      "timepicker": {
+        "hidden": false,
+        "refresh_intervals": [
+          "5s",
+          "10s",
+          "30s",
+          "1m",
+          "5m",
+          "15m",
+          "30m",
+          "1h",
+          "2h",
+          "1d"
+        ]
+      },
+      "timezone": "",
+      "title": "Kyma / Components / Controllers",
+      "uid": "WK_q8xdMl",
+      "version": 4
+    }

--- a/resources/monitoring/templates/grafana/kyma-dashboards/kyma-frontends.yaml
+++ b/resources/monitoring/templates/grafana/kyma-dashboards/kyma-frontends.yaml
@@ -1,0 +1,610 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: monitoring-kyma-frontends-dashboard
+  labels:
+    grafana_dashboard: "1"
+    app: monitoring-grafana
+data:
+  kyma-frontends-dashboard.json: |-
+    {
+      "annotations": {
+        "list": [
+          {
+            "builtIn": 1,
+            "datasource": "-- Grafana --",
+            "enable": true,
+            "hide": true,
+            "iconColor": "rgba(0, 211, 255, 1)",
+            "name": "Annotations & Alerts",
+            "type": "dashboard"
+          }
+        ]
+      },
+      "editable": false,
+      "gnetId": null,
+      "graphTooltip": 0,
+      "id": 57,
+      "iteration": 1600434829873,
+      "links": [],
+      "panels": [
+        {
+          "content": "\nAll pods having label `kyma-project.io/component: frontend`\n\n",
+          "datasource": null,
+          "fieldConfig": {
+            "defaults": {
+              "custom": {}
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 2,
+            "w": 12,
+            "x": 0,
+            "y": 0
+          },
+          "id": 16,
+          "mode": "markdown",
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "Note",
+          "type": "text"
+        },
+        {
+          "collapsed": false,
+          "datasource": null,
+          "gridPos": {
+            "h": 1,
+            "w": 24,
+            "x": 0,
+            "y": 2
+          },
+          "id": 4,
+          "panels": [],
+          "title": "Pod Metrics",
+          "type": "row"
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": null,
+          "fieldConfig": {
+            "defaults": {
+              "custom": {}
+            },
+            "overrides": []
+          },
+          "fill": 1,
+          "fillGradient": 0,
+          "gridPos": {
+            "h": 9,
+            "w": 12,
+            "x": 0,
+            "y": 3
+          },
+          "hiddenSeries": false,
+          "id": 2,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 2,
+          "nullPointMode": "null",
+          "options": {
+            "dataLinks": []
+          },
+          "percentage": false,
+          "pointradius": 2,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "sum by(container) (container_memory_usage_bytes{namespace=\"$namespace\", pod=\"$pod\", container_name!=\"POD\",container!=\"\"})",
+              "interval": "",
+              "legendFormat": "Current: {{`{{container_name}}`}}",
+              "refId": "A"
+            },
+            {
+              "expr": "sum by(container) (kube_pod_container_resource_requests{namespace=\"$namespace\", resource=\"memory\", pod=\"$pod\"})",
+              "interval": "",
+              "legendFormat": "Requests: {{`{{container}}`}}",
+              "refId": "B"
+            },
+            {
+              "expr": "sum by(container) (kube_pod_container_resource_limits{namespace=\"$namespace\", resource=\"memory\", pod=\"$pod\"})",
+              "interval": "",
+              "legendFormat": "Limit: {{`{{ container }}`}}",
+              "refId": "C"
+            },
+            {
+              "expr": "sum by(container) (container_memory_cache{ namespace=\"$namespace\", pod=~\"$pod\", container!=\"POD\"})",
+              "interval": "",
+              "legendFormat": "Cache: {{`{{ container }}`}}",
+              "refId": "D"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeRegions": [],
+          "timeShift": null,
+          "title": "Memory Usage",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "bytes",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": null,
+          "fieldConfig": {
+            "defaults": {
+              "custom": {}
+            },
+            "overrides": []
+          },
+          "fill": 1,
+          "fillGradient": 0,
+          "gridPos": {
+            "h": 9,
+            "w": 12,
+            "x": 12,
+            "y": 3
+          },
+          "hiddenSeries": false,
+          "id": 8,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "nullPointMode": "null",
+          "options": {
+            "dataLinks": []
+          },
+          "percentage": false,
+          "pointradius": 2,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "sum by (container) (irate(container_cpu_usage_seconds_total{namespace=\"$namespace\", image!=\"\", pod=\"$pod\", container!=\"POD\"}[4m]))",
+              "interval": "",
+              "legendFormat": "Current: {{`{{ container }}`}}",
+              "refId": "A"
+            },
+            {
+              "expr": "sum by(container) (kube_pod_container_resource_requests{namespace=\"$namespace\", resource=\"cpu\", pod=\"$pod\"})",
+              "interval": "",
+              "legendFormat": "Requested: {{`{{ container }}`}}",
+              "refId": "B"
+            },
+            {
+              "expr": "sum by(container) (kube_pod_container_resource_limits{namespace=\"$namespace\", resource=\"cpu\", pod=\"$pod\"})",
+              "interval": "",
+              "legendFormat": "Limit: {{`{{ container }}`}}",
+              "refId": "C"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeRegions": [],
+          "timeShift": null,
+          "title": "CPU Usage",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": "0",
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": "0",
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": null,
+          "fieldConfig": {
+            "defaults": {
+              "custom": {}
+            },
+            "overrides": []
+          },
+          "fill": 1,
+          "fillGradient": 0,
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 12
+          },
+          "hiddenSeries": false,
+          "id": 6,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "nullPointMode": "null",
+          "options": {
+            "dataLinks": []
+          },
+          "percentage": false,
+          "pointradius": 2,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "sort_desc(sum by (pod) (irate(container_network_receive_bytes_total{namespace=\"$namespace\", pod=\"$pod\"}[4m])))",
+              "interval": "",
+              "legendFormat": "RX: {{`{{ pod }}`}}",
+              "refId": "A"
+            },
+            {
+              "expr": "sort_desc(sum by (pod) (irate(container_network_transmit_bytes_total{namespace=\"$namespace\", pod=\"$pod\"}[4m])))",
+              "interval": "",
+              "legendFormat": "TX: {{`{{ pod }}`}}",
+              "refId": "B"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeRegions": [],
+          "timeShift": null,
+          "title": "Network I/O",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": null,
+          "fieldConfig": {
+            "defaults": {
+              "custom": {}
+            },
+            "overrides": []
+          },
+          "fill": 1,
+          "fillGradient": 0,
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 12
+          },
+          "hiddenSeries": false,
+          "id": 10,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "nullPointMode": "null",
+          "options": {
+            "dataLinks": []
+          },
+          "percentage": false,
+          "pointradius": 2,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "max by (container) (kube_pod_container_status_restarts_total{ namespace=\"$namespace\", pod=\"$pod\"})",
+              "interval": "",
+              "legendFormat": "Restarts: {{`{{ container }}`}}",
+              "refId": "A"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeRegions": [],
+          "timeShift": null,
+          "title": "Total Restarts Per Container",
+          "tooltip": {
+            "shared": false,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": "0",
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": "0",
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
+        },
+        {
+          "collapsed": false,
+          "datasource": null,
+          "gridPos": {
+            "h": 1,
+            "w": 24,
+            "x": 0,
+            "y": 20
+          },
+          "id": 12,
+          "panels": [],
+          "title": "Logs",
+          "type": "row"
+        },
+        {
+          "datasource": "Loki",
+          "fieldConfig": {
+            "defaults": {
+              "custom": {}
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 24,
+            "x": 0,
+            "y": 21
+          },
+          "id": 14,
+          "options": {
+            "showLabels": false,
+            "showTime": true,
+            "sortOrder": "Descending",
+            "wrapLogMessage": true
+          },
+          "targets": [
+            {
+              "expr": "{namespace=\"$namespace\", instance=\"$pod\"}",
+              "refId": "A"
+            }
+          ],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "Logs",
+          "type": "logs"
+        }
+      ],
+      "refresh": "10s",
+      "schemaVersion": 25,
+      "tags": [
+        "kyma"
+      ],
+      "templating": {
+        "list": [
+          {
+            "allValue": null,
+            "current": {
+              "selected": false,
+              "text": "kyma-system",
+              "value": "kyma-system"
+            },
+            "datasource": "Prometheus",
+            "definition": "label_values(kube_pod_labels{label_kyma_project_io_component=\"frontend\"},namespace)",
+            "hide": 0,
+            "includeAll": false,
+            "label": null,
+            "multi": false,
+            "name": "namespace",
+            "options": [],
+            "query": "label_values(kube_pod_labels{label_kyma_project_io_component=\"frontend\"},namespace)",
+            "refresh": 1,
+            "regex": "",
+            "skipUrlSync": false,
+            "sort": 1,
+            "tagValuesQuery": "",
+            "tags": [],
+            "tagsQuery": "",
+            "type": "query",
+            "useTags": false
+          },
+          {
+            "allValue": null,
+            "current": {
+              "selected": true,
+              "text": "helm-broker-addons-ui-7bf8767656-h2j2l",
+              "value": "helm-broker-addons-ui-7bf8767656-h2j2l"
+            },
+            "datasource": "Prometheus",
+            "definition": "label_values(kube_pod_labels{label_kyma_project_io_component=\"frontend\",namespace=\"$namespace\"},pod)",
+            "hide": 0,
+            "includeAll": false,
+            "label": null,
+            "multi": false,
+            "name": "pod",
+            "options": [],
+            "query": "label_values(kube_pod_labels{label_kyma_project_io_component=\"frontend\",namespace=\"$namespace\"},pod)",
+            "refresh": 1,
+            "regex": "",
+            "skipUrlSync": false,
+            "sort": 1,
+            "tagValuesQuery": "",
+            "tags": [],
+            "tagsQuery": "",
+            "type": "query",
+            "useTags": false
+          }
+        ]
+      },
+      "time": {
+        "from": "now-1h",
+        "to": "now"
+      },
+      "timepicker": {
+        "hidden": false,
+        "refresh_intervals": [
+          "5s",
+          "10s",
+          "30s",
+          "1m",
+          "5m",
+          "15m",
+          "30m",
+          "1h",
+          "2h",
+          "1d"
+        ]
+      },
+      "timezone": "",
+      "title": "Kyma / Components / Frontends",
+      "uid": "WK_q8xdMk",
+      "version": 10
+    }

--- a/resources/monitoring/templates/prometheus/kyma-rules/kyma-rules.yaml
+++ b/resources/monitoring/templates/prometheus/kyma-rules/kyma-rules.yaml
@@ -57,24 +57,6 @@ spec:
       annotations:
         description: "{{`{{ $labels.namespace }}`}}/{{`{{ $labels.pod }}`}} is not running"
         summary: "{{`{{ $labels.pod }}`}} is not running"
-  - name: cpu-90-percent-usage-rule
-    rules:
-    - alert: CPU90PercentUsage
-      expr:   sum (rate(container_cpu_usage_seconds_total{namespace=~"kyma-system|natss"}[2m])) by (pod) * on(pod) group_left(app) label_replace(max(kube_pod_labels{label_alertcpu="yes"}) by (pod), "pod", "$1", "pod", "(.*)") * 100 > 90
-      for: 10m
-      labels:
-        severity: critical
-      annotations:
-        message:  "Pod {{`{{$labels.pod}}`}} in namespace: {{`{{ $labels.namespace }}`}} is having {{`{{$value}}`}} % usage"
-  - name: mem-90-percent-usage-rule
-    rules:
-    - alert: MEM90PercentUsage
-      expr:   sum(container_memory_working_set_bytes{namespace=~"kyma-system|natss"}) by (pod) / sum(label_join(kube_pod_container_resource_limits_memory_bytes, "pod", "", "pod")) by (pod)  * on(pod) group_left(app)   label_replace(max(kube_pod_labels{label_alertmem="yes"}) by (pod), "pod", "$1", "pod", "(.*)") * 100 > 90
-      for: 10m
-      labels:
-        severity: critical
-      annotations:
-        message:  "Pod {{`{{$labels.pod}}`}} in namespace: {{`{{ $labels.namespace }}`}} is having {{`{{$value}}`}} % usage"
   - name: pvc-90-percent-full-rule
     rules:
     - alert: PVC90PercentFull

--- a/resources/nats-streaming/templates/_helpers.tpl
+++ b/resources/nats-streaming/templates/_helpers.tpl
@@ -20,16 +20,4 @@ app.kubernetes.io/name: {{ .Values.global.natsStreaming.fullname }}
 app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end -}}
 
-{{- /*
-nats-streaming.labels.kyma prints Kyma-specific labels.
-
-Kyma labels are set on various objects to integrate with other technical components (monitoring, ...).
-*/ -}}
-{{- define "nats-streaming.labels.kyma" -}}
-kyma-grafana: {{ .Values.monitoring.grafana }}
-kyma-alerts: {{ .Values.monitoring.alerts }}
-alertcpu: {{ .Values.monitoring.alertcpu | quote }}
-alertmem: {{ .Values.monitoring.alertmem | quote }}
-{{- end -}}
-
 {{/* vim: set filetype=mustache: */}}

--- a/resources/nats-streaming/templates/statefulset.yaml
+++ b/resources/nats-streaming/templates/statefulset.yaml
@@ -20,7 +20,6 @@ spec:
         sidecar.istio.io/inject: "false"
       labels:
 {{ include "nats-streaming.labels.standard" . | indent 8 }}
-{{ include "nats-streaming.labels.kyma" . | indent 8 }}
         rand: {{ randAlpha 6 }}
     spec:
       initContainers:

--- a/resources/nats-streaming/values.yaml
+++ b/resources/nats-streaming/values.yaml
@@ -65,8 +65,3 @@ configurationFiles:
     # authorization {} it handled via init container+secrets. don't extend here
   stan.conf: |
     # content of configuration file used to override default NATS Streaming server settings
-monitoring:
-  grafana: enabled
-  alerts: enabled
-  alertcpu: 'yes'
-  alertmem: 'yes'

--- a/resources/permission-controller/templates/deployment.yaml
+++ b/resources/permission-controller/templates/deployment.yaml
@@ -3,6 +3,7 @@ kind: Deployment
 metadata:
   name: {{ include "namespace-permission-controller.fullname" . }}
   labels:
+    kyma-project.io/component: controller
 {{ include "namespace-permission-controller.labels" . | indent 4 }}
 spec:
   replicas: {{ .Values.deployment.replicaCount }}
@@ -18,6 +19,7 @@ spec:
       labels:
         app: {{ include "namespace-permission-controller.name" . }}
         release: {{ .Release.Name }}
+        kyma-project.io/component: controller
     spec:
       containers:
         - name: {{ .Chart.Name }}

--- a/resources/rafter/charts/asyncapi-service/templates/deployment.yaml
+++ b/resources/rafter/charts/asyncapi-service/templates/deployment.yaml
@@ -7,6 +7,7 @@ metadata:
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
     helm.sh/chart: {{ include "rafterAsyncAPIService.chart" . }}
+    kyma-project.io/component: backend
   {{- if .Values.deployment.labels }}
     {{ include "rafterAsyncAPIService.tplValue" ( dict "value" .Values.deployment.labels "context" . ) | nindent 4 }}
   {{- end }}
@@ -31,6 +32,7 @@ spec:
         app.kubernetes.io/instance: {{ .Release.Name }}
         app.kubernetes.io/managed-by: {{ .Release.Service }}
         helm.sh/chart: {{ include "rafterAsyncAPIService.chart" . }}
+        kyma-project.io/component: backend
       {{- if .Values.pod.labels }}
         {{ include "rafterAsyncAPIService.tplValue" ( dict "value" .Values.pod.labels "context" . ) | nindent 8 }}
       {{- end }}

--- a/resources/rafter/charts/controller-manager/templates/deployment.yaml
+++ b/resources/rafter/charts/controller-manager/templates/deployment.yaml
@@ -8,6 +8,7 @@ metadata:
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
     helm.sh/chart: {{ include "rafter.chart" . }}
+    kyma-project.io/component: controller
   {{- if .Values.deployment.labels }}
     {{ include "rafter.tplValue" ( dict "value" .Values.deployment.labels "context" . ) | nindent 4 }}
   {{- end }}
@@ -31,6 +32,7 @@ spec:
         app.kubernetes.io/instance: {{ .Release.Name }}
         app.kubernetes.io/managed-by: {{ .Release.Service }}
         helm.sh/chart: {{ include "rafter.chart" . }}
+        kyma-project.io/component: controller
       {{- if .Values.pod.labels }}
         {{ include "rafter.tplValue" ( dict "value" .Values.pod.labels "context" . ) | nindent 8 }}
       {{- end }}

--- a/resources/rafter/charts/front-matter-service/templates/deployment.yaml
+++ b/resources/rafter/charts/front-matter-service/templates/deployment.yaml
@@ -7,6 +7,7 @@ metadata:
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
     helm.sh/chart: {{ include "rafterFrontMatterService.chart" . }}
+    kyma-project.io/component: backend
   {{- if .Values.deployment.labels }}
     {{ include "rafterFrontMatterService.tplValue" ( dict "value" .Values.deployment.labels "context" . ) | nindent 4 }}
   {{- end }}
@@ -30,6 +31,7 @@ spec:
         app.kubernetes.io/instance: {{ .Release.Name }}
         app.kubernetes.io/managed-by: {{ .Release.Service }}
         helm.sh/chart: {{ include "rafterFrontMatterService.chart" . }}
+        kyma-project.io/component: backend
       {{- if .Values.pod.labels }}
         {{ include "rafterFrontMatterService.tplValue" ( dict "value" .Values.pod.labels "context" . ) | nindent 8 }}
       {{- end }}

--- a/resources/rafter/charts/upload-service/templates/deployment.yaml
+++ b/resources/rafter/charts/upload-service/templates/deployment.yaml
@@ -7,6 +7,7 @@ metadata:
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
     helm.sh/chart: {{ include "rafterUploadService.chart" . }}
+    kyma-project.io/component: backend
   {{- if .Values.deployment.labels }}
     {{ include "rafterUploadService.tplValue" ( dict "value" .Values.deployment.labels "context" . ) | nindent 4 }}
   {{- end }}
@@ -30,6 +31,7 @@ spec:
         app.kubernetes.io/instance: {{ .Release.Name }}
         app.kubernetes.io/managed-by: {{ .Release.Service }}
         helm.sh/chart: {{ include "rafterUploadService.chart" . }}
+        kyma-project.io/component: backend
       {{- if .Values.pod.labels }}
         {{ include "rafterUploadService.tplValue" ( dict "value" .Values.pod.labels "context" . ) | nindent 8 }}
       {{- end }}

--- a/resources/serverless/templates/deployment.yaml
+++ b/resources/serverless/templates/deployment.yaml
@@ -4,6 +4,7 @@ metadata:
   name: {{ template "fullname" . }}-ctrl-mngr
   namespace: {{ .Release.Namespace }}
   labels:
+    kyma-project.io/component: controller
     {{- include "tplValue" ( dict "value" .Values.global.commonLabels "context" . ) | nindent 4 }}
   {{- if .Values.deployment.labels }}
     {{- include "tplValue" ( dict "value" .Values.deployment.labels "context" . ) | nindent 4 }}
@@ -28,6 +29,7 @@ spec:
         app: {{ template "name" . }}
         app.kubernetes.io/name: {{ template "name" . }}
         app.kubernetes.io/instance: "{{ .Release.Name }}"
+        kyma-project.io/component: controller
       {{- if .Values.pod.labels }}
         {{ include "tplValue" ( dict "value" .Values.pod.labels "context" . ) | nindent 8 }}
       {{- end }}

--- a/resources/service-catalog-addons/charts/service-binding-usage-controller/templates/deployment.yaml
+++ b/resources/service-catalog-addons/charts/service-binding-usage-controller/templates/deployment.yaml
@@ -7,6 +7,7 @@ metadata:
     chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
+    kyma-project.io/component: controller
 spec:
   replicas: {{ .Values.replicaCount }}
   selector:
@@ -20,6 +21,7 @@ spec:
       labels:
         app: {{ template "fullname" . }}
         release: {{ .Release.Name }}
+        kyma-project.io/component: controller
     spec:
       serviceAccountName: {{ template "fullname" . }}
       {{- with .Values.securityContext }}

--- a/resources/service-catalog-addons/charts/service-catalog-ui/templates/deployment.yaml
+++ b/resources/service-catalog-addons/charts/service-catalog-ui/templates/deployment.yaml
@@ -7,6 +7,7 @@ metadata:
     chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
+    kyma-project.io/component: frontend
 spec:
   selector:
     matchLabels:
@@ -20,6 +21,7 @@ spec:
       labels:
         app: {{ template "name" . }}
         release: {{ .Release.Name }}
+        kyma-project.io/component: frontend
     spec:
       containers:
         - name: {{ .Chart.Name }}

--- a/resources/service-manager-proxy/templates/deployment.yaml
+++ b/resources/service-manager-proxy/templates/deployment.yaml
@@ -7,6 +7,7 @@ metadata:
     chart: {{ template "service-broker-proxy.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
+    kyma-project.io/component: backend
 spec:
   replicas: {{ .Values.replicaCount }}
   selector:
@@ -20,6 +21,7 @@ spec:
       labels:
         app: {{ template "service-broker-proxy.name" . }}
         release: {{ .Release.Name }}
+        kyma-project.io/component: backend
     spec:
       {{- with .Values.securityContext }}
       securityContext:

--- a/resources/testing/charts/octopus/templates/manager.yaml
+++ b/resources/testing/charts/octopus/templates/manager.yaml
@@ -10,6 +10,7 @@ metadata:
     heritage: "{{ .Release.Service }}"
     control-plane: controller-manager
     controller-tools.k8s.io: "1.0"
+    kyma-project.io/component: controller
 spec:
   selector:
     app: {{ template "octopus.name" . }}
@@ -44,6 +45,7 @@ spec:
         app: {{ template "octopus.name" . }}
         control-plane: controller-manager
         controller-tools.k8s.io: "1.0"
+        kyma-project.io/component: controller
     spec:
       serviceAccountName: {{ template "octopus.fullname" . }}
       containers:


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/master/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

In the past, an attempt was made to categorize all custom Kyma components with labels and enable monitoring and alerting based on that. That attempt failed, as there were outdated alert rules and dashboards not functioning properly.

The idea is still great but should be started more easily by focussing on categorizing and having a default dashboard available.

So I introduced a label `kyma-project.io/component: controller|backend|frontend` to be placed on the pods and introduced a Grafana dashboard for those three categories.

Everything else leftover from the first attempt I deleted.

Changes proposed in this pull request:

- Labeled all Kyma owned deployments/pods
- Have 3 new dashboards for the categories (Kyma / Components / Frontends | Backends | Controllers)
- Deleted leftovers

Follow up actions:
- Add istio metrics to Frontend and Backend dashboards
- Add controller_runtime metrics for Controller dashboards
- Check that each controller is exposing controller_runtime metrics
- Check that every golang component is exposing golang metrics


**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
