### PR TITLE
disabled readinessProbe for kcproxy for local setup

### DIFF
--- a/resources/kiali/templates/kyma-additions/kcproxy-deployment.yaml
+++ b/resources/kiali/templates/kyma-additions/kcproxy-deployment.yaml
@@ -86,6 +86,7 @@ spec:
         - name: http
           containerPort: {{ .Values.kcproxy.port }}
           protocol: TCP
+{{- if not .Values.global.isLocalEnv }}
         livenessProbe:
           httpGet:
             path: /oauth/health
@@ -94,5 +95,6 @@ spec:
           httpGet:
             path: /oauth/health
             port: http
+{{- end }}
         resources:
 {{ toYaml .Values.kcproxy.resources | indent 10 }}

--- a/resources/monitoring/charts/grafana/templates/kyma-additions/auth-proxy-deployment.yaml
+++ b/resources/monitoring/charts/grafana/templates/kyma-additions/auth-proxy-deployment.yaml
@@ -92,6 +92,7 @@ spec:
         - name: http
           containerPort: {{ .Values.kyma.authProxy.port }}
           protocol: TCP
+{{- if not .Values.global.isLocalEnv }}
         livenessProbe:
           httpGet:
             path: /oauth/health
@@ -100,6 +101,7 @@ spec:
           httpGet:
             path: /oauth/health
             port: http
+{{- end }}
         resources:
 {{ toYaml .Values.kyma.authProxy.resources | indent 10 }}
 {{- end}}

--- a/resources/tracing/templates/kyma-additions/kcproxy-deployment.yaml
+++ b/resources/tracing/templates/kyma-additions/kcproxy-deployment.yaml
@@ -87,6 +87,7 @@ spec:
         - name: http
           containerPort: {{ .Values.kcproxy.inPort }}
           protocol: TCP
+{{- if not .Values.global.isLocalEnv }}
         livenessProbe:
           httpGet:
             path: /oauth/health
@@ -95,5 +96,6 @@ spec:
           httpGet:
             path: /oauth/health
             port: http
+{{- end }}
         resources:
 {{ toYaml .Values.kcproxy.resources | indent 10 }}


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/master/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Enabling the tracing or kiali component for the local setup is failing as the installation by CLI is adding the host entries at the end of the installation process. The keycloak proxy used by the components requires the external dex address to be working at startup. With that the installation hangs forever.

Changes proposed in this pull request:

- Disable the readinessProbe of keycloak for local setups, so that startup will fail but not block the installation
- ...
- ...

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
