### PR TITLE
Use new switch `eventing.backend` in eventing Helm charts

### DIFF
--- a/resources/eventing/charts/controller/templates/clusterrole.yaml
+++ b/resources/eventing/charts/controller/templates/clusterrole.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.global.isBEBEnabled }}
+{{- if eq .Values.global.eventing.backend "beb" }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:

--- a/resources/eventing/charts/controller/templates/clusterrolebinding.yaml
+++ b/resources/eventing/charts/controller/templates/clusterrolebinding.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.global.isBEBEnabled }}
+{{- if eq .Values.global.eventing.backend "beb" }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:

--- a/resources/eventing/charts/controller/templates/deployment.yaml
+++ b/resources/eventing/charts/controller/templates/deployment.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.global.isBEBEnabled }}
+{{- if eq .Values.global.eventing.backend "beb" }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/resources/eventing/charts/controller/templates/oauth2-client.yaml
+++ b/resources/eventing/charts/controller/templates/oauth2-client.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.global.isBEBEnabled }}
+{{- if eq .Values.global.eventing.backend "beb" }}
 apiVersion: hydra.ory.sh/v1alpha1
 kind: OAuth2Client
 metadata:

--- a/resources/eventing/charts/controller/templates/service.yaml
+++ b/resources/eventing/charts/controller/templates/service.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.global.isBEBEnabled }}
+{{- if eq .Values.global.eventing.backend "beb" }}
 apiVersion: v1
 kind: Service
 metadata:

--- a/resources/eventing/charts/controller/templates/serviceaccount.yaml
+++ b/resources/eventing/charts/controller/templates/serviceaccount.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.global.isBEBEnabled }}
+{{- if eq .Values.global.eventing.backend "beb" }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/resources/eventing/charts/event-publisher-nats/templates/clusterrole.yaml
+++ b/resources/eventing/charts/event-publisher-nats/templates/clusterrole.yaml
@@ -1,4 +1,4 @@
-{{- if not .Values.global.isBEBEnabled }}
+{{- if eq .Values.global.eventing.backend "nats" }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:

--- a/resources/eventing/charts/event-publisher-nats/templates/clusterrolebinding.yaml
+++ b/resources/eventing/charts/event-publisher-nats/templates/clusterrolebinding.yaml
@@ -1,4 +1,4 @@
-{{- if not .Values.global.isBEBEnabled }}
+{{- if eq .Values.global.eventing.backend "nats" }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:

--- a/resources/eventing/charts/event-publisher-nats/templates/deployment.yaml
+++ b/resources/eventing/charts/event-publisher-nats/templates/deployment.yaml
@@ -1,4 +1,4 @@
-{{- if not .Values.global.isBEBEnabled }}
+{{- if eq .Values.global.eventing.backend "nats" }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/resources/eventing/charts/event-publisher-nats/templates/service.yaml
+++ b/resources/eventing/charts/event-publisher-nats/templates/service.yaml
@@ -1,4 +1,4 @@
-{{- if not .Values.global.isBEBEnabled }}
+{{- if eq .Values.global.eventing.backend "nats" }}
 apiVersion: v1
 kind: Service
 metadata:

--- a/resources/eventing/charts/event-publisher-nats/templates/serviceaccount.yaml
+++ b/resources/eventing/charts/event-publisher-nats/templates/serviceaccount.yaml
@@ -1,4 +1,4 @@
-{{- if not .Values.global.isBEBEnabled }}
+{{- if eq .Values.global.eventing.backend "nats" }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/resources/eventing/charts/event-publisher-proxy/templates/clusterrole.yaml
+++ b/resources/eventing/charts/event-publisher-proxy/templates/clusterrole.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.global.isBEBEnabled }}
+{{- if eq .Values.global.eventing.backend "beb" }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:

--- a/resources/eventing/charts/event-publisher-proxy/templates/clusterrolebinding.yaml
+++ b/resources/eventing/charts/event-publisher-proxy/templates/clusterrolebinding.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.global.isBEBEnabled }}
+{{- if eq .Values.global.eventing.backend "beb" }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:

--- a/resources/eventing/charts/event-publisher-proxy/templates/deployment.yaml
+++ b/resources/eventing/charts/event-publisher-proxy/templates/deployment.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.global.isBEBEnabled }}
+{{- if eq .Values.global.eventing.backend "beb" }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/resources/eventing/charts/event-publisher-proxy/templates/service.yaml
+++ b/resources/eventing/charts/event-publisher-proxy/templates/service.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.global.isBEBEnabled }}
+{{- if eq .Values.global.eventing.backend "beb" }}
 apiVersion: v1
 kind: Service
 metadata:

