### PR TITLE
Fix fast integration tests (patch operation failure)

### DIFF
--- a/tests/fast-integration/test/fixtures/commerce-mock/index.js
+++ b/tests/fast-integration/test/fixtures/commerce-mock/index.js
@@ -194,6 +194,7 @@ async function ensureCommerceMockTestFixture(mockNamespace, targetNamespace) {
   expect(
     commerceApplicationGatewayDeployment.body.spec.template.spec.containers[0].args[6]
   ).to.match(/^--skipVerify/);
+  delete commerceApplicationGatewayDeployment.body.metadata['generation']; 
   commerceApplicationGatewayDeployment.body.spec.template.spec.containers[0].args[6] =
     "--skipVerify=true";
 

--- a/tests/fast-integration/test/fixtures/commerce-mock/index.js
+++ b/tests/fast-integration/test/fixtures/commerce-mock/index.js
@@ -173,8 +173,13 @@ async function patchAppGatewayDeployment() {
   ).to.match(/^--skipVerify/);
   const patch = [{"op": "replace", "path": "/spec/template/spec/containers/0/args/6", "value": "--skipVerify=true"}]
   const options = { "headers": { "Content-type": k8s.PatchUtils.PATCH_FORMAT_JSON_PATCH}};
-  await k8sDynamicApi.requestPromise({ url: k8sDynamicApi.basePath + commerceApplicationGatewayDeployment.body.metadata.selfLink, 
-    method: 'PATCH', body:patch, json:true, headers:options.headers }).catch(expectNoK8sErr);
+  await k8sDynamicApi.requestPromise({ 
+    url: k8sDynamicApi.basePath + commerceApplicationGatewayDeployment.body.metadata.selfLink, 
+    method: 'PATCH', 
+    body: patch, 
+    json: true, 
+    headers: options.headers 
+  }).catch(expectNoK8sErr);
 
   const patchedDeployment = await k8sAppsApi.readNamespacedDeployment("commerce-application-gateway", "kyma-integration");
   expect(


### PR DESCRIPTION
Patch deployment operation fails frequently because object has been modified: https://github.com/kyma-incubator/local-kyma/runs/1684454944?check_suite_focus=true#step:6:157