### PR TITLE
Add a migration step for Kyma with Compass

### DIFF
--- a/docs/migration-guides/1.15-1.17.md
+++ b/docs/migration-guides/1.15-1.17.md
@@ -69,7 +69,7 @@ To make sure this job runs correctly, run this command **after** you've performe
 kubectl patch compassconnection compass-connection --type=merge -p '{"spec":{"refreshCredentialsNow":true}}' 
 ```
 
-This ensures that the client get reloaded and the correct `cacert` data is saved in Kyma 1.17.
+This ensures that the client gets reloaded and the correct `cacert` data is saved in Kyma 1.17.
 
 ## Migrate from 1.16.0-rc3 to 1.17
 

--- a/docs/migration-guides/1.15-1.17.md
+++ b/docs/migration-guides/1.15-1.17.md
@@ -57,6 +57,20 @@ In Release Candidate 1.16.0-rc3, we change the `instance` label on the logs corr
 Also, the `container` label for a function pointing to `lambda` in the previous releases now points to `function`. 
 If you search for the logs from a function with the `container: lambda` filter, you will need to change it to `container: function` from this release on.
 
+### Kyma with Compass
+
+> **CAUTION:** This step only applies to Kyma **with Compass**.
+
+In Kyma 1.17, the name of [this Application Connector Secret](https://github.com/kyma-project/kyma/blob/release-1.17/resources/core/charts/gateway/templates/application-connector-certs.yaml) changed from `kyma-gateway-certs-cacert` to `app-connector-certs`. This resulted in the CA certificate data (`cacert`) being lost at upgrade from 1.16.0-rc3 to 1.17. To prevent that, we introduced a [migration job](https://github.com/kyma-project/kyma/blob/release-1.17/resources/core/charts/gateway/templates/cacert-migrate-job.yaml) that makes sure the data copied from the old Kyma version to the new one persists and is migrated correctly. 
+
+To make sure this job runs correctly, run this command **after** you've performed an upgrade to Release Candidate 1.16.0-rc3 and **before** upgrade to 1.17:
+
+```bash
+kubectl patch compassconnection compass-connection --type=merge -p '{"spec":{"refreshCredentialsNow":true}}' 
+```
+
+This ensures that the client get reloaded and the correct `cacert` data is saved in Kyma 1.17.
+
 ## Migrate from 1.16.0-rc3 to 1.17
 
 ### Istio


### PR DESCRIPTION
**Description**

To ensure correct migration of certain data from 1.15 to 1.17, certain steps need to be performed and we need to let the user know.

Changes proposed in this pull request:

- Add a migration step for Kyma with Compass to the migration guide from 1.15 to 1.17
