### PR TITLE
Fix grafana scrape target

### DIFF
--- a/resources/monitoring/charts/grafana/templates/kyma-additions/auth-proxy-service.yaml
+++ b/resources/monitoring/charts/grafana/templates/kyma-additions/auth-proxy-service.yaml
@@ -1,3 +1,9 @@
+{{- /*
+  Customization: due to kyma-installer limitations, extraExposePorts has to be a multi-line string and not a list
+  Extra label to be excluded by the service monitor:
+    app.kubernetes.io/component: auth-proxy
+*/ -}}
+
 {{- if .Values.kyma.authProxy.enabled }}
 apiVersion: v1
 kind: Service

--- a/resources/monitoring/charts/grafana/templates/service.yaml
+++ b/resources/monitoring/charts/grafana/templates/service.yaml
@@ -1,5 +1,7 @@
 {{- /*
-  # Customization: due to kyma-installer limitations, extraExposePorts has to be a multi-line string and not a list
+  Customization: due to kyma-installer limitations, extraExposePorts has to be a multi-line string and not a list
+  Extra label to be included by the service monitor:
+    app.kubernetes.io/component: grafana
 */ -}}
 
 apiVersion: v1
@@ -9,6 +11,7 @@ metadata:
   namespace: {{ template "grafana.namespace" . }}
   labels:
     {{- include "grafana.labels" . | nindent 4 }}
+    app.kubernetes.io/component: grafana
 {{- if .Values.service.labels }}
 {{ toYaml .Values.service.labels | indent 4 }}
 {{- end }}

--- a/resources/monitoring/charts/grafana/values.yaml
+++ b/resources/monitoring/charts/grafana/values.yaml
@@ -128,7 +128,8 @@ service:
   targetPort: 3000
     # targetPort: 4181 To be used with a proxy extraContainer
   annotations: {}
-  labels: {}
+  labels:
+    app.kubernetes.io/component: grafana
   portName: http-service
 
 serviceMonitor:

--- a/resources/monitoring/charts/grafana/values.yaml
+++ b/resources/monitoring/charts/grafana/values.yaml
@@ -128,8 +128,7 @@ service:
   targetPort: 3000
     # targetPort: 4181 To be used with a proxy extraContainer
   annotations: {}
-  labels:
-    app.kubernetes.io/component: grafana
+  labels: {}
   portName: http-service
 
 serviceMonitor:

--- a/resources/monitoring/charts/prometheus-istio/templates/servicemonitor.yaml
+++ b/resources/monitoring/charts/prometheus-istio/templates/servicemonitor.yaml
@@ -5,6 +5,7 @@ metadata:
   name: {{ template "prometheus.server.fullname" . }}-server
   namespace: {{ $.Release.Namespace }}
   labels:
+    app: {{ template "prometheus.server.fullname" . }}-server
     {{- include "prometheus.server.labels" . | nindent 4 }}
 spec:
   namespaceSelector:

--- a/resources/monitoring/templates/grafana/servicemonitor.yaml
+++ b/resources/monitoring/templates/grafana/servicemonitor.yaml
@@ -11,6 +11,7 @@ spec:
   selector:
     matchLabels:
       app.kubernetes.io/name: grafana
+      app.kubernetes.io/component: grafana
       app.kubernetes.io/instance: {{ $.Release.Name | quote }}
   namespaceSelector:
     matchNames:


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/master/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- Fixes a problem caused by recent `grafana` and `prometheus-operator` chart upgrades resulting in a wrong service being included in a `prometheus` scrape pool
- Re-adds the app label to be the `prometheus-istio` servicemonitor in order to be consistent with the rest of servicemonitors

**Related issue(s)**
Fixes #10188
