### PR TITLE
Double Kiali memory limit

### DIFF
--- a/resources/kiali/values.yaml
+++ b/resources/kiali/values.yaml
@@ -399,7 +399,7 @@ kiali:
       resources:
         limits:
           cpu: 100m
-          memory: 70Mi
+          memory: 140Mi
         requests:
           cpu: 10m
           memory: 20Mi


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/master/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- During one of the debugging sessions we noticed that Kiali memory limit was set too low. Memory usage was spiking above 70MB when >2 users are accessing Kiali at the same time
