### PR TITLE
filtering metrics for logging

### DIFF
--- a/resources/logging/charts/fluentbit/templates/service-monitor.yaml
+++ b/resources/logging/charts/fluentbit/templates/service-monitor.yaml
@@ -29,6 +29,6 @@ spec:
       {{- end }}
       metricRelabelings:
       - sourceLabels: [ __name__ ]
-        regex: ^(fluentbit_input_bytes_total|fluentbit_output_proc_bytes_total|fluentbit_output_errors_total|fluentbit_output_retries_total|fluentbit_output_retries_failed_total|process_start_time_seconds)$
+        regex: ^(fluentbit_.*|go_.*|process_.*)$
         action: keep
 {{- end }}

--- a/resources/logging/templates/loki/servicemonitor.yaml
+++ b/resources/logging/templates/loki/servicemonitor.yaml
@@ -27,5 +27,9 @@ spec:
     {{- if .Values.loki.serviceMonitor.scrapeTimeout }}
     scrapeTimeout: {{ .Values.loki.serviceMonitor.scrapeTimeout }}
     {{- end }}
+    metricRelabelings:
+      - sourceLabels: [ __name__ ]
+        regex: ^(loki_.*|log_.*|promhttp_.*|querier_.*|go_.*|process_.*)$
+        action: keep
 {{- end }}
 {{- end }}


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/master/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**
It turned out that the Loki pod is exposing metrics jaeger and prometheus metrics as well (probably as they are using the related client libraries.
The PR filters the scraped metrics so that only meaningful ones are getting picked up

Changes proposed in this pull request:

- filtered loki metrics
- improved fluentbit metric filtering
- ...

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
