### PR TITLE
Add emsPublisherUrlSuffix as a config value

### DIFF
--- a/resources/eventing/charts/event-publisher-proxy/templates/deployment.yaml
+++ b/resources/eventing/charts/event-publisher-proxy/templates/deployment.yaml
@@ -32,11 +32,13 @@ spec:
                 secretKeyRef:
                   name: {{ include "eventing.secretName" . }}
                   key: token-endpoint
-            - name: EMS_PUBLISH_URL
+            - name: EMS_URL
               valueFrom:
                 secretKeyRef:
                   name: {{ include "eventing.secretName" . }}
                   key: ems-publish-url
+            - name: EMS_PUBLISH_URL
+              value: $(EMS_URL)/{{ .Values.beb.config.emsPublisherUrlSuffix }}
             - name: BEB_NAMESPACE
               valueFrom:
                 secretKeyRef:

--- a/resources/eventing/charts/event-publisher-proxy/values.yaml
+++ b/resources/eventing/charts/event-publisher-proxy/values.yaml
@@ -24,3 +24,8 @@ resources:
   requests:
     cpu: 32m
     memory: 64Mi
+
+beb:
+  config:
+    # emsPublisherUrlSuffix is the suffix added to EMS url obtained from service key
+    emsPublisherUrlSuffix: sap/ems/v1/events

--- a/resources/eventing/charts/event-publisher-proxy/values.yaml
+++ b/resources/eventing/charts/event-publisher-proxy/values.yaml
@@ -29,3 +29,4 @@ beb:
   config:
     # emsPublisherUrlSuffix is the suffix added to EMS url obtained from service key
     emsPublisherUrlSuffix: sap/ems/v1/events
+


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/master/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**
For publishing events to EMS, a suffix must be added to the EMS URL obtained from Service Key.
The value of the suffix is made configurable

Changes proposed in this pull request:

- Add a new configurable value for EMS URL suffix

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
See https://github.com/kyma-project/kyma/issues/10317