### PR TITLE
Update the curl version to latest in the end to end external solution test

### DIFF
--- a/tests/end-to-end/external-solution-integration/Dockerfile
+++ b/tests/end-to-end/external-solution-integration/Dockerfile
@@ -12,6 +12,7 @@ LABEL source=git@github.com:kyma-project/kyma.git
 
 COPY --from=builder /e2e /
 
+# temporarily install latest cURL to mitigate the security issues
 RUN apk update && apk add ca-certificates && apk add --no-cache --update-cache --repository http://nl.alpinelinux.org/alpine/edge/main/ curl && rm -rf /var/cache/apk/*
 
 ENTRYPOINT ["/e2e"]

--- a/tests/end-to-end/external-solution-integration/Dockerfile
+++ b/tests/end-to-end/external-solution-integration/Dockerfile
@@ -7,7 +7,7 @@ COPY . $SRC_DIR
 
 RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -o /e2e ./cmd/runner
 
-FROM alpine:3.10
+FROM alpine:3.12.3
 LABEL source=git@github.com:kyma-project/kyma.git
 
 COPY --from=builder /e2e /

--- a/tests/end-to-end/external-solution-integration/Dockerfile
+++ b/tests/end-to-end/external-solution-integration/Dockerfile
@@ -12,6 +12,6 @@ LABEL source=git@github.com:kyma-project/kyma.git
 
 COPY --from=builder /e2e /
 
-RUN apk update && apk add ca-certificates && apk add curl && rm -rf /var/cache/apk/*
+RUN apk update && apk add ca-certificates && apk add --no-cache --update-cache --repository http://nl.alpinelinux.org/alpine/edge/main/ curl && rm -rf /var/cache/apk/*
 
 ENTRYPOINT ["/e2e"]

--- a/tests/end-to-end/external-solution-integration/Dockerfile
+++ b/tests/end-to-end/external-solution-integration/Dockerfile
@@ -7,12 +7,11 @@ COPY . $SRC_DIR
 
 RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -o /e2e ./cmd/runner
 
-FROM alpine:3.12.3
+FROM alpine:edge
 LABEL source=git@github.com:kyma-project/kyma.git
 
 COPY --from=builder /e2e /
 
-# temporarily install latest cURL to mitigate the security issues
-RUN apk update && apk add ca-certificates && apk add --no-cache --update-cache --repository http://nl.alpinelinux.org/alpine/edge/main/ curl && rm -rf /var/cache/apk/*
+RUN apk update && apk add ca-certificates && apk add curl && rm -rf /var/cache/apk/*
 
 ENTRYPOINT ["/e2e"]

--- a/tests/end-to-end/external-solution-integration/chart/external-solution/values.yaml
+++ b/tests/end-to-end/external-solution-integration/chart/external-solution/values.yaml
@@ -3,7 +3,7 @@ containerRegistry:
 
 image:
   dir: ""
-  version: 415d6886
+  version: PR-10327
   pullPolicy: "Always"
 
 testServiceImage:


### PR DESCRIPTION
Fix for the security issue: CVE ID: CVE-2020-8169

Installing the latest version of cURL in alpine 3.10 is curl-7.66.0-r3 which is not matching the recommended version of cURL 7.71.0, so I force installing the latest version of cURL from the edge branch.