--- a/resources/eventing/charts/event-publisher-proxy/templates/serviceaccount.yaml
+++ b/resources/eventing/charts/event-publisher-proxy/templates/serviceaccount.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.global.isBEBEnabled }}
+{{- if eq .Values.global.eventing.backend "beb" }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/resources/eventing/charts/nats-controller/templates/clusterrole.yaml
+++ b/resources/eventing/charts/nats-controller/templates/clusterrole.yaml
@@ -1,4 +1,4 @@
-{{- if not .Values.global.isBEBEnabled }}
+{{- if eq .Values.global.eventing.backend "nats" }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:

--- a/resources/eventing/charts/nats-controller/templates/clusterrolebinding.yaml
+++ b/resources/eventing/charts/nats-controller/templates/clusterrolebinding.yaml
@@ -1,4 +1,4 @@
-{{- if not .Values.global.isBEBEnabled }}
+{{- if eq .Values.global.eventing.backend "nats" }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:

--- a/resources/eventing/charts/nats-controller/templates/deployment.yaml
+++ b/resources/eventing/charts/nats-controller/templates/deployment.yaml
@@ -1,4 +1,4 @@
-{{- if not .Values.global.isBEBEnabled }}
+{{- if eq .Values.global.eventing.backend "nats" }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/resources/eventing/charts/nats-controller/templates/service.yaml
+++ b/resources/eventing/charts/nats-controller/templates/service.yaml
@@ -1,4 +1,4 @@
-{{- if not .Values.global.isBEBEnabled }}
+{{- if eq .Values.global.eventing.backend "nats" }}
 apiVersion: v1
 kind: Service
 metadata:

--- a/resources/eventing/charts/nats-controller/templates/serviceaccount.yaml
+++ b/resources/eventing/charts/nats-controller/templates/serviceaccount.yaml
@@ -1,4 +1,4 @@
-{{- if not .Values.global.isBEBEnabled }}
+{{- if eq .Values.global.eventing.backend "nats" }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/resources/eventing/charts/nats/templates/00-prereqs.yaml
+++ b/resources/eventing/charts/nats/templates/00-prereqs.yaml
@@ -1,4 +1,4 @@
-{{- if not .Values.global.isBEBEnabled }}
+{{- if eq .Values.global.eventing.backend "nats" }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/resources/eventing/charts/nats/templates/10-deployment.yaml
+++ b/resources/eventing/charts/nats/templates/10-deployment.yaml
@@ -1,4 +1,4 @@
-{{- if not .Values.global.isBEBEnabled }}
+{{- if eq .Values.global.eventing.backend "nats" }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/resources/eventing/charts/nats/templates/20-service.yaml
+++ b/resources/eventing/charts/nats/templates/20-service.yaml
@@ -1,4 +1,4 @@
-{{- if not .Values.global.isBEBEnabled }}
+{{- if eq .Values.global.eventing.backend "nats" }}
 apiVersion: v1
 kind: Service
 metadata:

--- a/resources/eventing/charts/nats/templates/30-destination-rule.yaml
+++ b/resources/eventing/charts/nats/templates/30-destination-rule.yaml
@@ -1,4 +1,4 @@
-{{- if not .Values.global.isBEBEnabled }}
+{{- if eq .Values.global.eventing.backend "nats" }}
 apiVersion: networking.istio.io/v1alpha3
 kind: DestinationRule
 metadata:

--- a/resources/eventing/charts/nats/templates/40-cr.yaml
+++ b/resources/eventing/charts/nats/templates/40-cr.yaml
@@ -1,4 +1,4 @@
-{{- if not .Values.global.isBEBEnabled }}
+{{- if eq .Values.global.eventing.backend "nats" }}
 apiVersion: nats.io/v1alpha2
 kind: NatsCluster
 metadata:

--- a/resources/eventing/values.yaml
+++ b/resources/eventing/values.yaml
@@ -10,9 +10,9 @@ global:
   # domainName is the global domain used in Kyma
   domainName: ""
 
-  # isBEBEnabled determines whether BEB is enabled
-  # if true BEB is enabled else NATS is enabled
-  isBEBEnabled: false
+  eventing:
+    # backend defines the provisioned eventing backend, either NATS or BEB
+    backend: nats
 
 authentication:
   # oauthClientId is the Oauth2 client id used in order to get an Oauth2 token from BEB


### PR DESCRIPTION
Remove the usage of `isBEBEnabled` in `eventing` Helm charts
Use a new switch with enum values to be either NATS or BEB for now