### PR TITLE
added new ingress apiGroup to role for tracing

### DIFF
--- a/resources/tracing/templates/role.yaml
+++ b/resources/tracing/templates/role.yaml
@@ -43,6 +43,12 @@ rules:
   verbs:
   - '*'
 - apiGroups:
+  - networking.k8s.io
+  resources:
+  - ingresses
+  verbs:
+  - "*"
+- apiGroups:
   - extensions
   resources:
   - replicasets


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/master/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**
The jaeger-operator pod spammed an error log every second on k8s 1.19:
````
time="2020-12-06T19:31:40Z" level=error msg="failed to apply the changes" error="ingresses.networking.k8s.io is forbidden: User \"system:serviceaccount:kyma-system:tracing\" cannot list resource \"ingresses\" in API group \"networking.k8s.io\" in the namespace \"kyma-system\"" execution="2020-12-06 19:31:39.568032359 +0000 UTC" instance=tracing-jaeger namespace=kyma-system
```
It seems that the apiGroup of ingress changed, see this warning:
```
Warning: extensions/v1beta1 Ingress is deprecated in v1.14+, unavailable in v1.22+; use networking.k8s.io/v1 Ingress
```

Changes proposed in this pull request:

- added new apigroup to the tracing role
- ...
- ...

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
