### PR TITLE
fixed loki access from grafana

### DIFF
--- a/resources/logging/templates/loki/authorizationpolicy.yaml
+++ b/resources/logging/templates/loki/authorizationpolicy.yaml
@@ -29,7 +29,7 @@ spec:
          - "cluster.local/ns/kyma-system/sa/monitoring-grafana"
      to:
      - operation:
-         paths: ["/loki/api/v1/labels","/loki/api/v1/tail","/loki/api/v1/label/*","/loki/api/v1/query","/loki/api/v1/query_range"]
+         paths: ["/loki/api/v1/label","/loki/api/v1/tail","/loki/api/v1/label/*","/loki/api/v1/query","/loki/api/v1/query_range"]
          methods: ["GET"]
    # fluent-bit with SA can push to v1 API
    - from:

--- a/resources/logging/templates/loki/authorizationpolicy.yaml
+++ b/resources/logging/templates/loki/authorizationpolicy.yaml
@@ -29,7 +29,7 @@ spec:
          - "cluster.local/ns/kyma-system/sa/monitoring-grafana"
      to:
      - operation:
-         paths: ["/loki/api/v1/label","/loki/api/v1/tail","/loki/api/v1/label/*","/loki/api/v1/query","/loki/api/v1/query_range"]
+         paths: ["/loki/api/v1/*"]
          methods: ["GET"]
    # fluent-bit with SA can push to v1 API
    - from:


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/master/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**
Grafana was not able to query the loki labels as the access to "/loki/api/v1/label" and "/loki/api/v1/series" was not allowed.

Changes proposed in this pull request:

- Fixed related authorizationPolicy by allowing GET access to all "/loki/api/v1" endpoints for grafana
- ...
- ...

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
