### PR TITLE
Fix problems in istio-proxy-reset job

### DIFF
--- a/resources/istio/files/istio-proxy-reset.sh
+++ b/resources/istio/files/istio-proxy-reset.sh
@@ -36,7 +36,6 @@ do
     parentObjectName=$(jq -r '.metadata.ownerReferences[0].name' <<< "${podJson}")
 
     case "${parentObjectKind}" in
-        #https://github.tools.sap/kyma/backlog/issues/1074
         ("null")
             ;&
         ("")

--- a/resources/istio/files/istio-proxy-reset.sh
+++ b/resources/istio/files/istio-proxy-reset.sh
@@ -5,6 +5,8 @@ expectedIstioProxyVersion="${EXPECTED_ISTIO_PROXY_IMAGE:-eu.gcr.io/kyma-project/
 #We use this image prefix to detect if there's an istio proxy in the Pod. If you have different prefixes (shouldn't be the case), just define several jobs.
 istioProxyImageNamePrefix="${COMMON_ISTIO_PROXY_IMAGE_PREFIX:-eu.gcr.io/kyma-project/external/istio/proxyv2}"
 
+dryRun="${DRY_RUN:-false}"
+
 for NS in $(kubectl get ns -l kyma-project.io/created-by=e2e-upgrade-test-runner -o name | cut -d '/' -f2); do
     "kubectl delete rs -n $NS --all"
 done
@@ -64,7 +66,11 @@ do
     namespace="${attributes[1]}"
     name="${attributes[2]}"
 
-    kubectl rollout restart "${kind}" "${name}" -n "${namespace}"
+    if [[ "${dryRun}" == "false" ]]; then
+        kubectl rollout restart "${kind}" "${name}" -n "${namespace}"
+    else
+        echo "[dryrun]" kubectl rollout restart "${kind}" "${name}" -n "${namespace}"
+    fi
 
 done
 

--- a/resources/istio/files/istio-proxy-reset.sh
+++ b/resources/istio/files/istio-proxy-reset.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+
+#We expect all sidecars to be in this version
+expectedIstioProxyVersion="${EXPECTED_ISTIO_PROXY_IMAGE:-eu.gcr.io/kyma-project/external/istio/proxyv2:1.7.4-distroless}"
+#We use this image prefix to detect if there's an istio proxy in the Pod. If you have different prefixes (shouldn't be the case), just define several jobs.
+istioProxyImageNamePrefix="${COMMON_ISTIO_PROXY_IMAGE_PREFIX:-eu.gcr.io/kyma-project/external/istio/proxyv2}"
+
+for NS in $(kubectl get ns -l kyma-project.io/created-by=e2e-upgrade-test-runner -o name | cut -d '/' -f2); do
+    "kubectl delete rs -n $NS --all"
+done
+
+declare -A objectsToRestart
+
+#This query selects all pods that have containers with an istio-proxy image in a version other than expected.
+#Istio proxy image is detected by image name prefix, by default: "eu.gcr.io/kyma-project/external/istio/proxyv2"
+jqQuery='.items | .[] | select(.spec.containers[].image | startswith("'"${istioProxyImageNamePrefix}"'") and (endswith("'"${expectedIstioProxyVersion}"'") | not))  | "\(.metadata.name)/\(.metadata.namespace)"'
+
+pods=$(kubectl get po -A -o json | jq -rc "${jqQuery}" )
+
+podArray=($(echo $pods | tr " " "\n"))
+
+echo "NUMBER OF PODS MATCHED: ${#podArray[@]}"
+
+for i in "${podArray[@]}"
+do
+    namespacedName=($(echo $i | tr "/" "\n"))
+
+    podName="${namespacedName[0]}"
+    namespace="${namespacedName[1]}"
+
+    podJson=$(kubectl get pod "${podName}" -n "${namespace}" -o json)
+
+    parentObjectKind=$(jq -r '.metadata.ownerReferences[0].kind' <<< "${podJson}" | tr '[:upper:]' '[:lower:]')
+    parentObjectName=$(jq -r '.metadata.ownerReferences[0].name' <<< "${podJson}")
+
+    case "${parentObjectKind}" in
+        #https://github.tools.sap/kyma/backlog/issues/1074
+        ("null")
+            ;&
+        ("")
+            echo "Pod ${podName} in namespace ${namespace} has no parent object. Skipping..."
+            continue
+            ;;
+        ("replicaset")
+            parentDeploymentName=$(kubectl get "${parentObjectKind}" "${parentObjectName}" -n "${namespace}" -o jsonpath='{.metadata.ownerReferences[0].name}')
+            echo "deployment ${parentDeploymentName} in namespace ${namespace} eligible for restart"
+            objectsToRestart["deployment/${namespace}/${parentDeploymentName}"]=""
+            ;;
+        (*)
+            echo "${parentObjectKind} ${parentObjectName} in namespace ${namespace} eligible for restart"
+            objectsToRestart["${parentObjectKind}/${namespace}/${parentObjectName}"]=""
+            ;;
+    esac
+done
+
+echo "NUMBER OF OBJECTS TO RESTART: ${#objectsToRestart[@]}"
+
+for key in "${!objectsToRestart[@]}"
+do
+
+    attributes=($(echo "${key}" | tr "/" "\n"))
+
+    kind="${attributes[0]}"
+    namespace="${attributes[1]}"
+    name="${attributes[2]}"
+
+    kubectl rollout restart "${kind}" "${name}" -n "${namespace}"
+
+done
+

