### PR TITLE
Fix the event-publisher-proxy receiver test to be more resilient

### DIFF
--- a/resources/eventing/charts/event-publisher-proxy/values.yaml
+++ b/resources/eventing/charts/event-publisher-proxy/values.yaml
@@ -9,7 +9,7 @@ image:
   # name is the name of the container image for the event-publisher-proxy
   name: "event-publisher-proxy"
   # tag is the container tag of the event-publisher-proxy image
-  tag: "cacbe4f2"
+  tag: "PR-10432"
   # pullPolicy is the pullPolicy for the event-publisher-proxy image
   pullPolicy: "IfNotPresent"
 


### PR DESCRIPTION
**Description**

Fix the event-publisher-proxy receiver test to be more resilient:

- Make sure that the event receiver is started.
- Leverage net.Listen to use free ports to start the event receiver.