### PR TITLE
Remove Softicious logo from the main README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,5 +89,4 @@ Follow these steps:
 <p align="center">
   <img src="https://github.com/kyma-project/website/blob/master/content/adopters/logos/arineo.svg" alt="Arineo" width="250" height="40" />
   <img src="https://github.com/kyma-project/website/blob/master/content/adopters/logos/dotsource.svg" alt="dotSource" width="250" height="40" />
-  <img src="https://github.com/kyma-project/website/blob/master/content/adopters/logos/softicious.svg" alt="Softicious" width="250" height="40" />
 </p>


### PR DESCRIPTION

**Description**

Changes proposed in this pull request:

- Removed the Softicious logo from the main `README.md` after [removing it from Adopters](https://github.com/kyma-project/website/issues/641).