### PR TITLE
added livenessProbe for keycloak deployments

### DIFF
--- a/resources/kiali/templates/kyma-additions/kcproxy-deployment.yaml
+++ b/resources/kiali/templates/kyma-additions/kcproxy-deployment.yaml
@@ -86,5 +86,9 @@ spec:
         - name: http
           containerPort: {{ .Values.kcproxy.port }}
           protocol: TCP
+        livenessProbe:
+          httpGet:
+            path: /oauth/health
+            port: http
         resources:
 {{ toYaml .Values.kcproxy.resources | indent 10 }}

--- a/resources/monitoring/charts/grafana/templates/kyma-additions/auth-proxy-deployment.yaml
+++ b/resources/monitoring/charts/grafana/templates/kyma-additions/auth-proxy-deployment.yaml
@@ -92,6 +92,10 @@ spec:
         - name: http
           containerPort: {{ .Values.kyma.authProxy.port }}
           protocol: TCP
+        livenessProbe:
+          httpGet:
+            path: /oauth/health
+            port: http
         resources:
 {{ toYaml .Values.kyma.authProxy.resources | indent 10 }}
 {{- end}}

--- a/resources/tracing/templates/kyma-additions/kcproxy-deployment.yaml
+++ b/resources/tracing/templates/kyma-additions/kcproxy-deployment.yaml
@@ -87,5 +87,9 @@ spec:
         - name: http
           containerPort: {{ .Values.kcproxy.inPort }}
           protocol: TCP
+        livenessProbe:
+          httpGet:
+            path: /oauth/health
+            port: http
         resources:
 {{ toYaml .Values.kcproxy.resources | indent 10 }}


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/master/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**
In the linked PR we removed liveness and readinessProbe for keycloak proxy instances in order to not block an installation in case dex is not available. That fixed the problems of a hanging installation indeed.
Unfortunately, it also removes the istio rewriting magic so that a health endpoint is available for the pod without requiring mtls. With that you cannot check the health of the pod easily from inside a cluster by calling something like: `monitoring-grafana-secured.kyma-system:80/oauth/health`
As indeed only the readinessProbe is relevant for helm chart installation, re-adding the livenessProbe only will satisfy all.

Changes proposed in this pull request:

- Adds the livenessProbe for all keycloak prxy deployments
- ...
- ...

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
https://github.com/kyma-project/kyma/pull/10132