### PR TITLE
Upgrade prometheus pushgateway charts to latest.

### DIFF
--- a/resources/monitoring/charts/prometheus-pushgateway/.helmignore
+++ b/resources/monitoring/charts/prometheus-pushgateway/.helmignore
@@ -19,3 +19,6 @@
 .project
 .idea/
 *.tmproj
+
+# OWNERS file for Kubernetes
+OWNERS

--- a/resources/monitoring/charts/prometheus-pushgateway/Chart.yaml
+++ b/resources/monitoring/charts/prometheus-pushgateway/Chart.yaml
@@ -1,5 +1,4 @@
 apiVersion: v1
-appVersion: "1.3.0"
 description: A Helm chart for prometheus pushgateway
 name: prometheus-pushgateway
 version: 1.5.0

--- a/resources/monitoring/charts/prometheus-pushgateway/Chart.yaml
+++ b/resources/monitoring/charts/prometheus-pushgateway/Chart.yaml
@@ -1,7 +1,8 @@
 apiVersion: v1
+appVersion: "1.3.0"
 description: A Helm chart for prometheus pushgateway
 name: prometheus-pushgateway
-version: 1.4.0
+version: 1.5.0
 home: https://github.com/prometheus/pushgateway
 sources:
 - https://github.com/prometheus/pushgateway

--- a/resources/monitoring/charts/prometheus-pushgateway/templates/_helpers.tpl
+++ b/resources/monitoring/charts/prometheus-pushgateway/templates/_helpers.tpl
@@ -1,3 +1,7 @@
+
+# Customizations:
+# 1. Added Selector labels
+
 {{/* vim: set filetype=mustache: */}}
 {{/*
 Expand the name of the chart.
@@ -46,10 +50,11 @@ Create the name of the service account to use
 {{/*
 Create default labels
 */}}
-{{- define "prometheus-pushgateway.labels" -}}
-helm.sh/chart: {{ include "prometheus-pushgateway.chart" . }}
-{{ include "prometheus-pushgateway.selectorLabels" . }}
-app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- define "prometheus-pushgateway.defaultLabels" -}}
+{{- $labelChart := include "prometheus-pushgateway.chart" $ -}}
+{{- $labelApp := include "prometheus-pushgateway.name" $ -}}
+{{- $labels := dict "app" $labelApp "chart" $labelChart "release" .Release.Name "heritage" .Release.Service -}}
+{{ merge .extraLabels $labels | toYaml | indent 4 }}
 {{- end -}}
 
 {{/*

--- a/resources/monitoring/charts/prometheus-pushgateway/templates/_helpers.tpl
+++ b/resources/monitoring/charts/prometheus-pushgateway/templates/_helpers.tpl
@@ -52,9 +52,21 @@ Create the name of the service account to use
 Create default labels
 */}}
 {{- define "prometheus-pushgateway.defaultLabels" -}}
-helm.sh/chart: {{ include "prometheus-pushgateway.chart" . }}
-{{ include "prometheus-pushgateway.selectorLabels" . }}
-app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- $labelChart := include "prometheus-pushgateway.chart" $ -}}
+{{- $labelApp := include "prometheus-pushgateway.name" $ -}}
+{{- $labels := dict "app.kubernetes.io/name" $labelApp -}}
+{{- $_ := set $labels "helm.sh/chart" $labelChart -}}
+{{- $_ := set $labels "app.kubernetes.io/instance" .Release.Name -}}
+{{- $_ := set $labels "app.kubernetes.io/managed-by" .Release.Service -}}
+{{ merge .extraLabels $labels | toYaml | indent 4 }}
+{{- end -}}
+
+{{/*
+Selector labels
+*/}}
+{{- define "prometheus-pushgateway.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "prometheus-pushgateway.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end -}}
 
 {{/*
@@ -66,12 +78,4 @@ Return the appropriate apiVersion for networkpolicy.
 {{- else if semverCompare "^1.7-0" .Capabilities.KubeVersion.GitVersion -}}
 {{- print "networking.k8s.io/v1" -}}
 {{- end -}}
-{{- end -}}
-
-{{/*
-Selector labels
-*/}}
-{{- define "prometheus-pushgateway.selectorLabels" -}}
-app.kubernetes.io/name: {{ include "prometheus-pushgateway.name" . }}
-app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end -}}

