### PR TITLE
Istio sidecar version troubleshooting docs

### DIFF
--- a/docs/migration-guides/1.15-1.17.md
+++ b/docs/migration-guides/1.15-1.17.md
@@ -15,7 +15,7 @@ Kyma 1.16.0-rc3 comes with a new Istio version: 1.5.10, which introduces a new c
 All Istio-related objects in Kyma are updated, but the migration may be necessary for the Istio objects created manually in your cluster.
 Please read the [Istio upgrade notes](https://istio.io/latest/news/releases/1.5.x/announcing-1.5/upgrade-notes/) for the details.
 Please ensure you're not using Istio RBAC, which is [deprecated](https://istio.io/v1.5/docs/reference/config/security/istio.rbac.v1alpha1/) and may not work after the upgrade. Use the [Authorization Policy](https://istio.io/latest/docs/reference/config/security/authorization-policy/) to configure authorization for your services.
-Ensure Istio sidecars for all workloads are in the proper version after the upgrade. See the [Troubleshooting sidecar version](https://kyma-project.io/docs/1.17.1/components/service-mesh/#troubleshooting-istio-sidecar-version-after-kyma-upgrade)
+Ensure Istio sidecars for all workloads are in the proper version after the upgrade. See the [Troubleshooting sidecar version](../service-mesh/#troubleshooting-istio-sidecar-version-after-kyma-upgrade)
 In addition, consider migrating existing Authentication Policy to equivalent PeerAuthentication and RequestAuthentication objects.
 
 ### Eventing
@@ -114,4 +114,4 @@ kubectl get vs --all-namespaces -o=go-template --template='{{ range .items }}{{ 
 The command returns a list of pairs consisting of the Virtual Service name and allowed origins. Look for entries different from `{VS_NAME} : [*]` and migrate them manually to the [new version](https://istio.io/latest/docs/reference/config/networking/virtual-service/#CorsPolicy). You can find the old configuration under the key `spec.http.corsPolicy.allowOrigin`.
 
 
-Ensure Istio sidecars for all workloads are in the proper version after the upgrade. See the [Troubleshooting sidecar version](https://kyma-project.io/docs/1.17.1/components/service-mesh/#troubleshooting-istio-sidecar-version-after-kyma-upgrade)
+Ensure Istio sidecars for all workloads are in the proper version after the upgrade. See the [Troubleshooting sidecar version](../service-mesh/#troubleshooting-istio-sidecar-version-after-kyma-upgrade)

--- a/docs/migration-guides/1.15-1.17.md
+++ b/docs/migration-guides/1.15-1.17.md
@@ -15,7 +15,7 @@ Kyma 1.16.0-rc3 comes with a new Istio version: 1.5.10, which introduces a new c
 All Istio-related objects in Kyma are updated, but the migration may be necessary for the Istio objects created manually in your cluster.
 Please read the [Istio upgrade notes](https://istio.io/latest/news/releases/1.5.x/announcing-1.5/upgrade-notes/) for the details.
 Please ensure you're not using Istio RBAC, which is [deprecated](https://istio.io/v1.5/docs/reference/config/security/istio.rbac.v1alpha1/) and may not work after the upgrade. Use the [Authorization Policy](https://istio.io/latest/docs/reference/config/security/authorization-policy/) to configure authorization for your services.
-Ensure Istio sidecars for all Pods are in the proper version after the upgrade. See the [Troubleshooting sidecar version](https://kyma-project.io/?docs/1.17.1/components/service-mesh/#troubleshooting-istio-sidecar-version-after-kyma-upgrade) for more information.
+Ensure Istio sidecars for all Pods are in the proper version after the upgrade. See the [Troubleshooting sidecar version](https://kyma-project.io/?docs/1.17.1/components/service-mesh/=troubleshooting-istio-sidecar-version-after-kyma-upgrade) for more information.
 In addition, consider migrating existing Authentication Policy to equivalent PeerAuthentication and RequestAuthentication objects.
 
 ### Eventing
@@ -114,4 +114,4 @@ kubectl get vs --all-namespaces -o=go-template --template='{{ range .items }}{{ 
 The command returns a list of pairs consisting of the Virtual Service name and allowed origins. Look for entries different from `{VS_NAME} : [*]` and migrate them manually to the [new version](https://istio.io/latest/docs/reference/config/networking/virtual-service/#CorsPolicy). You can find the old configuration under the key `spec.http.corsPolicy.allowOrigin`.
 
 
-Ensure Istio sidecars for all Pods are in the proper version after the upgrade. See the [Troubleshooting sidecar version](https://kyma-project.io/?docs/1.17.1/components/service-mesh/#troubleshooting-istio-sidecar-version-after-kyma-upgrade) for more information.
+Ensure Istio sidecars for all Pods are in the proper version after the upgrade. See the [Troubleshooting sidecar version](https://kyma-project.io/?docs/1.17.1/components/service-mesh/=troubleshooting-istio-sidecar-version-after-kyma-upgrade) for more information.

--- a/docs/migration-guides/1.15-1.17.md
+++ b/docs/migration-guides/1.15-1.17.md
@@ -15,7 +15,7 @@ Kyma 1.16.0-rc3 comes with a new Istio version: 1.5.10, which introduces a new c
 All Istio-related objects in Kyma are updated, but the migration may be necessary for the Istio objects created manually in your cluster.
 Please read the [Istio upgrade notes](https://istio.io/latest/news/releases/1.5.x/announcing-1.5/upgrade-notes/) for the details.
 Please ensure you're not using Istio RBAC, which is [deprecated](https://istio.io/v1.5/docs/reference/config/security/istio.rbac.v1alpha1/) and may not work after the upgrade. Use the [Authorization Policy](https://istio.io/latest/docs/reference/config/security/authorization-policy/) to configure authorization for your services.
-Ensure Istio sidecars for all workloads are in the proper version after the upgrade. See the [Troubleshooting sidecar version](../service-mesh/#troubleshooting-istio-sidecar-version-after-kyma-upgrade)
+Ensure Istio sidecars for all Pods are in the proper version after the upgrade. See the [Troubleshooting sidecar version](../service-mesh/#troubleshooting-istio-sidecar-version-after-kyma-upgrade)
 In addition, consider migrating existing Authentication Policy to equivalent PeerAuthentication and RequestAuthentication objects.
 
 ### Eventing
@@ -114,4 +114,4 @@ kubectl get vs --all-namespaces -o=go-template --template='{{ range .items }}{{ 
 The command returns a list of pairs consisting of the Virtual Service name and allowed origins. Look for entries different from `{VS_NAME} : [*]` and migrate them manually to the [new version](https://istio.io/latest/docs/reference/config/networking/virtual-service/#CorsPolicy). You can find the old configuration under the key `spec.http.corsPolicy.allowOrigin`.
 
 
-Ensure Istio sidecars for all workloads are in the proper version after the upgrade. See the [Troubleshooting sidecar version](../service-mesh/#troubleshooting-istio-sidecar-version-after-kyma-upgrade)
+Ensure Istio sidecars for all Pods are in the proper version after the upgrade. See the [Troubleshooting sidecar version](../service-mesh/#troubleshooting-istio-sidecar-version-after-kyma-upgrade)

--- a/docs/migration-guides/1.15-1.17.md
+++ b/docs/migration-guides/1.15-1.17.md
@@ -3,7 +3,7 @@
 To upgrade Kyma from 1.15 to 1.17 you have to perform two steps:
 1. upgrade to a Release Candidate version of Kyma tagged 1.16.0-rc3,
 2. upgrade to an official Release 1.17 version of Kyma
- 
+
  This document contains two sections describing actions you have to perform before or after each step.
 
 ## Migrate from 1.15 to 1.16.0-rc3
@@ -15,6 +15,7 @@ Kyma 1.16.0-rc3 comes with a new Istio version: 1.5.10, which introduces a new c
 All Istio-related objects in Kyma are updated, but the migration may be necessary for the Istio objects created manually in your cluster.
 Please read the [Istio upgrade notes](https://istio.io/latest/news/releases/1.5.x/announcing-1.5/upgrade-notes/) for the details.
 Please ensure you're not using Istio RBAC, which is [deprecated](https://istio.io/v1.5/docs/reference/config/security/istio.rbac.v1alpha1/) and may not work after the upgrade. Use the [Authorization Policy](https://istio.io/latest/docs/reference/config/security/authorization-policy/) to configure authorization for your services.
+Ensure Istio sidecars for all workloads are in the proper version after the upgrade. See the [Troubleshooting sidecar version](https://kyma-project.io/docs/1.17.1/components/service-mesh/#troubleshooting-istio-sidecar-version-after-kyma-upgrade)
 In addition, consider migrating existing Authentication Policy to equivalent PeerAuthentication and RequestAuthentication objects.
 
 ### Eventing
@@ -31,10 +32,10 @@ To remove the `knative-serving` chart, execute:
 
 ```bash
 helm delete knative-serving -n knative-serving
-``` 
+```
 >**NOTE:** This requires Helm version 3.x
 
-This command renders Knative-Serving inactive, but all user-created configuration is still available in the cluster. 
+This command renders Knative-Serving inactive, but all user-created configuration is still available in the cluster.
 To remove the CustomResourceDefinitions for Knative-Serving along with the respective CustomResources, run:
 
 ```bash
@@ -54,19 +55,19 @@ kubectl delete crd \
 ### Logging
 
 In Release Candidate 1.16.0-rc3, we change the `instance` label on the logs corresponding to the Pod name to `pod`, which fits the observability ecosystem better.
-Also, the `container` label for a function pointing to `lambda` in the previous releases now points to `function`. 
+Also, the `container` label for a function pointing to `lambda` in the previous releases now points to `function`.
 If you search for the logs from a function with the `container: lambda` filter, you will need to change it to `container: function` from this release on.
 
 ### Kyma with Compass
 
 > **CAUTION:** This step only applies to Kyma **with Compass**.
 
-In Kyma 1.17, the name of [this Application Connector Secret](https://github.com/kyma-project/kyma/blob/release-1.17/resources/core/charts/gateway/templates/application-connector-certs.yaml) changed from `kyma-gateway-certs-cacert` to `app-connector-certs`. This resulted in the CA certificate data (`cacert`) being lost at upgrade from 1.16.0-rc3 to 1.17. To prevent that, we introduced a [migration job](https://github.com/kyma-project/kyma/blob/release-1.17/resources/core/charts/gateway/templates/cacert-migrate-job.yaml) that makes sure the data copied from the old Kyma version to the new one persists and is migrated correctly. 
+In Kyma 1.17, the name of [this Application Connector Secret](https://github.com/kyma-project/kyma/blob/release-1.17/resources/core/charts/gateway/templates/application-connector-certs.yaml) changed from `kyma-gateway-certs-cacert` to `app-connector-certs`. This resulted in the CA certificate data (`cacert`) being lost at upgrade from 1.16.0-rc3 to 1.17. To prevent that, we introduced a [migration job](https://github.com/kyma-project/kyma/blob/release-1.17/resources/core/charts/gateway/templates/cacert-migrate-job.yaml) that makes sure the data copied from the old Kyma version to the new one persists and is migrated correctly.
 
 To make sure this job runs correctly, run this command **after** you've performed an upgrade to Release Candidate 1.16.0-rc3 and **before** upgrade to 1.17:
 
 ```bash
-kubectl patch compassconnection compass-connection --type=merge -p '{"spec":{"refreshCredentialsNow":true}}' 
+kubectl patch compassconnection compass-connection --type=merge -p '{"spec":{"refreshCredentialsNow":true}}'
 ```
 
 This ensures that the client gets reloaded and the correct `cacert` data is saved in Kyma 1.17.
@@ -75,7 +76,7 @@ This ensures that the client gets reloaded and the correct `cacert` data is save
 
 ### Istio
 
-Kyma 1.17 comes with a new Istio version: 1.7.4. 
+Kyma 1.17 comes with a new Istio version: 1.7.4.
 
 >**NOTE:** To upgrade successfully, make sure your cluster runs Kubernetes version 1.16 or higher.
 
@@ -111,3 +112,6 @@ kubectl get vs --all-namespaces -o=go-template --template='{{ range .items }}{{ 
 ```
 
 The command returns a list of pairs consisting of the Virtual Service name and allowed origins. Look for entries different from `{VS_NAME} : [*]` and migrate them manually to the [new version](https://istio.io/latest/docs/reference/config/networking/virtual-service/#CorsPolicy). You can find the old configuration under the key `spec.http.corsPolicy.allowOrigin`.
+
+
+Ensure Istio sidecars for all workloads are in the proper version after the upgrade. See the [Troubleshooting sidecar version](https://kyma-project.io/docs/1.17.1/components/service-mesh/#troubleshooting-istio-sidecar-version-after-kyma-upgrade)

--- a/docs/migration-guides/1.15-1.17.md
+++ b/docs/migration-guides/1.15-1.17.md
@@ -15,7 +15,7 @@ Kyma 1.16.0-rc3 comes with a new Istio version: 1.5.10, which introduces a new c
 All Istio-related objects in Kyma are updated, but the migration may be necessary for the Istio objects created manually in your cluster.
 Please read the [Istio upgrade notes](https://istio.io/latest/news/releases/1.5.x/announcing-1.5/upgrade-notes/) for the details.
 Please ensure you're not using Istio RBAC, which is [deprecated](https://istio.io/v1.5/docs/reference/config/security/istio.rbac.v1alpha1/) and may not work after the upgrade. Use the [Authorization Policy](https://istio.io/latest/docs/reference/config/security/authorization-policy/) to configure authorization for your services.
-Ensure Istio sidecars for all Pods are in the proper version after the upgrade. See the [Troubleshooting sidecar version](../service-mesh/#troubleshooting-istio-sidecar-version-after-kyma-upgrade)
+Ensure Istio sidecars for all Pods are in the proper version after the upgrade. See the [Troubleshooting sidecar version](../service-mesh/#troubleshooting-istio-sidecar-version-after-kyma-upgrade) for more information.
 In addition, consider migrating existing Authentication Policy to equivalent PeerAuthentication and RequestAuthentication objects.
 
 ### Eventing
@@ -114,4 +114,4 @@ kubectl get vs --all-namespaces -o=go-template --template='{{ range .items }}{{ 
 The command returns a list of pairs consisting of the Virtual Service name and allowed origins. Look for entries different from `{VS_NAME} : [*]` and migrate them manually to the [new version](https://istio.io/latest/docs/reference/config/networking/virtual-service/#CorsPolicy). You can find the old configuration under the key `spec.http.corsPolicy.allowOrigin`.
 
 
-Ensure Istio sidecars for all Pods are in the proper version after the upgrade. See the [Troubleshooting sidecar version](../service-mesh/#troubleshooting-istio-sidecar-version-after-kyma-upgrade)
+Ensure Istio sidecars for all Pods are in the proper version after the upgrade. See the [Troubleshooting sidecar version](../service-mesh/#troubleshooting-istio-sidecar-version-after-kyma-upgrade) for more information.

--- a/docs/migration-guides/1.15-1.17.md
+++ b/docs/migration-guides/1.15-1.17.md
@@ -15,7 +15,7 @@ Kyma 1.16.0-rc3 comes with a new Istio version: 1.5.10, which introduces a new c
 All Istio-related objects in Kyma are updated, but the migration may be necessary for the Istio objects created manually in your cluster.
 Please read the [Istio upgrade notes](https://istio.io/latest/news/releases/1.5.x/announcing-1.5/upgrade-notes/) for the details.
 Please ensure you're not using Istio RBAC, which is [deprecated](https://istio.io/v1.5/docs/reference/config/security/istio.rbac.v1alpha1/) and may not work after the upgrade. Use the [Authorization Policy](https://istio.io/latest/docs/reference/config/security/authorization-policy/) to configure authorization for your services.
-Ensure Istio sidecars for all Pods are in the proper version after the upgrade. See the [Troubleshooting sidecar version](../service-mesh/#troubleshooting-istio-sidecar-version-after-kyma-upgrade) for more information.
+Ensure Istio sidecars for all Pods are in the proper version after the upgrade. See the [Troubleshooting sidecar version](https://kyma-project.io/?docs/1.17.1/components/service-mesh/#troubleshooting-istio-sidecar-version-after-kyma-upgrade) for more information.
 In addition, consider migrating existing Authentication Policy to equivalent PeerAuthentication and RequestAuthentication objects.
 
 ### Eventing
@@ -114,4 +114,4 @@ kubectl get vs --all-namespaces -o=go-template --template='{{ range .items }}{{ 
 The command returns a list of pairs consisting of the Virtual Service name and allowed origins. Look for entries different from `{VS_NAME} : [*]` and migrate them manually to the [new version](https://istio.io/latest/docs/reference/config/networking/virtual-service/#CorsPolicy). You can find the old configuration under the key `spec.http.corsPolicy.allowOrigin`.
 
 
-Ensure Istio sidecars for all Pods are in the proper version after the upgrade. See the [Troubleshooting sidecar version](../service-mesh/#troubleshooting-istio-sidecar-version-after-kyma-upgrade) for more information.
+Ensure Istio sidecars for all Pods are in the proper version after the upgrade. See the [Troubleshooting sidecar version](https://kyma-project.io/?docs/1.17.1/components/service-mesh/#troubleshooting-istio-sidecar-version-after-kyma-upgrade) for more information.

--- a/docs/service-mesh/10-05-sidecar.md
+++ b/docs/service-mesh/10-05-sidecar.md
@@ -4,7 +4,7 @@ type: Troubleshooting
 ---
 
 
-Kyma has sidecar injection enabled by default - a sidecar is injected to every Pod in a cluster, without the need adding any labels. For more information, read [this document](#details-sidecar-proxy-injection).
+Kyma has sidecar injection enabled by default - a sidecar is injected to every Pod in a cluster without the need to add any labels. For more information, read [this document](#details-sidecar-proxy-injection).
 If a Pod doesn't have a sidecar and you did not disable sidecar injection on purpose, follow these steps to troubleshoot:
 
 1. Check if sidecar injection is disabled in the Namespace of the Pod. Run this command to check the `istio-injection` label:

--- a/docs/service-mesh/10-05-sidecar.md
+++ b/docs/service-mesh/10-05-sidecar.md
@@ -4,7 +4,7 @@ type: Troubleshooting
 ---
 
 
-Kyma has sidecar injection enabled by default - a sidecar is injected to every Deployment in a cluster, without the need adding any labels. For more information, read [this document](#details-sidecar-proxy-injection).
+Kyma has sidecar injection enabled by default - a sidecar is injected to every Pod in a cluster, without the need adding any labels. For more information, read [this document](#details-sidecar-proxy-injection).
 If a Pod doesn't have a sidecar and you did not disable sidecar injection on purpose, follow these steps to troubleshoot:
 
 1. Check if sidecar injection is disabled in the Namespace of the Pod. Run this command to check the `istio-injection` label:
@@ -14,16 +14,16 @@ If a Pod doesn't have a sidecar and you did not disable sidecar injection on pur
     ```
 
     If the command returns `disabled` the sidecar injection is disabled in this Namespace. To add a sidecar to the Pod, move the Pod's deployment to a Namespace that has sidecar injection enabled, or remove the label from the Namespace and restart the Pod.
-    
+
     >**WARNING:** Removing the `istio-injection=disabled` label from Namespace results in injecting sidecars to all Pods inside of the Namespace.
-  
+
 2. Check if sidecar injection is disabled in the Pod's Deployment:
 
     ```bash
     kubectl get deployments {DEPLOYMENT_NAME} -n {NAMESPACE} -o jsonpath='{ .spec.template.metadata.annotations }'
     ```
-   
+
    Sidecar injection is disabled if the output contains the `sidecar.istio.io/inject:false` line. Delete the label and restart the Pod to enable sidecar injection for the Deployment.
-   
+
 
 For more information, read [this document](#details-sidecar-proxy-injection) or follow the [Istio documentation](https://istio.io/docs/ops/common-problems/injection/).

--- a/docs/service-mesh/10-06-sidecar-version.md
+++ b/docs/service-mesh/10-06-sidecar-version.md
@@ -1,5 +1,5 @@
 ---
-title: Istio sidecar version after Kyma upgrade
+title: Incompatible Istio sidecar version after Kyma upgrade
 type: Troubleshooting
 ---
 
@@ -9,7 +9,7 @@ Kyma has sidecar injection enabled by default - a sidecar is injected to every P
 The sidecar version in Pods must match the installed Istio version. Otherwise, mesh connectivity may be broken.
 This issue may appear during Kyma upgrade. When Kyma is upgraded to a new version along with a new Istio version, existing sidecars injected into Pods remain in an original version.
 Kyma contains the `istio-proxy-reset` job that performs a rollout for most common workload types, such as Deployments, DaemonSets, etc. The job ensures all Kyma components are properly updated.
-Some user-defined workloads can't be rolled out automatically. This applies, for example, to a standalone Pod without any backing management mechanism, such as ReplicaSet or a Job.
+However, some user-defined workloads can't be rolled out automatically. This applies, for example, to a standalone Pod without any backing management mechanism, such as a ReplicaSet or a Job.
 Such user-defined workloads, that are not part of Kyma, must be manually restarted to work correctly with the updated Istio version.
 
 To check if any Pods or workloads require a manual restart, follow these steps:

--- a/docs/service-mesh/10-06-sidecar-version.md
+++ b/docs/service-mesh/10-06-sidecar-version.md
@@ -4,7 +4,7 @@ type: Troubleshooting
 ---
 
 
-Kyma has sidecar injection enabled by default - a sidecar is injected to every Deployment in a cluster, without the need to add any labels. For more information, read [this document](#details-sidecar-proxy-injection).
+Kyma has sidecar injection enabled by default - a sidecar is injected to every Pod in a cluster, without the need to add any labels. For more information, read [this document](#details-sidecar-proxy-injection).
 
 The sidecar version in Pods must match the installed Istio version, otherwise mesh connectivity may be broken.
 This is not an issue when installing Kyma, but it may be a problem during upgrades. When Kyma is upgraded to a new version along with a new Istio version, existing sidecars injected into Pods remain in an original version.

--- a/docs/service-mesh/10-06-sidecar-version.md
+++ b/docs/service-mesh/10-06-sidecar-version.md
@@ -1,0 +1,35 @@
+---
+title: Istio sidecar version after Kyma upgrade
+type: Troubleshooting
+---
+
+
+Kyma has sidecar injection enabled by default - a sidecar is injected to every Deployment in a cluster, without the need to add any labels. For more information, read [this document](#details-sidecar-proxy-injection).
+
+The sidecar version in Pods must match the installed Istio version, otherwise mesh connectivity may be broken.
+This is not an issue when installing Kyma, but it may be a problem during upgrades. When Kyma is upgraded to a new version along with a new Istio version, existing sidecars injected into Pods remain in an original version.
+Kyma contains an `istio-proxy-reset` job, that performs a rollout for most common workload types like deployments, daemonsets, etc. The job ensures all Kyma components are properly updated.
+Certain kinds of user-defined workloads can't be rolled out automatically, for example, a standalone Pod without any backing management mechanism (like ReplicaSet or a Job).
+Such user-defined workloads (that are not part of Kyma) must be manually restarted to work correctly with the updated Istio version.
+
+To find if any pods/workloads require a manual restart, you can:
+
+* Get the list of Pods with outdated sidecar version. You can get the Istio version for a Kyma release from the Istio chart version located in `resources/Istio/Chart.yaml` file. The returned list is in `name/namespace` format, empty output means no Pods require migration. Use the following command:
+
+    ```bash
+    EXPECTED_ISTIO_PROXY_IMAGE="1.7.4-distroless" #Valid for Kyma: 1.17.x, 1.18.x
+    COMMON_ISTIO_PROXY_IMAGE_PREFIX="eu.gcr.io/kyma-project/external/istio/proxyv2"
+    kubectl get pods -A -o json | jq -rc '.items | .[] | select(.spec.containers[].image | startswith("'"${COMMON_ISTIO_PROXY_IMAGE_PREFIX}"'") and (endswith("'"${EXPECTED_ISTIO_PROXY_IMAGE}"'") | not))  | "\(.metadata.name)/\(.metadata.namespace)"'
+    ```
+
+
+* Run the `istio-proxy-reset` script in dry-run mode. Execute the command from within the directory with checked-out Kyma sources. You can get the Istio version for the Kyma release from the Istio chart version located in `resources/Istio/Chart.yaml` file. The output contains information about objects (Pods, Deployments, etc.) that require rollout.
+
+    ```bash
+    EXPECTED_ISTIO_PROXY_IMAGE="1.7.4-distroless" #Valid for Kyma: 1.17.x, 1.18.x
+    COMMON_ISTIO_PROXY_IMAGE_PREFIX="eu.gcr.io/kyma-project/external/istio/proxyv2"
+    DRY_RUN="true"
+    ./resources/istio/files/istio-proxy-reset.sh
+    ```
+
+After you found a set of objects that require the manual update, restart their related workloads so that new Istio sidecars are injected into the Pods.

--- a/docs/service-mesh/10-06-sidecar-version.md
+++ b/docs/service-mesh/10-06-sidecar-version.md
@@ -4,38 +4,38 @@ type: Troubleshooting
 ---
 
 
-Kyma has sidecar injection enabled by default - a sidecar is injected to every Pod in a cluster, without the need to add any labels. For more information, read [this document](#details-sidecar-proxy-injection).
+Kyma has sidecar injection enabled by default - a sidecar is injected to every Pod in a cluster without the need to add any labels. For more information, read [this document](#details-sidecar-proxy-injection).
 
-The sidecar version in Pods must match the installed Istio version, otherwise mesh connectivity may be broken.
-This is not an issue when installing Kyma, but it may be a problem during upgrades. When Kyma is upgraded to a new version along with a new Istio version, existing sidecars injected into Pods remain in an original version.
-Kyma contains an `istio-proxy-reset` job, that performs a rollout for most common workload types like deployments, daemonsets, etc. The job ensures all Kyma components are properly updated.
-Certain kinds of user-defined workloads can't be rolled out automatically, for example, a standalone Pod without any backing management mechanism (like ReplicaSet or a Job).
-Such user-defined workloads (that are not part of Kyma) must be manually restarted to work correctly with the updated Istio version.
+The sidecar version in Pods must match the installed Istio version. Otherwise, mesh connectivity may be broken.
+This issue may appear during Kyma upgrade. When Kyma is upgraded to a new version along with a new Istio version, existing sidecars injected into Pods remain in an original version.
+Kyma contains the `istio-proxy-reset` job that performs a rollout for most common workload types, such as Deployments, DaemonSets, etc. The job ensures all Kyma components are properly updated.
+Some user-defined workloads can't be rolled out automatically. This applies, for example, to a standalone Pod without any backing management mechanism, such as ReplicaSet or a Job.
+Such user-defined workloads, that are not part of Kyma, must be manually restarted to work correctly with the updated Istio version.
 
-To find if any Pods or workloads require a manual restart please follow the steps:
+To check if any Pods or workloads require a manual restart, follow these steps:
 
-1) Get the installed Istio version using either method:
+1. Check the installed Istio version using one of these methods:
 
-    * From istiod deployment in a running cluster:
+    * From the `istiod` deployment in a running cluster:
         ```bash
         export KYMA_ISTIO_VERSION=$(kubectl get deployment istiod -n istio-system -o json | jq '.spec.template.spec.containers | .[].image' | sed 's/[^:"]*[:]//' | sed 's/["]//g')
         ```
 
-    * From Kyma sources - execute from within directory with Kyma sources:
+    * From Kyma sources - run this command from within the directory that contains Kyma sources:
         ```bash
         export KYMA_ISTIO_VERSION=$(cat resources/istio/Chart.yaml | grep version | sed 's/[^:]*[:]//' | sed 's/ //g')
         ```
 
-2) Get the list of objects which require rollout, using any method:
+2. Get the list of objects which require rollout using one of these methods:
 
-    * Find all Pods with outdated sidecars. The returned list is in `name/namespace` format, empty output means no Pods require migration. Execute:
+    * Find all Pods with outdated sidecars. The returned list follows the `name/namespace` format. The empty output means that there is no Pod that requires migration. To find all outdated Pods, run:
         ```bash
         COMMON_ISTIO_PROXY_IMAGE_PREFIX="eu.gcr.io/kyma-project/external/istio/proxyv2"
         kubectl get pods -A -o json | jq -rc '.items | .[] | select(.spec.containers[].image | startswith("'"${COMMON_ISTIO_PROXY_IMAGE_PREFIX}"'") and (endswith("'"${KYMA_ISTIO_VERSION}"'") | not))  | "\(.metadata.name)/\(.metadata.namespace)"'
         ```
 
 
-    * Run the `istio-proxy-reset` script in dry-run mode. The output contains information about objects (Pods, Deployments, etc.) that require rollout. Execute the command from within the directory with checked-out Kyma sources:
+    * Run the `istio-proxy-reset` script in the dry-run mode. The output contains information about objects, such as Pods, Deployments, etc., that require rollout. To run the script, run this command from within the directory with checked-out Kyma sources:
         ```bash
         EXPECTED_ISTIO_PROXY_IMAGE="${KYMA_ISTIO_VERSION}"
         COMMON_ISTIO_PROXY_IMAGE_PREFIX="eu.gcr.io/kyma-project/external/istio/proxyv2"
@@ -43,4 +43,4 @@ To find if any Pods or workloads require a manual restart please follow the step
         ./resources/istio/files/istio-proxy-reset.sh
         ```
 
-After you found a set of objects that require the manual update, restart their related workloads so that new Istio sidecars are injected into the Pods.
+After you find a set of objects that require the manual update, restart their related workloads so that new Istio sidecars are injected into the Pods.

--- a/docs/service-mesh/10-06-sidecar-version.md
+++ b/docs/service-mesh/10-06-sidecar-version.md
@@ -12,30 +12,30 @@ Kyma contains an `istio-proxy-reset` job, that performs a rollout for most commo
 Certain kinds of user-defined workloads can't be rolled out automatically, for example, a standalone Pod without any backing management mechanism (like ReplicaSet or a Job).
 Such user-defined workloads (that are not part of Kyma) must be manually restarted to work correctly with the updated Istio version.
 
-To find if any pods/workloads require a manual restart please follow the steps:
+To find if any Pods or workloads require a manual restart please follow the steps:
 
 1) Get the installed Istio version using either method:
 
-    * From istiod deployment
+    * From istiod deployment in a running cluster:
         ```bash
         export KYMA_ISTIO_VERSION=$(kubectl get deployment istiod -n istio-system -o json | jq '.spec.template.spec.containers | .[].image' | sed 's/[^:"]*[:]//' | sed 's/["]//g')
         ```
 
-    * From Kyma sources:
+    * From Kyma sources - execute from within directory with Kyma sources:
         ```bash
         export KYMA_ISTIO_VERSION=$(cat resources/istio/Chart.yaml | grep version | sed 's/[^:]*[:]//' | sed 's/ //g')
         ```
 
 2) Get the list of objects which require rollout, using any method:
 
-    * Find all Pods with outdated sidecars. The returned list is in `name/namespace` format, empty output means no Pods require migration.
+    * Find all Pods with outdated sidecars. The returned list is in `name/namespace` format, empty output means no Pods require migration. Execute:
         ```bash
         COMMON_ISTIO_PROXY_IMAGE_PREFIX="eu.gcr.io/kyma-project/external/istio/proxyv2"
         kubectl get pods -A -o json | jq -rc '.items | .[] | select(.spec.containers[].image | startswith("'"${COMMON_ISTIO_PROXY_IMAGE_PREFIX}"'") and (endswith("'"${KYMA_ISTIO_VERSION}"'") | not))  | "\(.metadata.name)/\(.metadata.namespace)"'
         ```
 
 
-    * Run the `istio-proxy-reset` script in dry-run mode. Execute the command from within the directory with checked-out Kyma sources. The output contains information about objects (Pods, Deployments, etc.) that require rollout.
+    * Run the `istio-proxy-reset` script in dry-run mode. The output contains information about objects (Pods, Deployments, etc.) that require rollout. Execute the command from within the directory with checked-out Kyma sources:
         ```bash
         EXPECTED_ISTIO_PROXY_IMAGE="${KYMA_ISTIO_VERSION}"
         COMMON_ISTIO_PROXY_IMAGE_PREFIX="eu.gcr.io/kyma-project/external/istio/proxyv2"

--- a/resources/istio/files/istio-proxy-reset.sh
+++ b/resources/istio/files/istio-proxy-reset.sh
@@ -8,7 +8,11 @@ istioProxyImageNamePrefix="${COMMON_ISTIO_PROXY_IMAGE_PREFIX:-eu.gcr.io/kyma-pro
 dryRun="${DRY_RUN:-false}"
 
 for NS in $(kubectl get ns -l kyma-project.io/created-by=e2e-upgrade-test-runner -o name | cut -d '/' -f2); do
-    "kubectl delete rs -n $NS --all"
+    if [[ "${dryRun}" == "false" ]]; then
+        kubectl delete rs -n "${NS}" --all
+    else
+        echo "[dryrun] kubectl delete rs -n ${NS}"
+    fi
 done
 
 declare -A objectsToRestart
@@ -68,7 +72,7 @@ do
     if [[ "${dryRun}" == "false" ]]; then
         kubectl rollout restart "${kind}" "${name}" -n "${namespace}"
     else
-        echo "[dryrun]" kubectl rollout restart "${kind}" "${name}" -n "${namespace}"
+        echo "[dryrun] kubectl rollout restart ${kind} ${name} -n ${namespace}"
     fi
 
 done


### PR DESCRIPTION
**Description**

Docs for troubleshooting Istio sidecar version after Kyma upgrade.
Updated Release Notes for 1.17.1

Changes proposed in this pull request:

- New troubleshooting guide for Istio
- 1.15 - 1.17 Migration Guide update.
- Fix for dry-run in istio-proxy-reset job.

**Related issue(s)**
See also: #10173 