### PR TITLE
Changes in Docker registry docs

### DIFF
--- a/docs/serverless/01-01-serverless.md
+++ b/docs/serverless/01-01-serverless.md
@@ -8,3 +8,5 @@ Similarly to cloud providers, Kyma offers a service (known as "functions-as-a-se
 
 - Configure it to be triggered by events coming from external sources to which you subscribe.
 - Expose it to an external endpoint (HTTPS).
+
+> **CAUTION:** In its default configuration, Serverless uses persistent volumes as the internal registry to store Docker images for Functions. The default storage size of a single volume is 20 GB. This internal registry is suitable for local development. For production purposes, we recommend to use an [external Docker registry](#tutorials-set-an-external-docker-registry).

--- a/docs/serverless/02-01-serverless.md
+++ b/docs/serverless/02-01-serverless.md
@@ -20,8 +20,6 @@ Serverless relies heavily on Kubernetes resources. It uses [Deployments](https:/
 
 6. The Job creates a Pod which builds the production Docker image based on the Function's definition. The Job then pushes this image to a Docker registry.
 
-    > **NOTE:** Serverless offers a built-in internal Docker registry that is suitable for local development. For production purposes, switch to an [external Docker registry](#tutorials-set-an-external-docker-registry).
-
 7. FC monitors the Job status. When the image creation finishes successfully, FC creates a Deployment that uses the newly built image.
 
 8. FC creates a Service that points to the Deployment.

--- a/docs/serverless/03-07-security.md
+++ b/docs/serverless/03-07-security.md
@@ -15,4 +15,4 @@ To eliminate potential security risks when using Functions, bear in mind these f
 
     - Source code of all Functions within this Namespace
     - Internal Docker registry that contains Function images
-    - Secrets allowing the build Job to pull and push images from and to the Docker registry 
+    - Secrets allowing the build Job to pull and push images from and to the Docker registry (in non-system Namespaces)

--- a/docs/serverless/03-07-security.md
+++ b/docs/serverless/03-07-security.md
@@ -15,3 +15,4 @@ To eliminate potential security risks when using Functions, bear in mind these f
 
     - Source code of all Functions within this Namespace
     - Internal Docker registry that contains Function images
+    - Secrets allowing the build Job to pull and push images from and to the Docker registry 


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Updated the note with the recommendation to use an external registry for prod.
- Added info on the default PVC size.
- Added the point to the security doc clearly stating that admins have access to Secrets (used by build Jobs to pull and push Function images) in all non-system namespaces.


