### PR TITLE
Removed knative sinkbinding and legacysinkbinding mutatingwebhookconfigurations

### DIFF
--- a/resources/knative-eventing/charts/knative-eventing/templates/eventing.yaml
+++ b/resources/knative-eventing/charts/knative-eventing/templates/eventing.yaml
@@ -1129,48 +1129,6 @@ webhooks:
   sideEffects: None
   timeoutSeconds: {{ .Values.webhook.timeout }}
 ---
-apiVersion: admissionregistration.k8s.io/v1beta1
-kind: MutatingWebhookConfiguration
-metadata:
-  labels:
-    eventing.knative.dev/release: "v0.12.0"
-  name: sinkbindings.webhook.sources.knative.dev
-webhooks:
-- admissionReviewVersions:
-  - v1beta1
-  clientConfig:
-    service:
-      name: eventing-webhook
-      namespace: knative-eventing
-  failurePolicy: {{ .Values.webhook.failurePolicy }}
-  name: sinkbindings.webhook.sources.knative.dev
-  sideEffects: None
-  namespaceSelector:
-    matchExpressions:
-{{ toYaml .Values.webhook.webhookMatchExp | indent 4 }}
-  timeoutSeconds: {{ .Values.webhook.timeout }}
----
-apiVersion: admissionregistration.k8s.io/v1beta1
-kind: MutatingWebhookConfiguration
-metadata:
-  labels:
-    eventing.knative.dev/release: "v0.12.0"
-  name: legacysinkbindings.webhook.sources.knative.dev
-webhooks:
-- admissionReviewVersions:
-  - v1beta1
-  clientConfig:
-    service:
-      name: eventing-webhook
-      namespace: knative-eventing
-  failurePolicy: {{ .Values.webhook.failurePolicy }}
-  name: legacysinkbindings.webhook.sources.knative.dev
-  sideEffects: None
-  namespaceSelector:
-    matchExpressions:
-{{ toYaml .Values.webhook.webhookMatchExp | indent 4 }}
-  timeoutSeconds: {{ .Values.webhook.timeout }}
----
 apiVersion: v1
 kind: Secret
 metadata:

--- a/resources/knative-eventing/values.yaml
+++ b/resources/knative-eventing/values.yaml
@@ -26,9 +26,6 @@ knative-eventing:
         operator: NotIn
         values:
           - kube-system
-          - kyma-system
-          - kyma-installer
-          - istio-system
   sourcesController:
     resources:
       limits:


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/master/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- Removed knative sinkbinding and legacysinkbinding mutatingwebhookconfigurations
- Removed kyma-system, istio-system and kyma-installer from list of webhookMatchExp as they don't have a label with key `gardener.cloud/purpose` 
