### PR TITLE
Fix cpu.limit value for monitoring production profile

### DIFF
--- a/resources/monitoring/profile-production.yaml
+++ b/resources/monitoring/profile-production.yaml
@@ -2,7 +2,7 @@ prometheus:
   prometheusSpec:
     resources:
       limits:
-        cpu: 1
+        cpu: 1000m
         memory: 4Gi
       requests:
         cpu: 300m


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/master/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Jobs that use production profile fail on the installation step: 
https://storage.googleapis.com/kyma-prow-logs/logs/kyma-integration-production-gardener-azure/1351259402513944576/build-log.txt
```
Component: monitoring, Log: Helm installation of release "monitoring" failed: Prometheus.monitoring.coreos.com 
"monitoring-prometheus" is invalid: spec.resources.limits.cpu: 
Invalid value: "integer": spec.resources.limits.cpu in body must be of type string: "integer"
```

Similar issue: https://github.com/instrumenta/kubeval/issues/22

Changes proposed in this pull request:

- ...
- ...
- ...

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
