### PR TITLE
Add improvement to UAA-activator component

### DIFF
--- a/components/uaa-activator/internal/dex/configurator.go
+++ b/components/uaa-activator/internal/dex/configurator.go
@@ -7,7 +7,7 @@ import (
 	"github.com/kyma-project/kyma/components/uaa-activator/internal/repeat"
 
 	"github.com/pkg/errors"
-	"gopkg.in/yaml.v2"
+	yaml "gopkg.in/yaml.v2"
 	appsv1 "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"

--- a/components/uaa-activator/internal/uaa/config.go
+++ b/components/uaa-activator/internal/uaa/config.go
@@ -1,6 +1,8 @@
 package uaa
 
 import (
+	"time"
+
 	"github.com/kubernetes-sigs/service-catalog/pkg/apis/servicecatalog/v1beta1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -12,4 +14,5 @@ type Config struct {
 	ServiceBinding              client.ObjectKey
 	ClusterServiceClassName     string `envconfig:"default=xsuaa"`
 	ClusterServicePlanName      string `envconfig:"default=z54zhz47zdx5loz51z6z58zhvcdz59-b207b177b40ffd4b314b30635590e0ad"`
+	NewInstanceCreateDelay      time.Duration `envconfig:"default=3s"`
 }

--- a/components/uaa-activator/internal/uaa/config.go
+++ b/components/uaa-activator/internal/uaa/config.go
@@ -12,7 +12,7 @@ type Config struct {
 	ServiceInstanceParamsSecret v1beta1.SecretKeyReference
 	ServiceInstance             client.ObjectKey
 	ServiceBinding              client.ObjectKey
-	ClusterServiceClassName     string `envconfig:"default=xsuaa"`
-	ClusterServicePlanName      string `envconfig:"default=z54zhz47zdx5loz51z6z58zhvcdz59-b207b177b40ffd4b314b30635590e0ad"`
+	ClusterServiceClassName     string        `envconfig:"default=xsuaa"`
+	ClusterServicePlanName      string        `envconfig:"default=z54zhz47zdx5loz51z6z58zhvcdz59-b207b177b40ffd4b314b30635590e0ad"`
 	NewInstanceCreateDelay      time.Duration `envconfig:"default=3s"`
 }

--- a/components/uaa-activator/internal/uaa/creator.go
+++ b/components/uaa-activator/internal/uaa/creator.go
@@ -2,6 +2,7 @@ package uaa
 
 import (
 	"context"
+	"time"
 
 	"github.com/kyma-project/kyma/components/uaa-activator/internal/repeat"
 
@@ -39,6 +40,11 @@ func (p *Creator) EnsureUAAInstance(ctx context.Context) error {
 		if err != nil {
 			return errors.Wrap(err, "while removing ServiceInstance in not ready state")
 		}
+		// there is a problem with communication with the UAA. If an instance after deletion is created
+		// in too short a period of time, the UAA provider will return information that the instance with
+		// the given 'xsappname' is in the deleting process and the new instance will not be triggered to create it
+		// so there is a delay before a request for a new instance is sent
+		time.Sleep(p.config.NewInstanceCreateDelay)
 	}
 
 	err := p.cli.Create(ctx, &instance)

--- a/resources/uaa-activator/templates/job.yaml
+++ b/resources/uaa-activator/templates/job.yaml
@@ -43,6 +43,8 @@ spec:
               value: "{{ .Release.Namespace }}"
             - name: UAA_SERVICEBINDING_NAME
               value: "uaa-issuer-secret"
+            - name: UAA_NEW_INSTANCE_CREATE_DELAY
+              value: "3s"
 
             - name: DEX_CONFIG_MAP_NAMESPACE
               value: "{{ .Release.Namespace }}"

--- a/resources/uaa-activator/values.yaml
+++ b/resources/uaa-activator/values.yaml
@@ -10,7 +10,7 @@ global:
 image:
   registryPath: eu.gcr.io/kyma-project
   pullPolicy: IfNotPresent
-  version: "76a9d5d1"
+  version: "PR-9809"
 
 nameOverride: ""
 fullnameOverride: ""


### PR DESCRIPTION
**Description**
There is a problem with communication with the UAA. If an instance after deletion is created in too short a period of time, the UAA provider will return information that the instance with the given `xsappname` is in the deleting process and the new instance will not be triggered to create it, so there has to be a delay before a request for a new instance will be sent.

Changes proposed in this pull request:

- Add improvement to UAA-activator component with delay new instance creation