### PR TITLE
Connect event publisher proxy to application operator

### DIFF
--- a/components/application-connectivity-validator/README.md
+++ b/components/application-connectivity-validator/README.md
@@ -13,6 +13,7 @@ A single instance of the component is deployed for an Application and uses these
 - **eventServicePathPrefixV1** is the path prefix for which requests are forwarded to the Event Service V1 API. The default value is `/v1/events`.
 - **eventServicePathPrefixV2** is the path prefix for which requests are forwarded to the Event Service V2 API. The default value is `/v2/events`.
 - **eventServiceHost** is the host and the port of the Event Service. The default value is `events-api:8080`.
+- **eventMeshDestinationPath** is the destination path for the requests coming to the Event Mesh. The default value is `/`.
 - **appRegistryPathPrefix** is the path prefix for which requests are forwarded to the Application Registry. The default value is `/v1/metadata`.
 - **appRegistryHost** is the host and the port of the Event Service. The default value is `application-registry-external-api:8081`.
 

--- a/components/application-connectivity-validator/cmd/applicationconnectivityvalidator/applicationconnectivityvalidator.go
+++ b/components/application-connectivity-validator/cmd/applicationconnectivityvalidator/applicationconnectivityvalidator.go
@@ -51,6 +51,7 @@ func main() {
 		options.eventServiceHost,
 		options.eventMeshPathPrefix,
 		options.eventMeshHost,
+		options.eventMeshDestinationPath,
 		options.appRegistryPathPrefix,
 		options.appRegistryHost,
 		applicationGetter,

--- a/components/application-connectivity-validator/cmd/applicationconnectivityvalidator/options.go
+++ b/components/application-connectivity-validator/cmd/applicationconnectivityvalidator/options.go
@@ -15,6 +15,7 @@ type options struct {
 	eventServiceHost         string
 	eventMeshPathPrefix      string
 	eventMeshHost            string
+	eventMeshDestinationPath string
 	appRegistryPathPrefix    string
 	appRegistryHost          string
 	cacheExpirationMinutes   int
@@ -31,6 +32,7 @@ func parseArgs() *options {
 	eventServiceHost := flag.String("eventServiceHost", "events-api:8080", "Host (and port) of the Event Service")
 	eventMeshPathPrefix := flag.String("eventMeshPathPrefix", "/events", "Prefix of paths that will be directed to the Event Mesh")
 	eventMeshHost := flag.String("eventMeshHost", "events-adapter:8080", "Host (and port) of the Event Mesh adapter")
+	eventMeshDestinationPath := flag.String("eventMeshDestinationPath", "/", "Path of the destination of the requests to the Event Mesh")
 	appRegistryPathPrefix := flag.String("appRegistryPathPrefix", "/v1/metadata", "Prefix of paths that will be directed to the Application Registry")
 	appRegistryHost := flag.String("appRegistryHost", "application-registry-external-api:8081", "Host (and port) of the Application Registry")
 	cacheExpirationMinutes := flag.Int("cacheExpirationMinutes", 1, "Expiration time for client IDs stored in cache expressed in minutes")
@@ -48,6 +50,7 @@ func parseArgs() *options {
 		eventServiceHost:         *eventServiceHost,
 		eventMeshPathPrefix:      *eventMeshPathPrefix,
 		eventMeshHost:            *eventMeshHost,
+		eventMeshDestinationPath: *eventMeshDestinationPath,
 		appRegistryPathPrefix:    *appRegistryPathPrefix,
 		appRegistryHost:          *appRegistryHost,
 		cacheExpirationMinutes:   *cacheExpirationMinutes,
@@ -59,11 +62,12 @@ func (o *options) String() string {
 	return fmt.Sprintf("--proxyPort=%d --externalAPIPort=%d --tenant=%s --group=%s "+
 		"--eventServicePathPrefixV1=%s --eventServicePathPrefixV2=%s --eventServiceHost=%s "+
 		"--eventMeshPathPrefix=%s --eventMeshHost=%s "+
+		"--eventMeshDestinationPath=%s "+
 		"--appRegistryPathPrefix=%s --appRegistryHost=%s"+
 		"--cacheExpirationMinutes=%d --cacheCleanupMinutes=%d",
 		o.proxyPort, o.externalAPIPort, o.tenant, o.group,
 		o.eventServicePathPrefixV1, o.eventServicePathPrefixV2, o.eventServiceHost,
-		o.eventMeshPathPrefix, o.eventMeshHost,
+		o.eventMeshPathPrefix, o.eventMeshHost, o.eventMeshDestinationPath,
 		o.appRegistryPathPrefix, o.appRegistryHost,
 		o.cacheExpirationMinutes, o.cacheCleanupMinutes)
 }

--- a/components/application-connectivity-validator/internal/validationproxy/handler.go
+++ b/components/application-connectivity-validator/internal/validationproxy/handler.go
@@ -22,6 +22,8 @@ import (
 
 const (
 	CertificateInfoHeader = "X-Forwarded-Client-Cert"
+	// In a BEB enabled cluster, validator should forward the event coming to /{application}/v2/events and /{application}/events to /publish endpoint of EventPublisherProxy(https://github.com/kyma-project/kyma/tree/master/components/event-publisher-proxy#send-events)
+	BEBEnabledPublishEndpoint = "/publish"
 )
 
 type ProxyHandler interface {
@@ -47,6 +49,7 @@ type proxyHandler struct {
 	eventServiceHost         string
 	eventMeshPathPrefix      string
 	eventMeshHost            string
+	isBEBEnabled             bool
 	appRegistryPathPrefix    string
 	appRegistryHost          string
 
@@ -66,11 +69,15 @@ func NewProxyHandler(
 	eventServiceHost string,
 	eventMeshPathPrefix string,
 	eventMeshHost string,
+	eventMeshDestinationPath string,
 	appRegistryPathPrefix string,
 	appRegistryHost string,
 	applicationGetter ApplicationGetter,
 	cache Cache) *proxyHandler {
-
+	isBEBEnabled := false
+	if eventMeshDestinationPath == BEBEnabledPublishEndpoint {
+		isBEBEnabled = true
+	}
 	return &proxyHandler{
 		group:                    group,
 		tenant:                   tenant,
@@ -79,11 +86,12 @@ func NewProxyHandler(
 		eventServiceHost:         eventServiceHost,
 		eventMeshPathPrefix:      eventMeshPathPrefix,
 		eventMeshHost:            eventMeshHost,
+		isBEBEnabled:             isBEBEnabled,
 		appRegistryPathPrefix:    appRegistryPathPrefix,
 		appRegistryHost:          appRegistryHost,
 
 		eventsProxy:      createReverseProxy(eventServiceHost, withEmptyRequestHost, withEmptyXFwdClientCert, withHTTPScheme),
-		eventMeshProxy:   createReverseProxy(eventMeshHost, withRewriteBaseURL("/"), withEmptyRequestHost, withEmptyXFwdClientCert, withHTTPScheme),
+		eventMeshProxy:   createReverseProxy(eventMeshHost, withRewriteBaseURL(eventMeshDestinationPath), withEmptyRequestHost, withEmptyXFwdClientCert, withHTTPScheme),
 		appRegistryProxy: createReverseProxy(appRegistryHost, withEmptyRequestHost, withHTTPScheme),
 
 		applicationGetter: applicationGetter,
@@ -164,9 +172,14 @@ func (ph *proxyHandler) getClientIDsFromResource(applicationName string) ([]stri
 
 func (ph *proxyHandler) mapRequestToProxy(path string) (*httputil.ReverseProxy, apperrors.AppError) {
 	switch {
-	case strings.HasPrefix(path, ph.eventServicePathPrefixV1), strings.HasPrefix(path, ph.eventServicePathPrefixV2):
+	case strings.HasPrefix(path, ph.eventServicePathPrefixV1):
 		return ph.eventsProxy, nil
 
+	case strings.HasPrefix(path, ph.eventServicePathPrefixV2):
+		if ph.isBEBEnabled {
+			return ph.eventMeshProxy, nil
+		}
+		return ph.eventsProxy, nil
 	case strings.HasPrefix(path, ph.eventMeshPathPrefix):
 		return ph.eventMeshProxy, nil
 

--- a/components/application-connectivity-validator/internal/validationproxy/handler.go
+++ b/components/application-connectivity-validator/internal/validationproxy/handler.go
@@ -172,14 +172,21 @@ func (ph *proxyHandler) getClientIDsFromResource(applicationName string) ([]stri
 
 func (ph *proxyHandler) mapRequestToProxy(path string) (*httputil.ReverseProxy, apperrors.AppError) {
 	switch {
+	// For a cluster which is BEB enabled, events reaching with prefix /{application}/v1/events will be routed to /{application}/v1/events endpoint of event-publisher-proxy
+	// For a cluster which is not BEB enabled, events reaching with prefix /{application}/events will be routed to /{application}/v1/events endpoint of event-service
 	case strings.HasPrefix(path, ph.eventServicePathPrefixV1):
 		return ph.eventsProxy, nil
 
+	// For a cluster which is BEB enabled, events reaching /{application}/v2/events will be routed to /publish endpoint of event-publisher-proxy
+	// For a cluster which is not BEB enabled, events reaching /{application}/v2/events will be routed to /{application}/v2/events endpoint of event-service
 	case strings.HasPrefix(path, ph.eventServicePathPrefixV2):
 		if ph.isBEBEnabled {
 			return ph.eventMeshProxy, nil
 		}
 		return ph.eventsProxy, nil
+
+	// For a cluster which is BEB enabled, events reaching /{application}/events will be routed to /publish endpoint of event-publisher-proxy
+	// For a cluster which is not BEB enabled, events reaching /{application}/events will be routed to / endpoint of http-source-adapter
 	case strings.HasPrefix(path, ph.eventMeshPathPrefix):
 		return ph.eventMeshProxy, nil
 

--- a/components/application-operator/README.md
+++ b/components/application-operator/README.md
@@ -40,6 +40,7 @@ The Application Operator has the following parameters:
  - **gatewayOncePerNamespace** is a flag that specifies whether Application Gateway should be deployed once per Namespace based on ServiceInstance or for every Application. The default value is `false`.
  - **strictMode** is a toggle used to enable or disable Istio authorization policy for validator and HTTP source adapter. The default value is `disabled`.
  - **healthPort** is the number of the TCP port used to perform health checking of the Application Operator.
+ - **isBEBEnabled** is a toggle used to enable or disable eventing based on BEB. The default value is `false`.
  
 ## Testing on a local deployment
 

--- a/components/application-operator/charts/application/templates/deployment.yaml
+++ b/components/application-operator/charts/application/templates/deployment.yaml
@@ -67,6 +67,7 @@ spec:
             name: http-api-port
 {{- end }}
 ---
+{{- if not .Values.global.isBEBEnabled }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -124,3 +125,4 @@ spec:
         ports:
         - containerPort: {{ .Values.eventService.deployment.args.externalAPIPort }}
           name: http-api-port
+{{- end }}

--- a/components/application-operator/charts/application/templates/httpsource.yaml
+++ b/components/application-operator/charts/application/templates/httpsource.yaml
@@ -1,3 +1,4 @@
+{{- if not .Values.global.isBEBEnabled }}
 apiVersion: sources.kyma-project.io/v1alpha1
 kind: HTTPSource
 metadata:
@@ -5,3 +6,4 @@ metadata:
   namespace: {{ .Release.Namespace }}
 spec:
   source: {{ .Release.Name }}
+{{- end }}

--- a/components/application-operator/charts/application/templates/validator.yaml
+++ b/components/application-operator/charts/application/templates/validator.yaml
@@ -42,9 +42,15 @@ spec:
             - "--group={{ .Values.global.group }}"
             - "--eventServicePathPrefixV1=/{{ .Release.Name }}/v1/events"
             - "--eventServicePathPrefixV2=/{{ .Release.Name }}/v2/events"
+            {{- if .Values.global.isBEBEnabled }}
+            - "--eventServiceHost={{ .Values.eventPublisherProxy.service.name }}.{{ .Values.eventPublisherProxy.service.namespace }}"
+            - "--eventMeshHost={{ .Values.eventPublisherProxy.service.name }}.{{ .Values.eventPublisherProxy.service.namespace }}"
+            - "--eventMeshDestinationPath=/{{ .Values.eventPublisherProxy.publishCEEndpoint }}"
+            {{- else }}
             - "--eventServiceHost={{ .Release.Name }}-event-service:{{ .Values.eventService.service.externalapi.port }}"
-            - "--eventMeshPathPrefix=/{{ .Release.Name }}/events"
             - "--eventMeshHost={{ .Release.Name }}.{{ .Release.Namespace }}"
+            {{- end }}
+            - "--eventMeshPathPrefix=/{{ .Release.Name }}/events"
             - "--appRegistryPathPrefix=/{{ .Release.Name }}/v1/metadata"
             - "--appRegistryHost={{ .Values.applicationConnectivityValidator.args.appRegistryHost }}"
             - "--cacheExpirationMinutes={{ .Values.applicationConnectivityValidator.args.cacheExpirationMinutes }}"

--- a/components/application-operator/charts/application/values.yaml
+++ b/components/application-operator/charts/application/values.yaml
@@ -39,6 +39,13 @@ acceptanceTest:
   image:
     pullPolicy: IfNotPresent
 
+eventPublisherProxy:
+  publishCEEndpoint: publish
+  service:
+    ## The name refers to the svc of event-publisher-proxy(https://github.com/kyma-project/kyma/blob/master/resources/eventing/charts/event-publisher-proxy/templates/service.yaml)
+    name: eventing-event-publisher-proxy
+    namespace: kyma-system
+
 # console-backend is a ServiceAccount which is installed as a part of *core* chart
 authorizationPolicy:
   serviceAccount:

--- a/components/application-operator/cmd/manager/manager.go
+++ b/components/application-operator/cmd/manager/manager.go
@@ -152,6 +152,7 @@ func newApplicationReleaseManager(options *options, cfg *rest.Config, helmClient
 		ApplicationConnectivityValidatorImage: options.applicationConnectivityValidatorImage,
 		GatewayOncePerNamespace:               options.gatewayOncePerNamespace,
 		StrictMode:                            options.strictMode,
+		IsBEBEnabled:                          options.isBEBEnabled,
 	}
 
 	appClient, err := versioned.NewForConfig(cfg)

--- a/components/application-operator/cmd/manager/options.go
+++ b/components/application-operator/cmd/manager/options.go
@@ -21,6 +21,7 @@ type options struct {
 	strictMode                            string
 	healthPort                            string
 	helmDriver                            string
+	isBEBEnabled                          bool
 }
 
 func parseArgs() *options {
@@ -39,7 +40,7 @@ func parseArgs() *options {
 	gatewayOncePerNamespace := flag.Bool("gatewayOncePerNamespace", false, "Specifies if Gateway should be deployed once per Namespace based on ServiceInstance or for every Application")
 	strictMode := flag.String("strictMode", "disabled", "Toggles Istio authorization policy for Validator and HTTP source adapter")
 	healthPort := flag.String("healthPort", "8090", "Port for healthcheck server")
-
+	isBEBEnabled := flag.Bool("isBEBEnabled", false, "Toggles creation of eventing infrastructure based on BEB if BEB is enabled")
 	flag.Parse()
 
 	return &options{
@@ -57,6 +58,7 @@ func parseArgs() *options {
 		strictMode:                            *strictMode,
 		healthPort:                            *healthPort,
 		helmDriver:                            *helmDriver,
+		isBEBEnabled:                          *isBEBEnabled,
 	}
 }
 
@@ -64,9 +66,9 @@ func (o *options) String() string {
 	return fmt.Sprintf("--appName=%s --domainName=%s --namespace=%s"+
 		" --syncPeriod=%d --installationTimeout=%d --helmDriver=%s"+
 		" --applicationGatewayImage=%s --applicationGatewayTestsImage=%s --eventServiceImage=%s --eventServiceTestsImage=%s"+
-		" --applicationConnectivityValidatorImage=%s --gatewayOncePerNamespace=%v --strictMode=%s --healthPort=%s ",
+		" --applicationConnectivityValidatorImage=%s --gatewayOncePerNamespace=%v --strictMode=%s --healthPort=%s --isBEBEnabled=%v ",
 		o.appName, o.domainName, o.namespace,
 		o.syncPeriod, o.installationTimeout, o.helmDriver,
 		o.applicationGatewayImage, o.applicationGatewayTestsImage, o.eventServiceImage, o.eventServiceTestsImage,
-		o.applicationConnectivityValidatorImage, o.gatewayOncePerNamespace, o.strictMode, o.healthPort)
+		o.applicationConnectivityValidatorImage, o.gatewayOncePerNamespace, o.strictMode, o.healthPort, o.isBEBEnabled)
 }

--- a/components/application-operator/pkg/kymahelm/application/overrides.go
+++ b/components/application-operator/pkg/kymahelm/application/overrides.go
@@ -11,4 +11,5 @@ type OverridesData struct {
 	Group                                 string `json:"group,omitempty"`
 	GatewayOncePerNamespace               bool   `json:"deployGatewayOncePerNamespace,omitempty"`
 	StrictMode                            string `json:"strictMode,omitempty"`
+	IsBEBEnabled                          bool   `json:"isBEBEnabled,omitempty"`
 }

--- a/resources/application-connector/charts/application-operator/templates/controller.yaml
+++ b/resources/application-connector/charts/application-operator/templates/controller.yaml
@@ -62,6 +62,7 @@ spec:
         - "--gatewayOncePerNamespace={{ .Values.global.disableLegacyConnectivity }}"
         - "--strictMode={{ .Values.global.strictMode }}"
         - "--healthPort={{ .Values.controller.args.healthPort }}"
+        - "--isBEBEnabled={{ .Values.global.isBEBEnabled }}"
         image: {{ .Values.global.containerRegistry.path }}/application-operator:{{ .Values.global.application_operator.version }}
         imagePullPolicy: {{ .Values.controller.image.pullPolicy | quote }}
         resources:

--- a/resources/application-connector/values.yaml
+++ b/resources/application-connector/values.yaml
@@ -9,6 +9,7 @@ global:
   isLocalEnv: false
   namespace: kyma-integration
   strictMode: disabled
+  isBEBEnabled: false
   ingress:
     domainName: "TBD"
   helm:
@@ -23,7 +24,7 @@ global:
   containerRegistry:
     path: eu.gcr.io/kyma-project
   application_operator:
-    version: "PR-9890"
+    version: "PR-10051"
   application_operator_tests:
     version: "470796a1"
   connector_service:
@@ -53,7 +54,7 @@ global:
   application_connectivity_certs_setup_job:
     version: "PR-9890"
   application_connectivity_validator:
-    version: "PR-9890"
+    version: "PR-10051"
   application_broker_eventing_migration:
     version: "a8a6bca9"
 


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/master/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- Based on a global flag, `global.isBEBEnabled`=true/false, validator should deploy pods in `kyma-integration` ns for eventing.
- If BEB is enabled in a cluster, event publisher proxy should be connected to connectivity validator and the necessary wiring should be done by application operator

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
See https://github.com/kyma-project/kyma/issues/9861