### PR TITLE
Update the event-sources controller-manager and http-adapter images

### DIFF
--- a/resources/event-sources/values.yaml
+++ b/resources/event-sources/values.yaml
@@ -5,11 +5,11 @@ global:
     name: controller-manager
     image: event-sources-controller-manager
     dir: ''
-    version: "PR-10606"
+    version: "6bbd5901"
   httpAdapter:
     image: event-sources-http-adapter
     dir: ''
-    version: "PR-10606"
+    version: "6bbd5901"
     tracingEnabled: "true"
 
 deployment:


### PR DESCRIPTION
**Description**

Image update for the event-sources controller-manager and http-adapter with the fix for CVE-2021-3121.