### PR TITLE
Make kyma-admin user name settable

### DIFF
--- a/resources/cluster-users/templates/rbac-roles.yaml
+++ b/resources/cluster-users/templates/rbac-roles.yaml
@@ -502,7 +502,7 @@ roleRef:
   name: kyma-admin
 subjects:
 - kind: User
-  name: admin@kyma.cx
+  name: {{ .Values.users.adminName }}
   apiGroup: rbac.authorization.k8s.io
 {{ if .Values.users.adminGroup }}
 - kind: Group

--- a/resources/cluster-users/values.yaml
+++ b/resources/cluster-users/values.yaml
@@ -107,4 +107,5 @@ global:
     domainName: "kyma.local"
 
 users:
+  adminName: "admin@kyma.cx"
   adminGroup:


### PR DESCRIPTION
Changes proposed in this pull request:

- Make kyma-admin user name settable, it is necessary to inject by overrides another name of the admin (owner of the cluster/SKR)