### PR TITLE
Bump image versions in compass runtime agent chart to the latest versions

### DIFF
--- a/resources/compass-runtime-agent/values.yaml
+++ b/resources/compass-runtime-agent/values.yaml
@@ -3,11 +3,11 @@ global:
     containerRegistry:
       path: eu.gcr.io/kyma-project
     runtimeAgent:
-      version: "4feb544b"
+      version: "77ca2463"
     runtimeAgentTests:
-      version: "cda9f380"
+      version: "77ca2463"
     compassExternalSolutionTests:
-      version: "1a5b13b8"
+      version: "8f4ccfc0"
   istio:
     gateway:
       name: kyma-gateway


### PR DESCRIPTION
Update of following image versions:

    runtimeAgent:  from: 4feb544b (Nov 18, 2020) to 77ca2463 (Nov 23, 2020)
    runtimeAgentTests:  from: cda9f380 (Sep 29, 2020) to 77ca2463 (Nov 23, 2020)
    compassExternalSolutionTests:  from: 1a5b13b8 (Aug 5, 2020)  to 8f4ccfc0 (Jan 15, 2021)

For compassExternalSolutionTests there is a fix for the security issue: CVE ID: CVE-2020-8169
