### PR TITLE
Update of version of image of external-solution-end-to-end-tests to newest version

### DIFF
--- a/resources/core/values.yaml
+++ b/resources/core/values.yaml
@@ -33,7 +33,7 @@ global:
     version: 6fd499b9
   e2e_external_solution:
     dir:
-    version: "PR-9354"
+    version: ab053ac3
   e2e_external_solution_test_service:
     dir:
     version: 9913ea21


### PR DESCRIPTION
Change from version: "PR-9354" to  version: ab053ac3 

for e2e_external_solution in the file 

resources/core/values.yaml

The new version image tag is taken from 

https://console.cloud.google.com/gcr/images/kyma-project/EU/external-solution-end-to-end-tests?gcrImageListsize=30