### PR TITLE
Scrape sample limit for prometheus istio envoy job

### DIFF
--- a/resources/monitoring/charts/prometheus-istio/values.yaml
+++ b/resources/monitoring/charts/prometheus-istio/values.yaml
@@ -1256,6 +1256,7 @@ serverFiles:
           - targets:
             - localhost:9090
       - job_name: istio-system/envoy-stats/0
+        sample_limit: 20000
         honor_timestamps: true
         metrics_path: /stats/prometheus
         scheme: http


### PR DESCRIPTION
**Description**
Added sample limit 20000 for the prometheus scrape job istio envoy 
Changes proposed in this pull request:

- ...
- ...
- ...

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
