### PR TITLE
Use tagged version of httpbin image

### DIFF
--- a/resources/api-gateway/values.yaml
+++ b/resources/api-gateway/values.yaml
@@ -83,7 +83,7 @@ tests:
     after-upgrade: true
   image:
     registry: "eu.gcr.io/kyma-project"
-    version: PR-9846
+    version: PR-9858
   env:
     testUser: "admin-user"
     timeout: 120

--- a/tests/end-to-end/upgrade/chart/upgrade/values.yaml
+++ b/tests/end-to-end/upgrade/chart/upgrade/values.yaml
@@ -7,7 +7,7 @@ subscriberimage:
 
 image:
   dir:
-  version: PR-9846
+  version: PR-9858
   pullPolicy: "IfNotPresent"
 
 dex:

--- a/tests/end-to-end/upgrade/pkg/tests/api-gateway/apigateway.go
+++ b/tests/end-to-end/upgrade/pkg/tests/api-gateway/apigateway.go
@@ -46,7 +46,7 @@ var (
 	serviceName    = "httpbin-apigateway-test"
 	deploymentName = serviceName
 	containerName  = serviceName
-	httpbinImage   = "eu.gcr.io/kyma-project/external/kennethreitz/httpbin:latest"
+	httpbinImage   = "eu.gcr.io/kyma-project/external/kennethreitz/httpbin:20201004"
 	clientID       = "dummy_client"
 	clientSecret   = "dummy_secret"
 	scope          = "read"

--- a/tests/integration/api-gateway/gateway-tests/manifests/testing-app.yaml
+++ b/tests/integration/api-gateway/gateway-tests/manifests/testing-app.yaml
@@ -31,7 +31,7 @@ spec:
         version: v1
     spec:
       containers:
-      - image: eu.gcr.io/kyma-project/external/kennethreitz/httpbin:latest
+      - image: eu.gcr.io/kyma-project/external/kennethreitz/httpbin:20201004
         command:
           - /bin/bash
           - -c

--- a/tests/perf/prerequisites/istio/app.yaml
+++ b/tests/perf/prerequisites/istio/app.yaml
@@ -31,7 +31,7 @@ spec:
     spec:
       serviceAccountName: httpbin
       containers:
-        - image: eu.gcr.io/kyma-project/external/kennethreitz/httpbin:latest
+        - image: eu.gcr.io/kyma-project/external/kennethreitz/httpbin:20201004
           imagePullPolicy: IfNotPresent
           name: httpbin
           ports:

--- a/tests/perf/prerequisites/ory/deployment.yaml
+++ b/tests/perf/prerequisites/ory/deployment.yaml
@@ -36,7 +36,7 @@ spec:
     spec:
       serviceAccountName: httpbin
       containers:
-        - image: eu.gcr.io/kyma-project/external/kennethreitz/httpbin:latest
+        - image: eu.gcr.io/kyma-project/external/kennethreitz/httpbin:20201004
           imagePullPolicy: IfNotPresent
           name: httpbin
           ports:
@@ -74,7 +74,7 @@ spec:
     spec:
       serviceAccountName: httpbin
       containers:
-        - image: eu.gcr.io/kyma-project/external/kennethreitz/httpbin:latest
+        - image: eu.gcr.io/kyma-project/external/kennethreitz/httpbin:20201004
           imagePullPolicy: IfNotPresent
           name: httpbin
           ports:
@@ -112,7 +112,7 @@ spec:
     spec:
       serviceAccountName: httpbin
       containers:
-        - image: eu.gcr.io/kyma-project/external/kennethreitz/httpbin:latest
+        - image: eu.gcr.io/kyma-project/external/kennethreitz/httpbin:20201004
           imagePullPolicy: IfNotPresent
           name: httpbin
           ports:
@@ -150,7 +150,7 @@ spec:
     spec:
       serviceAccountName: httpbin
       containers:
-        - image: eu.gcr.io/kyma-project/external/kennethreitz/httpbin:latest
+        - image: eu.gcr.io/kyma-project/external/kennethreitz/httpbin:20201004
           imagePullPolicy: IfNotPresent
           name: httpbin
           ports:


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/master/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

PR #9846 introduced httpbin images from kyma-project container image repository, but the `latest` tag in some images is caught by a script on upgrade pipeline which ensures that no components in Kyma use images tagged `latest`.

Changes proposed in this pull request:

- use tagged version of httpbin image

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
