### PR TITLE
Fix Eventing provisioning through KEB

### DIFF
--- a/resources/eventing/templates/backendmodule.yaml
+++ b/resources/eventing/templates/backendmodule.yaml
@@ -1,4 +1,6 @@
+{{- if not (lookup "ui.kyma-project.io/v1alpha1" "BackendModule" "" "eventing") }}
 apiVersion: ui.kyma-project.io/v1alpha1
 kind: BackendModule
 metadata:
   name: eventing
+{{- end }}

--- a/resources/eventing/templates/secret.yaml
+++ b/resources/eventing/templates/secret.yaml
@@ -2,7 +2,6 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ include "eventing.secretName" . }}
-  namespace: {{ .Values.global.secretNamespace }}
   labels: {{- include "eventing.labels" . | nindent 4 }}
 data:
   client-id: "{{ .Values.authentication.oauthClientId | b64enc }}"

--- a/resources/eventing/values.yaml
+++ b/resources/eventing/values.yaml
@@ -7,8 +7,6 @@ global:
   # secretName defines optionally another name than the default secret name
   secretName: ""
 
-  secretNamespace: "kyma-installer"
-
   # domainName is the global domain used in Kyma
   domainName: ""
 


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/master/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**
Fix the issue related to having the secrets in another namespace as the component

Changes proposed in this pull request:

- The  Eventing secrets are deployed in "kyma-system" namespace together with the Eventing pods


**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
See: https://github.com/kyma-project/kyma/issues/10593