### PR TITLE
Increase the time window for log queries

### DIFF
--- a/tests/integration/logging/pkg/logstream/logstream.go
+++ b/tests/integration/logging/pkg/logstream/logstream.go
@@ -100,7 +100,7 @@ func Test(domain, authHeader, labelKey, labelValue string, start time.Time, http
 func Cleanup(spec PodSpec, coreInterface kubernetes.Interface) error {
 	gracePeriod := int64(0)
 	deleteOptions := metav1.DeleteOptions{GracePeriodSeconds: &gracePeriod}
-	listOptions := metav1.ListOptions{LabelSelector: fmt.Sprint("app=%s", spec.PodName)}
+	listOptions := metav1.ListOptions{LabelSelector: fmt.Sprintf("app=%s", spec.PodName)}
 	err := coreInterface.CoreV1().Pods(spec.Namespace).DeleteCollection(&deleteOptions, listOptions)
 	if err != nil {
 		return errors.Wrapf(err, "cannot delete %s", spec.PodName)

--- a/tests/integration/logging/pkg/logstream/logstream.go
+++ b/tests/integration/logging/pkg/logstream/logstream.go
@@ -69,7 +69,7 @@ func WaitForDummyPodToRun(namespace string, coreInterface kubernetes.Interface) 
 func Test(domain, authHeader, labelKey, labelValue string, start time.Time, httpClient *http.Client) error {
 	timeout := time.After(3 * time.Minute)
 	tick := time.NewTicker(5 * time.Second)
-	lokiURL := fmt.Sprintf(`https://loki.%s/api/prom/query?query={%s="%s"}&start=%d`, domain, labelKey, labelValue, start.Local().Unix())
+	lokiURL := fmt.Sprintf(`https://loki.%s/api/prom/query?query={%s="%s"}&start=%d`, domain, labelKey, labelValue, start.UnixNano())
 	for {
 		select {
 		case <-timeout:

--- a/tests/integration/logging/pkg/logstream/logstream.go
+++ b/tests/integration/logging/pkg/logstream/logstream.go
@@ -6,7 +6,6 @@ import (
 	"io"
 	"net/http"
 	"regexp"
-	"strconv"
 	"time"
 
 	"github.com/pkg/errors"
@@ -67,12 +66,10 @@ func WaitForDummyPodToRun(namespace string, coreInterface kubernetes.Interface) 
 }
 
 // Test querys loki api with the given label key-value pair and checks that the logs of the dummy pod are present
-func Test(domain string, labelKey string, labelValue string, authHeader string, httpClient *http.Client) error {
+func Test(domain, authHeader, labelKey, labelValue string, start time.Time, httpClient *http.Client) error {
 	timeout := time.After(3 * time.Minute)
 	tick := time.NewTicker(5 * time.Second)
-	currentTimeUnixNano := time.Now().UnixNano()
-	startTimeParam := strconv.FormatInt(currentTimeUnixNano, 10)
-	lokiURL := fmt.Sprintf(`https://loki.%s/api/prom/query?query={%s="%s"}&start=%s`, domain, labelKey, labelValue, startTimeParam)
+	lokiURL := fmt.Sprintf(`https://loki.%s/api/prom/query?query={%s="%s"}&start=%d`, domain, labelKey, labelValue, start.Local().Unix())
 	for {
 		select {
 		case <-timeout:


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/master/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- After analyzing the logs of failing `logging` tests, I came to the conclusion that they are caused by the start timestamp being set immediately before querying Loki. The counter pod is getting deployed asynchronously and if it manages to send logs before the first query, the test will fail. The proposed fix is to increase the time window by setting the start time before deploying the counter pod
- After a discussion with @rakesh-garimella it was decided to give the counter pod a more unique pod and container name in order to avoid label collisions. Test helpers were refactored In order to change them easily.

**Related issue(s)**
Fixes #10174
