### PR TITLE
Add alert rule when one or more targets for job has scrape limit exce…

### DIFF
--- a/resources/monitoring/templates/prometheus/kyma-rules/kyma-rules.yaml
+++ b/resources/monitoring/templates/prometheus/kyma-rules/kyma-rules.yaml
@@ -81,7 +81,7 @@ spec:
       annotations:
         description: One or more targets in the job monitoring-prometheus-istio-server have scrape limit exceeded
         summary: Scrape limit for one or more targets is exceeded.
-      expr: increase(prometheus_target_scrapes_exceeded_sample_limit_total{job="monitoring-prometheus-istio-server"}[1m]) > 1
+      expr: increase(prometheus_target_scrapes_exceeded_sample_limit_total{job="monitoring-prometheus-istio-server"}[1m]) > 0
       for: 1m
       labels:
         severity: critical

--- a/resources/monitoring/templates/prometheus/kyma-rules/kyma-rules.yaml
+++ b/resources/monitoring/templates/prometheus/kyma-rules/kyma-rules.yaml
@@ -75,3 +75,13 @@ spec:
         severity: warning
       annotations:
         message: Pod {{`{{`}} $labels.namespace {{`}}`}}/{{`{{`}} $labels.pod {{`}}`}} ({{`{{`}} $labels.container {{`}}`}}) is OOMKilled for 5 minutes.
+  - name: prometheus-rules
+    rules:
+    - alert: ScrapeLimitForTargetExceeded
+      annotations:
+        description: One or more targets in the job monitoring-prometheus-istio-server have scrape limit exceeded
+        summary: Scrape limit for one or more targets is exceeded.
+      expr: increase(prometheus_target_scrapes_exceeded_sample_limit_total{job="monitoring-prometheus-istio-server"}[1m]) > 1
+      for: 1m
+      labels:
+        severity: critical


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/master/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- We have scrape sample limits in place for pod monitors. Whenever one of the target reaches the scrape sample limits then alert should be fired as this means the metrics from now on would be dropped.

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
