### PR TITLE
Allow to switch container registry for serverless in the runtime

### DIFF
--- a/components/function-controller/internal/controllers/serverless/build_resources_test.go
+++ b/components/function-controller/internal/controllers/serverless/build_resources_test.go
@@ -76,7 +76,7 @@ func TestFunctionReconciler_buildDeployment(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			g := gomega.NewGomegaWithT(t)
 			r := &FunctionReconciler{}
-			got := r.buildDeployment(tt.args.instance, rtmCfg)
+			got := r.buildDeployment(tt.args.instance, rtmCfg, DockerConfig{})
 
 			for key, value := range got.Spec.Selector.MatchLabels {
 				g.Expect(got.Spec.Template.Labels[key]).To(gomega.Equal(value))
@@ -422,7 +422,7 @@ func TestFunctionReconciler_buildJob(t *testing.T) {
 
 	r := FunctionReconciler{}
 	// when
-	job := r.buildJob(&instance, rtmCfg, cmName)
+	job := r.buildJob(&instance, rtmCfg, cmName, DockerConfig{})
 
 	// then
 	g.Expect(job.ObjectMeta.GenerateName).To(gomega.Equal("my-function-build-"))

--- a/components/function-controller/internal/controllers/serverless/build_resources_test.go
+++ b/components/function-controller/internal/controllers/serverless/build_resources_test.go
@@ -3,14 +3,12 @@ package serverless
 import (
 	"testing"
 
-	"k8s.io/apimachinery/pkg/util/validation"
-
-	"github.com/kyma-project/kyma/components/function-controller/internal/controllers/serverless/runtime"
-
 	"github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/validation"
 
+	"github.com/kyma-project/kyma/components/function-controller/internal/controllers/serverless/runtime"
 	serverlessv1alpha1 "github.com/kyma-project/kyma/components/function-controller/pkg/apis/serverless/v1alpha1"
 )
 

--- a/components/function-controller/internal/controllers/serverless/config.go
+++ b/components/function-controller/internal/controllers/serverless/config.go
@@ -5,14 +5,15 @@ import (
 )
 
 type FunctionConfig struct {
-	ImageRegistryDockerConfigSecretName string        `envconfig:"default=serverless-image-pull-secret"`
-	ImagePullAccountName                string        `envconfig:"default=serverless-function"`
-	BuildServiceAccountName             string        `envconfig:"default=serverless-build"`
-	TargetCPUUtilizationPercentage      int32         `envconfig:"default=50"`
-	RequeueDuration                     time.Duration `envconfig:"default=1m"`
-	GitFetchRequeueDuration             time.Duration `envconfig:"default=30s"`
-	Build                               BuildConfig
-	Docker                              DockerConfig
+	ImageRegistryDefaultDockerConfigSecretName  string        `envconfig:"default=serverless-registry-config-default"`
+	ImageRegistryExternalDockerConfigSecretName string        `envconfig:"default=serverless-registry-config"`
+	ImagePullAccountName                        string        `envconfig:"default=serverless-function"`
+	BuildServiceAccountName                     string        `envconfig:"default=serverless-build"`
+	TargetCPUUtilizationPercentage              int32         `envconfig:"default=50"`
+	RequeueDuration                             time.Duration `envconfig:"default=1m"`
+	FunctionReadyRequeueDuration                time.Duration `envconfig:"default=5m"`
+	GitFetchRequeueDuration                     time.Duration `envconfig:"default=30s"`
+	Build                                       BuildConfig
 }
 
 type BuildConfig struct {
@@ -23,7 +24,7 @@ type BuildConfig struct {
 }
 
 type DockerConfig struct {
-	InternalRegistryEnabled bool   `envconfig:"default=true"`
-	InternalServerAddress   string `envconfig:"default=serverless-docker-registry.kyma-system.svc.cluster.local:5000"`
-	RegistryAddress         string `envconfig:"default=registry.kyma.local"`
+	ActiveRegistryConfigSecretName string
+	PushAddress                    string
+	PullAddress                    string
 }

--- a/components/function-controller/internal/controllers/serverless/configmap.go
+++ b/components/function-controller/internal/controllers/serverless/configmap.go
@@ -57,8 +57,8 @@ func (r *FunctionReconciler) updateConfigMap(ctx context.Context, log logr.Logge
 	})
 }
 
-func (r *FunctionReconciler) isOnConfigMapChange(instance *serverlessv1alpha1.Function, rtm runtime.Runtime, configMaps []corev1.ConfigMap, deployments []appsv1.Deployment) bool {
-	image := r.buildImageAddress(instance)
+func (r *FunctionReconciler) isOnConfigMapChange(instance *serverlessv1alpha1.Function, rtm runtime.Runtime, configMaps []corev1.ConfigMap, deployments []appsv1.Deployment, dockerConfig DockerConfig) bool {
+	image := r.buildImageAddress(instance, dockerConfig.PullAddress)
 	configurationStatus := r.getConditionStatus(instance.Status.Conditions, serverlessv1alpha1.ConditionConfigurationReady)
 
 	if len(deployments) == 1 &&

--- a/components/function-controller/internal/controllers/serverless/deployment.go
+++ b/components/function-controller/internal/controllers/serverless/deployment.go
@@ -30,15 +30,15 @@ const (
 	MinimumReplicasAvailable = "MinimumReplicasAvailable"
 )
 
-func (r *FunctionReconciler) isOnDeploymentChange(instance *serverlessv1alpha1.Function, rtmConfig runtime.Config, deployments []appsv1.Deployment) bool {
-	expectedDeployment := r.buildDeployment(instance, rtmConfig)
+func (r *FunctionReconciler) isOnDeploymentChange(instance *serverlessv1alpha1.Function, rtmConfig runtime.Config, deployments []appsv1.Deployment, dockerConfig DockerConfig) bool {
+	expectedDeployment := r.buildDeployment(instance, rtmConfig, dockerConfig)
 	resourceOk := len(deployments) == 1 && r.equalDeployments(deployments[0], expectedDeployment)
 
 	return !resourceOk
 }
 
-func (r *FunctionReconciler) onDeploymentChange(ctx context.Context, log logr.Logger, instance *serverlessv1alpha1.Function, rtmConfig runtime.Config, deployments []appsv1.Deployment) (ctrl.Result, error) {
-	newDeployment := r.buildDeployment(instance, rtmConfig)
+func (r *FunctionReconciler) onDeploymentChange(ctx context.Context, log logr.Logger, instance *serverlessv1alpha1.Function, rtmConfig runtime.Config, deployments []appsv1.Deployment, dockerConfig DockerConfig) (ctrl.Result, error) {
+	newDeployment := r.buildDeployment(instance, rtmConfig, dockerConfig)
 
 	switch {
 	case len(deployments) == 0:
@@ -108,7 +108,9 @@ func (r *FunctionReconciler) updateDeploymentStatus(ctx context.Context, log log
 	// trigger next reconcile loop, in which we should create svc
 	case r.isDeploymentReady(deployments[0]):
 		log.Info(fmt.Sprintf("Deployment %s is ready", deployments[0].GetName()))
-		return r.updateStatusWithoutRepository(ctx, ctrl.Result{}, instance, serverlessv1alpha1.Condition{
+		return r.updateStatusWithoutRepository(ctx, ctrl.Result{
+			RequeueAfter: r.config.FunctionReadyRequeueDuration,
+		}, instance, serverlessv1alpha1.Condition{
 			Type:               serverlessv1alpha1.ConditionRunning,
 			Status:             runningStatus,
 			LastTransitionTime: metav1.Now(),

--- a/components/function-controller/internal/controllers/serverless/function_reconcile.go
+++ b/components/function-controller/internal/controllers/serverless/function_reconcile.go
@@ -145,9 +145,7 @@ func (r *FunctionReconciler) Reconcile(request ctrl.Request) (ctrl.Result, error
 	dockerConfig, err := r.readDockerConfig(ctx, instance)
 	if err != nil {
 		log.Error(err, "Cannot read Docker registry configuration")
-		return ctrl.Result{
-			RequeueAfter: r.config.RequeueDuration,
-		}, err
+		return ctrl.Result{}, err
 	}
 
 	gitOptions, err := r.readGITOptions(ctx, instance)
@@ -290,7 +288,7 @@ func (r *FunctionReconciler) readDockerConfig(ctx context.Context, instance *ser
 		}
 	}
 
-	return DockerConfig{}, errors.New("Docker registry configuration not found")
+	return DockerConfig{}, errors.Errorf("Docker registry configuration not found, none of configuration secrets (%s, %s) found in function namespace", r.config.ImageRegistryDefaultDockerConfigSecretName, r.config.ImageRegistryExternalDockerConfigSecretName)
 }
 
 func (r *FunctionReconciler) readSecretData(data map[string][]byte) map[string]string {

--- a/components/function-controller/internal/controllers/serverless/function_reconcile.go
+++ b/components/function-controller/internal/controllers/serverless/function_reconcile.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/pkg/errors"
+
 	"github.com/go-logr/logr"
 	appsv1 "k8s.io/api/apps/v1"
 	autoscalingv1 "k8s.io/api/autoscaling/v1"
@@ -140,6 +142,14 @@ func (r *FunctionReconciler) Reconcile(request ctrl.Request) (ctrl.Result, error
 		return ctrl.Result{}, err
 	}
 
+	dockerConfig, err := r.readDockerConfig(ctx, instance)
+	if err != nil {
+		log.Error(err, "Cannot read Docker registry configuration")
+		return ctrl.Result{
+			RequeueAfter: r.config.RequeueDuration,
+		}, err
+	}
+
 	gitOptions, err := r.readGITOptions(ctx, instance)
 	if err != nil {
 		return r.updateStatusWithoutRepository(ctx, ctrl.Result{}, instance, serverlessv1alpha1.Condition{
@@ -173,14 +183,14 @@ func (r *FunctionReconciler) Reconcile(request ctrl.Request) (ctrl.Result, error
 			Reference: instance.Spec.Reference,
 			BaseDir:   instance.Spec.Repository.BaseDir,
 		}, revision)
-	case instance.Spec.Type != serverlessv1alpha1.SourceTypeGit && r.isOnConfigMapChange(instance, rtm, configMaps.Items, deployments.Items):
+	case instance.Spec.Type != serverlessv1alpha1.SourceTypeGit && r.isOnConfigMapChange(instance, rtm, configMaps.Items, deployments.Items, dockerConfig):
 		return r.onConfigMapChange(ctx, log, instance, rtm, configMaps.Items)
-	case instance.Spec.Type == serverlessv1alpha1.SourceTypeGit && r.isOnJobChange(instance, rtmCfg, jobs.Items, deployments.Items, gitOptions):
-		return r.onGitJobChange(ctx, log, instance, rtmCfg, jobs.Items, gitOptions)
-	case instance.Spec.Type != serverlessv1alpha1.SourceTypeGit && r.isOnJobChange(instance, rtmCfg, jobs.Items, deployments.Items, git.Options{}):
-		return r.onJobChange(ctx, log, instance, rtmCfg, configMaps.Items[0].GetName(), jobs.Items)
-	case r.isOnDeploymentChange(instance, rtmCfg, deployments.Items):
-		return r.onDeploymentChange(ctx, log, instance, rtmCfg, deployments.Items)
+	case instance.Spec.Type == serverlessv1alpha1.SourceTypeGit && r.isOnJobChange(instance, rtmCfg, jobs.Items, deployments.Items, gitOptions, dockerConfig):
+		return r.onGitJobChange(ctx, log, instance, rtmCfg, jobs.Items, gitOptions, dockerConfig)
+	case instance.Spec.Type != serverlessv1alpha1.SourceTypeGit && r.isOnJobChange(instance, rtmCfg, jobs.Items, deployments.Items, git.Options{}, dockerConfig):
+		return r.onJobChange(ctx, log, instance, rtmCfg, configMaps.Items[0].GetName(), jobs.Items, dockerConfig)
+	case r.isOnDeploymentChange(instance, rtmCfg, deployments.Items, dockerConfig):
+		return r.onDeploymentChange(ctx, log, instance, rtmCfg, deployments.Items, dockerConfig)
 	case r.isOnServiceChange(instance, services.Items):
 		return r.onServiceChange(ctx, log, instance, services.Items)
 	case r.isOnHorizontalPodAutoscalerChange(instance, hpas.Items, deployments.Items):
@@ -248,6 +258,39 @@ func (r *FunctionReconciler) readGITOptions(ctx context.Context, instance *serve
 		Reference: instance.Spec.Reference,
 		Auth:      auth,
 	}, nil
+}
+
+func (r *FunctionReconciler) readDockerConfig(ctx context.Context, instance *serverlessv1alpha1.Function) (DockerConfig, error) {
+	var secret corev1.Secret
+	// try reading user config
+	if err := r.client.Get(ctx, client.ObjectKey{Namespace: instance.Namespace, Name: r.config.ImageRegistryExternalDockerConfigSecretName}, &secret); err == nil {
+		data := r.readSecretData(secret.Data)
+		return DockerConfig{
+			ActiveRegistryConfigSecretName: r.config.ImageRegistryExternalDockerConfigSecretName,
+			PushAddress:                    data["registryAddress"],
+			PullAddress:                    data["registryAddress"],
+		}, nil
+	}
+
+	// try reading default config
+	if err := r.client.Get(ctx, client.ObjectKey{Namespace: instance.Namespace, Name: r.config.ImageRegistryDefaultDockerConfigSecretName}, &secret); err == nil {
+		data := r.readSecretData(secret.Data)
+		if data["isInternal"] == "true" {
+			return DockerConfig{
+				ActiveRegistryConfigSecretName: r.config.ImageRegistryDefaultDockerConfigSecretName,
+				PushAddress:                    data["registryAddress"],
+				PullAddress:                    data["serverAddress"],
+			}, nil
+		} else {
+			return DockerConfig{
+				ActiveRegistryConfigSecretName: r.config.ImageRegistryDefaultDockerConfigSecretName,
+				PushAddress:                    data["registryAddress"],
+				PullAddress:                    data["registryAddress"],
+			}, nil
+		}
+	}
+
+	return DockerConfig{}, errors.New("Docker registry configuration not found")
 }
 
 func (r *FunctionReconciler) readSecretData(data map[string][]byte) map[string]string {

--- a/components/function-controller/internal/controllers/serverless/function_reconcile.go
+++ b/components/function-controller/internal/controllers/serverless/function_reconcile.go
@@ -4,9 +4,8 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/pkg/errors"
-
 	"github.com/go-logr/logr"
+	"github.com/pkg/errors"
 	appsv1 "k8s.io/api/apps/v1"
 	autoscalingv1 "k8s.io/api/autoscaling/v1"
 	batchv1 "k8s.io/api/batch/v1"

--- a/components/function-controller/internal/controllers/serverless/function_reconcile_gitops_test.go
+++ b/components/function-controller/internal/controllers/serverless/function_reconcile_gitops_test.go
@@ -363,7 +363,7 @@ var _ = ginkgo.Describe("Function", func() {
 				gomega.Expect(len(deployments.Items)).To(gomega.Equal(1))
 
 				deployment := &deployments.Items[0]
-				expectedImage := reconciler.buildImageAddress(function)
+				expectedImage := reconciler.buildImageAddress(function, "registry.kyma.local")
 				gomega.Expect(deployment).To(gomega.Not(gomega.BeNil()))
 				gomega.Expect(deployment).To(haveSpecificContainer0Image(expectedImage))
 				gomega.Expect(deployment).To(haveLabelLen(7))
@@ -430,7 +430,7 @@ var _ = ginkgo.Describe("Function", func() {
 				}
 				gomega.Expect(resourceClient.Status().Update(context.TODO(), deployment)).To(gomega.Succeed())
 
-				gomega.Ω(reconciler.Reconcile(request)).To(beOKReconcileResult)
+				gomega.Ω(reconciler.Reconcile(request)).To(beFinishedReconcileResult)
 
 				function = &serverlessv1alpha1.Function{}
 				gomega.Expect(resourceClient.Get(context.TODO(), request.NamespacedName, function)).To(gomega.Succeed())
@@ -441,7 +441,7 @@ var _ = ginkgo.Describe("Function", func() {
 				gomega.Expect(function).To(haveConditionReasonDeploymentReady)
 
 				ginkgo.By("should not change state on reconcile")
-				gomega.Ω(reconciler.Reconcile(request)).To(beOKReconcileResult)
+				gomega.Ω(reconciler.Reconcile(request)).To(beFinishedReconcileResult)
 
 				function = &serverlessv1alpha1.Function{}
 				gomega.Expect(resourceClient.Get(context.TODO(), request.NamespacedName, function)).To(gomega.Succeed())

--- a/components/function-controller/internal/controllers/serverless/function_reconcile_matchers_test.go
+++ b/components/function-controller/internal/controllers/serverless/function_reconcile_matchers_test.go
@@ -13,6 +13,7 @@ import (
 )
 
 var beOKReconcileResult = recResultMatcher(false, 0)
+var beFinishedReconcileResult = recResultMatcher(false, time.Minute*5)
 
 func recResultMatcher(requeue bool, requeueAfter time.Duration) gtypes.GomegaMatcher {
 	return gstruct.MatchAllFields(gstruct.Fields{

--- a/components/function-controller/internal/controllers/serverless/function_reconcile_test.go
+++ b/components/function-controller/internal/controllers/serverless/function_reconcile_test.go
@@ -5,8 +5,6 @@ import (
 	"fmt"
 	"time"
 
-	"k8s.io/apimachinery/pkg/util/intstr"
-
 	"github.com/onsi/ginkgo"
 	"github.com/onsi/gomega"
 	appsv1 "k8s.io/api/apps/v1"
@@ -16,6 +14,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/client-go/tools/record"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/log"

--- a/components/function-controller/internal/controllers/serverless/function_reconcile_test.go
+++ b/components/function-controller/internal/controllers/serverless/function_reconcile_test.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"time"
 
+	"k8s.io/apimachinery/pkg/util/intstr"
+
 	"github.com/onsi/ginkgo"
 	"github.com/onsi/gomega"
 	appsv1 "k8s.io/api/apps/v1"
@@ -14,7 +16,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/client-go/tools/record"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/log"
@@ -70,149 +71,21 @@ var _ = ginkgo.Describe("Function", func() {
 		gomega.Expect(configMapList.Items[0].Data[FunctionSourceKey]).To(gomega.Equal(function.Spec.Source))
 		gomega.Expect(configMapList.Items[0].Data[FunctionDepsKey]).To(gomega.Equal("{}"))
 
-		ginkgo.By("creating the Job")
-		result, err = reconciler.Reconcile(request)
-		gomega.Expect(err).To(gomega.BeNil())
-		gomega.Expect(result.Requeue).To(gomega.BeFalse())
-		gomega.Expect(result.RequeueAfter).To(gomega.Equal(time.Second * 0))
+		assertSuccessfulFunctionBuild(reconciler, request, fnLabels, false)
 
-		function = &serverlessv1alpha1.Function{}
-		gomega.Expect(resourceClient.Get(context.TODO(), request.NamespacedName, function)).To(gomega.Succeed())
-		gomega.Expect(function.Status.Conditions).To(gomega.HaveLen(2))
-		gomega.Expect(reconciler.getConditionStatus(function.Status.Conditions, serverlessv1alpha1.ConditionConfigurationReady)).To(gomega.Equal(corev1.ConditionTrue))
-		gomega.Expect(reconciler.getConditionStatus(function.Status.Conditions, serverlessv1alpha1.ConditionBuildReady)).To(gomega.Equal(corev1.ConditionUnknown))
-		gomega.Expect(reconciler.getConditionStatus(function.Status.Conditions, serverlessv1alpha1.ConditionRunning)).To(gomega.Equal(corev1.ConditionUnknown))
+		assertSuccessfulFunctionDeployment(reconciler, request, fnLabels, "registry.kyma.local", false)
 
-		jobList := &batchv1.JobList{}
-		err = reconciler.client.ListByLabel(context.TODO(), function.GetNamespace(), fnLabels, jobList)
-		gomega.Expect(err).To(gomega.BeNil())
-		gomega.Expect(jobList.Items).To(gomega.HaveLen(1))
-
-		ginkgo.By("build in progress")
-		result, err = reconciler.Reconcile(request)
-		gomega.Expect(err).To(gomega.BeNil())
-		gomega.Expect(result.Requeue).To(gomega.BeFalse())
-		gomega.Expect(result.RequeueAfter).To(gomega.Equal(time.Second * 0))
-
-		function = &serverlessv1alpha1.Function{}
-		gomega.Expect(resourceClient.Get(context.TODO(), request.NamespacedName, function)).To(gomega.Succeed())
-		gomega.Expect(function.Status.Conditions).To(gomega.HaveLen(2))
-		gomega.Expect(reconciler.getConditionStatus(function.Status.Conditions, serverlessv1alpha1.ConditionConfigurationReady)).To(gomega.Equal(corev1.ConditionTrue))
-		gomega.Expect(reconciler.getConditionStatus(function.Status.Conditions, serverlessv1alpha1.ConditionBuildReady)).To(gomega.Equal(corev1.ConditionUnknown))
-		gomega.Expect(reconciler.getConditionStatus(function.Status.Conditions, serverlessv1alpha1.ConditionRunning)).To(gomega.Equal(corev1.ConditionUnknown))
-
-		gomega.Expect(reconciler.getConditionReason(function.Status.Conditions, serverlessv1alpha1.ConditionBuildReady)).To(gomega.Equal(serverlessv1alpha1.ConditionReasonJobRunning))
-
-		ginkgo.By("build finished")
-		job := &batchv1.Job{}
-		gomega.Expect(resourceClient.Get(context.TODO(), types.NamespacedName{Namespace: jobList.Items[0].GetNamespace(), Name: jobList.Items[0].GetName()}, job)).To(gomega.Succeed())
-		gomega.Expect(job).ToNot(gomega.BeNil())
-		job.Status.Succeeded = 1
-		now := metav1.Now()
-		job.Status.CompletionTime = &now
-		gomega.Expect(resourceClient.Status().Update(context.TODO(), job)).To(gomega.Succeed())
-
-		result, err = reconciler.Reconcile(request)
-		gomega.Expect(err).To(gomega.BeNil())
-		gomega.Expect(result.Requeue).To(gomega.BeFalse())
-		gomega.Expect(result.RequeueAfter).To(gomega.Equal(time.Second * 0))
-
-		function = &serverlessv1alpha1.Function{}
-		gomega.Expect(resourceClient.Get(context.TODO(), request.NamespacedName, function)).To(gomega.Succeed())
-		gomega.Expect(function.Status.Conditions).To(gomega.HaveLen(2))
-		gomega.Expect(reconciler.getConditionStatus(function.Status.Conditions, serverlessv1alpha1.ConditionConfigurationReady)).To(gomega.Equal(corev1.ConditionTrue))
-		gomega.Expect(reconciler.getConditionStatus(function.Status.Conditions, serverlessv1alpha1.ConditionBuildReady)).To(gomega.Equal(corev1.ConditionTrue))
-		gomega.Expect(reconciler.getConditionStatus(function.Status.Conditions, serverlessv1alpha1.ConditionRunning)).To(gomega.Equal(corev1.ConditionUnknown))
-
-		gomega.Expect(reconciler.getConditionReason(function.Status.Conditions, serverlessv1alpha1.ConditionBuildReady)).To(gomega.Equal(serverlessv1alpha1.ConditionReasonJobFinished))
-
-		ginkgo.By("deploy started")
-		result, err = reconciler.Reconcile(request)
-		gomega.Expect(err).To(gomega.BeNil())
-		gomega.Expect(result.Requeue).To(gomega.BeFalse())
-		gomega.Expect(result.RequeueAfter).To(gomega.Equal(time.Second * 0))
-
-		function = &serverlessv1alpha1.Function{}
-		gomega.Expect(resourceClient.Get(context.TODO(), request.NamespacedName, function)).To(gomega.Succeed())
-		gomega.Expect(function.Status.Conditions).To(gomega.HaveLen(conditionLen))
-		gomega.Expect(reconciler.getConditionStatus(function.Status.Conditions, serverlessv1alpha1.ConditionConfigurationReady)).To(gomega.Equal(corev1.ConditionTrue))
-		gomega.Expect(reconciler.getConditionStatus(function.Status.Conditions, serverlessv1alpha1.ConditionBuildReady)).To(gomega.Equal(corev1.ConditionTrue))
-		gomega.Expect(reconciler.getConditionStatus(function.Status.Conditions, serverlessv1alpha1.ConditionRunning)).To(gomega.Equal(corev1.ConditionUnknown))
-
-		deployments := &appsv1.DeploymentList{}
-		gomega.Expect(resourceClient.ListByLabel(context.TODO(), request.Namespace, fnLabels, deployments)).To(gomega.Succeed())
-		gomega.Expect(len(deployments.Items)).To(gomega.Equal(1))
-		deployment := &deployments.Items[0]
-		gomega.Expect(deployment).ToNot(gomega.BeNil())
-		gomega.Expect(deployment.Spec.Template.Spec.Containers).To(gomega.HaveLen(1))
-		gomega.Expect(deployment.Spec.Template.Spec.Containers[0].Image).To(gomega.Equal(reconciler.buildImageAddress(function)))
-		gomega.Expect(deployment.Spec.Template.Labels).To(gomega.HaveLen(7))
-		gomega.Expect(deployment.Spec.Template.Labels[serverlessv1alpha1.FunctionNameLabel]).To(gomega.Equal(function.Name))
-		gomega.Expect(deployment.Spec.Template.Labels[serverlessv1alpha1.FunctionManagedByLabel]).To(gomega.Equal(serverlessv1alpha1.FunctionControllerValue))
-		gomega.Expect(deployment.Spec.Template.Labels[serverlessv1alpha1.FunctionUUIDLabel]).To(gomega.Equal(string(function.UID)))
-		gomega.Expect(deployment.Spec.Template.Labels[serverlessv1alpha1.FunctionResourceLabel]).To(gomega.Equal(serverlessv1alpha1.FunctionResourceLabelDeploymentValue))
-		gomega.Expect(deployment.Spec.Template.Labels[testBindingLabel1]).To(gomega.Equal("foobar"))
-		gomega.Expect(deployment.Spec.Template.Labels[testBindingLabel2]).To(gomega.Equal(testBindingLabelValue))
-		gomega.Expect(deployment.Spec.Template.Labels["foo"]).To(gomega.Equal("bar"))
-
-		ginkgo.By("service creation")
-		result, err = reconciler.Reconcile(request)
-		gomega.Expect(err).To(gomega.BeNil())
-		gomega.Expect(result.Requeue).To(gomega.BeFalse())
-		gomega.Expect(result.RequeueAfter).To(gomega.Equal(time.Duration(0)))
-
-		function = &serverlessv1alpha1.Function{}
-		gomega.Expect(resourceClient.Get(context.TODO(), request.NamespacedName, function)).To(gomega.Succeed())
-		gomega.Expect(function.Status.Conditions).To(gomega.HaveLen(conditionLen))
-		gomega.Expect(reconciler.getConditionStatus(function.Status.Conditions, serverlessv1alpha1.ConditionConfigurationReady)).To(gomega.Equal(corev1.ConditionTrue))
-		gomega.Expect(reconciler.getConditionStatus(function.Status.Conditions, serverlessv1alpha1.ConditionBuildReady)).To(gomega.Equal(corev1.ConditionTrue))
-		gomega.Expect(reconciler.getConditionStatus(function.Status.Conditions, serverlessv1alpha1.ConditionRunning)).To(gomega.Equal(corev1.ConditionUnknown))
-
-		gomega.Expect(reconciler.getConditionReason(function.Status.Conditions, serverlessv1alpha1.ConditionRunning)).To(gomega.Equal(serverlessv1alpha1.ConditionReasonServiceCreated))
-
-		svc := &corev1.Service{}
-		gomega.Expect(resourceClient.Get(context.TODO(), request.NamespacedName, svc)).To(gomega.Succeed())
-		gomega.Expect(err).To(gomega.BeNil())
-
-		gomega.Expect(svc.Spec.Ports).To(gomega.HaveLen(1))
-		gomega.Expect(svc.Spec.Ports[0].Name).To(gomega.Equal("http"))
-		gomega.Expect(svc.Spec.Ports[0].TargetPort).To(gomega.Equal(intstr.FromInt(8080)))
-
-		gomega.Expect(labels.AreLabelsInWhiteList(svc.Spec.Selector, job.Spec.Template.Labels)).To(gomega.BeFalse(), "svc selector should not catch job pods")
-		gomega.Expect(svc.Spec.Selector).To(gomega.Equal(deployment.Spec.Selector.MatchLabels))
-
-		ginkgo.By("hpa creation")
-		result, err = reconciler.Reconcile(request)
-		gomega.Expect(err).To(gomega.BeNil())
-		gomega.Expect(result.Requeue).To(gomega.BeFalse())
-		gomega.Expect(result.RequeueAfter).To(gomega.Equal(time.Duration(0)))
-
-		function = &serverlessv1alpha1.Function{}
-		gomega.Expect(resourceClient.Get(context.TODO(), request.NamespacedName, function)).To(gomega.Succeed())
-		gomega.Expect(function.Status.Conditions).To(gomega.HaveLen(conditionLen))
-		gomega.Expect(reconciler.getConditionStatus(function.Status.Conditions, serverlessv1alpha1.ConditionConfigurationReady)).To(gomega.Equal(corev1.ConditionTrue))
-		gomega.Expect(reconciler.getConditionStatus(function.Status.Conditions, serverlessv1alpha1.ConditionBuildReady)).To(gomega.Equal(corev1.ConditionTrue))
-		gomega.Expect(reconciler.getConditionStatus(function.Status.Conditions, serverlessv1alpha1.ConditionRunning)).To(gomega.Equal(corev1.ConditionUnknown))
-
-		gomega.Expect(reconciler.getConditionReason(function.Status.Conditions, serverlessv1alpha1.ConditionRunning)).To(gomega.Equal(serverlessv1alpha1.ConditionReasonHorizontalPodAutoscalerCreated))
-
-		hpaList := &autoscalingv1.HorizontalPodAutoscalerList{}
-		err = reconciler.client.ListByLabel(context.TODO(), function.GetNamespace(), fnLabels, hpaList)
-		gomega.Expect(err).To(gomega.BeNil())
-		gomega.Expect(hpaList.Items).To(gomega.HaveLen(1))
-
-		hpaSpec := hpaList.Items[0].Spec
-
-		gomega.Expect(hpaSpec.ScaleTargetRef.Name).To(gomega.Equal(deployment.GetName()))
-		gomega.Expect(hpaSpec.ScaleTargetRef.Kind).To(gomega.Equal("Deployment"))
-		gomega.Expect(hpaSpec.ScaleTargetRef.APIVersion).To(gomega.Equal(appsv1.SchemeGroupVersion.String()))
-
-		ginkgo.By("deployment ready")
-		deployment.Status.Conditions = []appsv1.DeploymentCondition{
-			{Type: appsv1.DeploymentAvailable, Status: corev1.ConditionTrue, Reason: MinimumReplicasAvailable},
-			{Type: appsv1.DeploymentProgressing, Status: corev1.ConditionTrue, Reason: NewRSAvailableReason},
+		ginkgo.By("should detect registry configuration change and rebuild function")
+		customDockerRegistryConfiguration := corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "serverless-registry-config",
+				Namespace: testNamespace,
+			},
+			StringData: map[string]string{
+				"registryAddress": "registry.external.host",
+			},
 		}
-		gomega.Expect(resourceClient.Status().Update(context.TODO(), deployment)).To(gomega.Succeed())
+		gomega.Expect(resourceClient.Create(context.TODO(), &customDockerRegistryConfiguration)).To(gomega.Succeed())
 
 		result, err = reconciler.Reconcile(request)
 		gomega.Expect(err).To(gomega.BeNil())
@@ -223,24 +96,14 @@ var _ = ginkgo.Describe("Function", func() {
 		gomega.Expect(resourceClient.Get(context.TODO(), request.NamespacedName, function)).To(gomega.Succeed())
 		gomega.Expect(function.Status.Conditions).To(gomega.HaveLen(conditionLen))
 		gomega.Expect(reconciler.getConditionStatus(function.Status.Conditions, serverlessv1alpha1.ConditionConfigurationReady)).To(gomega.Equal(corev1.ConditionTrue))
-		gomega.Expect(reconciler.getConditionStatus(function.Status.Conditions, serverlessv1alpha1.ConditionBuildReady)).To(gomega.Equal(corev1.ConditionTrue))
-		gomega.Expect(reconciler.getConditionStatus(function.Status.Conditions, serverlessv1alpha1.ConditionRunning)).To(gomega.Equal(corev1.ConditionTrue))
-		gomega.Expect(reconciler.getConditionReason(function.Status.Conditions, serverlessv1alpha1.ConditionRunning)).To(gomega.Equal(serverlessv1alpha1.ConditionReasonDeploymentReady))
-
-		ginkgo.By("should not change state on reconcile")
-		result, err = reconciler.Reconcile(request)
-		gomega.Expect(err).To(gomega.BeNil())
-		gomega.Expect(result.Requeue).To(gomega.BeFalse())
-		gomega.Expect(result.RequeueAfter).To(gomega.Equal(time.Duration(0)))
-
-		function = &serverlessv1alpha1.Function{}
-		gomega.Expect(resourceClient.Get(context.TODO(), request.NamespacedName, function)).To(gomega.Succeed())
-		gomega.Expect(function.Status.Conditions).To(gomega.HaveLen(conditionLen))
-		gomega.Expect(reconciler.getConditionStatus(function.Status.Conditions, serverlessv1alpha1.ConditionConfigurationReady)).To(gomega.Equal(corev1.ConditionTrue))
-		gomega.Expect(reconciler.getConditionStatus(function.Status.Conditions, serverlessv1alpha1.ConditionBuildReady)).To(gomega.Equal(corev1.ConditionTrue))
+		gomega.Expect(reconciler.getConditionStatus(function.Status.Conditions, serverlessv1alpha1.ConditionBuildReady)).To(gomega.Equal(corev1.ConditionUnknown))
 		gomega.Expect(reconciler.getConditionStatus(function.Status.Conditions, serverlessv1alpha1.ConditionRunning)).To(gomega.Equal(corev1.ConditionTrue))
 
-		gomega.Expect(reconciler.getConditionReason(function.Status.Conditions, serverlessv1alpha1.ConditionRunning)).To(gomega.Equal(serverlessv1alpha1.ConditionReasonDeploymentReady))
+		gomega.Expect(reconciler.getConditionReason(function.Status.Conditions, serverlessv1alpha1.ConditionBuildReady)).To(gomega.Equal(serverlessv1alpha1.ConditionReasonJobsDeleted))
+
+		assertSuccessfulFunctionBuild(reconciler, request, fnLabels, true)
+
+		assertSuccessfulFunctionDeployment(reconciler, request, fnLabels, "registry.external.host", true)
 	})
 
 	ginkgo.It("should set proper status on deployment fail", func() {
@@ -992,4 +855,202 @@ var _ = ginkgo.Describe("Function", func() {
 func deleteFunction(ctx context.Context, function *serverlessv1alpha1.Function) {
 	err := resourceClient.Delete(ctx, function)
 	gomega.Expect(err).To(gomega.BeNil())
+}
+
+func assertSuccessfulFunctionBuild(reconciler *FunctionReconciler, request ctrl.Request, fnLabels map[string]string, rebuilding bool) {
+	initialDeploymentCondition := corev1.ConditionUnknown
+	initialConditionsCount := 2
+	if rebuilding {
+		initialDeploymentCondition = corev1.ConditionTrue
+		initialConditionsCount = 3
+	}
+
+	ginkgo.By("creating the Job")
+	result, err := reconciler.Reconcile(request)
+	gomega.Expect(err).To(gomega.BeNil())
+	gomega.Expect(result.Requeue).To(gomega.BeFalse())
+	gomega.Expect(result.RequeueAfter).To(gomega.Equal(time.Second * 0))
+
+	function := &serverlessv1alpha1.Function{}
+	gomega.Expect(resourceClient.Get(context.TODO(), request.NamespacedName, function)).To(gomega.Succeed())
+	gomega.Expect(function.Status.Conditions).To(gomega.HaveLen(initialConditionsCount))
+	gomega.Expect(reconciler.getConditionStatus(function.Status.Conditions, serverlessv1alpha1.ConditionConfigurationReady)).To(gomega.Equal(corev1.ConditionTrue))
+	gomega.Expect(reconciler.getConditionStatus(function.Status.Conditions, serverlessv1alpha1.ConditionBuildReady)).To(gomega.Equal(corev1.ConditionUnknown))
+	gomega.Expect(reconciler.getConditionStatus(function.Status.Conditions, serverlessv1alpha1.ConditionRunning)).To(gomega.Equal(initialDeploymentCondition))
+
+	jobList := &batchv1.JobList{}
+	err = reconciler.client.ListByLabel(context.TODO(), function.GetNamespace(), fnLabels, jobList)
+	gomega.Expect(err).To(gomega.BeNil())
+	gomega.Expect(jobList.Items).To(gomega.HaveLen(1))
+
+	ginkgo.By("build in progress")
+	result, err = reconciler.Reconcile(request)
+	gomega.Expect(err).To(gomega.BeNil())
+	gomega.Expect(result.Requeue).To(gomega.BeFalse())
+	gomega.Expect(result.RequeueAfter).To(gomega.Equal(time.Second * 0))
+
+	function = &serverlessv1alpha1.Function{}
+	gomega.Expect(resourceClient.Get(context.TODO(), request.NamespacedName, function)).To(gomega.Succeed())
+	gomega.Expect(function.Status.Conditions).To(gomega.HaveLen(initialConditionsCount))
+	gomega.Expect(reconciler.getConditionStatus(function.Status.Conditions, serverlessv1alpha1.ConditionConfigurationReady)).To(gomega.Equal(corev1.ConditionTrue))
+	gomega.Expect(reconciler.getConditionStatus(function.Status.Conditions, serverlessv1alpha1.ConditionBuildReady)).To(gomega.Equal(corev1.ConditionUnknown))
+	gomega.Expect(reconciler.getConditionStatus(function.Status.Conditions, serverlessv1alpha1.ConditionRunning)).To(gomega.Equal(initialDeploymentCondition))
+
+	gomega.Expect(reconciler.getConditionReason(function.Status.Conditions, serverlessv1alpha1.ConditionBuildReady)).To(gomega.Equal(serverlessv1alpha1.ConditionReasonJobRunning))
+
+	ginkgo.By("build finished")
+	job := &batchv1.Job{}
+	gomega.Expect(resourceClient.Get(context.TODO(), types.NamespacedName{Namespace: jobList.Items[0].GetNamespace(), Name: jobList.Items[0].GetName()}, job)).To(gomega.Succeed())
+	gomega.Expect(job).ToNot(gomega.BeNil())
+	job.Status.Succeeded = 1
+	now := metav1.Now()
+	job.Status.CompletionTime = &now
+	gomega.Expect(resourceClient.Status().Update(context.TODO(), job)).To(gomega.Succeed())
+
+	result, err = reconciler.Reconcile(request)
+	gomega.Expect(err).To(gomega.BeNil())
+	gomega.Expect(result.Requeue).To(gomega.BeFalse())
+	gomega.Expect(result.RequeueAfter).To(gomega.Equal(time.Second * 0))
+
+	function = &serverlessv1alpha1.Function{}
+	gomega.Expect(resourceClient.Get(context.TODO(), request.NamespacedName, function)).To(gomega.Succeed())
+	gomega.Expect(function.Status.Conditions).To(gomega.HaveLen(initialConditionsCount))
+	gomega.Expect(reconciler.getConditionStatus(function.Status.Conditions, serverlessv1alpha1.ConditionConfigurationReady)).To(gomega.Equal(corev1.ConditionTrue))
+	gomega.Expect(reconciler.getConditionStatus(function.Status.Conditions, serverlessv1alpha1.ConditionBuildReady)).To(gomega.Equal(corev1.ConditionTrue))
+	gomega.Expect(reconciler.getConditionStatus(function.Status.Conditions, serverlessv1alpha1.ConditionRunning)).To(gomega.Equal(initialDeploymentCondition))
+
+	gomega.Expect(reconciler.getConditionReason(function.Status.Conditions, serverlessv1alpha1.ConditionBuildReady)).To(gomega.Equal(serverlessv1alpha1.ConditionReasonJobFinished))
+}
+
+func assertSuccessfulFunctionDeployment(reconciler *FunctionReconciler, request ctrl.Request, fnLabels map[string]string, registryAddress string, redeployment bool) {
+	ginkgo.By("deploy started")
+	result, err := reconciler.Reconcile(request)
+	gomega.Expect(err).To(gomega.BeNil())
+	gomega.Expect(result.Requeue).To(gomega.BeFalse())
+	gomega.Expect(result.RequeueAfter).To(gomega.Equal(time.Second * 0))
+
+	function := &serverlessv1alpha1.Function{}
+	gomega.Expect(resourceClient.Get(context.TODO(), request.NamespacedName, function)).To(gomega.Succeed())
+	gomega.Expect(function.Status.Conditions).To(gomega.HaveLen(conditionLen))
+	gomega.Expect(reconciler.getConditionStatus(function.Status.Conditions, serverlessv1alpha1.ConditionConfigurationReady)).To(gomega.Equal(corev1.ConditionTrue))
+	gomega.Expect(reconciler.getConditionStatus(function.Status.Conditions, serverlessv1alpha1.ConditionBuildReady)).To(gomega.Equal(corev1.ConditionTrue))
+	gomega.Expect(reconciler.getConditionStatus(function.Status.Conditions, serverlessv1alpha1.ConditionRunning)).To(gomega.Equal(corev1.ConditionUnknown))
+
+	deployments := &appsv1.DeploymentList{}
+	gomega.Expect(resourceClient.ListByLabel(context.TODO(), request.Namespace, fnLabels, deployments)).To(gomega.Succeed())
+	gomega.Expect(len(deployments.Items)).To(gomega.Equal(1))
+	deployment := &deployments.Items[0]
+	gomega.Expect(deployment).ToNot(gomega.BeNil())
+	gomega.Expect(deployment.Spec.Template.Spec.Containers).To(gomega.HaveLen(1))
+	gomega.Expect(deployment.Spec.Template.Spec.Containers[0].Image).To(gomega.Equal(reconciler.buildImageAddress(function, registryAddress)))
+	gomega.Expect(deployment.Spec.Template.Labels).To(gomega.HaveLen(7))
+	gomega.Expect(deployment.Spec.Template.Labels[serverlessv1alpha1.FunctionNameLabel]).To(gomega.Equal(function.Name))
+	gomega.Expect(deployment.Spec.Template.Labels[serverlessv1alpha1.FunctionManagedByLabel]).To(gomega.Equal(serverlessv1alpha1.FunctionControllerValue))
+	gomega.Expect(deployment.Spec.Template.Labels[serverlessv1alpha1.FunctionUUIDLabel]).To(gomega.Equal(string(function.UID)))
+	gomega.Expect(deployment.Spec.Template.Labels[serverlessv1alpha1.FunctionResourceLabel]).To(gomega.Equal(serverlessv1alpha1.FunctionResourceLabelDeploymentValue))
+	gomega.Expect(deployment.Spec.Template.Labels[testBindingLabel1]).To(gomega.Equal("foobar"))
+	gomega.Expect(deployment.Spec.Template.Labels[testBindingLabel2]).To(gomega.Equal(testBindingLabelValue))
+	gomega.Expect(deployment.Spec.Template.Labels["foo"]).To(gomega.Equal("bar"))
+
+	if !redeployment {
+		ginkgo.By("service creation")
+		result, err = reconciler.Reconcile(request)
+		gomega.Expect(err).To(gomega.BeNil())
+		gomega.Expect(result.Requeue).To(gomega.BeFalse())
+		gomega.Expect(result.RequeueAfter).To(gomega.Equal(time.Duration(0)))
+
+		function = &serverlessv1alpha1.Function{}
+		gomega.Expect(resourceClient.Get(context.TODO(), request.NamespacedName, function)).To(gomega.Succeed())
+		gomega.Expect(function.Status.Conditions).To(gomega.HaveLen(conditionLen))
+		gomega.Expect(reconciler.getConditionStatus(function.Status.Conditions, serverlessv1alpha1.ConditionConfigurationReady)).To(gomega.Equal(corev1.ConditionTrue))
+		gomega.Expect(reconciler.getConditionStatus(function.Status.Conditions, serverlessv1alpha1.ConditionBuildReady)).To(gomega.Equal(corev1.ConditionTrue))
+		gomega.Expect(reconciler.getConditionStatus(function.Status.Conditions, serverlessv1alpha1.ConditionRunning)).To(gomega.Equal(corev1.ConditionUnknown))
+
+		gomega.Expect(reconciler.getConditionReason(function.Status.Conditions, serverlessv1alpha1.ConditionRunning)).To(gomega.Equal(serverlessv1alpha1.ConditionReasonServiceCreated))
+	}
+
+	ginkgo.By("service ready")
+	jobList := &batchv1.JobList{}
+	err = reconciler.client.ListByLabel(context.TODO(), function.GetNamespace(), fnLabels, jobList)
+	gomega.Expect(err).To(gomega.BeNil())
+	gomega.Expect(jobList.Items).To(gomega.HaveLen(1))
+	job := &batchv1.Job{}
+	gomega.Expect(resourceClient.Get(context.TODO(), types.NamespacedName{Namespace: jobList.Items[0].GetNamespace(), Name: jobList.Items[0].GetName()}, job)).To(gomega.Succeed())
+	gomega.Expect(job).ToNot(gomega.BeNil())
+
+	svc := &corev1.Service{}
+	gomega.Expect(resourceClient.Get(context.TODO(), request.NamespacedName, svc)).To(gomega.Succeed())
+	gomega.Expect(err).To(gomega.BeNil())
+
+	gomega.Expect(svc.Spec.Ports).To(gomega.HaveLen(1))
+	gomega.Expect(svc.Spec.Ports[0].Name).To(gomega.Equal("http"))
+	gomega.Expect(svc.Spec.Ports[0].TargetPort).To(gomega.Equal(intstr.FromInt(8080)))
+
+	gomega.Expect(labels.AreLabelsInWhiteList(svc.Spec.Selector, job.Spec.Template.Labels)).To(gomega.BeFalse(), "svc selector should not catch job pods")
+	gomega.Expect(svc.Spec.Selector).To(gomega.Equal(deployment.Spec.Selector.MatchLabels))
+
+	if !redeployment {
+		ginkgo.By("hpa creation")
+		result, err = reconciler.Reconcile(request)
+		gomega.Expect(err).To(gomega.BeNil())
+		gomega.Expect(result.Requeue).To(gomega.BeFalse())
+		gomega.Expect(result.RequeueAfter).To(gomega.Equal(time.Duration(0)))
+
+		function = &serverlessv1alpha1.Function{}
+		gomega.Expect(resourceClient.Get(context.TODO(), request.NamespacedName, function)).To(gomega.Succeed())
+		gomega.Expect(function.Status.Conditions).To(gomega.HaveLen(conditionLen))
+		gomega.Expect(reconciler.getConditionStatus(function.Status.Conditions, serverlessv1alpha1.ConditionConfigurationReady)).To(gomega.Equal(corev1.ConditionTrue))
+		gomega.Expect(reconciler.getConditionStatus(function.Status.Conditions, serverlessv1alpha1.ConditionBuildReady)).To(gomega.Equal(corev1.ConditionTrue))
+		gomega.Expect(reconciler.getConditionStatus(function.Status.Conditions, serverlessv1alpha1.ConditionRunning)).To(gomega.Equal(corev1.ConditionUnknown))
+
+		gomega.Expect(reconciler.getConditionReason(function.Status.Conditions, serverlessv1alpha1.ConditionRunning)).To(gomega.Equal(serverlessv1alpha1.ConditionReasonHorizontalPodAutoscalerCreated))
+	}
+
+	ginkgo.By("hpa ready")
+
+	hpaList := &autoscalingv1.HorizontalPodAutoscalerList{}
+	err = reconciler.client.ListByLabel(context.TODO(), function.GetNamespace(), fnLabels, hpaList)
+	gomega.Expect(err).To(gomega.BeNil())
+	gomega.Expect(hpaList.Items).To(gomega.HaveLen(1))
+
+	hpaSpec := hpaList.Items[0].Spec
+
+	gomega.Expect(hpaSpec.ScaleTargetRef.Name).To(gomega.Equal(deployment.GetName()))
+	gomega.Expect(hpaSpec.ScaleTargetRef.Kind).To(gomega.Equal("Deployment"))
+	gomega.Expect(hpaSpec.ScaleTargetRef.APIVersion).To(gomega.Equal(appsv1.SchemeGroupVersion.String()))
+
+	ginkgo.By("deployment ready")
+	deployment.Status.Conditions = []appsv1.DeploymentCondition{
+		{Type: appsv1.DeploymentAvailable, Status: corev1.ConditionTrue, Reason: MinimumReplicasAvailable},
+		{Type: appsv1.DeploymentProgressing, Status: corev1.ConditionTrue, Reason: NewRSAvailableReason},
+	}
+	gomega.Expect(resourceClient.Status().Update(context.TODO(), deployment)).To(gomega.Succeed())
+
+	result, err = reconciler.Reconcile(request)
+	gomega.Expect(err).To(gomega.BeNil())
+	gomega.Expect(result.Requeue).To(gomega.BeFalse())
+	gomega.Expect(result.RequeueAfter).To(gomega.Equal(time.Minute * 5))
+
+	function = &serverlessv1alpha1.Function{}
+	gomega.Expect(resourceClient.Get(context.TODO(), request.NamespacedName, function)).To(gomega.Succeed())
+	gomega.Expect(function.Status.Conditions).To(gomega.HaveLen(conditionLen))
+	gomega.Expect(reconciler.getConditionStatus(function.Status.Conditions, serverlessv1alpha1.ConditionConfigurationReady)).To(gomega.Equal(corev1.ConditionTrue))
+	gomega.Expect(reconciler.getConditionStatus(function.Status.Conditions, serverlessv1alpha1.ConditionBuildReady)).To(gomega.Equal(corev1.ConditionTrue))
+	gomega.Expect(reconciler.getConditionStatus(function.Status.Conditions, serverlessv1alpha1.ConditionRunning)).To(gomega.Equal(corev1.ConditionTrue))
+	gomega.Expect(reconciler.getConditionReason(function.Status.Conditions, serverlessv1alpha1.ConditionRunning)).To(gomega.Equal(serverlessv1alpha1.ConditionReasonDeploymentReady))
+
+	ginkgo.By("should not change state on reconcile")
+	result, err = reconciler.Reconcile(request)
+	gomega.Expect(err).To(gomega.BeNil())
+	gomega.Expect(result.Requeue).To(gomega.BeFalse())
+	gomega.Expect(result.RequeueAfter).To(gomega.Equal(time.Minute * 5))
+
+	function = &serverlessv1alpha1.Function{}
+	gomega.Expect(resourceClient.Get(context.TODO(), request.NamespacedName, function)).To(gomega.Succeed())
+	gomega.Expect(function.Status.Conditions).To(gomega.HaveLen(conditionLen))
+	gomega.Expect(reconciler.getConditionStatus(function.Status.Conditions, serverlessv1alpha1.ConditionConfigurationReady)).To(gomega.Equal(corev1.ConditionTrue))
+	gomega.Expect(reconciler.getConditionStatus(function.Status.Conditions, serverlessv1alpha1.ConditionBuildReady)).To(gomega.Equal(corev1.ConditionTrue))
+	gomega.Expect(reconciler.getConditionStatus(function.Status.Conditions, serverlessv1alpha1.ConditionRunning)).To(gomega.Equal(corev1.ConditionTrue))
+
+	gomega.Expect(reconciler.getConditionReason(function.Status.Conditions, serverlessv1alpha1.ConditionRunning)).To(gomega.Equal(serverlessv1alpha1.ConditionReasonDeploymentReady))
 }

--- a/components/function-controller/internal/controllers/serverless/suite_test.go
+++ b/components/function-controller/internal/controllers/serverless/suite_test.go
@@ -85,8 +85,18 @@ var _ = ginkgo.BeforeSuite(func(done ginkgo.Done) {
 			Name: testNamespace,
 		},
 	}
+	dockerRegistryConfiguration := corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "serverless-registry-config-default",
+			Namespace: testNamespace,
+		},
+		StringData: map[string]string{
+			"registryAddress": "registry.kyma.local",
+		},
+	}
 	gomega.Expect(resourceClient.Create(context.TODO(), &ns)).To(gomega.Succeed())
 	gomega.Expect(resourceClient.Create(context.TODO(), &runtimeDockerfileConfigMap)).To(gomega.Succeed())
+	gomega.Expect(resourceClient.Create(context.TODO(), &dockerRegistryConfiguration)).To(gomega.Succeed())
 
 	close(done)
 }, 60)

--- a/resources/serverless/templates/deployment.yaml
+++ b/resources/serverless/templates/deployment.yaml
@@ -72,19 +72,14 @@ spec:
             - name: APP_LEADER_ELECTION_ENABLED
               value: "true"
           {{- end }}
-            - name: APP_FUNCTION_DOCKER_INTERNAL_REGISTRY_ENABLED
-              value: "{{ .Values.dockerRegistry.enableInternal }}"
-            - name: APP_FUNCTION_DOCKER_INTERNAL_SERVER_ADDRESS
-              value: "{{- include "tplValue" ( dict "value" .Values.dockerRegistry.internalServerAddress "context" . ) }}"
-            - name: APP_FUNCTION_DOCKER_REGISTRY_ADDRESS
-              value: "{{- include "tplValue" ( dict "value" .Values.dockerRegistry.registryAddress "context" . ) }}"
             {{ include "createEnv" ( dict "name" "APP_KUBERNETES_CONFIG_MAP_REQUEUE_DURATION" "value" .Values.containers.manager.envs.configMapRequeueDuration "context" . ) | nindent 12 }}
             {{ include "createEnv" ( dict "name" "APP_KUBERNETES_SECRET_REQUEUE_DURATION" "value" .Values.containers.manager.envs.secretRequeueDuration "context" . ) | nindent 12 }}
             {{ include "createEnv" ( dict "name" "APP_KUBERNETES_SERVICE_ACCOUNT_REQUEUE_DURATION" "value" .Values.containers.manager.envs.serviceAccountRequeueDuration "context" . ) | nindent 12 }}
             {{ include "createEnv" ( dict "name" "APP_KUBERNETES_ROLE_REQUEUE_DURATION" "value" .Values.containers.manager.envs.roleRequeueDuration "context" . ) | nindent 12 }}
             {{ include "createEnv" ( dict "name" "APP_KUBERNETES_ROLEBINDING_REQUEUE_DURATION" "value" .Values.containers.manager.envs.roleBindingRequeueDuration "context" . ) | nindent 12 }}
             {{ include "createEnv" ( dict "name" "APP_KUBERNETES_EXCLUDED_NAMESPACES" "value" .Values.containers.manager.envs.namespaceExcludedNames "context" . ) | nindent 12 }}
-            {{ include "createEnv" ( dict "name" "APP_FUNCTION_IMAGE_REGISTRY_DOCKER_CONFIG_SECRET_NAME" "value" .Values.containers.manager.envs.imageRegistryDockerConfigSecretName "context" . ) | nindent 12 }}
+            {{ include "createEnv" ( dict "name" "APP_FUNCTION_IMAGE_REGISTRY_DEFAULT_DOCKER_CONFIG_SECRET_NAME" "value" .Values.containers.manager.envs.imageRegistryDefaultDockerConfigSecretName "context" . ) | nindent 12 }}
+            {{ include "createEnv" ( dict "name" "APP_FUNCTION_IMAGE_REGISTRY_EXTERNAL_DOCKER_CONFIG_SECRET_NAME" "value" .Values.containers.manager.envs.imageRegistryExternalDockerConfigSecretName "context" . ) | nindent 12 }}
             {{ include "createEnv" ( dict "name" "APP_FUNCTION_BUILD_SERVICE_ACCOUNT_NAME" "value" .Values.containers.manager.envs.buildServiceAccountName "context" . ) | nindent 12 }}
             {{ include "createEnv" ( dict "name" "APP_FUNCTION_IMAGE_PULL_ACCOUNT_NAME" "value" .Values.containers.manager.envs.imagePullAccountName "context" . ) | nindent 12 }}
             {{ include "createEnv" ( dict "name" "APP_FUNCTION_REQUEUE_DURATION" "value" .Values.containers.manager.envs.functionRequeueDuration "context" . ) | nindent 12 }}

--- a/resources/serverless/templates/secrets.yaml
+++ b/resources/serverless/templates/secrets.yaml
@@ -2,34 +2,25 @@
 {{- $password := include "tplValue" ( dict "value" .Values.dockerRegistry.password "context" . ) -}}
 {{- $internalServerAddress := include "tplValue" ( dict "value" .Values.dockerRegistry.internalServerAddress "context" . ) -}}
 {{- $serverAddress := include "tplValue" ( dict "value" .Values.dockerRegistry.serverAddress "context" . ) -}}
+{{- $registryAddress := include "tplValue" ( dict "value" .Values.dockerRegistry.registryAddress "context" . ) -}}
 {{- $encodedUsernamePassword := printf "%s:%s" $username $password | b64enc }}
 apiVersion: v1
 kind: Secret
 type: kubernetes.io/dockerconfigjson
+metadata:
+  name: {{ template "fullname" . }}-registry-config-default
+  namespace: {{ .Release.Namespace }}
+  labels:
+    serverless.kyma-project.io/config: credentials
 data:
-{{- if .Values.dockerRegistry.enableInternal }}
+  username: "{{ $username | b64enc }}"
+  password: "{{ $password | b64enc }}"
+  serverAddress: "{{ $serverAddress | b64enc }}"
+  isInternal: "{{ .Values.dockerRegistry.enableInternal | toString | b64enc }}"
+  {{- if .Values.dockerRegistry.enableInternal }}
+  registryAddress: "{{ $internalServerAddress | b64enc }}"
   .dockerconfigjson: "{{- (printf "{\"auths\": {\"%s\": {\"auth\": \"%s\"}, \"%s\": {\"auth\": \"%s\"}}}" $internalServerAddress $encodedUsernamePassword $serverAddress $encodedUsernamePassword) | b64enc }}"
-{{- else }}
+  {{- else }}
+  registryAddress: "{{ $registryAddress | b64enc }}"
   .dockerconfigjson: "{{- (printf "{\"auths\": {\"%s\": {\"auth\": \"%s\"}}}" $serverAddress $encodedUsernamePassword) | b64enc }}"
-{{- end }}
-metadata:
-  name: {{ template "fullname" . }}-image-pull-secret
-  namespace: {{ .Release.Namespace }}
-  labels:
-    serverless.kyma-project.io/config: credentials
-    serverless.kyma-project.io/credentials: image-pull-secret
----
-{{- if .Values.dockerRegistry.enableInternal }}
-apiVersion: v1
-kind: Secret
-type: kubernetes.io/basic-auth
-metadata:
-  name: {{ template "fullname" . }}-registry-credentials
-  namespace: {{ .Release.Namespace }}
-  labels:
-    serverless.kyma-project.io/config: credentials
-    serverless.kyma-project.io/credentials: registry-credentials
-stringData:
-  username: "{{ $username }}"
-  password: "{{ $password }}"
-{{- end }}
+  {{- end }}

--- a/resources/serverless/templates/service-accounts.yaml
+++ b/resources/serverless/templates/service-accounts.yaml
@@ -15,7 +15,8 @@ metadata:
     serverless.kyma-project.io/config: service-account
 automountServiceAccountToken: false
 imagePullSecrets:
-  - name: {{ template "fullname" . }}-image-pull-secret
+  - name: {{ template "fullname" . }}-registry-config
+  - name: {{ template "fullname" . }}-registry-config-default
 ---
 apiVersion: v1
 kind: ServiceAccount

--- a/resources/serverless/values.yaml
+++ b/resources/serverless/values.yaml
@@ -77,7 +77,7 @@ global:
 images:
   manager:
     repository: "eu.gcr.io/kyma-project/function-controller"
-    tag: "PR-10436"
+    tag: "PR-10434"
     pullPolicy: IfNotPresent
   runtimes:
     nodejs12:
@@ -126,8 +126,10 @@ containers:
         value: 5m
       namespaceExcludedNames:
         value: "istio-system,knative-eventing,kube-node-lease,kube-public,kube-system,kyma-installer,kyma-integration,kyma-system,natss,compass-system"
-      imageRegistryDockerConfigSecretName:
-        value: '{{ template "fullname" . }}-image-pull-secret'
+      imageRegistryExternalDockerConfigSecretName:
+        value: '{{ template "fullname" . }}-registry-config'
+      imageRegistryDefaultDockerConfigSecretName:
+        value: '{{ template "fullname" . }}-registry-config-default'
       imagePullAccountName:
         value: '{{ template "fullname" . }}-function'
       buildServiceAccountName:
@@ -203,7 +205,7 @@ docker-registry:
   extraVolumes:
     - name: registry-credentials
       secret:
-        secretName: serverless-registry-credentials
+        secretName: serverless-registry-config-default
         items:
           - key: username
             path: username.txt


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/master/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- Allow switching container registry for serverless in the runtime.
- Add reconciliation requeue after 1 minute when function deployment is in `Ready` state (should fix inconsistent git function source syncs and allow to detect registry changes).
- Add removing functionality to the serverless secret controller, so that when a user removes his custom external registry configuration secret from the `kyma-system` namespace, the propagated secrets are also deleted.

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
See https://github.com/kyma-project/kyma/issues/10238