### PR TITLE
Upgrade uaa-activator SI and SB creator

### DIFF
--- a/components/uaa-activator/internal/uaa/creator.go
+++ b/components/uaa-activator/internal/uaa/creator.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/kubernetes-sigs/service-catalog/pkg/apis/servicecatalog/v1beta1"
 	"github.com/pkg/errors"
+	v1 "k8s.io/api/core/v1"
 	apiErrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/util/retry"
@@ -31,6 +32,14 @@ func NewCreator(cli client.Client, config Config) *Creator {
 // Additionally, wait until ServiceInstance is in a ready state.
 func (p *Creator) EnsureUAAInstance(ctx context.Context) error {
 	instance := p.uaaServiceInstance()
+
+	// remove not ready ServiceInstance before create new one
+	if err := p.instanceIsReady(ctx); err != nil {
+		err := p.removeUAAInstance(ctx, instance)
+		if err != nil {
+			return errors.Wrap(err, "while removing ServiceInstance in not ready state")
+		}
+	}
 
 	err := p.cli.Create(ctx, &instance)
 	switch {
@@ -96,6 +105,11 @@ func (p *Creator) EnsureUAABinding(ctx context.Context) error {
 		return errors.Wrapf(err, "while waiting for %s", p.config.ServiceBinding.String())
 	}
 
+	err = repeat.UntilSuccess(ctx, p.secretExist(ctx))
+	if err != nil {
+		return errors.Wrapf(err, "while waiting for Secret %s", p.config.ServiceBinding.String())
+	}
+
 	return nil
 }
 
@@ -133,6 +147,24 @@ func (p *Creator) uaaServiceBinding() v1beta1.ServiceBinding {
 	}
 }
 
+func (p *Creator) removeUAAInstance(ctx context.Context, instance v1beta1.ServiceInstance) error {
+	err := p.cli.Delete(ctx, &instance)
+	switch {
+	case err == nil:
+	case apiErrors.IsNotFound(err):
+		return nil
+	case err != nil:
+		return errors.Wrap(err, "while deleting UAA ServiceInstance")
+	}
+
+	err = repeat.UntilSuccess(ctx, p.instanceWasRemoved(ctx))
+	if err != nil {
+		return errors.Wrapf(err, "while waiting for removing %s", p.config.ServiceInstance.String())
+	}
+
+	return nil
+}
+
 func (p *Creator) instanceIsReady(ctx context.Context) func() error {
 	return func() error {
 		instance := v1beta1.ServiceInstance{}
@@ -151,6 +183,22 @@ func (p *Creator) instanceIsReady(ctx context.Context) func() error {
 	}
 }
 
+func (p *Creator) instanceWasRemoved(ctx context.Context) func() error {
+	return func() error {
+		instance := v1beta1.ServiceInstance{}
+		err := p.cli.Get(ctx, p.config.ServiceInstance, &instance)
+
+		if apiErrors.IsNotFound(err) {
+			return nil
+		}
+		if err != nil {
+			return errors.Wrap(err, "while checking if ServiceInstance was removed")
+		}
+
+		return errors.Errorf("ServiceInstance exist, status: %v", instance.Status)
+	}
+}
+
 func (p *Creator) bindingIsReady(ctx context.Context) func() error {
 	return func() error {
 		binding := v1beta1.ServiceBinding{}
@@ -166,5 +214,17 @@ func (p *Creator) bindingIsReady(ctx context.Context) func() error {
 		}
 
 		return errors.Errorf("ServiceBinding is not ready, status: %v", binding.Status)
+	}
+}
+
+func (p *Creator) secretExist(ctx context.Context) func() error {
+	return func() error {
+		secret := v1.Secret{}
+		err := p.cli.Get(ctx, p.config.ServiceBinding, &secret)
+		if err != nil {
+			return errors.Wrapf(err, "while fetching Secret %s", p.config.ServiceBinding.Name)
+		}
+
+		return nil
 	}
 }

--- a/resources/uaa-activator/values.yaml
+++ b/resources/uaa-activator/values.yaml
@@ -10,7 +10,7 @@ global:
 image:
   registryPath: eu.gcr.io/kyma-project
   pullPolicy: IfNotPresent
-  version: PR-9626
+  version: "PR-9625"
 
 nameOverride: ""
 fullnameOverride: ""


### PR DESCRIPTION
During the execution of `uaa-activator` could happen following errors, one is a consequence of the other.

In general, `uaa-activator` consists of several steps. The third step is responsible for creating ServiceBinding (SB). ServiceBinding is provisioned by ServiceCatalog (SC),
Once the process of creating the SB is complete, a new secret related to SB should be showing up.
SC does not ensure the creation of a secret, even if SB is ready/true. SC can show in logs Secret is triggered to create:
```
Sep 16, 2020 @ 20:02:53.427	I0916 18:02:53.427360       1 controller_binding.go:540] ServiceBinding "kyma-system/uaa-issuer-secret" v12239: Creating/updating Secret "kyma-system/uaa-issuer-secret" with 14 keys
Sep 16, 2020 @ 20:02:53.434	I0916 18:02:53.434422       1 controller_binding.go:698] ServiceBinding "kyma-system/uaa-issuer-secret" v12239: Injected bind result
```
but there may be some delays in creating the secret. `uaa-activator` does not check if secret already exists and immediately goes to the next step where secret is required.
This results in an error:
```
while rendering uaa connector config: while fetching Secret kyma-system/uaa-issuer-secret: secrets "uaa-issuer-secret" not found
```

If the first run fails, the process is repeated. Then `uaa-activator` could fail in the second step (where ServiceInstance (SI) is created) with error:
```
Application with xsappname <name_depend_on_cluster_host> already exists. To create a new service instance, ensure that the xsappname specified in your application's xs-security.json file together with the selected service plan of the UAA service broker lead to a new appid. To update an existing service instance, use the update-service command instead.;
```
for some reason `ApiError` [IsAlreadyExists](https://github.com/kyma-project/kyma/blob/master/components/uaa-activator/internal/uaa/creator.go#L38) does not return true (or error is nil), new SI is created, which causes the above error to occur.

PR ensures a new Secret exists when new SB is created and removes failed SI before creating new one.