### PR TITLE
do not generate fluent-bit config when existingConfigMap is set

### DIFF
--- a/resources/logging/charts/fluentbit/templates/configmap.yaml
+++ b/resources/logging/charts/fluentbit/templates/configmap.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.enabled }}
+{{- if and .Values.enabled (not .Values.existingConfigMap) }}
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/resources/logging/charts/fluentbit/templates/daemonset.yaml
+++ b/resources/logging/charts/fluentbit/templates/daemonset.yaml
@@ -194,7 +194,7 @@ spec:
 {{- if .Values.prometheusPushGateway.enabled }}
       - name: cron
         configMap:
-          name: {{ template "fluent-bit.fullname" . }}-config
+          name: {{ if .Values.existingConfigMap }}{{ .Values.existingConfigMap }}{{- else }}{{ template "fluent-bit.fullname" . }}-config{{- end }}
           items:
           - key: cron
             path: metrics

--- a/resources/logging/charts/fluentbit/values.yaml
+++ b/resources/logging/charts/fluentbit/values.yaml
@@ -294,9 +294,8 @@ serviceAccount:
   # If not set and create is true, a name is generated using the fullname template.
   name:
 
-# ConfigMap override where fullname is {{.Release.Name}}-{{.Values.existingConfigMap}}
-# Defining existingConfigMap will cause templates/config.yaml
-# to NOT generate a ConfigMap resource
+# Use an existing configMap as fluent-bit configuration.
+# If set, no ConfigMap resource gets genrated anymore
 existingConfigMap: ""
 
 # Extra volume mounts for the fluent-bit pod.


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/master/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- improved docu
- do not render configmap when flag is set
- fix usage for cron metrics

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
