### PR TITLE
Update Application Connector documentation

### DIFF
--- a/docs/application-connector/08-02-get-client-certificate.md
+++ b/docs/application-connector/08-02-get-client-certificate.md
@@ -166,5 +166,5 @@ curl https://gateway.kyma.local/{APP_NAME}/v1/metadata/services --cert {CLIENT_C
 Use this command to call the Event Service:
 
 ```bash
-curl -X POST https://gateway.kyma.local/{APP_NAME}/v1/events --cert {CLIENT_CERT_FILE_NAME}.crt --key {KEY_FILE_NAME}.key -k
+curl -X POST -H "Content-Type: application/json" https://gateway.kyma.local/{APP_NAME}/v1/events --cert {CLIENT_CERT_FILE_NAME}.crt --key {KEY_FILE_NAME}.key -k -d '{EVENT}'
 ```

--- a/docs/application-connector/08-02-get-client-certificate.md
+++ b/docs/application-connector/08-02-get-client-certificate.md
@@ -166,5 +166,5 @@ curl https://gateway.kyma.local/{APP_NAME}/v1/metadata/services --cert {CLIENT_C
 Use this command to call the Event Service:
 
 ```bash
-curl https://gateway.kyma.local/{APP_NAME}/v1/events/subscribed --cert {CLIENT_CERT_FILE_NAME}.crt --key {KEY_FILE_NAME}.key -k
+curl -X POST https://gateway.kyma.local/{APP_NAME}/v1/events --cert {CLIENT_CERT_FILE_NAME}.crt --key {KEY_FILE_NAME}.key -k
 ```

--- a/docs/application-connector/08-02-get-client-certificate.md
+++ b/docs/application-connector/08-02-get-client-certificate.md
@@ -120,8 +120,8 @@ Call the `metadata` endpoint with the generated certificate to get URLs to the f
 
 - the Application Registry API
 - the Event Service API
-- the `certificate renewal` endpoint
-- the `certificate revocation` endpoint
+- the certificate renewal endpoint
+- the certificate revocation endpoint
 
 The URL to the `metadata` endpoint is returned in the response body from the configuration URL. Use the value of the `api.infoUrl` property to get the URL. Run:
 

--- a/docs/application-connector/08-09-renew-client-cert.md
+++ b/docs/application-connector/08-09-renew-client-cert.md
@@ -5,7 +5,7 @@ type: Tutorials
 
 By default, a client certificate you generate when you connect an external solution to Kyma is valid for 92 days. Follow this tutorial to renew a client certificate.
  
-> **NOTE:** You as the user are responsible for rotating and renewing the certificates.
+> **NOTE:** You, as the user, are responsible for rotating and renewing the certificates.
 
 >**NOTE:** You can only renew client certificates that are still valid. If your client certificate is expired or revoked, you must generate a new one.
 

--- a/docs/application-connector/08-09-renew-client-cert.md
+++ b/docs/application-connector/08-09-renew-client-cert.md
@@ -4,6 +4,8 @@ type: Tutorials
 ---
 
 By default, a client certificate you generate when you connect an external solution to Kyma is valid for 92 days. Follow this tutorial to renew a client certificate.
+ 
+> **NOTE:** You as the user are responsible for rotating and renewing the certificates.
 
 >**NOTE:** You can only renew client certificates that are still valid. If your client certificate is expired or revoked, you must generate a new one.
 
@@ -19,10 +21,12 @@ By default, a client certificate you generate when you connect an external solut
    openssl req -new -sha256 -out renewal.csr -key {PATH_TO_KEY} -subj "{SUBJECT}"
    ```
 
-3. Send a request to the Connector Service to renew the certificate.
+3. Send a request to the Connector Service to renew the certificate. Use the certificate renewal endpoint.
+
+   > **NOTE:** To get the URL to the certificate renewal endpoint, see the tutorial on how to [call the metadata endpoint](https://kyma-project.io/docs/components/application-connector/#tutorials-get-the-client-certificate-call-the-metadata-endpoint).
 
    ```bash
