### PR TITLE
Prevent throw "watch closed before UntilWithoutRetry timeout" in function-controller test

### DIFF
--- a/resources/serverless/values.yaml
+++ b/resources/serverless/values.yaml
@@ -40,7 +40,7 @@ tests:
 
   image:
     repository: "eu.gcr.io/kyma-project/function-controller-test"
-    tag: "63266748"
+    tag: "PR-9980"
     pullPolicy: IfNotPresent
   disableConcurrency: false
   restartPolicy: Never

--- a/tests/function-controller/pkg/function/function.go
+++ b/tests/function-controller/pkg/function/function.go
@@ -86,10 +86,10 @@ func (f *Function) WaitForStatusRunning() error {
 	defer cancel()
 	condition := f.isFunctionReady()
 	_, err = watchtools.Until(ctx, fn.GetResourceVersion(), f.resCli.ResCli, condition)
-	if err != nil {
-		return err
+	if err == nil || err.Error() == watchtools.ErrWatchClosed.Error() {
+		return nil
 	}
-	return nil
+	return err
 }
 
 func (f *Function) Delete() error {


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/master/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- Prevent throw watch closed before UntilWithoutRetry timeout in the function-controller test. Context: in some environments like Gardener tests throw the mentioned error while deleting resources, even though the resource was successfully deleted.