### PR TITLE
label for deployment ory-oathkeeper with app: oathkeeper

### DIFF
--- a/resources/ory/charts/oathkeeper/templates/_helpers.tpl
+++ b/resources/ory/charts/oathkeeper/templates/_helpers.tpl
@@ -35,7 +35,7 @@ Create chart name and version as used by the chart label.
 Common labels
 */}}
 {{- define "oathkeeper.labels" -}}
-app: {{ .Chart.Name }}
+app: {{ include "oathkeeper.name" . }}
 app.kubernetes.io/name: {{ include "oathkeeper.name" . }}
 helm.sh/chart: {{ include "oathkeeper.chart" . }}
 app.kubernetes.io/instance: {{ .Release.Name }}

--- a/resources/ory/charts/oathkeeper/templates/_helpers.tpl
+++ b/resources/ory/charts/oathkeeper/templates/_helpers.tpl
@@ -35,6 +35,7 @@ Create chart name and version as used by the chart label.
 Common labels
 */}}
 {{- define "oathkeeper.labels" -}}
+app: {{ .Chart.Name }}
 app.kubernetes.io/name: {{ include "oathkeeper.name" . }}
 helm.sh/chart: {{ include "oathkeeper.chart" . }}
 app.kubernetes.io/instance: {{ .Release.Name }}


### PR DESCRIPTION
to fix the `source_app=unknown` issue on ory-oathkeeper although it is a part of the Istio mesh  (see [here](https://github.tools.sap/kyma/backlog/issues/809#issuecomment-141071))