### PR TITLE
Upgrade node exporter chart

### DIFF
--- a/resources/monitoring/charts/prometheus-node-exporter/Chart.yaml
+++ b/resources/monitoring/charts/prometheus-node-exporter/Chart.yaml
@@ -1,5 +1,4 @@
 apiVersion: v1
-appVersion: 1.0.1
 description: A Helm chart for prometheus node-exporter
 name: prometheus-node-exporter
 version: 1.12.0

--- a/resources/monitoring/charts/prometheus-node-exporter/Chart.yaml
+++ b/resources/monitoring/charts/prometheus-node-exporter/Chart.yaml
@@ -1,7 +1,8 @@
 apiVersion: v1
+appVersion: 1.0.1
 description: A Helm chart for prometheus node-exporter
 name: prometheus-node-exporter
-version: 1.9.1
+version: 1.12.0
 home: https://github.com/prometheus/node_exporter/
 sources:
 - https://github.com/prometheus/node_exporter/

--- a/resources/monitoring/charts/prometheus-node-exporter/templates/_helpers.tpl
+++ b/resources/monitoring/charts/prometheus-node-exporter/templates/_helpers.tpl
@@ -1,3 +1,14 @@
+{{- /*
+  Customization: Some changes are made to the default label set.
+  Added labels recommended by Kubernetes and Helm:
+    helm.sh/chart
+    app.kubernetes.io/managed-by
+    app.kubernetes.io/name
+    app.kubernetes.io/instance
+  Removed labels:
+    heritage
+*/ -}}
+
 {{/* vim: set filetype=mustache: */}}
 {{/*
 Expand the name of the chart.
@@ -38,6 +49,14 @@ chart: {{ template "prometheus-node-exporter.chart" . }}
 {{- end }}
 
 {{/*
+Selector labels
+*/}}
+{{- define "prometheus-node-exporter.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "prometheus-node-exporter.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end -}}
+
+{{/*
 Create chart name and version as used by the chart label.
 */}}
 {{- define "prometheus-node-exporter.chart" -}}
@@ -65,12 +84,4 @@ Allow the release namespace to be overridden for multi-namespace deployments in 
   {{- else -}}
     {{- .Release.Namespace -}}
   {{- end -}}
-{{- end -}}
-
-{{/*
-Selector labels
-*/}}
-{{- define "prometheus-node-exporter.selectorLabels" -}}
-app.kubernetes.io/name: {{ include "prometheus-node-exporter.name" . }}
-app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end -}}

--- a/resources/monitoring/charts/prometheus-node-exporter/templates/daemonset.yaml
+++ b/resources/monitoring/charts/prometheus-node-exporter/templates/daemonset.yaml
@@ -38,6 +38,7 @@ spec:
           args:
             - --path.procfs=/host/proc
             - --path.sysfs=/host/sys
+            - --path.rootfs=/host/root
             - --web.listen-address=$(HOST_IP):{{ .Values.service.port }}
 {{- if .Values.extraArgs }}
 {{ toYaml .Values.extraArgs | indent 12 }}
@@ -72,6 +73,10 @@ spec:
               readOnly:  true
             - name: sys
               mountPath: /host/sys
+              readOnly: true
+            - name: root
+              mountPath: /host/root
+              mountPropagation: HostToContainer
               readOnly: true
             {{- if .Values.extraHostVolumeMounts }}
             {{- range $_, $mount := .Values.extraHostVolumeMounts }}
@@ -128,6 +133,9 @@ spec:
         - name: sys
           hostPath:
             path: /sys
+        - name: root
+          hostPath:
+            path: /
         {{- if .Values.extraHostVolumeMounts }}
         {{- range $_, $mount := .Values.extraHostVolumeMounts }}
         - name: {{ $mount.name }}

--- a/resources/monitoring/charts/prometheus-node-exporter/templates/monitor.yaml
+++ b/resources/monitoring/charts/prometheus-node-exporter/templates/monitor.yaml
@@ -18,4 +18,8 @@ spec:
       {{- if .Values.prometheus.monitor.scrapeTimeout }}
       scrapeTimeout: {{ .Values.prometheus.monitor.scrapeTimeout }}
       {{- end }}
