### PR TITLE
removed probes for kcproxy

### DIFF
--- a/resources/kiali/templates/kyma-additions/kcproxy-deployment.yaml
+++ b/resources/kiali/templates/kyma-additions/kcproxy-deployment.yaml
@@ -86,15 +86,5 @@ spec:
         - name: http
           containerPort: {{ .Values.kcproxy.port }}
           protocol: TCP
-{{- if not .Values.global.isLocalEnv }}
-        livenessProbe:
-          httpGet:
-            path: /oauth/health
-            port: http
-        readinessProbe:
-          httpGet:
-            path: /oauth/health
-            port: http
-{{- end }}
         resources:
 {{ toYaml .Values.kcproxy.resources | indent 10 }}

--- a/resources/monitoring/charts/grafana/templates/kyma-additions/auth-proxy-deployment.yaml
+++ b/resources/monitoring/charts/grafana/templates/kyma-additions/auth-proxy-deployment.yaml
@@ -92,16 +92,6 @@ spec:
         - name: http
           containerPort: {{ .Values.kyma.authProxy.port }}
           protocol: TCP
-{{- if not .Values.global.isLocalEnv }}
-        livenessProbe:
-          httpGet:
-            path: /oauth/health
-            port: http
-        readinessProbe:
-          httpGet:
-            path: /oauth/health
-            port: http
-{{- end }}
         resources:
 {{ toYaml .Values.kyma.authProxy.resources | indent 10 }}
 {{- end}}

--- a/resources/tracing/templates/kyma-additions/kcproxy-deployment.yaml
+++ b/resources/tracing/templates/kyma-additions/kcproxy-deployment.yaml
@@ -87,15 +87,5 @@ spec:
         - name: http
           containerPort: {{ .Values.kcproxy.inPort }}
           protocol: TCP
-{{- if not .Values.global.isLocalEnv }}
-        livenessProbe:
-          httpGet:
-            path: /oauth/health
-            port: http
-        readinessProbe:
-          httpGet:
-            path: /oauth/health
-            port: http
-{{- end }}
         resources:
 {{ toYaml .Values.kcproxy.resources | indent 10 }}


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/master/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**
Keycloak-proxy requires a working OIDS issuer at startup time. If the configured issuer is not discoverable the startup will fail.
In kyma there are several usages of keycloak-proxy using dex as issuer. Here, the external issuer URL needs to be configured.
There are quite some reports where dex is not reachable while installation yet via the external URL causing the installation to hang and finally timeout. The installation hangs in that situation as there is a readiness/livenessProbe configured for the proxy. So helm install will wait till it is ready. As the availability of the external dex is a readiness criteria for the proxy and that that condition cannot be relaxed, we need to remove the probes for now.
Still, the proxy will be in a crash loop but will not hang the installation.
Changes proposed in this pull request:

- remove readiness/livenessProbe from all keycloak proxies
- ...
- ...

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
