### PR TITLE
Fix role templates name parameter for XSUAA instance

### DIFF
--- a/components/uaa-activator/internal/uaa/parameters.go
+++ b/components/uaa-activator/internal/uaa/parameters.go
@@ -170,5 +170,5 @@ func randomString(n int) string {
 // according to SM the name may only include characters 'a'-'z', 'A'-'Z', '0'-'9', and '_'
 func roleName(name, domain string) string {
 	r := strings.NewReplacer(".", "_", ",", "_", ":", "", ";", "", "-", "_", "/", "", "\\", "")
-	return fmt.Sprintf("%s_%s", r.Replace(name), r.Replace(domain))
+	return fmt.Sprintf("%s__%s", r.Replace(name), r.Replace(domain))
 }

--- a/components/uaa-activator/internal/uaa/parameters.go
+++ b/components/uaa-activator/internal/uaa/parameters.go
@@ -12,23 +12,21 @@ import (
 )
 
 type ParametersBuilder struct {
-	domain         string
-	redirectURL    string
-	developerGroup string
-	adminGroup     string
-	developerRole  string
-	adminRole      string
+	domain        string
+	redirectURL   string
+	developerRole string
+	adminRole     string
+	config        Config
 }
 
 func NewParametersBuilder(cfg Config, domain string) *ParametersBuilder {
 	shootName := strings.Split(domain, ".")[0]
 	return &ParametersBuilder{
-		domain:         domain,
-		redirectURL:    fmt.Sprintf("https://dex.%s/callback", strings.Trim(domain, "/")),
-		developerGroup: cfg.DeveloperGroup,
-		adminGroup:     cfg.NamespaceAdminGroup,
-		developerRole:  roleName(cfg.DeveloperRole, shootName),
-		adminRole:      roleName(cfg.NamespaceAdminRole, shootName),
+		domain:        domain,
+		redirectURL:   fmt.Sprintf("https://dex.%s/callback", strings.Trim(domain, "/")),
+		developerRole: roleName(cfg.DeveloperRole, shootName),
+		adminRole:     roleName(cfg.NamespaceAdminRole, shootName),
+		config:        cfg,
 	}
 }
 
@@ -78,11 +76,11 @@ func (pb *ParametersBuilder) Generate(instance *v1beta1.ServiceInstance) ([]byte
 				Description: "get user email",
 			},
 			{
-				Name:        fmt.Sprintf("$XSAPPNAME.%s", pb.developerGroup),
+				Name:        fmt.Sprintf("$XSAPPNAME.%s", pb.config.DeveloperGroup),
 				Description: "Runtime developer access to all managed resources",
 			},
 			{
-				Name:        fmt.Sprintf("$XSAPPNAME.%s", pb.adminGroup),
+				Name:        fmt.Sprintf("$XSAPPNAME.%s", pb.config.NamespaceAdminGroup),
 				Description: "Runtime admin access to all managed resources",
 			},
 		},
@@ -91,17 +89,17 @@ func (pb *ParametersBuilder) Generate(instance *v1beta1.ServiceInstance) ([]byte
 		},
 		RoleTemplates: []RoleTemplate{
 			{
-				Name:        pb.developerRole,
+				Name:        pb.config.DeveloperRole,
 				Description: "Runtime developer access to all managed resources",
 				ScopeReferences: []string{
-					fmt.Sprintf("$XSAPPNAME.%s", pb.developerGroup),
+					fmt.Sprintf("$XSAPPNAME.%s", pb.config.DeveloperGroup),
 				},
 			},
 			{
-				Name:        pb.adminRole,
+				Name:        pb.config.NamespaceAdminRole,
 				Description: "Runtime admin access to all managed resources",
 				ScopeReferences: []string{
-					fmt.Sprintf("$XSAPPNAME.%s", pb.adminGroup),
+					fmt.Sprintf("$XSAPPNAME.%s", pb.config.NamespaceAdminGroup),
 				},
 			},
 		},
@@ -110,14 +108,14 @@ func (pb *ParametersBuilder) Generate(instance *v1beta1.ServiceInstance) ([]byte
 				Name:        pb.developerRole,
 				Description: "Kyma Runtime Developer Role Collection for development tasks in given custom namespaces",
 				RoleTemplateReference: []string{
-					fmt.Sprintf("$XSAPPNAME.%s", pb.developerRole),
+					fmt.Sprintf("$XSAPPNAME.%s", pb.config.DeveloperRole),
 				},
 			},
 			{
 				Name:        pb.adminRole,
 				Description: "Kyma Runtime Namespace Admin Role Collection for administration tasks across all custom namespaces",
 				RoleTemplateReference: []string{
-					fmt.Sprintf("$XSAPPNAME.%s", pb.adminRole),
+					fmt.Sprintf("$XSAPPNAME.%s", pb.config.NamespaceAdminRole),
 				},
 			},
 		},