-   curl -X POST https://gateway.{DOMAIN}/v1/applications/certificates/renewals -d '{"csr":"BASE64_ENCODED_CSR"}' -k --cert {PATH_TO_OLD_CRT} --key {PATH_TO_KEY}
+   curl -X POST https://gateway.{CLUSTER_DOMAIN}/v1/applications/certificates/renewals -d '{"csr":"BASE64_ENCODED_CSR"}' -k --cert {PATH_TO_OLD_CRT} --key {PATH_TO_KEY}
    ```
 
    A successful call returns a renewed client certificate:

--- a/docs/application-connector/08-10-revoke-cert.md
+++ b/docs/application-connector/08-10-revoke-cert.md
@@ -3,7 +3,7 @@ title: Revoke a client certificate
 type: Tutorials
 ---
 
-You can revoke a client certificate generated for your Application. Revocation prevents a certificate from being [renewed](#tutorials-renew-the-client-certificate). A revoked certificate, however, continues to be valid until it expires.
+You can revoke a client certificate generated for your Application. Revocation prevents a certificate from being [renewed](#tutorials-renew-the-client-certificate). A revoked certificate, however, continues to be valid until it expires. 
 
 To revoke a client certificate, send a request to the `certificates/revocations` endpoint. Pass the certificate you want to revoke and a key that matches this certificate in the call. Run:
     

--- a/docs/application-connector/08-11-rotate-root-ca.md
+++ b/docs/application-connector/08-11-rotate-root-ca.md
@@ -10,7 +10,9 @@ Two different components use the Root CA certificate. As a result, the certifica
   - The `connector-service-app-ca` Connector Service CA Secret responsible for signing certificate requests
   - The `app-connector-certs` Istio Secret responsible for security in the Connector Service API
 
-Keeping both Secrets up-to-date is vital for the security of your implementation as it guarantees that the Connector Service issues proper certificates and no unregistered Applications can access its API.
+Keeping both Secrets up-to-date is vital for the security of your implementation as it guarantees that the Connector Service issues proper certificates and no unregistered Applications can access its API. 
+
+> **NOTE:** You as the user are responsible for rotating and renewing the certificates.
 
 The Root CA certificate has a set expiration date and must be renewed periodically to prevent its expiration. You must also renew the Root CA certificate and key every time they are compromised.
 

--- a/docs/application-connector/08-11-rotate-root-ca.md
+++ b/docs/application-connector/08-11-rotate-root-ca.md
@@ -30,7 +30,7 @@ To successfully rotate a soon-to-expire CA certificate, replace it with a new ce
    kubectl -n kyma-integration get secret connector-service-app-ca -o=jsonpath='{.data.ca\.key}' | base64 --decode > ca.key
    ```
 