--- a/resources/istio/templates/istio-proxy-reset.yaml
+++ b/resources/istio/templates/istio-proxy-reset.yaml
@@ -56,61 +56,14 @@ spec:
       containers:
         - name: proxy-reset
           image: eu.gcr.io/kyma-project/incubator/develop/k8s-tools:20201023-5de446cf
+          env:
+          - name: EXPECTED_ISTIO_PROXY_IMAGE
+            value: {{ .Values.kyma.proxyResetJob.expectedIstioProxyImage }}
+          - name: COMMON_ISTIO_PROXY_IMAGE_PREFIX
+            value: {{ .Values.kyma.proxyResetJob.commonIstioProxyImagePrefix }}
           command:
             - /bin/bash
             - -c
             - |
-              for NS in $(kubectl get ns -l kyma-project.io/created-by=e2e-upgrade-test-runner -o name | cut -d '/' -f2); do
-                kubectl delete rs -n $NS --all
-              done
+{{.Files.Get "files/istio-proxy-reset.sh" | printf "%s" | indent 16}}
 
-              declare -A objectsToRestart
-
-              pods=$(kubectl get po -A -o json | jq -rc '.items | .[] | select(.spec.containers | .[].image == "docker.io/istio/proxyv2:1.4.10-distroless") | "\(.metadata.name)/\(.metadata.namespace)"' )
-              podArray=($(echo $pods | tr " " "\n"))
-
-              echo "NUMBER OF PODS MATCHED: ${#podArray[@]}"
-
-              for i in "${podArray[@]}"
-              do
-                namespacedName=($(echo $i | tr "/" "\n"))
-
-                podName="${namespacedName[0]}"
-                namespace="${namespacedName[1]}"
-
-                podJson=$(kubectl get pod "${podName}" -n "${namespace}" -o json)
-
-                parentObjectKind=$(jq -r '.metadata.ownerReferences[0].kind' <<< "${podJson}" | tr '[:upper:]' '[:lower:]')
-                parentObjectName=$(jq -r '.metadata.ownerReferences[0].name' <<< "${podJson}")
-
-                case "${parentObjectKind}" in
-                ("")
-                  echo "Pod ${podName} in namespace ${namespace} has no parent object. Skipping..."
-                  continue
-                  ;;
-                ("replicaset")
-                  parentDeploymentName=$(kubectl get "${parentObjectKind}" "${parentObjectName}" -n "${namespace}" -o jsonpath='{.metadata.ownerReferences[0].name}')
-                  echo "deployment ${parentDeploymentName} in namespace ${namespace} eligible for restart"
-                  objectsToRestart["deployment/${namespace}/${parentDeploymentName}"]=""
-                  ;;
-                (*)
-                  echo "${parentObjectKind} ${parentObjectName} in namespace ${namespace} eligible for restart"
-                  objectsToRestart["${parentObjectKind}/${namespace}/${parentObjectName}"]=""
-                  ;;
-                esac
-              done
-
-              echo "NUMBER OF OBJECTS TO RESTART: ${#objectsToRestart[@]}"
-
-              for key in "${!objectsToRestart[@]}"
-              do
-
-                attributes=($(echo "${key}" | tr "/" "\n"))
-
-                kind="${attributes[0]}"
-                namespace="${attributes[1]}"
-                name="${attributes[2]}"
-
-                kubectl rollout restart "${kind}" "${name}" -n "${namespace}"
-
-              done

