### PR TITLE
Rename API Packages to API Bundles and fix the link to their documentation

### DIFF
--- a/docs/runtime-agent/03-02-configuring-runtime.md
+++ b/docs/runtime-agent/03-02-configuring-runtime.md
@@ -5,9 +5,9 @@ type: Details
 
 > **NOTE:** To represent API and Event Definitions of the Applications connected to a Runtime, Open Service Broker API usage is recommended.
 
-In a Kyma Runtime, during Runtime configuration, Application's Packages are integrated into [Service Catalog](components/service-catalog) using [Application](components/application-connector#custom-resource-application) custom resources and [Application Broker](components/application-connector#architecture-application-broker).
-By default, a single Application is represented as a [ServiceClass](components/service-catalog/#architecture-resources), and a single Package is represented as a [ServicePlan](components/service-catalog/#architecture-resources) in Service Catalog.
-Refer to the documentation to learn more about [API Packages](https://github.com/kyma-incubator/compass/blob/master/docs/compass/03-packages-api.md).
+In a Kyma Runtime, during Runtime configuration, Application's Bundles are integrated into [Service Catalog](components/service-catalog) using [Application](components/application-connector#custom-resource-application) custom resources and [Application Broker](components/application-connector#architecture-application-broker).
+By default, a single Application is represented as a [ServiceClass](components/service-catalog/#architecture-resources), and a single Bundle is represented as a [ServicePlan](components/service-catalog/#architecture-resources) in Service Catalog.
+Refer to the documentation to learn more about [API Bundles](https://github.com/kyma-incubator/compass/blob/master/docs/compass/03-bundles-api.md).
 
 Runtime Agent periodically requests for the configuration of its Runtime from Compass.
 Changes in the configuration for the Runtime are applied by the Runtime Agent on the Runtime.


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Rename `API Packages` to `API Bundles`, following the [recent change in Compass](https://github.com/kyma-incubator/compass/commit/db75220d5d942e03bf55b7c24569031c87b1c538#diff-ea6eb741146d2eaf8065b51a83d212dc8aeb5bcbd05c5bde61dd235e0e338c36)
- Fix the link to API Bundles documentation
