### PR TITLE
Remove dead Istio pilot link

### DIFF
--- a/resources/monitoring/charts/grafana/README.md
+++ b/resources/monitoring/charts/grafana/README.md
@@ -9,7 +9,6 @@ In Kyma, you can find these dashboards under [grafana](../../templates/grafana/)
 Some of the available dashboards:
 
 * **Istio** - Displays Istio metrics for services (HTTP and TCP) as well as the Service Mesh. Find the configuration of this dashboard in [this](../../../../resources/istio/templates/monitoring/grafana/dashboards/istio-mesh.yaml) file.
-* **Pilot** - Displays metrics on request latency, discovery calls and various cache types. Find the configuration of this dashboard in [this](../../../../resources/istio/templates/monitoring/grafana/dashboards/istio-pilot.yaml) file.
 * **Nodes** - Displays information pertaining to Kubernetes nodes utilization. Find the configuration of this dashboard in [this](../../templates/grafana/dashboards/nodes.yaml) file.
 * **Pods** - Displays Pod metrics such as CPU and Memory. Find the configuration of this dashboard in [this](../../templates/grafana/dashboards/pods.yaml) file.
 * **StatefulSet** - Displays Kubernetes StatefulSet metrics such as replica count, CPU and Memory. Find the configuration of this dashboard in [this](../../templates/grafana/dashboards/statefulset.yaml) file.


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/master/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

A dead link produced a [governance](https://storage.googleapis.com/kyma-prow-logs/logs/kyma-governance-nightly/1323475185587720196/build-log.txt) error. It was a link to Istio Pilot, which was removed because we don't have the component anymore: see https://github.com/kyma-project/kyma/pull/9838. 

Changes proposed in this pull request:

- Remove dead link


**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
