### PR TITLE
Fix logging integration tests

### DIFF
--- a/resources/logging/values.yaml
+++ b/resources/logging/values.yaml
@@ -226,7 +226,7 @@ global:
   logging_integration_tests:
     name: logging-integration-tests
     dir: 
-    version: 4544695c
+    version: PR-10242
     enabled: true
     env:
       testUser: "admin-user"

--- a/tests/integration/logging/pkg/logstream/logstream.go
+++ b/tests/integration/logging/pkg/logstream/logstream.go
@@ -111,7 +111,7 @@ func logQLEncode(labelsToSelect map[string]string) string {
 	for key, value := range labelsToSelect {
 		sb.WriteString(fmt.Sprintf(`%s="%s"`, key, value))
 
-		if keyIndex < len(labelsToSelect) {
+		if keyIndex < len(labelsToSelect)-1 {
 			sb.WriteRune(',')
 		}
 

--- a/tests/integration/logging/pkg/logstream/logstream.go
+++ b/tests/integration/logging/pkg/logstream/logstream.go
@@ -84,7 +84,7 @@ func Test(domain, authHeader, logPrefix string, labelsToSelect map[string]string
 	timeout := time.After(3 * time.Minute)
 	tick := time.NewTicker(5 * time.Second)
 	query := logQLEncode(labelsToSelect)
-	lokiURL := fmt.Sprintf(`https://loki.%s/api/prom/query?query=%s}&start=%d`, domain, query, start)
+	lokiURL := fmt.Sprintf(`https://loki.%s/api/prom/query?query=%s&start=%d`, domain, query, start)
 	for {
 		select {
 		case <-timeout:
@@ -107,9 +107,15 @@ func Test(domain, authHeader, logPrefix string, labelsToSelect map[string]string
 func logQLEncode(labelsToSelect map[string]string) string {
 	var sb strings.Builder
 	sb.WriteRune('{')
+	keyIndex := 0
 	for key, value := range labelsToSelect {
-		sb.WriteString(fmt.Sprintf(`%s:"%s"`, key, value))
-		sb.WriteRune(',')
+		sb.WriteString(fmt.Sprintf(`%s="%s"`, key, value))
+
+		if keyIndex < len(labelsToSelect) {
+			sb.WriteRune(',')
+		}
+
+		keyIndex++
 	}
 	sb.WriteRune('}')
 	return sb.String()

--- a/tests/integration/logging/pkg/logstream/logstream.go
+++ b/tests/integration/logging/pkg/logstream/logstream.go
@@ -6,7 +6,6 @@ import (
 	"io"
 	"net/http"
 	"regexp"
-	"strconv"
 	"time"
 
 	"github.com/pkg/errors"
@@ -16,23 +15,35 @@ import (
 	"k8s.io/client-go/kubernetes"
 )
 
-// DeployDummyPod deploys a pod which keeps logging a counter
-func DeployDummyPod(namespace string, coreInterface kubernetes.Interface) error {
-	labels := map[string]string{
-		"app": "test-counter-pod",
-	}
-	args := []string{"sh", "-c", "let i=1; while true; do echo \"$i: logTest-$(date)\"; let i++; sleep 2; done"}
+//PodSpec represents a test logging pod configuration
+type PodSpec struct {
+	PodName       string
+	ContainerName string
+	Namespace     string
+	LogPrefix     string
+}
 
-	_, err := coreInterface.CoreV1().Pods(namespace).Create(&corev1.Pod{
+// DeployDummyPod deploys a pod which keeps logging a counter
+func DeployDummyPod(spec PodSpec, coreInterface kubernetes.Interface) error {
+	labels := map[string]string{
+		"app": spec.PodName,
+	}
+	args := []string{
+		"sh",
+		"-c",
+		fmt.Sprintf("let i=1; while true; do echo \"$i: %s-$(date)\"; let i++; sleep 2; done", spec.LogPrefix),
+	}
+
+	_, err := coreInterface.CoreV1().Pods(spec.Namespace).Create(&corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:   "test-counter-pod",
+			Name:   spec.PodName,
 			Labels: labels,
 		},
 		Spec: corev1.PodSpec{
 			RestartPolicy: "Never",
 			Containers: []corev1.Container{
 				{
-					Name:  "count",
+					Name:  spec.ContainerName,
 					Image: "alpine:3.8",
 					Args:  args,
 				},
@@ -40,24 +51,24 @@ func DeployDummyPod(namespace string, coreInterface kubernetes.Interface) error 
 		},
 	})
 	if err != nil {
-		return errors.Wrap(err, "cannot create test-counter-pod")
+		return errors.Wrapf(err, "cannot create %s", spec.PodName)
 	}
 	return nil
 }
 
 // WaitForDummyPodToRun waits until the dummy pod is running
-func WaitForDummyPodToRun(namespace string, coreInterface kubernetes.Interface) error {
+func WaitForDummyPodToRun(spec PodSpec, coreInterface kubernetes.Interface) error {
 	timeout := time.After(2 * time.Minute)
 	tick := time.NewTicker(1 * time.Second)
 	for {
 		select {
 		case <-timeout:
 			tick.Stop()
-			return errors.Errorf("timed out while waiting for test-counter-pod to be Running!")
+			return errors.Errorf("timed out while waiting for %s to be Running!", spec.PodName)
 		case <-tick.C:
-			pod, err := coreInterface.CoreV1().Pods(namespace).Get("test-counter-pod", metav1.GetOptions{})
+			pod, err := coreInterface.CoreV1().Pods(spec.Namespace).Get(spec.PodName, metav1.GetOptions{})
 			if err != nil {
-				return errors.Wrap(err, "cannot get test-counter-pod")
+				return errors.Wrapf(err, "cannot get %s", spec.PodName)
 			}
 			if pod.Status.Phase == corev1.PodRunning {
 				return nil
@@ -67,23 +78,22 @@ func WaitForDummyPodToRun(namespace string, coreInterface kubernetes.Interface) 
 }
 
 // Test querys loki api with the given label key-value pair and checks that the logs of the dummy pod are present
-func Test(domain string, labelKey string, labelValue string, authHeader string, httpClient *http.Client) error {
+func Test(domain, authHeader, labelKey, labelValue, logPrefix string, httpClient *http.Client) error {
+	start := time.Now().UnixNano()
 	timeout := time.After(3 * time.Minute)
 	tick := time.NewTicker(5 * time.Second)
-	currentTimeUnixNano := time.Now().UnixNano()
-	startTimeParam := strconv.FormatInt(currentTimeUnixNano, 10)
-	lokiURL := fmt.Sprintf(`https://loki.%s/api/prom/query?query={%s="%s"}&start=%s`, domain, labelKey, labelValue, startTimeParam)
+	lokiURL := fmt.Sprintf(`https://loki.%s/api/prom/query?query={%s="%s"}&start=%d`, domain, labelKey, labelValue, start)
 	for {
 		select {
 		case <-timeout:
 			tick.Stop()
-			return errors.Errorf(`the string "logTest-" is not present in logs when using the following query: {%s="%s"}`, labelKey, labelValue)
+			return errors.Errorf(`the string "%s" is not present in logs when using the following query: {%s="%s"}`, logPrefix, labelKey, labelValue)
 		case <-tick.C:
 			respBody, err := doGet(httpClient, lokiURL, authHeader)
 			if err != nil {
 				return errors.Wrap(err, "cannot query loki for logs")
 			}
-			var testDataRegex = regexp.MustCompile(`logTest-`)
+			var testDataRegex = regexp.MustCompile(logPrefix)
 			submatches := testDataRegex.FindStringSubmatch(respBody)
 			if submatches != nil {
 				return nil
@@ -93,13 +103,13 @@ func Test(domain string, labelKey string, labelValue string, authHeader string, 
 }
 
 // Cleanup terminates the dummy pod
-func Cleanup(namespace string, coreInterface kubernetes.Interface) error {
+func Cleanup(spec PodSpec, coreInterface kubernetes.Interface) error {
 	gracePeriod := int64(0)
 	deleteOptions := metav1.DeleteOptions{GracePeriodSeconds: &gracePeriod}
-	listOptions := metav1.ListOptions{LabelSelector: "app=test-counter-pod"}
-	err := coreInterface.CoreV1().Pods(namespace).DeleteCollection(&deleteOptions, listOptions)
+	listOptions := metav1.ListOptions{LabelSelector: fmt.Sprintf("app=%s", spec.PodName)}
+	err := coreInterface.CoreV1().Pods(spec.Namespace).DeleteCollection(&deleteOptions, listOptions)
 	if err != nil {
-		return errors.Wrap(err, "cannot delete test-counter-pod")
+		return errors.Wrapf(err, "cannot delete %s", spec.PodName)
 	}
 	return nil
 }

--- a/tests/integration/logging/test-logging.go
+++ b/tests/integration/logging/test-logging.go
@@ -84,18 +84,17 @@ func testLogStream(spec logstream.PodSpec) error {
 	}
 	authHeader := jwt.SetAuthHeader(token)
 
-	err = logstream.Test(domain, authHeader, "container", spec.ContainerName, spec.LogPrefix, httpClient)
+	labelsToSelect := map[string]string{
+		"container": spec.ContainerName,
+		"app":       spec.PodName,
+		"namespace": spec.Namespace,
+	}
+
+	err = logstream.Test(domain, authHeader, spec.LogPrefix, labelsToSelect, httpClient)
 	if err != nil {
 		return err
 	}
-	err = logstream.Test(domain, authHeader, "app", spec.PodName, spec.LogPrefix, httpClient)
-	if err != nil {
-		return err
-	}
-	err = logstream.Test(domain, authHeader, "namespace", spec.Namespace, spec.LogPrefix, httpClient)
-	if err != nil {
-		return err
-	}
+
 	return nil
 }
 

--- a/tests/integration/logging/test-logging.go
+++ b/tests/integration/logging/test-logging.go
@@ -14,7 +14,14 @@ import (
 	"k8s.io/client-go/tools/clientcmd"
 )
 
-const namespace = "kyma-system"
+var (
+	loggingPodSpec = logstream.PodSpec{
+		PodName:       "logging-test-app",
+		ContainerName: "logging-test-counter",
+		Namespace:     "kyma-system",
+		LogPrefix:     "logTest",
+	}
+)
 
 func main() {
 	kubeConfig, err := loadKubeConfigOrDie()
@@ -26,28 +33,28 @@ func main() {
 		log.Fatalf("cannot create k8s clientset: %v", err)
 	}
 	log.Println("Cleaning up before starting logging test")
-	err = logstream.Cleanup(namespace, k8sClient)
+	err = logstream.Cleanup(loggingPodSpec, k8sClient)
 	if err != nil {
 		log.Fatal(err)
 	}
-	log.Println("Deploying test-counter-pod")
-	err = logstream.DeployDummyPod(namespace, k8sClient)
+	log.Println("Deploying the logging test pod")
+	err = logstream.DeployDummyPod(loggingPodSpec, k8sClient)
 	if err != nil {
 		log.Fatal(err)
 	}
-	log.Println("Waiting for test-counter-pod to run...")
-	err = logstream.WaitForDummyPodToRun(namespace, k8sClient)
+	log.Println("Waiting for the logging test pod to run...")
+	err = logstream.WaitForDummyPodToRun(loggingPodSpec, k8sClient)
 	if err != nil {
 		log.Fatal(err)
 	}
-	log.Println("Test if logs from test-counter-pod are streamed by Loki")
-	err = testLogStream(namespace)
+	log.Println("Test if logs from the logging test pod are streamed by Loki")
+	err = testLogStream(loggingPodSpec)
 	if err != nil {
-		logstream.Cleanup(namespace, k8sClient)
+		logstream.Cleanup(loggingPodSpec, k8sClient)
 		log.Fatal(err)
 	}
-	log.Println("Deleting test-counter-pod")
-	err = logstream.Cleanup(namespace, k8sClient)
+	log.Println("Deleting the logging test pod")
+	err = logstream.Cleanup(loggingPodSpec, k8sClient)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -69,22 +76,23 @@ func loadKubeConfigOrDie() (*rest.Config, error) {
 	return cfg, nil
 }
 
-func testLogStream(namespace string) error {
+func testLogStream(spec logstream.PodSpec) error {
 	httpClient := getHttpClient()
 	token, domain, err := jwt.GetToken()
 	if err != nil {
 		return err
 	}
 	authHeader := jwt.SetAuthHeader(token)
-	err = logstream.Test(domain, "container", "count", authHeader, httpClient)
+
+	err = logstream.Test(domain, authHeader, "container", spec.ContainerName, spec.LogPrefix, httpClient)
 	if err != nil {
 		return err
 	}
-	err = logstream.Test(domain, "app", "test-counter-pod", authHeader, httpClient)
+	err = logstream.Test(domain, authHeader, "app", spec.PodName, spec.LogPrefix, httpClient)
 	if err != nil {
 		return err
 	}
-	err = logstream.Test(domain, "namespace", namespace, authHeader, httpClient)
+	err = logstream.Test(domain, authHeader, "namespace", spec.Namespace, spec.LogPrefix, httpClient)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/master/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- After a discussion with @rakesh-garimella it was decided to give the counter pod a more unique pod and container name in order to avoid label collisions. Test helpers were refactored In order to change them easily.

- Loki API limits the number of log entries it returns. So in case of a query that potentially returns a lot of log entries, expected log lines might be missing. For example:
`{namespace="kyma-system"}` returns all logs from all Kyma components in the kyma namespace, which can be a lot of logs
`{app="logging-test-app"}` returns logs from the main app and from the istio proxy, which is quite chatty
In order to fix it, separate Loki API queries were merged in a single one that should only return log entries starting from "logTest"

**Related issue(s)**
Fixes #10174