-1. Generate a new certificate for the key you obtained and save it to the `new-ca.crt` file.
+2. Generate a new certificate for the key you obtained and save it to the `new-ca.crt` file.
 
    ```bash
    openssl req -new -key ca.key -x509 -sha256 -days {TTL_DAYS} -nodes -out new-ca.crt
@@ -38,47 +38,47 @@ To successfully rotate a soon-to-expire CA certificate, replace it with a new ce
 
    >**NOTE:** Use the `-days` flag to set the TTL (Time to live) of the newly generated certificate.
 
-1. Encode the newly created certificate with base64.
+3. Encode the newly created certificate with base64.
   
    ```bash
    cat new-ca.crt | base64
    ```
 
-1. Replace the old certificate in the Connector Service CA Secret. Edit the Secret and replace the `ca.crt` value with the new base64-encoded certificate.
+4. Replace the old certificate in the Connector Service CA Secret. Edit the Secret and replace the `ca.crt` value with the new base64-encoded certificate.
   
    ```bash
    kubectl -n kyma-integration edit secret connector-service-app-ca
    ```
 
-1. Get the existing Istio CA certificate. Fetch it from the `app-connector-certs` Secret and save it to the `old-ca.crt` file.
+5. Get the existing Istio CA certificate. Fetch it from the `app-connector-certs` Secret and save it to the `old-ca.crt` file.
   
    ```bash
    kubectl -n istio-system get secret app-connector-certs -o=jsonpath='{.data.cacert}' | base64 --decode > old-ca.crt
    ```
 
-1. Merge the old certificate and the newly generated certificate into a single `merged-ca.crt` file.
+6. Merge the old certificate and the newly generated certificate into a single `merged-ca.crt` file.
   
    ```bash
    cat old-ca.crt new-ca.crt > merged-ca.crt
    ```
 
-1. Encode the newly created `merged-ca.crt` certificate file with base64.
+7. Encode the newly created `merged-ca.crt` certificate file with base64.
   
    ```bash
    cat merged-ca.crt | base64
    ```
 
-1. Replace the old certificate in the Istio Secret. Edit the Secret and replace the `cacert` value with the `merged-ca.crt` base64-encoded certificate.
+8. Replace the old certificate in the Istio Secret. Edit the Secret and replace the `cacert` value with the `merged-ca.crt` base64-encoded certificate.
   
    ```bash
    kubectl -n istio-system edit secret app-connector-certs
    ```
 
-1. Wait for all the client certificates to be renewed. 
+9. Wait for all the client certificates to be renewed. 
 
     > **NOTE:** In the case of a Kyma Runtime connected to the central Connector Service, the system renews the certificates automatically using the information stored in the Secrets. Alternatively, you can renew the certificates in said Runtime yourself. To do that, create a CertificateRequest custom resource (CR) in the Runtime in which you want to renew the certificates.
 
-1. After the client certificates are renewed, remove the `app-connector-certs` Secret entry which contains the old certificate. First, encode the `new-ca.crt` file with base64.
+10. After the client certificates are renewed, remove the `app-connector-certs` Secret entry which contains the old certificate. First, encode the `new-ca.crt` file with base64.
   
    > **CAUTION:** Do not proceed with this step until all the client certificates are renewed!
 
@@ -86,7 +86,7 @@ To successfully rotate a soon-to-expire CA certificate, replace it with a new ce
    cat new-ca.crt | base64
    ```
 
-1. Edit the Secret and replace the `cacert` value with the base64-encoded `new-ca.crt` certificate.
+11. Edit the Secret and replace the `cacert` value with the base64-encoded `new-ca.crt` certificate.
   
    ```bash
    kubectl -n istio-system edit secret app-connector-certs
@@ -120,7 +120,7 @@ To successfully rotate a soon-to-expire CA certificate, replace it with a new ce
    kubectl -n kyma-integration edit secret connector-service-app-ca
    ```
 
-5. Replace the old certificate in the Istio Secret. Edit the Secret and replace the `ca.crt` value with the new base64-encoded certificate.
+5. Replace the old certificate in the Istio Secret. Edit the Secret and replace the `cacert` value with the new base64-encoded certificate.
    
    ```bash
    kubectl -n istio-system edit secret app-connector-certs

--- a/docs/application-connector/08-11-rotate-root-ca.md
+++ b/docs/application-connector/08-11-rotate-root-ca.md
@@ -12,8 +12,6 @@ Two different components use the Root CA certificate. As a result, the certifica
 
 Keeping both Secrets up-to-date is vital for the security of your implementation as it guarantees that the Connector Service issues proper certificates and no unregistered Applications can access its API. 
 
-> **NOTE:** You as the user are responsible for rotating and renewing the certificates.
-
 The Root CA certificate has a set expiration date and must be renewed periodically to prevent its expiration. You must also renew the Root CA certificate and key every time they are compromised.
 
 This tutorial describes the procedure you must follow for these scenarios:


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Fix the name of the value to change in the Istio Secret (`ca.crt` -> `cacert`) 
- Add a note that the user is responsible for renewing and rotating the client certificates for their integration
- Fix the curl command to call Event Service 
- Apply minor editorial fixes


**Related issues**
Resolves #9316 