### PR TITLE
Change upgrade test behavior during cleanup ServiceInstance

### DIFF
--- a/tests/end-to-end/upgrade/chart/upgrade/values.yaml
+++ b/tests/end-to-end/upgrade/chart/upgrade/values.yaml
@@ -7,7 +7,7 @@ subscriberimage:
 
 image:
   dir:
-  version: PR-9481
+  version: PR-9703
   pullPolicy: "IfNotPresent"
 
 dex:


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

During the cleanup "upgrade test" process, the test will no longer wait (more than 3 min) for removing ServiceInstance if SI conditions are:
```
[
  {
    "message": "The instance is being deprovisioned asynchronously",
    "reason": "Deprovisioning",
    "status": "False",
    "type": "Ready"
  }
]
```
which means SI is still in deprovisioning process, in other error condtiotions test will fail.