### PR TITLE
Multiline parser configuration

### DIFF
--- a/resources/logging/charts/fluent-bit/templates/configmap.yaml
+++ b/resources/logging/charts/fluent-bit/templates/configmap.yaml
@@ -59,13 +59,13 @@ data:
         DB.sync           {{ .Values.config.inputs.tail.dbSync }}
         Mem_Buf_Limit     {{ .Values.config.inputs.tail.memBufLimit }}
         exit_on_eof       {{ .Values.config.inputs.tail.exitOnEof }}
-        {{- if and (.Values.config.inputs.tail.multiline) (eq .Values.config.inputs.tail.multiline "Off") }}
+        {{- if eq .Values.config.inputs.tail.multiline "Off" }}
         Parser            {{ .Values.config.inputs.tail.parser }}
         Docker_Mode       {{ .Values.config.inputs.tail.dockerMode }}
         Docker_Mode_Flush {{ .Values.config.inputs.tail.dockerModeFlush }}
         {{- end }}
         Key               {{ .Values.config.inputs.tail.key }}
-        {{- if and (.Values.config.inputs.tail.multiline) (eq .Values.config.inputs.tail.multiline "On") }}
+        {{- if eq .Values.config.inputs.tail.multiline "On" }}
         Multiline         {{ .Values.config.inputs.tail.multiline }}
         Multiline_Flush   {{ .Values.config.inputs.tail.multilineFlush }}
         Parser_Firstline  {{ .Values.config.inputs.tail.parserFirstline }}

--- a/resources/logging/charts/fluent-bit/templates/configmap.yaml
+++ b/resources/logging/charts/fluent-bit/templates/configmap.yaml
@@ -59,13 +59,13 @@ data:
         DB.sync           {{ .Values.config.inputs.tail.dbSync }}
         Mem_Buf_Limit     {{ .Values.config.inputs.tail.memBufLimit }}
         exit_on_eof       {{ .Values.config.inputs.tail.exitOnEof }}
-        {{- if eq .Values.config.inputs.tail.multiline "Off" }}
+        {{- if and (.Values.config.inputs.tail.multiline) (eq .Values.config.inputs.tail.multiline "Off") }}
         Parser            {{ .Values.config.inputs.tail.parser }}
         Docker_Mode       {{ .Values.config.inputs.tail.dockerMode }}
         Docker_Mode_Flush {{ .Values.config.inputs.tail.dockerModeFlush }}
         {{- end }}
         Key               {{ .Values.config.inputs.tail.key }}
-        {{- if eq .Values.config.inputs.tail.multiline "On" }}
+        {{- if and (.Values.config.inputs.tail.multiline) (eq .Values.config.inputs.tail.multiline "On") }}
         Multiline         {{ .Values.config.inputs.tail.multiline }}
         Multiline_Flush   {{ .Values.config.inputs.tail.multilineFlush }}
         Parser_Firstline  {{ .Values.config.inputs.tail.parserFirstline }}

--- a/resources/logging/charts/fluent-bit/templates/configmap.yaml
+++ b/resources/logging/charts/fluent-bit/templates/configmap.yaml
@@ -59,10 +59,17 @@ data:
         DB.sync           {{ .Values.config.inputs.tail.dbSync }}
         Mem_Buf_Limit     {{ .Values.config.inputs.tail.memBufLimit }}
         exit_on_eof       {{ .Values.config.inputs.tail.exitOnEof }}
+        {{- if eq .Values.config.inputs.tail.multiline "Off" -}}
         Parser            {{ .Values.config.inputs.tail.parser }}
         Docker_Mode       {{ .Values.config.inputs.tail.dockerMode }}
         Docker_Mode_Flush {{ .Values.config.inputs.tail.dockerModeFlush }}
+        {{- end -}}
         Key               {{ .Values.config.inputs.tail.key }}
+        {{- if eq .Values.config.inputs.tail.multiline "On" -}}
+        Multiline         {{ .Values.config.inputs.tail.multiline }}
+        Multiline_Flush   {{ .Values.config.inputs.tail.multilineFlush }}
+        Parser_Firstline  {{ .Values.config.inputs.tail.parserFirstline }}
+        {{- en -}}
         
 {{- end }}
 

--- a/resources/logging/charts/fluent-bit/templates/configmap.yaml
+++ b/resources/logging/charts/fluent-bit/templates/configmap.yaml
@@ -59,17 +59,17 @@ data:
         DB.sync           {{ .Values.config.inputs.tail.dbSync }}
         Mem_Buf_Limit     {{ .Values.config.inputs.tail.memBufLimit }}
         exit_on_eof       {{ .Values.config.inputs.tail.exitOnEof }}
-        {{- if eq .Values.config.inputs.tail.multiline "Off" -}}
+        {{- if eq .Values.config.inputs.tail.multiline "Off" }}
         Parser            {{ .Values.config.inputs.tail.parser }}
         Docker_Mode       {{ .Values.config.inputs.tail.dockerMode }}
         Docker_Mode_Flush {{ .Values.config.inputs.tail.dockerModeFlush }}
