### PR TITLE
Bump images for application connector and compass runtime agent after istio 1.5 merge

### DIFF
--- a/resources/application-connector/values.yaml
+++ b/resources/application-connector/values.yaml
@@ -23,37 +23,37 @@ global:
   containerRegistry:
     path: eu.gcr.io/kyma-project
   application_operator:
-    version: "PR-9512"
+    version: "d0516ff9"
   application_operator_tests:
-    version: "PR-9512"
+    version: "d0516ff9"
   connector_service:
-    version: "PR-9407"
+    version: "b9871385"
   connector_service_tests:
-    version: "PR-9407"
+    version: "b9871385"
   connection_token_handler:
-    version: "PR-9407"
+    version: "b9871385"
   connection_token_handler_tests:
-    version: "PR-9407"
+    version: "b9871385"
   event_service:
     version: "d4372526"
   event_service_integration_tests:
     version: "2c51c024"
   application_gateway:
-    version: "PR-9512"
+    version: "d0516ff9"
   application_gateway_tests:
-    version: "PR-9512"
+    version: "d0516ff9"
   application_gateway_legacy_tests:
     version: "4eeef0b7"
   application_registry:
-    version: "PR-9512"
+    version: "d0516ff9"
   application_registry_tests:
-    version: "PR-9407"
+    version: "b9871385"
   application_broker:
     version: "PR-9389"
   application_connectivity_certs_setup_job:
-    version: "PR-9407"
+    version: "b9871385"
   application_connectivity_validator:
-    version: "PR-9512"
+    version: "d0516ff9"
   application_broker_eventing_migration:
     version: "PR-9389"
 

--- a/resources/compass-runtime-agent/values.yaml
+++ b/resources/compass-runtime-agent/values.yaml
@@ -5,7 +5,7 @@ global:
     runtimeAgent:
       version: "d0516ff9"
     runtimeAgentTests:
-      version: "1066324c"
+      version: "b9871385"
     compassExternalSolutionTests:
       version: "1a5b13b8"
   istio:

--- a/resources/compass-runtime-agent/values.yaml
+++ b/resources/compass-runtime-agent/values.yaml
@@ -3,7 +3,7 @@ global:
     containerRegistry:
       path: eu.gcr.io/kyma-project
     runtimeAgent:
-      version: "PR-9512"
+      version: "d0516ff9"
     runtimeAgentTests:
       version: "1066324c"
     compassExternalSolutionTests:


### PR DESCRIPTION
Description

Changes proposed in this pull request:

Images bump for components:

- application-operator, 
- application-operator-tests,
- connector-service, 
- connector-service-tests, 
- connection-token-handler, 
- connection-token-handler-tests,
- application-gateway, 
- application-gateway-tests,
- application-registry, 
- application-registry-tests, 
- application-connectivity-certs-setup-job
- application-connectivity-validator
- compass-runtime-agent
- compass-runtime-agent-tests

