### PR TITLE
Speed up fast-integration tests (do not wait for namespace cleanup)

### DIFF
--- a/tests/fast-integration/test/commerce-mock.js
+++ b/tests/fast-integration/test/commerce-mock.js
@@ -25,7 +25,7 @@ describe("CommerceMock tests", function () {
   });
 
   it("Test namespaces should be deleted", async function () {
-    await cleanMockTestFixture("mocks", testNamespace);
+    await cleanMockTestFixture("mocks", testNamespace, false);
   });
 
 })

--- a/tests/fast-integration/test/fixtures/commerce-mock/index.js
+++ b/tests/fast-integration/test/fixtures/commerce-mock/index.js
@@ -168,18 +168,18 @@ async function patchAppGatewayDeployment() {
     },
     12,
     5000
-  ).catch(err=>{ throw new Error("Timeout: commerce-application-gateway is not ready")});
+  ).catch(err => { throw new Error("Timeout: commerce-application-gateway is not ready") });
   expect(
     commerceApplicationGatewayDeployment.body.spec.template.spec.containers[0].args[6]
   ).to.match(/^--skipVerify/);
-  const patch = [{"op": "replace", "path": "/spec/template/spec/containers/0/args/6", "value": "--skipVerify=true"}]
-  const options = { "headers": { "Content-type": k8s.PatchUtils.PATCH_FORMAT_JSON_PATCH}};
-  await k8sDynamicApi.requestPromise({ 
-    url: k8sDynamicApi.basePath + commerceApplicationGatewayDeployment.body.metadata.selfLink, 
-    method: 'PATCH', 
-    body: patch, 
-    json: true, 
-    headers: options.headers 
+  const patch = [{ "op": "replace", "path": "/spec/template/spec/containers/0/args/6", "value": "--skipVerify=true" }]
+  const options = { "headers": { "Content-type": k8s.PatchUtils.PATCH_FORMAT_JSON_PATCH } };
+  await k8sDynamicApi.requestPromise({
+    url: k8sDynamicApi.basePath + commerceApplicationGatewayDeployment.body.metadata.selfLink,
+    method: 'PATCH',
+    body: patch,
+    json: true,
+    headers: options.headers
   }).catch(expectNoK8sErr);
 
   const patchedDeployment = await k8sAppsApi.readNamespacedDeployment("commerce-application-gateway", "kyma-integration");
@@ -254,7 +254,7 @@ function getResourcePaths(namespace) {
 
 }
 
-function cleanMockTestFixture(mockNamespace, targetNamespace) {
+function cleanMockTestFixture(mockNamespace, targetNamespace, wait = true) {
   for (let path of getResourcePaths(mockNamespace).concat(getResourcePaths(targetNamespace))) {
     deleteAllK8sResources(path)
   }
@@ -265,7 +265,7 @@ function cleanMockTestFixture(mockNamespace, targetNamespace) {
       name: 'commerce'
     }
   })
-  return deleteNamespaces([mockNamespace, targetNamespace]);
+  return deleteNamespaces([mockNamespace, targetNamespace], wait);
 
 }
 module.exports = {

--- a/tests/fast-integration/test/fixtures/getting-started-guides/index.js
+++ b/tests/fast-integration/test/fixtures/getting-started-guides/index.js
@@ -161,11 +161,11 @@ function getResourcePaths(namespace) {
   ]
 }
 
-function cleanGettingStartedTestFixture() {
+function cleanGettingStartedTestFixture(wait = true) {
   for (let path of getResourcePaths(orderService)) {
     deleteAllK8sResources(path)
   }
-  return deleteNamespaces([orderService]);
+  return deleteNamespaces([orderService], wait);
 }
 
 module.exports = {

--- a/tests/fast-integration/test/getting-started-guides.js
+++ b/tests/fast-integration/test/getting-started-guides.js
@@ -16,7 +16,7 @@ describe("Getting Started Guide Tests", function () {
   })
 
   it("Namespace should be deleted", async function () {
-    await cleanGettingStartedTestFixture();
+    await cleanGettingStartedTestFixture(false);
   })
 });
 


### PR DESCRIPTION
Namespace deletion up is slow. We do not need to wait for it.