-        {{- end -}}
+        {{- end }}
         Key               {{ .Values.config.inputs.tail.key }}
-        {{- if eq .Values.config.inputs.tail.multiline "On" -}}
+        {{- if eq .Values.config.inputs.tail.multiline "On" }}
         Multiline         {{ .Values.config.inputs.tail.multiline }}
         Multiline_Flush   {{ .Values.config.inputs.tail.multilineFlush }}
         Parser_Firstline  {{ .Values.config.inputs.tail.parserFirstline }}
-        {{- end -}}
+        {{- end }}
         
 {{- end }}
 

--- a/resources/logging/charts/fluent-bit/templates/configmap.yaml
+++ b/resources/logging/charts/fluent-bit/templates/configmap.yaml
@@ -69,7 +69,7 @@ data:
         Multiline         {{ .Values.config.inputs.tail.multiline }}
         Multiline_Flush   {{ .Values.config.inputs.tail.multilineFlush }}
         Parser_Firstline  {{ .Values.config.inputs.tail.parserFirstline }}
-        {{- en -}}
+        {{- end -}}
         
 {{- end }}
 

--- a/resources/logging/charts/fluent-bit/templates/kyma-additions/_parsers.tpl
+++ b/resources/logging/charts/fluent-bit/templates/kyma-additions/_parsers.tpl
@@ -119,7 +119,7 @@
 [PARSER]
     Name              java
     Format            regex
-    Regex             ^(?<time>\d{4}-\d{1,2}-\d{1,2} \d{1,2}:\d{1,2}:\d{1,2},\d{1,3}) (?<level>[^\s]+) \d{3,5} \[(?<thread>.*)\] (?<message>.*)
+    Regex             ^(?<time>\d{4}-\d{1,2}-\d{1,2} \d{1,2}:\d{1,2}:\d{1,2},\d{1,3}) (?<level>[^\s]+) \[(?<thread>.*)\] (?<message>.*)
     Time_Key          time
     Time_Format       %Y-%m-%d %H:%M:%S,%L
 {{- end -}}

--- a/resources/logging/charts/fluent-bit/templates/kyma-additions/_parsers.tpl
+++ b/resources/logging/charts/fluent-bit/templates/kyma-additions/_parsers.tpl
@@ -115,4 +115,11 @@
     Name    kube-custom
     Format  regex
     Regex   (?<tag>[^.]+)?\.?(?<pod_name>[a-z0-9](?:[-a-z0-9]*[a-z0-9])?(?:\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*)_(?<namespace_name>[^_]+)_(?<container_name>.+)-(?<docker_id>[a-z0-9]{64})\.log$
+
+[PARSER]
+    Name              java
+    Format            regex
+    Regex             ^(?<time>\d{4}-\d{1,2}-\d{1,2} \d{1,2}:\d{1,2}:\d{1,2},\d{1,3}) (?<level>[^\s]+) \d{3,5} \[(?<thread>.*)\] (?<message>.*)
+    Time_Key          time
+    Time_Format       %Y-%m-%d %H:%M:%S,%L
 {{- end -}}

--- a/resources/logging/charts/fluent-bit/values.yaml
+++ b/resources/logging/charts/fluent-bit/values.yaml
@@ -182,6 +182,12 @@ config:
       dockerModeFlush: 4
       # When a message is unstructured (no parser applied), it's appended as a string under the key name log. This option allows to define an alternative name for that key.
       key: log
+      # If enabled, the plugin will try to discover multiline messages and use the proper parsers to compose the outgoing messages. Note that when this option is enabled the Parser option is not used.
+      multiline: Off
+      # Wait period time in seconds to process queued multiline messages
+      multilineFlush: 4
+      # Name of the parser that matchs the beginning of a multiline message.
+      parserFirstline:
       exclude:
         namespaces:
     additional: ""

--- a/resources/logging/charts/fluent-bit/values.yaml
+++ b/resources/logging/charts/fluent-bit/values.yaml
@@ -183,7 +183,7 @@ config:
       # When a message is unstructured (no parser applied), it's appended as a string under the key name log. This option allows to define an alternative name for that key.
       key: log
       # If enabled, the plugin will try to discover multiline messages and use the proper parsers to compose the outgoing messages. Note that when this option is enabled the Parser option is not used.
-      multiline: Off
+      multiline: "Off"
       # Wait period time in seconds to process queued multiline messages
       multilineFlush: 4
       # Name of the parser that matchs the beginning of a multiline message.


### PR DESCRIPTION
**Description**
This PR add multiline log parser configuration parameters to the fluent-bit log configuration, contains also example log parser for the java application writing logs time stamp with nano seconds, log level, thread_name, and message

**Example:**

<YYYY-mm-dd HH:MM:SS,NANO_SECONDS> <Log_Level> <Thread_Name> <Message>

**Typical log line will look like :**

2021-02-16 14:54:13,086 DEBUG [hz._hzInstance_1_dev.cached.thread-3] com.hazelcast.logging.StandardLoggerFactory$StandardLogger: [100.96.5.50]:5701 [dev] [3.12.10] Sending SplitBrainJoinMessage to [100.96.3.227]:5701
