### PR TITLE
Add "watch" to role & clusterRole verbs

### DIFF
--- a/components/console-backend-service/internal/domain/roles/clusterRoleBinding.resolver.go
+++ b/components/console-backend-service/internal/domain/roles/clusterRoleBinding.resolver.go
@@ -34,7 +34,7 @@ func (r *Resolver) CreateClusterRoleBinding(ctx context.Context, name string, pa
 	for i, sub := range params.Subjects {
 		convertedSubjects[i] = v1.Subject{
 			Kind:     string(sub.Kind),
-			APIGroup: clusterRoleGroupVersionResource.Group,
+			APIGroup: clusterRoleBindingGroupVersionResource.Group,
 			Name:     sub.Name,
 		}
 	}

--- a/components/console-backend-service/internal/domain/roles/roleBinding.resolver.go
+++ b/components/console-backend-service/internal/domain/roles/roleBinding.resolver.go
@@ -34,7 +34,7 @@ func (r *Resolver) CreateRoleBinding(ctx context.Context, namespace string, name
 	for i, sub := range params.Subjects {
 		convertedSubjects[i] = v1.Subject{
 			Kind:     string(sub.Kind),
-			APIGroup: roleGroupVersionResource.Group,
+			APIGroup: roleBindingGroupVersionResource.Group,
 			Name:     sub.Name,
 		}
 	}

--- a/resources/console/charts/backend/templates/cluster-role.yaml
+++ b/resources/console/charts/backend/templates/cluster-role.yaml
@@ -13,7 +13,7 @@ rules:
     verbs: ["get", "list", "watch"]
   - apiGroups: ["rbac.authorization.k8s.io"]
     resources: ["roles", "clusterroles"]
-    verbs: ["get", "list"]
+    verbs: ["get", "list", "watch"]
   - apiGroups: ["rbac.authorization.k8s.io"]
     resources: ["rolebindings", "clusterrolebindings"]
     verbs: ["list", "watch", "create", "delete"]

--- a/resources/console/charts/backend/templates/deployment.yaml
+++ b/resources/console/charts/backend/templates/deployment.yaml
@@ -3,7 +3,7 @@ kind: Deployment
 metadata:
   name: {{ template "fullname" . }}
   labels:
-    app: {{ template "fullname" . }}
+    app: {{ template "name" . }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
@@ -12,7 +12,7 @@ spec:
   replicas: {{ .Values.replicaCount }}
   selector:
     matchLabels:
-      app: {{ template "fullname" . }}
+      app: {{ template "name" . }}
   strategy:
     type: RollingUpdate
     rollingUpdate:
@@ -20,7 +20,7 @@ spec:
   template:
     metadata:
       labels:
-        app: {{ template "fullname" . }}
+        app: {{ template "name" . }}
         chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
         release: "{{ .Release.Name }}"
         heritage: "{{ .Release.Service }}"

--- a/resources/console/charts/backend/templates/deployment.yaml
+++ b/resources/console/charts/backend/templates/deployment.yaml
@@ -3,7 +3,7 @@ kind: Deployment
 metadata:
   name: {{ template "fullname" . }}
   labels:
-    app: {{ template "name" . }}
+    app: {{ template "fullname" . }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
@@ -12,7 +12,7 @@ spec:
   replicas: {{ .Values.replicaCount }}
   selector:
     matchLabels:
-      app: {{ template "name" . }}
+      app: {{ template "fullname" . }}
   strategy:
     type: RollingUpdate
     rollingUpdate:
@@ -20,7 +20,7 @@ spec:
   template:
     metadata:
       labels:
-        app: {{ template "name" . }}
+        app: {{ template "fullname" . }}
         chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
         release: "{{ .Release.Name }}"
         heritage: "{{ .Release.Service }}"


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Add "watch" to role & clusterRole verbs - new-style domains run the subscription always, even though there will be no need for it.
- Adjust GVR for bindings in `roles` domain
- ~Change CBS pod label from `backend` to `console-backend` for consistency and overall wellbeing.~ - it looks like it breaks e2e tests.

I decided to take a risk and don't bump it, as changes in CBS image were introduced before (during bug hunt) and they won't bring in any regression.

**Related issue(s)**
