### PR TITLE
Re-add helm keep resource policy

### DIFF
--- a/resources/cluster-essentials/files/alertmanagerconfigs.monitoring.coreos.crd.yaml
+++ b/resources/cluster-essentials/files/alertmanagerconfigs.monitoring.coreos.crd.yaml
@@ -5,6 +5,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
+    "helm.sh/resource-policy": keep
     controller-gen.kubebuilder.io/version: v0.2.4
   creationTimestamp: null
   name: alertmanagerconfigs.monitoring.coreos.com

--- a/resources/cluster-essentials/files/alertmanagers.monitoring.coreos.crd.yaml
+++ b/resources/cluster-essentials/files/alertmanagers.monitoring.coreos.crd.yaml
@@ -5,6 +5,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
+    "helm.sh/resource-policy": keep
     controller-gen.kubebuilder.io/version: v0.2.4
   creationTimestamp: null
   name: alertmanagers.monitoring.coreos.com

--- a/resources/cluster-essentials/files/podmonitors.monitoring.crd.yaml
+++ b/resources/cluster-essentials/files/podmonitors.monitoring.crd.yaml
@@ -5,6 +5,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
+    "helm.sh/resource-policy": keep
     controller-gen.kubebuilder.io/version: v0.2.4
   creationTimestamp: null
   name: podmonitors.monitoring.coreos.com

--- a/resources/cluster-essentials/files/probes.monitoring.coreos.crd.yaml
+++ b/resources/cluster-essentials/files/probes.monitoring.coreos.crd.yaml
@@ -5,6 +5,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
+    "helm.sh/resource-policy": keep
     controller-gen.kubebuilder.io/version: v0.2.4
   creationTimestamp: null
   name: probes.monitoring.coreos.com

--- a/resources/cluster-essentials/files/prometheuses.monitoring.crd.yaml
+++ b/resources/cluster-essentials/files/prometheuses.monitoring.crd.yaml
@@ -5,6 +5,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
+    "helm.sh/resource-policy": keep
     controller-gen.kubebuilder.io/version: v0.2.4
   creationTimestamp: null
   name: prometheuses.monitoring.coreos.com

--- a/resources/cluster-essentials/files/prometheusrules.monitoring.crd.yaml
+++ b/resources/cluster-essentials/files/prometheusrules.monitoring.crd.yaml
@@ -5,6 +5,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
+    "helm.sh/resource-policy": keep
     controller-gen.kubebuilder.io/version: v0.2.4
   creationTimestamp: null
   name: prometheusrules.monitoring.coreos.com

--- a/resources/cluster-essentials/files/servicemonitors.monitoring.crd.yaml
+++ b/resources/cluster-essentials/files/servicemonitors.monitoring.crd.yaml
@@ -5,6 +5,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
+    "helm.sh/resource-policy": keep
     controller-gen.kubebuilder.io/version: v0.2.4
   creationTimestamp: null
   name: servicemonitors.monitoring.coreos.com

--- a/resources/cluster-essentials/files/thanosrulers.monitoring.crd.yaml
+++ b/resources/cluster-essentials/files/thanosrulers.monitoring.crd.yaml
@@ -5,6 +5,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
+    "helm.sh/resource-policy": keep
     controller-gen.kubebuilder.io/version: v0.2.4
   creationTimestamp: null
   name: thanosrulers.monitoring.coreos.com


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:
During the recent monitoring chart upgrade the resource policy annotations were removed casuing problems with kyma upgrades. Adding them back
 Related to https://github.com/kyma-project/kyma/issues/9891