+{{- if .Values.prometheus.monitor.relabelings }}
+      relabelings:
+{{ toYaml .Values.prometheus.monitor.relabelings | indent 6 }}
+{{- end }}
 {{- end }}

--- a/resources/monitoring/charts/prometheus-node-exporter/templates/serviceaccount.yaml
+++ b/resources/monitoring/charts/prometheus-node-exporter/templates/serviceaccount.yaml
@@ -1,3 +1,7 @@
+{{- /*
+  Customization: Fixed an upstream chart inconistency by using the default label set
+*/ -}}
+
 {{- if .Values.rbac.create -}}
 {{- if .Values.serviceAccount.create -}}
 apiVersion: v1
@@ -6,7 +10,6 @@ metadata:
   name: {{ template "prometheus-node-exporter.serviceAccountName" . }}
   namespace: {{ template "prometheus-node-exporter.namespace" . }}
   labels:
-    app: {{ template "prometheus-node-exporter.name" . }}
     {{ include "prometheus-node-exporter.labels" . | indent 4 }}
 imagePullSecrets:
 {{ toYaml .Values.serviceAccount.imagePullSecrets | indent 2 }}

--- a/resources/monitoring/charts/prometheus-node-exporter/values.yaml
+++ b/resources/monitoring/charts/prometheus-node-exporter/values.yaml
@@ -3,7 +3,7 @@
 # Declare variables to be passed into your templates.
 image:
   repository: eu.gcr.io/kyma-project/incubator/develop/node-exporter
-  tag: 0.18.1-6f374cc6
+  tag: 1.0.1-3ee7f789
   pullPolicy: IfNotPresent
 
 service:
@@ -15,19 +15,13 @@ service:
   annotations:
     prometheus.io/scrape: "true"
 
-podLabels:
-  jobLabel: node-exporter
-
-extraArgs:
-    - --collector.filesystem.ignored-mount-points=^/(dev|proc|sys|var/lib/docker/.+)($|/)
-    - --collector.filesystem.ignored-fs-types=^(autofs|binfmt_misc|cgroup|configfs|debugfs|devpts|devtmpfs|fusectl|hugetlbfs|mqueue|overlay|proc|procfs|pstore|rpc_pipefs|securityfs|sysfs|tracefs)$
-
 prometheus:
   monitor:
     enabled: false
     additionalLabels: {}
     namespace: ""
 
+    relabelings: []
     scrapeTimeout: 10s
 
 ## Customize the updateStrategy if set
@@ -57,6 +51,8 @@ serviceAccount:
   imagePullSecrets: []
 
 securityContext:
+  fsGroup: 65534
+  runAsGroup: 65534
   runAsNonRoot: true
   runAsUser: 65534
 
@@ -91,7 +87,8 @@ affinity: {}
 podAnnotations: {}
 
 # Extra labels to be added to node exporter pods
-podLabels: {}
+podLabels:
+  jobLabel: node-exporter
 
 ## Assign a nodeSelector if operating a hybrid cluster
 ##
@@ -108,9 +105,11 @@ tolerations:
 
 ## Additional container arguments
 ##
-extraArgs: []
+extraArgs:
 #   - --collector.diskstats.ignored-devices=^(ram|loop|fd|(h|s|v)d[a-z]|nvme\\d+n\\d+p)\\d+$
 #   - --collector.textfile.directory=/run/prometheus
+    - --collector.filesystem.ignored-mount-points=^/(dev|proc|sys|var/lib/docker/.+)($|/)
+    - --collector.filesystem.ignored-fs-types=^(autofs|binfmt_misc|cgroup|configfs|debugfs|devpts|devtmpfs|fusectl|hugetlbfs|mqueue|overlay|proc|procfs|pstore|rpc_pipefs|securityfs|sysfs|tracefs)$
 
 ## Additional mounts from the host
 ##


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Bump the image version to 1.0.1
- Carry over changes from the chart version 1.12.0

**Related issue(s)**
See also #9897 
