### PR TITLE
reduce dropped labels for istio, make istio scrape config configurable

### DIFF
--- a/resources/monitoring/charts/prometheus-istio/values.yaml
+++ b/resources/monitoring/charts/prometheus-istio/values.yaml
@@ -1255,53 +1255,43 @@ serverFiles:
         static_configs:
           - targets:
             - localhost:9090
-      - job_name: istio-system/envoy-stats/0
-        sample_limit: 20000
-        honor_timestamps: true
-        metrics_path: /stats/prometheus
-        scheme: http
-        kubernetes_sd_configs:
-        - role: endpoints
-        relabel_configs:
-        - source_labels: [__meta_kubernetes_service_label_istio_prometheus_ignore]
-          separator: ;
-          regex: .+
-          replacement: $1
-          action: drop
-        - source_labels: [__meta_kubernetes_pod_container_port_number]
-          separator: ;
-          regex: "15090"
-          replacement: $1
-          action: keep
-        - source_labels: [__meta_kubernetes_pod_container_port_name]
-          separator: ;
-          regex: .*-envoy-prom
-          replacement: $1
-          action: keep
-        metric_relabel_configs:
-        - separator: ;
-          regex: ^(grpc_response_status|source_version|source_principal|source_app|response_flags|request_protocol|destination_version|destination_principal|destination_app|destination_canonical_service|destination_canonical_revision|source_canonical_revision|source_canonical_service)$
-          replacement: $1
-          action: labeldrop
 
 # adds additional scrape configs to prometheus.yml
 # must be a string so you have to add a | after extraScrapeConfigs:
 # example adds prometheus-blackbox-exporter scrape config
-extraScrapeConfigs:
-  # - job_name: 'prometheus-blackbox-exporter'
-  #   metrics_path: /probe
-  #   params:
-  #     module: [http_2xx]
-  #   static_configs:
-  #     - targets:
-  #       - https://example.com
-  #   relabel_configs:
-  #     - source_labels: [__address__]
-  #       target_label: __param_target
-  #     - source_labels: [__param_target]
-  #       target_label: instance
-  #     - target_label: __address__
-  #       replacement: prometheus-blackbox-exporter:9115
+extraScrapeConfigs: |
+  - job_name: istio-system/envoy-stats/0
+    sample_limit: {{.Values.envoyStats.sampleLimit}}
+    honor_timestamps: true
+    metrics_path: /stats/prometheus
+    scheme: http
+    kubernetes_sd_configs:
+    - role: endpoints
+    relabel_configs:
+    - source_labels: [__meta_kubernetes_service_label_istio_prometheus_ignore]
+      separator: ;
+      regex: .+
+      replacement: $1
+      action: drop
+    - source_labels: [__meta_kubernetes_pod_container_port_number]
+      separator: ;
+      regex: "15090"
+      replacement: $1
+      action: keep
+    - source_labels: [__meta_kubernetes_pod_container_port_name]
+      separator: ;
+      regex: .*-envoy-prom
+      replacement: $1
+      action: keep
+    metric_relabel_configs:
+    - separator: ;
+      regex: {{.Values.envoyStats.labeldropRegex}}
+      replacement: $1
+      action: labeldrop
+
+envoyStats:
+  sampleLimit: "20000"
+  labeldropRegex: "^(grpc_response_status|source_version|destination_version|source_app|destination_app)$"
 
 # Adds option to add alert_relabel_configs to avoid duplicate alerts in alertmanager
 # useful in H/A prometheus with different external labels but the same alerts


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/master/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**
The scrape envoyStats scrape config for the prometheus-istio instance is not configurable yet via overrides. This PR moves the config to the "additionalScrapeConfigs" section so that a multi-line string can be provided. Furthermore, it allows to have the sample-limit and metricsRelabelling regexp configurable.

Changes proposed in this pull request:

- move envoyStats scrape config to additional section
- have sample-limit configurable
- have regexp for relabelling configurable
- reduce the amount of labels dropped for istio to have kiali working again

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
