### PR TITLE
Mark SKR compatible test definitions

### DIFF
--- a/resources/application-connector/charts/application-operator/values.yaml
+++ b/resources/application-connector/charts/application-operator/values.yaml
@@ -13,6 +13,7 @@ tests:
   labels:
     integration: true
     after-upgrade: true
+    e2e-skr: true
   image:
     pullPolicy: IfNotPresent
   gateway:

--- a/resources/dex/values.yaml
+++ b/resources/dex/values.yaml
@@ -97,6 +97,7 @@ tests:
   labels:
     integration: true
     after-upgrade: true
+    e2e-skr: true
 
 livenessProbe:
   enabled: false

--- a/resources/knative-eventing-kafka/values.yaml
+++ b/resources/knative-eventing-kafka/values.yaml
@@ -67,3 +67,4 @@ test:
   labels:
     integration: true
     after-upgrade: true
+    e2e-skr: true

--- a/resources/rafter/values.yaml
+++ b/resources/rafter/values.yaml
@@ -9,6 +9,7 @@ tests:
   labels:
     integration: true
     after-upgrade: true
+    e2e-skr: true
 
   image:
     repository: "eu.gcr.io/kyma-project/rafter-test"

--- a/resources/serverless/values.yaml
+++ b/resources/serverless/values.yaml
@@ -21,6 +21,7 @@ tests:
   labels:
     integration: true
     after-upgrade: true
+    e2e-skr: true
 
   long:
     initTimeout: 120s


### PR DESCRIPTION
**Description**
Adding a label to test definitions which are SKR compatible can be executed as part of the SKR e2e test.

Only test definitions which could be successfully executed on an SKR cluster were enabled.

**Related issue(s)**

