### PR TITLE
Bump uaa-activator image

### DIFF
--- a/resources/uaa-activator/values.yaml
+++ b/resources/uaa-activator/values.yaml
@@ -13,7 +13,7 @@ global:
 image:
   registryPath: eu.gcr.io/kyma-project
   pullPolicy: IfNotPresent
-  version: "PR-10493"
+  version: "4e3d4a67"
 
 initJobs:
   secret:


### PR DESCRIPTION
Changes proposed in this pull request:

- Bump `uaa-activator` component image to the latest master hash (preparation before release branch creation)