### PR TITLE
Fix alering e2e tests

### DIFF
--- a/resources/monitoring/values.yaml
+++ b/resources/monitoring/values.yaml
@@ -11,7 +11,7 @@ global:
   monitoring_integration_tests:
     name: monitoring-integration-tests
     dir:
-    version: PR-9934
+    version: PR-10010
     enabled: true
     labels:
       integration: true

--- a/tests/end-to-end/upgrade/chart/upgrade/values.yaml
+++ b/tests/end-to-end/upgrade/chart/upgrade/values.yaml
@@ -7,7 +7,8 @@ subscriberimage:
 
 image:
   dir:
-  version: PR-9934
+  version: PR-10010
+
   pullPolicy: "IfNotPresent"
 
 dex:

--- a/tests/end-to-end/upgrade/pkg/tests/monitoring/prom/alerts.go
+++ b/tests/end-to-end/upgrade/pkg/tests/monitoring/prom/alerts.go
@@ -19,4 +19,5 @@ type Alert struct {
 
 type AlertLabels struct {
 	AlertName string `json:"alertname"`
+	Severity  string `json:"severity"`
 }

--- a/tests/end-to-end/upgrade/pkg/tests/monitoring/targets_rules.go
+++ b/tests/end-to-end/upgrade/pkg/tests/monitoring/targets_rules.go
@@ -437,7 +437,7 @@ func (t TargetsAndRulesTest) checkAlerts() error {
 			alerts := resp.Data.Alerts
 			timeoutMessage = ""
 			for _, alert := range alerts {
-				if shouldIgnoreAlert(alert.Labels.AlertName) {
+				if shouldIgnoreAlert(alert) {
 					continue
 				}
 				if alert.State == "firing" {
@@ -452,17 +452,22 @@ func (t TargetsAndRulesTest) checkAlerts() error {
 	}
 }
 
-func shouldIgnoreAlert(alertName string) bool {
-	var alertsToBeIgnored = []string{
+func shouldIgnoreAlert(alert prom.Alert) bool {
+	if alert.Labels.Severity != "critical" {
+		return true
+	}
+
+	var alertNamesToIgnore = []string{
 		// Watchdog is an alert meant to ensure that the entire alerting pipeline is functional, so it should always be firing,
 		"Watchdog",
 	}
 
-	for _, alert := range alertsToBeIgnored {
-		if alert == alertName {
+	for _, name := range alertNamesToIgnore {
+		if name == alert.Labels.AlertName {
 			return true
 		}
 	}
+
 	return false
 }
 

--- a/tests/integration/monitoring/prom/alerts.go
+++ b/tests/integration/monitoring/prom/alerts.go
@@ -19,4 +19,5 @@ type Alert struct {
 
 type AlertLabels struct {
 	AlertName string `json:"alertname"`
+	Severity  string `json:"severity"`
 }

--- a/tests/integration/monitoring/test-monitoring.go
+++ b/tests/integration/monitoring/test-monitoring.go
@@ -379,7 +379,7 @@ func checkAlerts() {
 			alerts := resp.Data.Alerts
 			timeoutMessage = ""
 			for _, alert := range alerts {
-				if shouldIgnoreAlert(alert.Labels.AlertName) {
+				if shouldIgnoreAlert(alert) {
 					continue
 				}
 				if alert.State == "firing" {
@@ -395,14 +395,18 @@ func checkAlerts() {
 	}
 }
 
-func shouldIgnoreAlert(alertName string) bool {
-	var alertsToBeIgnored = []string{
+func shouldIgnoreAlert(alert prom.Alert) bool {
+	if alert.Labels.Severity != "critical" {
+		return true
+	}
+
+	var alertNamesToIgnore = []string{
 		// Watchdog is an alert meant to ensure that the entire alerting pipeline is functional, so it should always be firing,
 		"Watchdog",
 	}
 
-	for _, alert := range alertsToBeIgnored {
-		if alert == alertName {
+	for _, name := range alertNamesToIgnore {
+		if name == alert.Labels.AlertName {
 			return true
 		}
 	}


### PR DESCRIPTION
**Description**

Only fail the tests if a firing alert is of critical serverity

**Related issue(s)**
See also #9934
