### PR TITLE
Do not try to delete CR if CRD does not exist

### DIFF
--- a/resources/istio/files/istio-upgrade-1-6.sh
+++ b/resources/istio/files/istio-upgrade-1-6.sh
@@ -12,11 +12,11 @@ fi
 OPERATOR_FILE="/etc/istio/operator-1-6.yaml"
 
 echo "--> Remove deprecated resources"
-if kubectl api-versions | grep -c rbac.istio.io ; then
+if kubectl get customresourcedefinitions.apiextensions.k8s.io | grep -c clusterrbacconfigs.rbac.istio.io ; then
     kubectl delete clusterrbacconfigs.rbac.istio.io default --ignore-not-found=true
 fi
 
-if kubectl api-versions | grep -c authentication.istio.io ; then
+if kubectl get customresourcedefinitions.apiextensions.k8s.io | grep -c meshpolicies.authentication.istio.io ; then
     kubectl delete meshpolicies.authentication.istio.io -n istio-system default --ignore-not-found=true
 fi
 


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/master/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**
Upgrade job in 1.6 is deleting CR first then deletes CRD. If upgrade fails, rollback is done and then upgrade is retried.  Job fails cause `--ignore-not-found` flag returns error with status 1 as CRD is already deleted.

Changes proposed in this pull request:

- Delete CR only if CRD exists


**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
