### PR TITLE
Bump uaa-activator image, change role_template name

### DIFF
--- a/resources/uaa-activator/values.yaml
+++ b/resources/uaa-activator/values.yaml
@@ -7,13 +7,13 @@ global:
     developerGroup: runtimeDeveloper
     namespaceAdminGroup: runtimeNamespaceAdmin
   role:
-    developer: KymaRuntimeDeveloper
+    developer: KymaRuntimeNamespaceDeveloper
     namespaceAdmin: KymaRuntimeNamespaceAdmin
 
 image:
   registryPath: eu.gcr.io/kyma-project
   pullPolicy: IfNotPresent
-  version: "7980e693"
+  version: "4e3d4a67"
 
 initJobs:
   secret:


### PR DESCRIPTION
Changes proposed in this pull request:

- Fix `role_template` developer name inside ServiceInstance parameter (uaa-activator component)