### PR TITLE
Add parameterized reconciliation delay after the failure in Runtime Agent

### DIFF
--- a/components/compass-runtime-agent/cmd/main.go
+++ b/components/compass-runtime-agent/cmd/main.go
@@ -90,6 +90,7 @@ func main() {
 		RuntimeURLsConfig:            options.Runtime,
 		CertValidityRenewalThreshold: options.CertValidityRenewalThreshold,
 		MinimalCompassSyncTime:       options.MinimalCompassSyncTime,
+		TimeToRequeueAfterFailure:    options.TimeToRequeueAfterFailure,
 	}
 
 	compassConnectionSupervisor, err := controllerDependencies.InitializeController()

--- a/components/compass-runtime-agent/cmd/options.go
+++ b/components/compass-runtime-agent/cmd/options.go
@@ -18,6 +18,7 @@ type Config struct {
 	AgentConfigurationSecret     string        `envconfig:"default=compass-system/compass-agent-configuration"`
 	ControllerSyncPeriod         time.Duration `envconfig:"default=20s"`
 	MinimalCompassSyncTime       time.Duration `envconfig:"default=10s"`
+	TimeToRequeueAfterFailure    time.Duration `envconfig:"default=2m"`
 	CertValidityRenewalThreshold float64       `envconfig:"default=0.3"`
 	ClusterCertificatesSecret    string        `envconfig:"default=compass-system/cluster-client-certificates"`
 	CaCertificatesSecret         string        `envconfig:"default=istio-system/ca-certificates"`
@@ -34,14 +35,14 @@ type Config struct {
 
 func (o *Config) String() string {
 	return fmt.Sprintf("AgentConfigurationSecret=%s, "+
-		"ControllerSyncPeriod=%s, MinimalCompassSyncTime=%s, "+
+		"ControllerSyncPeriod=%s, MinimalCompassSyncTime=%s, TimeToRequeueAfterFailure=%s"+
 		"CertValidityRenewalThreshold=%f, ClusterCertificatesSecret=%s, CaCertificatesSecret=%s, "+
 		"SkipCompassTLSVerify=%v, GatewayPort=%d, UploadServiceUrl=%s, "+
 		"QueryLogging=%v, MetricsLoggingTimeInterval=%s, "+
 		"RuntimeEventsURL=%s, RuntimeConsoleURL=%s"+
 		"DirectorProxyPort=%v,  DirectorProxyInsecureSkipVerify=%v, HealthPort=%s",
 		o.AgentConfigurationSecret,
-		o.ControllerSyncPeriod.String(), o.MinimalCompassSyncTime.String(),
+		o.ControllerSyncPeriod.String(), o.MinimalCompassSyncTime.String(), o.TimeToRequeueAfterFailure.String(),
 		o.CertValidityRenewalThreshold, o.ClusterCertificatesSecret, o.CaCertificatesSecret,
 		o.SkipCompassTLSVerify, o.GatewayPort, o.UploadServiceUrl,
 		o.QueryLogging, o.MetricsLoggingTimeInterval,

--- a/components/compass-runtime-agent/internal/compassconnection/init.go
+++ b/components/compass-runtime-agent/internal/compassconnection/init.go
@@ -33,6 +33,7 @@ type DependencyConfig struct {
 	RuntimeURLsConfig            director.RuntimeURLsConfig
 	CertValidityRenewalThreshold float64
 	MinimalCompassSyncTime       time.Duration
+	TimeToRequeueAfterFailure    time.Duration
 }
 
 func (config DependencyConfig) InitializeController() (Supervisor, error) {
@@ -56,7 +57,12 @@ func (config DependencyConfig) InitializeController() (Supervisor, error) {
 		config.RuntimeURLsConfig,
 		config.ConnectionDataCache)
 
-	if err := InitCompassConnectionController(config.ControllerManager, connectionSupervisor, config.MinimalCompassSyncTime); err != nil {
+	err = InitCompassConnectionController(
+		config.ControllerManager,
+		connectionSupervisor,
+		config.MinimalCompassSyncTime,
+		config.TimeToRequeueAfterFailure)
+	if err != nil {
 		return nil, errors.Wrap(err, "Unable to register controllers to the manager")
 	}
 

--- a/resources/compass-runtime-agent/templates/deployment.yaml
+++ b/resources/compass-runtime-agent/templates/deployment.yaml
@@ -40,6 +40,8 @@ spec:
               value: {{ .Values.compassRuntimeAgent.sync.controllerSyncPeriod | quote }}
             - name: APP_MINIMAL_COMPASS_SYNC_TIME
               value: {{ .Values.compassRuntimeAgent.sync.minimalConfigSyncTime | quote }}
+            - name: APP_TIME_TO_REQUEUE_AFTER_FAILURE
+              value: {{ .Values.compassRuntimeAgent.sync.timeToRequeueAfterFailure | quote }}
             - name: APP_CERT_VALIDITY_RENEWAL_THRESHOLD
               value: {{ .Values.compassRuntimeAgent.certificates.renewal.validityThreshold | quote }}
             - name: APP_CLUSTER_CERTIFICATES_SECRET

--- a/resources/compass-runtime-agent/values.yaml
+++ b/resources/compass-runtime-agent/values.yaml
@@ -3,7 +3,7 @@ global:
     containerRegistry:
       path: eu.gcr.io/kyma-project
     runtimeAgent:
-      version: "PR-9593"
+      version: "PR-9650"
     runtimeAgentTests:
       version: "PR-9569"
     compassExternalSolutionTests:

--- a/resources/compass-runtime-agent/values.yaml
+++ b/resources/compass-runtime-agent/values.yaml
@@ -21,6 +21,7 @@ compassRuntimeAgent:
   sync:
     controllerSyncPeriod: 15s
     minimalConfigSyncTime: 15s
+    timeToRequeueAfterFailure: 2m
   resources:
     integrationNamespace: "kyma-integration"
     dexSecretNamespace: "kyma-system"


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/master/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- Add parameterized reconciliation delay after the failure in Runtime Agent

**Related issue(s)**

See the issue: #9617 
