### PR TITLE
Add info on labeling a new Namespace with the default broker

### DIFF
--- a/docs/getting-started/09-trigger-microservice-with-event.md
+++ b/docs/getting-started/09-trigger-microservice-with-event.md
@@ -23,34 +23,34 @@ Follow these steps:
 
 1. Run the `kubectl get brokers -n {NAMESPACE}` command to check if there already is the Knative's `default` Broker running in the Namespace where your Function is running. If not, you must manually inject the Broker into the Namespace to enable Trigger creation and event flow. To do that, run this command:
 
-```bash
-kubectl label namespace {NAMESPACE} knative-eventing-injection=enabled
-```
+  ```bash
+  kubectl label namespace {NAMESPACE} knative-eventing-injection=enabled
+  ```
 
 2. Create a [Trigger CR](https://knative.dev/docs/eventing/triggers/) for the `orders-service` microservice to subscribe it to the `order.deliverysent.v1` event type from Commerce mock:
 
-```yaml
-cat <<EOF | kubectl apply -f  -
-apiVersion: eventing.knative.dev/v1alpha1
-kind: Trigger
-metadata:
-  name: orders-service
-  namespace: orders-service
-spec:
-  broker: default
-  filter:
-    attributes:
-      eventtypeversion: v1
-      source: commerce-mock
-      type: order.deliverysent
-  subscriber:
-    ref:
-      apiVersion: v1
-      kind: Service
+  ```yaml
+  cat <<EOF | kubectl apply -f  -
+    apiVersion: eventing.knative.dev/v1alpha1
+    kind: Trigger
+    metadata:
       name: orders-service
       namespace: orders-service
-EOF
-```
+    spec:
+      broker: default
+      filter:
+        attributes:
+          eventtypeversion: v1
+          source: commerce-mock
+          type: order.deliverysent
+      subscriber:
+        ref:
+          apiVersion: v1
+          kind: Service
+          name: orders-service
+          namespace: orders-service
+  EOF
+  ```
 
 - **spec.filter.attributes.eventtypeversion** points to the specific event version type. In this example, it is `v1`.
 - **spec.filter.attributes.source** is the name of the Application CR which is the source of the events. In this example, it is `commerce-mock`.

--- a/docs/getting-started/09-trigger-microservice-with-event.md
+++ b/docs/getting-started/09-trigger-microservice-with-event.md
@@ -21,7 +21,11 @@ Follow these steps:
   kubectl
   </summary>
 
-1. Run the `kubectl get brokers -n {NAMESPACE}` command to check if there already is the Knative's `default` Broker running in the Namespace where your Function is running. If not, you must manually inject the Broker into the Namespace to enable Trigger creation and event flow. To do that, run this command: `kubectl label namespace {NAMESPACE} knative-eventing-injection=enabled`.
+1. Run the `kubectl get brokers -n {NAMESPACE}` command to check if there already is the Knative's `default` Broker running in the Namespace where your Function is running. If not, you must manually inject the Broker into the Namespace to enable Trigger creation and event flow. To do that, run this command:
+
+```bash
+kubectl label namespace {NAMESPACE} knative-eventing-injection=enabled
+```
 
 2. Create a [Trigger CR](https://knative.dev/docs/eventing/triggers/) for the `orders-service` microservice to subscribe it to the `order.deliverysent.v1` event type from Commerce mock:
 

--- a/docs/getting-started/09-trigger-microservice-with-event.md
+++ b/docs/getting-started/09-trigger-microservice-with-event.md
@@ -21,7 +21,9 @@ Follow these steps:
   kubectl
   </summary>
 
-1. Create a [Trigger CR](https://knative.dev/docs/eventing/triggers/) for the `orders-service` microservice to subscribe it to the `order.deliverysent.v1` event type from Commerce mock:
+1. Run the `kubectl get brokers -n {NAMESPACE}` command to check if there already is the Knative's `default` Broker running in the Namespace where your Function is running. If not, you must manually inject the Broker into the Namespace to enable Trigger creation and event flow. To do that, run this command: `kubectl label namespace {NAMESPACE} knative-eventing-injection=enabled`.
+
+2. Create a [Trigger CR](https://knative.dev/docs/eventing/triggers/) for the `orders-service` microservice to subscribe it to the `order.deliverysent.v1` event type from Commerce mock:
 
 ```yaml
 cat <<EOF | kubectl apply -f  -
@@ -50,7 +52,7 @@ EOF
 - **spec.filter.attributes.source** is the name of the Application CR which is the source of the events. In this example, it is `commerce-mock`.
 - **spec.filter.attributes.type** points to the event type to which you want to subscribe the microservice. In this example, it is `order.deliverysent`.
 
-2. Check that the Trigger CR was created and is ready. This is indicated by its status equal to `True`:
+3. Check that the Trigger CR was created and is ready. This is indicated by its status equal to `True`:
 
    ```bash
    kubectl get trigger orders-service -n orders-service -o=jsonpath="{.status.conditions[2].status}"

--- a/docs/serverless/08-05-trigger-function-with-event.md
+++ b/docs/serverless/08-05-trigger-function-with-event.md
@@ -27,6 +27,8 @@ Follows these steps:
   kubectl
   </summary>
 
+  > **CAUTION:** If you use a Namespace created through kubectl, you need to manually inject the Knative's Default Broker to this Namespace to enable Trigger creation and correct event flow. To do that, run this command: `kubectl label namespace {NAMESPACE} knative-eventing-injection=enabled`.
+
 1. Export these variables:
 
     ```bash

--- a/docs/serverless/08-05-trigger-function-with-event.md
+++ b/docs/serverless/08-05-trigger-function-with-event.md
@@ -29,9 +29,9 @@ Follows these steps:
 
 1. Run the `kubectl get brokers -n {NAMESPACE}` command to check if there already is the Knative's `default` Broker running in the Namespace where your Function is running. If not, you must manually inject the Broker into the Namespace to enable Trigger creation and event flow. To do that, run this command:
 
-```bash
-kubectl label namespace {NAMESPACE} knative-eventing-injection=enabled
-```
+  ```bash
+  kubectl label namespace {NAMESPACE} knative-eventing-injection=enabled
+  ```
 
 2. Export these variables:
 

--- a/docs/serverless/08-05-trigger-function-with-event.md
+++ b/docs/serverless/08-05-trigger-function-with-event.md
@@ -27,7 +27,11 @@ Follows these steps:
   kubectl
   </summary>
 
-1. Run the `kubectl get brokers -n {NAMESPACE}` command to check if there already is the Knative's `default` Broker running in the Namespace where your Function is running. If not, you must manually inject the Broker into the Namespace to enable Trigger creation and event flow. To do that, run this command: `kubectl label namespace {NAMESPACE} knative-eventing-injection=enabled`.
+1. Run the `kubectl get brokers -n {NAMESPACE}` command to check if there already is the Knative's `default` Broker running in the Namespace where your Function is running. If not, you must manually inject the Broker into the Namespace to enable Trigger creation and event flow. To do that, run this command:
+
+```bash
+kubectl label namespace {NAMESPACE} knative-eventing-injection=enabled
+```
 
 2. Export these variables:
 

--- a/docs/serverless/08-05-trigger-function-with-event.md
+++ b/docs/serverless/08-05-trigger-function-with-event.md
@@ -27,9 +27,9 @@ Follows these steps:
   kubectl
   </summary>
 
-  > **CAUTION:** If you use a Namespace created through kubectl, you need to manually inject the Knative's Default Broker to this Namespace to enable Trigger creation and correct event flow. To do that, run this command: `kubectl label namespace {NAMESPACE} knative-eventing-injection=enabled`.
+1. Run the `kubectl get brokers -n {NAMESPACE}` command to check if there already is the Knative's `default` Broker running in the Namespace. If not, you must manually inject it to the Namespace to enable Trigger creation and correct event flow. To do that, run this command: `kubectl label namespace {NAMESPACE} knative-eventing-injection=enabled`.
 
-1. Export these variables:
+2. Export these variables:
 
     ```bash
     export NAME={FUNCTION_NAME}
@@ -47,7 +47,7 @@ These variables refer to the following:
 - **EVENT_VERSION** points to the specific event version type, such as `v1`.
 - **EVENT_TYPE** points to the event type to which you want to subscribe your Function, such as `user.created`.
 
-2. Create a Trigger CR for your Function to subscribe your Function to a specific event type.
+3. Create a Trigger CR for your Function to subscribe your Function to a specific event type.
 
     ```yaml
     cat <<EOF | kubectl apply -f  -

--- a/docs/serverless/08-05-trigger-function-with-event.md
+++ b/docs/serverless/08-05-trigger-function-with-event.md
@@ -27,7 +27,7 @@ Follows these steps:
   kubectl
   </summary>
 
-1. Run the `kubectl get brokers -n {NAMESPACE}` command to check if there already is the Knative's `default` Broker running in the Namespace. If not, you must manually inject it to the Namespace to enable Trigger creation and correct event flow. To do that, run this command: `kubectl label namespace {NAMESPACE} knative-eventing-injection=enabled`.
+1. Run the `kubectl get brokers -n {NAMESPACE}` command to check if there already is the Knative's `default` Broker running in the Namespace where your Function is running. If not, you must manually inject it to the Namespace to enable Trigger creation and correct event flow. To do that, run this command: `kubectl label namespace {NAMESPACE} knative-eventing-injection=enabled`.
 
 2. Export these variables:
 

--- a/docs/serverless/08-05-trigger-function-with-event.md
+++ b/docs/serverless/08-05-trigger-function-with-event.md
@@ -27,7 +27,7 @@ Follows these steps:
   kubectl
   </summary>
 
-1. Run the `kubectl get brokers -n {NAMESPACE}` command to check if there already is the Knative's `default` Broker running in the Namespace where your Function is running. If not, you must manually inject it to the Namespace to enable Trigger creation and correct event flow. To do that, run this command: `kubectl label namespace {NAMESPACE} knative-eventing-injection=enabled`.
+1. Run the `kubectl get brokers -n {NAMESPACE}` command to check if there already is the Knative's `default` Broker running in the Namespace where your Function is running. If not, you must manually inject the Broker into the Namespace to enable Trigger creation and event flow. To do that, run this command: `kubectl label namespace {NAMESPACE} knative-eventing-injection=enabled`.
 
 2. Export these variables:
 

--- a/docs/serverless/10-01-failure-to-build-functions.md
+++ b/docs/serverless/10-01-failure-to-build-functions.md
@@ -54,7 +54,7 @@ To do this, follow these steps:
 
   > **CAUTION:** Do not remove Pods named `serverless-docker-registry-self-signed-cert-{UNIQUE_ID}`.
 
-3. Search for the `serverless-docker-registry`  PVC again to check that the capacity was resized:
+3. Search for the `serverless-docker-registry` PVC again to check that the capacity was resized:
 
   ```bash
   kubectl get pvc serverless-docker-registry -n kyma-system


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Update the Serverless tutorial and a Getting Started guide with a manual step requiring labeling a new Namespace with Knative's Default Broker when creating a namespace through kubectl.