--- a/resources/monitoring/charts/prometheus-pushgateway/templates/_helpers.tpl
+++ b/resources/monitoring/charts/prometheus-pushgateway/templates/_helpers.tpl
@@ -1,6 +1,7 @@
 
 # Customizations:
 # 1. Added Selector labels
+# 2. Modifed "prometheus-pushgateway.defaultLabels"
 
 {{/* vim: set filetype=mustache: */}}
 {{/*
@@ -51,10 +52,9 @@ Create the name of the service account to use
 Create default labels
 */}}
 {{- define "prometheus-pushgateway.defaultLabels" -}}
-{{- $labelChart := include "prometheus-pushgateway.chart" $ -}}
-{{- $labelApp := include "prometheus-pushgateway.name" $ -}}
-{{- $labels := dict "app" $labelApp "chart" $labelChart "release" .Release.Name "heritage" .Release.Service -}}
-{{ merge .extraLabels $labels | toYaml | indent 4 }}
+helm.sh/chart: {{ include "prometheus-pushgateway.chart" . }}
+{{ include "prometheus-pushgateway.selectorLabels" . }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
 {{- end -}}
 
 {{/*

--- a/resources/monitoring/charts/prometheus-pushgateway/templates/_helpers.tpl
+++ b/resources/monitoring/charts/prometheus-pushgateway/templates/_helpers.tpl
@@ -1,7 +1,12 @@
-
-# Customizations:
-# 1. Added Selector labels
-# 2. Modifed "prometheus-pushgateway.defaultLabels"
+{{- /*
+  Customization:
+  Added labels recommended by Kubernetes and Helm:
+    helm.sh/chart
+    app.kubernetes.io/managed-by
+    app.kubernetes.io/instance
+  Removed labels:
+    heritage
+*/ -}}
 
 {{/* vim: set filetype=mustache: */}}
 {{/*

--- a/resources/monitoring/charts/prometheus-pushgateway/templates/deployment.yaml
+++ b/resources/monitoring/charts/prometheus-pushgateway/templates/deployment.yaml
@@ -17,6 +17,7 @@ spec:
   template:
     metadata:
       labels:
+        {{- include "prometheus-pushgateway.defaultLabels" . | nindent 8 }}
         app: {{ template "prometheus-pushgateway.name" . }}
         release: {{ .Release.Name }}
       annotations:

--- a/resources/monitoring/charts/prometheus-pushgateway/templates/deployment.yaml
+++ b/resources/monitoring/charts/prometheus-pushgateway/templates/deployment.yaml
@@ -3,7 +3,7 @@ kind: Deployment
 metadata:
   name: {{ template "prometheus-pushgateway.fullname" . }}
   labels:
-{{ template "prometheus-pushgateway.defaultLabels" merge (dict "extraLabels" .Values.podLabels) .  }}
+    {{ include "prometheus-pushgateway.defaultLabels" . | nindent 4}}
 spec:
   replicas: {{ .Values.replicaCount }}
   {{- if .Values.strategy }}

--- a/resources/monitoring/charts/prometheus-pushgateway/templates/deployment.yaml
+++ b/resources/monitoring/charts/prometheus-pushgateway/templates/deployment.yaml
@@ -3,10 +3,7 @@ kind: Deployment
 metadata:
   name: {{ template "prometheus-pushgateway.fullname" . }}
   labels:
-    {{ include "prometheus-pushgateway.labels" . | nindent 4}}
-    {{- if .Values.serviceAccountLabels }}
-    {{ toYaml .Values.serviceAccountLabels | indent 4 }}
-    {{- end }}
+{{ template "prometheus-pushgateway.defaultLabels" merge (dict "extraLabels" .Values.podLabels) .  }}
 spec:
   replicas: {{ .Values.replicaCount }}
   {{- if .Values.strategy }}
@@ -20,7 +17,6 @@ spec:
   template:
     metadata:
       labels:
-        {{- include "prometheus-pushgateway.labels" . | nindent 8 }}
         app: {{ template "prometheus-pushgateway.name" . }}
         release: {{ .Release.Name }}
       annotations:

--- a/resources/monitoring/charts/prometheus-pushgateway/templates/deployment.yaml
+++ b/resources/monitoring/charts/prometheus-pushgateway/templates/deployment.yaml
@@ -3,7 +3,7 @@ kind: Deployment
 metadata:
   name: {{ template "prometheus-pushgateway.fullname" . }}
   labels:
-    {{ include "prometheus-pushgateway.defaultLabels" . | nindent 4}}
+{{ template "prometheus-pushgateway.defaultLabels" merge (dict "extraLabels" .Values.podLabels) .  }}
 spec:
   replicas: {{ .Values.replicaCount }}
   {{- if .Values.strategy }}
@@ -12,14 +12,11 @@ spec:
   {{- end }}
   selector:
     matchLabels:
-      app: {{ template "prometheus-pushgateway.name" . }}
-      release: {{ .Release.Name }}
+      {{- include "prometheus-pushgateway.selectorLabels" . | nindent 6 }}
   template:
     metadata:
       labels:
-        {{- include "prometheus-pushgateway.defaultLabels" . | nindent 8 }}
-        app: {{ template "prometheus-pushgateway.name" . }}
-        release: {{ .Release.Name }}
+        {{- include "prometheus-pushgateway.selectorLabels" . | nindent 8 }}
       annotations:
 {{ toYaml .Values.podAnnotations | indent 8 }}
     spec:

--- a/resources/monitoring/charts/prometheus-pushgateway/templates/ingress.yaml
+++ b/resources/monitoring/charts/prometheus-pushgateway/templates/ingress.yaml
@@ -14,7 +14,11 @@ metadata:
 {{ toYaml .Values.ingress.annotations | indent 4}}
 {{- end }}
   labels:
-    {{- include "prometheus-pushgateway.labels" . | nindent 4 }}
+    app: {{ template "prometheus-pushgateway.name" . }}
+    chart: {{ template "prometheus-pushgateway.chart" . }}
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+  name: {{ template "prometheus-pushgateway.fullname" . }}
 spec:
   rules:
     {{- range $host := .Values.ingress.hosts }}

--- a/resources/monitoring/charts/prometheus-pushgateway/templates/ingress.yaml
+++ b/resources/monitoring/charts/prometheus-pushgateway/templates/ingress.yaml
@@ -14,7 +14,7 @@ metadata:
 {{ toYaml .Values.ingress.annotations | indent 4}}
 {{- end }}
   labels:
-    {{ include "prometheus-pushgateway.defaultLabels" . | nindent 4}}
+{{ template "prometheus-pushgateway.defaultLabels" merge (dict "extraLabels" dict) .}}
   name: {{ template "prometheus-pushgateway.fullname" . }}
 spec:
   rules:

--- a/resources/monitoring/charts/prometheus-pushgateway/templates/ingress.yaml
+++ b/resources/monitoring/charts/prometheus-pushgateway/templates/ingress.yaml
@@ -14,10 +14,7 @@ metadata:
 {{ toYaml .Values.ingress.annotations | indent 4}}
 {{- end }}
   labels:
-    app: {{ template "prometheus-pushgateway.name" . }}
-    chart: {{ template "prometheus-pushgateway.chart" . }}
-    release: "{{ .Release.Name }}"
-    heritage: "{{ .Release.Service }}"
+    {{ include "prometheus-pushgateway.defaultLabels" . | nindent 4}}
   name: {{ template "prometheus-pushgateway.fullname" . }}
 spec:
   rules:

--- a/resources/monitoring/charts/prometheus-pushgateway/templates/kyma-additions/policy.yaml
+++ b/resources/monitoring/charts/prometheus-pushgateway/templates/kyma-additions/policy.yaml
@@ -4,7 +4,7 @@ kind: PeerAuthentication
 metadata:
   name: {{ template "prometheus-pushgateway.name" . }}
   labels:
-    {{ include "prometheus-pushgateway.defaultLabels" . | nindent 4}}
+{{ template "prometheus-pushgateway.defaultLabels" merge (dict "extraLabels" dict) .}}
   name: {{ template "prometheus-pushgateway.fullname" . }}
 spec:
   selector:

--- a/resources/monitoring/charts/prometheus-pushgateway/templates/kyma-additions/policy.yaml
+++ b/resources/monitoring/charts/prometheus-pushgateway/templates/kyma-additions/policy.yaml
@@ -4,7 +4,7 @@ kind: PeerAuthentication
 metadata:
   name: {{ template "prometheus-pushgateway.name" . }}
   labels:
-{{ template "prometheus-pushgateway.defaultLabels" merge (dict "extraLabels" .Values.persistentVolumeLabels) .  }}
+    {{ include "prometheus-pushgateway.defaultLabels" . | nindent 4}}
   name: {{ template "prometheus-pushgateway.fullname" . }}
 spec:
   selector:

--- a/resources/monitoring/charts/prometheus-pushgateway/templates/kyma-additions/policy.yaml
+++ b/resources/monitoring/charts/prometheus-pushgateway/templates/kyma-additions/policy.yaml
@@ -4,7 +4,8 @@ kind: PeerAuthentication
 metadata:
   name: {{ template "prometheus-pushgateway.name" . }}
   labels:
-    {{- include "prometheus-pushgateway.labels" . | nindent 4 }}
+{{ template "prometheus-pushgateway.defaultLabels" merge (dict "extraLabels" .Values.persistentVolumeLabels) .  }}
+  name: {{ template "prometheus-pushgateway.fullname" . }}
 spec:
   selector:
     matchLabels:

--- a/resources/monitoring/charts/prometheus-pushgateway/templates/networkpolicy.yaml
+++ b/resources/monitoring/charts/prometheus-pushgateway/templates/networkpolicy.yaml
@@ -10,21 +10,17 @@ metadata:
 {{- fail "One of `allowAll` or `customSelectors` must be specified." }}
 {{- end }}
   labels:
-    {{ include "prometheus-pushgateway.labels" . | nindent 4}}
-    {{- if .Values.serviceAccountLabels -}}
-    {{ toYaml .Values.serviceAccountLabels | indent 4 }}
-    {{- end -}}
+{{ template "prometheus-pushgateway.defaultLabels" merge (dict "extraLabels" .Values.podLabels) .  }}
 spec:
   podSelector:
     matchLabels:
       app: {{ template "prometheus-pushgateway.name" .}}
+      release: {{ .Release.Name }}
   ingress:
     - ports:
       - port: {{ .Values.service.targetPort }}
 {{- if .Values.networkPolicy.customSelectors }}
-    - from:
+      from:
 {{ toYaml .Values.networkPolicy.customSelectors | indent 8 }}
-{{- else if .Values.networkPolicy.allowAll }}
-    - {}
 {{- end -}}
 {{- end -}}

--- a/resources/monitoring/charts/prometheus-pushgateway/templates/networkpolicy.yaml
+++ b/resources/monitoring/charts/prometheus-pushgateway/templates/networkpolicy.yaml
@@ -10,7 +10,7 @@ metadata:
 {{- fail "One of `allowAll` or `customSelectors` must be specified." }}
 {{- end }}
   labels:
-{{ template "prometheus-pushgateway.defaultLabels" merge (dict "extraLabels" .Values.podLabels) .  }}
+    {{ include "prometheus-pushgateway.defaultLabels" . | nindent 4}}
 spec:
   podSelector:
     matchLabels:

--- a/resources/monitoring/charts/prometheus-pushgateway/templates/networkpolicy.yaml
+++ b/resources/monitoring/charts/prometheus-pushgateway/templates/networkpolicy.yaml
@@ -10,7 +10,7 @@ metadata:
 {{- fail "One of `allowAll` or `customSelectors` must be specified." }}
 {{- end }}
   labels:
-    {{ include "prometheus-pushgateway.defaultLabels" . | nindent 4}}
+{{ template "prometheus-pushgateway.defaultLabels" merge (dict "extraLabels" dict) .}}
 spec:
   podSelector:
     matchLabels:

--- a/resources/monitoring/charts/prometheus-pushgateway/templates/pdb.yaml
+++ b/resources/monitoring/charts/prometheus-pushgateway/templates/pdb.yaml
@@ -4,10 +4,10 @@ kind: PodDisruptionBudget
 metadata:
   name: {{ template "prometheus-pushgateway.fullname" . }}
   labels:
-{{ template "prometheus-pushgateway.defaultLabels" merge (dict "extraLabels" .Values.podLabels) .  }}
+    {{ include "prometheus-pushgateway.defaultLabels" . | nindent 4}}
 spec:
   selector:
     matchLabels:
-      app: {{ template "prometheus-pushgateway.name" . }}
+      {{- include "prometheus-pushgateway.selectorLabels" . | nindent 6 }}
 {{ toYaml .Values.podDisruptionBudget | indent 2 }}
 {{- end -}}

--- a/resources/monitoring/charts/prometheus-pushgateway/templates/pdb.yaml
+++ b/resources/monitoring/charts/prometheus-pushgateway/templates/pdb.yaml
@@ -4,13 +4,10 @@ kind: PodDisruptionBudget
 metadata:
   name: {{ template "prometheus-pushgateway.fullname" . }}
   labels:
-    {{ include "prometheus-pushgateway.labels" . | nindent 4}}
-    {{- if .Values.serviceAccountLabels -}}
-    {{ toYaml .Values.serviceAccountLabels | indent 4 }}
-    {{- end -}}
+{{ template "prometheus-pushgateway.defaultLabels" merge (dict "extraLabels" .Values.podLabels) .  }}
 spec:
   selector:
     matchLabels:
-      {{- include "prometheus-pushgateway.selectorLabels" . | nindent 6 }}
+      app: {{ template "prometheus-pushgateway.name" . }}
 {{ toYaml .Values.podDisruptionBudget | indent 2 }}
 {{- end -}}

--- a/resources/monitoring/charts/prometheus-pushgateway/templates/pdb.yaml
+++ b/resources/monitoring/charts/prometheus-pushgateway/templates/pdb.yaml
@@ -8,6 +8,6 @@ metadata:
 spec:
   selector:
     matchLabels:
-      {{- include "prometheus-pushgateway.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/name: {{ template "kube-state-metrics.name" . }}
 {{ toYaml .Values.podDisruptionBudget | indent 2 }}
 {{- end -}}

--- a/resources/monitoring/charts/prometheus-pushgateway/templates/pdb.yaml
+++ b/resources/monitoring/charts/prometheus-pushgateway/templates/pdb.yaml
@@ -4,7 +4,7 @@ kind: PodDisruptionBudget
 metadata:
   name: {{ template "prometheus-pushgateway.fullname" . }}
   labels:
-    {{ include "prometheus-pushgateway.defaultLabels" . | nindent 4}}
+{{ template "prometheus-pushgateway.defaultLabels" merge (dict "extraLabels" .Values.podLabels) .  }}
 spec:
   selector:
     matchLabels:

--- a/resources/monitoring/charts/prometheus-pushgateway/templates/pushgateway-pvc.yaml
+++ b/resources/monitoring/charts/prometheus-pushgateway/templates/pushgateway-pvc.yaml
@@ -8,10 +8,7 @@ metadata:
 {{ toYaml .Values.persistentVolume.annotations | indent 4 }}
   {{- end }}
   labels:
-    {{ include "prometheus-pushgateway.labels" . | nindent 4}}
-    {{- if .Values.serviceAccountLabels -}}
-    {{ toYaml .Values.serviceAccountLabels | indent 4 }}
-    {{- end -}}
+{{ template "prometheus-pushgateway.defaultLabels" merge (dict "extraLabels" .Values.persistentVolumeLabels) .  }}
   name: {{ template "prometheus-pushgateway.fullname" . }}
 spec:
   accessModes:

--- a/resources/monitoring/charts/prometheus-pushgateway/templates/pushgateway-pvc.yaml
+++ b/resources/monitoring/charts/prometheus-pushgateway/templates/pushgateway-pvc.yaml
@@ -8,7 +8,7 @@ metadata:
 {{ toYaml .Values.persistentVolume.annotations | indent 4 }}
   {{- end }}
   labels:
-    {{ include "prometheus-pushgateway.defaultLabels" . | nindent 4}}
+{{ template "prometheus-pushgateway.defaultLabels" merge (dict "extraLabels" .Values.persistentVolumeLabels) .  }}
   name: {{ template "prometheus-pushgateway.fullname" . }}
 spec:
   accessModes:

--- a/resources/monitoring/charts/prometheus-pushgateway/templates/pushgateway-pvc.yaml
+++ b/resources/monitoring/charts/prometheus-pushgateway/templates/pushgateway-pvc.yaml
@@ -8,7 +8,7 @@ metadata:
 {{ toYaml .Values.persistentVolume.annotations | indent 4 }}
   {{- end }}
   labels:
-{{ template "prometheus-pushgateway.defaultLabels" merge (dict "extraLabels" .Values.persistentVolumeLabels) .  }}
+    {{ include "prometheus-pushgateway.defaultLabels" . | nindent 4}}
   name: {{ template "prometheus-pushgateway.fullname" . }}
 spec:
   accessModes:

--- a/resources/monitoring/charts/prometheus-pushgateway/templates/service.yaml
+++ b/resources/monitoring/charts/prometheus-pushgateway/templates/service.yaml
@@ -5,10 +5,7 @@ metadata:
   annotations:
 {{ .Values.serviceAnnotations | toYaml | indent 4 }}
   labels:
-    {{ include "prometheus-pushgateway.labels" . | nindent 4}}
-    {{- if .Values.serviceAccountLabels }}
-    {{ toYaml .Values.serviceAccountLabels | indent 4 }}
-    {{- end }}
+{{ template "prometheus-pushgateway.defaultLabels" merge (dict "extraLabels" .Values.serviceLabels) .  }}
 spec:
   type: {{ .Values.service.type }}
   ports:
@@ -20,4 +17,5 @@ spec:
       protocol: TCP
       name: http
   selector:
-    {{- include "prometheus-pushgateway.selectorLabels" . | nindent 4 }}
+    app: {{ template "prometheus-pushgateway.name" . }}
+    release: {{ .Release.Name }}

--- a/resources/monitoring/charts/prometheus-pushgateway/templates/service.yaml
+++ b/resources/monitoring/charts/prometheus-pushgateway/templates/service.yaml
@@ -5,7 +5,7 @@ metadata:
   annotations:
 {{ .Values.serviceAnnotations | toYaml | indent 4 }}
   labels:
-    {{ include "prometheus-pushgateway.defaultLabels" . | nindent 4}}
+{{ template "prometheus-pushgateway.defaultLabels" merge (dict "extraLabels" .Values.serviceLabels) .  }}
 spec:
   type: {{ .Values.service.type }}
   ports:

--- a/resources/monitoring/charts/prometheus-pushgateway/templates/service.yaml
+++ b/resources/monitoring/charts/prometheus-pushgateway/templates/service.yaml
@@ -5,7 +5,7 @@ metadata:
   annotations:
 {{ .Values.serviceAnnotations | toYaml | indent 4 }}
   labels:
-{{ template "prometheus-pushgateway.defaultLabels" merge (dict "extraLabels" .Values.serviceLabels) .  }}
+    {{ include "prometheus-pushgateway.defaultLabels" . | nindent 4}}
 spec:
   type: {{ .Values.service.type }}
   ports:
@@ -17,5 +17,4 @@ spec:
       protocol: TCP
       name: http
   selector:
-    app: {{ template "prometheus-pushgateway.name" . }}
-    release: {{ .Release.Name }}
+    {{- include "prometheus-pushgateway.selectorLabels" . | nindent 4 }}

--- a/resources/monitoring/charts/prometheus-pushgateway/templates/serviceaccount.yaml
+++ b/resources/monitoring/charts/prometheus-pushgateway/templates/serviceaccount.yaml
@@ -4,8 +4,5 @@ kind: ServiceAccount
 metadata:
   name: {{ template "prometheus-pushgateway.serviceAccountName" . }}
   labels:
-    {{ include "prometheus-pushgateway.labels" . | nindent 4}}
-    {{- if .Values.serviceAccountLabels -}}
-    {{ toYaml .Values.serviceAccountLabels | indent 4 }}
-    {{- end -}}
+{{ template "prometheus-pushgateway.defaultLabels" merge (dict "extraLabels" .Values.serviceAccountLabels) .  }}
 {{- end -}}

--- a/resources/monitoring/charts/prometheus-pushgateway/templates/serviceaccount.yaml
+++ b/resources/monitoring/charts/prometheus-pushgateway/templates/serviceaccount.yaml
@@ -4,5 +4,5 @@ kind: ServiceAccount
 metadata:
   name: {{ template "prometheus-pushgateway.serviceAccountName" . }}
   labels:
-    {{ include "prometheus-pushgateway.defaultLabels" . | nindent 4}}
+{{ template "prometheus-pushgateway.defaultLabels" merge (dict "extraLabels" .Values.serviceAccountLabels) .  }}
 {{- end -}}

--- a/resources/monitoring/charts/prometheus-pushgateway/templates/serviceaccount.yaml
+++ b/resources/monitoring/charts/prometheus-pushgateway/templates/serviceaccount.yaml
@@ -4,5 +4,5 @@ kind: ServiceAccount
 metadata:
   name: {{ template "prometheus-pushgateway.serviceAccountName" . }}
   labels:
-{{ template "prometheus-pushgateway.defaultLabels" merge (dict "extraLabels" .Values.serviceAccountLabels) .  }}
+    {{ include "prometheus-pushgateway.defaultLabels" . | nindent 4}}
 {{- end -}}

--- a/resources/monitoring/charts/prometheus-pushgateway/templates/servicemonitor.yaml
+++ b/resources/monitoring/charts/prometheus-pushgateway/templates/servicemonitor.yaml
@@ -7,10 +7,7 @@ metadata:
   namespace: {{ .Values.serviceMonitor.namespace }}
   {{- end }}
   labels:
-    app: {{ template "prometheus-pushgateway.name" . }}
-    chart: {{ template "prometheus-pushgateway.chart" . }}
-    heritage: {{ .Release.Service }}
-    release: {{ .Release.Name }}
+    {{ include "prometheus-pushgateway.defaultLabels" . | nindent 4}}
     {{- if .Values.serviceMonitor.additionalLabels }}
 {{ toYaml .Values.serviceMonitor.additionalLabels | indent 4 }}
     {{- end }}
@@ -30,6 +27,5 @@ spec:
       - {{ .Release.Namespace }}
   selector:
     matchLabels:
-      app: {{ template "prometheus-pushgateway.name" . }}
-      release: {{ .Release.Name }}
+      {{- include "prometheus-pushgateway.selectorLabels" . | nindent 6 }}
 {{- end -}}

--- a/resources/monitoring/charts/prometheus-pushgateway/templates/servicemonitor.yaml
+++ b/resources/monitoring/charts/prometheus-pushgateway/templates/servicemonitor.yaml
@@ -7,7 +7,10 @@ metadata:
   namespace: {{ .Values.serviceMonitor.namespace }}
   {{- end }}
   labels:
-    {{- include "prometheus-pushgateway.labels" . | nindent 4 }}
+    app: {{ template "prometheus-pushgateway.name" . }}
+    chart: {{ template "prometheus-pushgateway.chart" . }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
     {{- if .Values.serviceMonitor.additionalLabels }}
 {{ toYaml .Values.serviceMonitor.additionalLabels | indent 4 }}
     {{- end }}
@@ -27,5 +30,6 @@ spec:
       - {{ .Release.Namespace }}
   selector:
     matchLabels:
-      {{- include "prometheus-pushgateway.selectorLabels" . | nindent 6 }}
+      app: {{ template "prometheus-pushgateway.name" . }}
+      release: {{ .Release.Name }}
 {{- end -}}

--- a/resources/monitoring/charts/prometheus-pushgateway/templates/servicemonitor.yaml
+++ b/resources/monitoring/charts/prometheus-pushgateway/templates/servicemonitor.yaml
@@ -7,10 +7,7 @@ metadata:
   namespace: {{ .Values.serviceMonitor.namespace }}
   {{- end }}
   labels:
-    {{ include "prometheus-pushgateway.defaultLabels" . | nindent 4}}
-    {{- if .Values.serviceMonitor.additionalLabels }}
-{{ toYaml .Values.serviceMonitor.additionalLabels | indent 4 }}
-    {{- end }}
+{{ template "prometheus-pushgateway.defaultLabels" merge (dict "extraLabels" .Values.serviceMonitor.additionalLabels) .  }}
 spec:
   endpoints:
   - port: http

--- a/resources/monitoring/charts/prometheus-pushgateway/values.yaml
+++ b/resources/monitoring/charts/prometheus-pushgateway/values.yaml
@@ -2,12 +2,11 @@
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 
-{{- /*
-  Customization:
-  Enabled servicemonitor and removed namespace: monitoring from servicemontor
-     serviceMonitor:
-        enabled: true
-*/ -}}
+#  Customization:
+#  Enabled servicemonitor and removed namespace: monitoring from servicemontor
+#     serviceMonitor:
+#        enabled: true
+ 
 image:
   repository: eu.gcr.io/kyma-project/external/prom/pushgateway
   tag: v1.3.0

--- a/resources/monitoring/charts/prometheus-pushgateway/values.yaml
+++ b/resources/monitoring/charts/prometheus-pushgateway/values.yaml
@@ -1,12 +1,13 @@
 # Default values for prometheus-pushgateway.
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
-# Customization:
-#   1. set enabeld to true
-#   2. removed namespace
-# serviceMonitor:
-# enabled: false
-# namspace: monitoring
+
+{{- /*
+  Customization:
+  Enabled servicemonitor and removed namespace: monitoring from servicemontor
+     serviceMonitor:
+        enabled: true
+*/ -}}
 image:
   repository: eu.gcr.io/kyma-project/external/prom/pushgateway
   tag: v1.3.0

--- a/resources/monitoring/charts/prometheus-pushgateway/values.yaml
+++ b/resources/monitoring/charts/prometheus-pushgateway/values.yaml
@@ -1,9 +1,15 @@
 # Default values for prometheus-pushgateway.
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
+# Customization:
+#   1. set enabeld to true
+#   2. removed namespace
+# serviceMonitor:
+# enabled: false
+# namspace: monitoring
 image:
   repository: eu.gcr.io/kyma-project/external/prom/pushgateway
-  tag: v1.2.0
+  tag: v1.3.0
   pullPolicy: IfNotPresent
 
 service:


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/master/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- Update prometheus pushgateway to latest upstream charts
- Carried over the way default label handling from the upstream chart:
```
metadata:
  labels:
{{ template "prometheus-pushgateway.defaultLabels" merge (dict "extraLabels" .Values.someAdditionalLabels) .  }}
```

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
https://github.com/kyma-project/kyma/issues/9897