--- a/components/uaa-activator/internal/uaa/parameters_test.go
+++ b/components/uaa-activator/internal/uaa/parameters_test.go
@@ -87,7 +87,7 @@ func TestParametersBuilder_Generate(t *testing.T) {
 
 func parametersAreEqual(t *testing.T, schema Schema) {
 	roles := []string{"KymaRuntimeDeveloper", "KymaRuntimeNamespaceAdmin"}
-	rolesWithSuffix := []string{"KymaRuntimeDeveloper_uaa_test", "KymaRuntimeNamespaceAdmin_uaa_test"}
+	rolesWithSuffix := []string{"KymaRuntimeDeveloper__uaa_test", "KymaRuntimeNamespaceAdmin__uaa_test"}
 	rolesWithName := []string{"$XSAPPNAME.KymaRuntimeDeveloper", "$XSAPPNAME.KymaRuntimeNamespaceAdmin"}
 	groups := []string{"$XSAPPNAME.runtimeDeveloper", "$XSAPPNAME.runtimeNamespaceAdmin"}
 	scopesGroup := []string{"$XSAPPNAME.email", "$XSAPPNAME.runtimeDeveloper", "$XSAPPNAME.runtimeNamespaceAdmin"}

--- a/components/uaa-activator/internal/uaa/parameters_test.go
+++ b/components/uaa-activator/internal/uaa/parameters_test.go
@@ -86,8 +86,9 @@ func TestParametersBuilder_Generate(t *testing.T) {
 }
 
 func parametersAreEqual(t *testing.T, schema Schema) {
-	roles := []string{"KymaRuntimeDeveloper_uaa_test", "KymaRuntimeNamespaceAdmin_uaa_test"}
-	rolesWithName := []string{"$XSAPPNAME.KymaRuntimeDeveloper_uaa_test", "$XSAPPNAME.KymaRuntimeNamespaceAdmin_uaa_test"}
+	roles := []string{"KymaRuntimeDeveloper", "KymaRuntimeNamespaceAdmin"}
+	rolesWithSuffix := []string{"KymaRuntimeDeveloper_uaa_test", "KymaRuntimeNamespaceAdmin_uaa_test"}
+	rolesWithName := []string{"$XSAPPNAME.KymaRuntimeDeveloper", "$XSAPPNAME.KymaRuntimeNamespaceAdmin"}
 	groups := []string{"$XSAPPNAME.runtimeDeveloper", "$XSAPPNAME.runtimeNamespaceAdmin"}
 	scopesGroup := []string{"$XSAPPNAME.email", "$XSAPPNAME.runtimeDeveloper", "$XSAPPNAME.runtimeNamespaceAdmin"}
 
@@ -115,8 +116,8 @@ func parametersAreEqual(t *testing.T, schema Schema) {
 	require.Contains(t, groups, schema.RoleTemplates[1].ScopeReferences[0])
 
 	require.Len(t, schema.RoleCollections, 2)
-	require.Contains(t, roles, schema.RoleCollections[0].Name)
-	require.Contains(t, roles, schema.RoleCollections[1].Name)
+	require.Contains(t, rolesWithSuffix, schema.RoleCollections[0].Name)
+	require.Contains(t, rolesWithSuffix, schema.RoleCollections[1].Name)
 	require.Len(t, schema.RoleCollections[0].RoleTemplateReference, 1)
 	require.Len(t, schema.RoleCollections[1].RoleTemplateReference, 1)
 	require.Contains(t, rolesWithName, schema.RoleCollections[0].RoleTemplateReference[0])

--- a/resources/uaa-activator/values.yaml
+++ b/resources/uaa-activator/values.yaml
@@ -13,7 +13,7 @@ global:
 image:
   registryPath: eu.gcr.io/kyma-project
   pullPolicy: IfNotPresent
-  version: "df0d6541"
+  version: "PR-10382"
 
 initJobs:
   secret:


### PR DESCRIPTION
**Description**
Following PR fixes name in parameters send inside XSUAA ServiceInstance. With this fix, only `role_collection` name will be unique, `role_templates` name stays the same, e.g. let's assume our shoot name has a name "uaa-test", the parameters will looks like:
```json
(...)
  "role-templates": [
    {
      "name": "KymaRuntimeDeveloper",
      "description": "Runtime developer access to all managed resources",
      "scope-references": [
        "$XSAPPNAME.runtimeDeveloper"
      ]
    },
    {
      "name": "KymaRuntimeNamespaceAdmin",
      "description": "Runtime admin access to all managed resources",
      "scope-references": [
        "$XSAPPNAME.runtimeNamespaceAdmin"
      ]
    }
  ],
  "role-collections": [
    {
      "name": "KymaRuntimeDeveloper_uaa_test",
      "description": "Kyma Runtime Developer Role Collection for development tasks in given custom namespaces",
      "role-template-references": [
        "$XSAPPNAME.KymaRuntimeDeveloper"
      ]
    },
    {
      "name": "KymaRuntimeNamespaceAdmin_uaa_test",
      "description": "Kyma Runtime Namespace Admin Role Collection for administration tasks across all custom namespaces",
      "role-template-references": [
        "$XSAPPNAME.KymaRuntimeNamespaceAdmin"
      ]
    }
  ],
(...)  
```
