### PR TITLE
Prometheus retention size for default and local installation profile

### DIFF
--- a/docs/monitoring/05-04-production-profile.md
+++ b/docs/monitoring/05-04-production-profile.md
@@ -27,11 +27,11 @@ The table shows the parameters of each profile and their values:
 
  Parameter  | Description | Default profile| Production profile | Local profile|
 |-----------|-------------|----------------|--------------------|--------------|
-| **retentionSize** | Maximum number of bytes that storage blocks can use. The oldest data will be removed first. | `2GB` | `15GB` | `500MB` | 
+| **retentionSize** | Maximum number of bytes that storage blocks can use. The oldest data will be removed first. | `256MB` | `15GB` | `256MB` | 
 | **retention** | Time period for which Prometheus stores metrics in an in-memory database. Prometheus stores the recent data for the specified amount of time to avoid reading all data from the disk. This parameter only applies to in-memory storage.|`1d`| `30d` | `2h`|
 | **prometheusSpec.volumeClaimTemplate.spec.resources.requests.storage** | Amount of storage requested by the Prometheus Pod. |`10Gi`| `20Gi` | `1Gi` |
 | **prometheusSpec.resources.limits.cpu** | Maximum number of CPUs available for the Prometheus Pod to use. | `600m`| `1` | `150m`|
-| **prometheusSpec.resources.limits.memory** | Maximum amount of memory available for the Prometheus Pod to use. |`1500Mi` | `3Gi` |`800Mi`|
+| **prometheusSpec.resources.limits.memory** | Maximum amount of memory available for the Prometheus Pod to use. |`2000Mi` | `3Gi` |`800Mi`|
 | **prometheusSpec.resources.requests.cpu** |  Number of CPUs requested by the Prometheus Pod to operate.| `300m`| `300m` | `100m` |
 | **prometheusSpec.resources.requests.memory** | Amount of memory requested by the Prometheus Pod to operate. | `1000Mi`| `1Gi` | `200Mi` |
 | **alertmanager.alertmanagerSpec.retention** | Time period for which Alertmanager retains data.| `120h` | `240h` | `1h` |

--- a/installation/resources/installer-config-local.yaml.tpl
+++ b/installation/resources/installer-config-local.yaml.tpl
@@ -150,7 +150,7 @@ data:
   prometheus.prometheusSpec.resources.requests.cpu: "100m"
   prometheus.prometheusSpec.resources.requests.memory: "200Mi"
   prometheus.prometheusSpec.retention: "2h"
-  prometheus.prometheusSpec.retentionSize: "500MB"
+  prometheus.prometheusSpec.retentionSize: "256MB"
   prometheus.prometheusSpec.storageSpec.volumeClaimTemplate.spec.resources.requests.storage: "1Gi"
   grafana.persistence.enabled: "false"
 ---

--- a/resources/monitoring/values.yaml
+++ b/resources/monitoring/values.yaml
@@ -1631,7 +1631,7 @@ prometheus:
 
     ## Maximum size of metrics
     ##
-    retentionSize: 2GB
+    retentionSize: 256MB
 
     ## Enable compression of the write-ahead log using Snappy.
     ##

--- a/resources/monitoring/values.yaml
+++ b/resources/monitoring/values.yaml
@@ -1635,7 +1635,7 @@ prometheus:
 
     ## Enable compression of the write-ahead log using Snappy.
     ##
-    walCompression: false
+    walCompression: true
 
     ## If true, the Operator won't process any Prometheus configuration changes
     ##


### PR DESCRIPTION
**Description**
Prometheus retention size config updated for default and local installation profile to 256 MB

Changes proposed in this pull request:

- ...
- ...
- ...

**Related issue(s)**