--- a/resources/istio/templates/istio-proxy-reset.yaml
+++ b/resources/istio/templates/istio-proxy-reset.yaml
@@ -58,7 +58,7 @@ spec:
           image: eu.gcr.io/kyma-project/incubator/develop/k8s-tools:20201023-5de446cf
           env:
           - name: EXPECTED_ISTIO_PROXY_IMAGE
-            value: {{ .Values.kyma.proxyResetJob.expectedIstioProxyImage }}
+            value: {{ .Values.kyma.proxyResetJob.commonIstioProxyImagePrefix }}:{{ .Chart.Version }}
           - name: COMMON_ISTIO_PROXY_IMAGE_PREFIX
             value: {{ .Values.kyma.proxyResetJob.commonIstioProxyImagePrefix }}
           command:
@@ -66,4 +66,3 @@ spec:
             - -c
             - |
 {{.Files.Get "files/istio-proxy-reset.sh" | printf "%s" | indent 16}}
-

--- a/resources/istio/values.yaml
+++ b/resources/istio/values.yaml
@@ -4,7 +4,7 @@ global:
   tracing:
     enabled: true
     zipkinAddress: "zipkin.kyma-system:9411"
-    
+
 kyma:
   namespaces2Label:
     - istio-system
@@ -12,6 +12,9 @@ kyma:
   labelJob:
     image: eu.gcr.io/kyma-project/incubator/develop/k8s-tools
     tag: "20201023-5de446cf"
+  proxyResetJob:
+    expectedIstioProxyImage: "eu.gcr.io/kyma-project/external/istio/proxyv2:1.7.4-distroless"
+    commonIstioProxyImagePrefix: "eu.gcr.io/kyma-project/external/istio/proxyv2"
 
 istio:
   installer:

--- a/resources/istio/values.yaml
+++ b/resources/istio/values.yaml
@@ -13,7 +13,6 @@ kyma:
     image: eu.gcr.io/kyma-project/incubator/develop/k8s-tools
     tag: "20201023-5de446cf"
   proxyResetJob:
-    expectedIstioProxyImage: "eu.gcr.io/kyma-project/external/istio/proxyv2:1.7.4-distroless"
     commonIstioProxyImagePrefix: "eu.gcr.io/kyma-project/external/istio/proxyv2"
 
 istio:


### PR DESCRIPTION
**Description**
Improve istio-proxy-reset-job.
This PR addressed two problems:
- "null" parent for plain old Pods without backing deployment/replicaset etc.
- Poor Pod selection: Hard-coded old version of Istio Proxy to select the Pods that should be migrated. Logic is reversed now: the user provides the expected Istio Proxy version, and the logic selects all Pods that don't match this version.

Changes proposed in this pull request:

- Improved Pod matching logic
- Fixed problem with null parent
- Put the script into a separate file to support manual testing/maintenance
- Add dry-run option to support manual testing/maintenance
- Expose job's parameters as entries in values.yaml to simplify future maintenance
