### PR TITLE
Change eventTypeVersion to version

### DIFF
--- a/docs/serverless/08-07-sync-function-with-gitops.md
+++ b/docs/serverless/08-07-sync-function-with-gitops.md
@@ -231,7 +231,7 @@ You will create a sample inline Function and modify it by adding a trigger to it
       sourceType: inline
       sourcePath: {FULL_PATH_TO_WORKSPACE_FOLDER}
   triggers:
-    - eventTypeVersion: evt1
+    - version: evt1
       source: the-source
       type: t1
   ```


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

Renamed `eventTypeVersion` to `version`. in the GitOps tutorials to match changes in the trigger configuration in CLI.

**Related issue(s)**
See alsohttps://github.com/kyma-incubator/hydroform/pull/131
