### PR TITLE
Use the newest version of k8s-tools

### DIFF
--- a/resources/cluster-essentials/values.yaml
+++ b/resources/cluster-essentials/values.yaml
@@ -2,7 +2,7 @@ jobs:
   crdsInConfigMap: 20
   image:
     repository: eu.gcr.io/kyma-project/incubator/develop/k8s-tools
-    tag: "20201023-5de446cf"
+    tag: "20201125-caa631b9"
   installer:
     namespace: kyma-installer
 


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

Use the latest version of `k8s-tools` to fix the problem with `cluster-essential` upgrade timeouts
