### PR TITLE
Fix a broken link to PodPreset

### DIFF
--- a/docs/service-catalog/03-01-provisioning.md
+++ b/docs/service-catalog/03-01-provisioning.md
@@ -18,7 +18,7 @@ Provisioning a service means creating an instance of a service. To provision a s
 Binding is a process of connecting a ServiceInstance and an application. The binding process consists of two parts:
 
 - User creates a ServiceBinding. When you create a ServiceBinding, the Service Catalog creates a Secret with credentials needed to access the application.
-- User creates a ServiceBindingUsage. After creating this custom resource, ServiceBindingUsage uses the [PodPreset](https://kubernetes.io/docs/concepts/workloads/pods/podpreset/) to inject credentials into the application, which allows you to consume the service.
+- User creates a ServiceBindingUsage. After creating this custom resource, ServiceBindingUsage uses the [PodPreset](https://v1-19.docs.kubernetes.io/docs/concepts/workloads/pods/podpreset/) to inject credentials into the application, which allows you to consume the service.
 
 ![Binding](./assets/binding.svg)
 


### PR DESCRIPTION
Since PodPreset has been removed from Kubernetes, the new versions of the official Kubernetes documentation no longer contain information on this CR. That's why we need to change the link to point to the last version of K8S documentation that described it.

**Description**

Changes proposed in this pull request:

- Fix a broken link to PodPreset
