### PR TITLE
Fix probe namespace selector on SKR

### DIFF
--- a/resources/monitoring/templates/prometheus/prometheus.yaml
+++ b/resources/monitoring/templates/prometheus/prometheus.yaml
@@ -193,7 +193,6 @@ spec:
 {{ else }}
   ruleSelector: {}
 {{- end }}
-{{- end }}
 {{- if .Values.prometheus.prometheusSpec.probeSelector }}
   probeSelector:
 {{ toYaml .Values.prometheus.prometheusSpec.probeSelector | indent 4 }}
@@ -209,6 +208,7 @@ spec:
 {{ toYaml .Values.prometheus.prometheusSpec.probeNamespaceSelector | indent 4 }}
 {{ else }}
   probeNamespaceSelector: {}
+{{- end }}
 {{- end }}
 {{- if .Values.prometheus.prometheusSpec.remoteRead }}
   remoteRead:


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/master/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

The new version of `prometheus-operator`  comes with a few new CRDs. One of them is `probes`.
Prometheus CR has now a `probeSelector` and  `probeNamespaceSelector` (similar to existing selectors and namespace selectors for pod and service monitors etc.). We have customization on SKRs which restricts service and pod monitors, rules, and now probes to only reside in kyma-managed namespaces. This prevents customer-managed resources from being picked up by our Prometheus.

The PR fixes a bug closing and `{{- else }}` statement too early and thus overriding `probeNamespaceSelector` and `probeSelector` with empty values.

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
