### PR TITLE
Fix CVE-2020-1971 for nats-init image

### DIFF
--- a/components/nats-init/Dockerfile
+++ b/components/nats-init/Dockerfile
@@ -1,5 +1,9 @@
-FROM alpine:3.12
+FROM alpine:3.13
 LABEL source=git@github.com:kyma-project/kyma.git
+
+RUN apk update && \
+    ## Solves CVE-2020-1971
+    apk add --no-cache openssl=1.1.1j-r0
 
 WORKDIR /nats-streaming/
 

--- a/resources/nats-streaming/values.yaml
+++ b/resources/nats-streaming/values.yaml
@@ -17,7 +17,7 @@ global:
     path: eu.gcr.io/kyma-project
   natsInit:
     dir: ""
-    version: ac5a2495
+    version: PR-10637
   namespace: natss
   natsStreaming:
     fullname: nats-streaming


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/master/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- Fix CVE-2020-1971 for nats-init image. Release notes are [here](https://www.openssl.org/news/openssl-1.1.1-notes.html).
