### PR TITLE
Remove @bszwarc from documentation CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -344,16 +344,16 @@ components/etcd-tls-setup-job/ @PK85 @mszostok @piotrmiskiewicz @polskikiel @ksp
 /tests/end-to-end/upgrade/pkg/tests/rafter/ @m00g3n @aerfio @pPrecel @magicmatatjahu @dbadura @tgorgol @kfurgol
 
 # All .md files
-*.md @kazydek @klaudiagrz @bszwarc @mmitoraj @majakurcius @alexandra-simeonova @superojla
+*.md @kazydek @klaudiagrz @mmitoraj @majakurcius @alexandra-simeonova @superojla
 
 # All files and subdirectories in /docs
-/docs/ @kazydek @klaudiagrz @bszwarc @mmitoraj @majakurcius @alexandra-simeonova @superojla
+/docs/ @kazydek @klaudiagrz @mmitoraj @majakurcius @alexandra-simeonova @superojla
 
 # Owners of the .kyma-project-io folder
 /.kyma-project-io/ @m00g3n @aerfio @pPrecel @magicmatatjahu
 
 # Config file for MILV - milv.config.yaml
-milv.config.yaml @m00g3n @aerfio @pPrecel @magicmatatjahu @kazydek @klaudiagrz @bszwarc @mmitoraj @majakurcius @alexandra-simeonova @superojla
+milv.config.yaml @m00g3n @aerfio @pPrecel @magicmatatjahu @kazydek @klaudiagrz @mmitoraj @majakurcius @alexandra-simeonova @superojla
 
 # performance tests
 /tests/perf/ @a-thaler @hisarbalik @lilitgh @suleymanakbas91 @clebs @rakesh-garimella


### PR DESCRIPTION
**Description**

Since Barbara Cz. left Kyma in September and has not continued contributing to our documentation, she should be removed from CODEOWNERS.

Changes proposed in this pull request:

- Remove @bszwarc from Kyma documentation CODEOWNERS.
