### PR TITLE
Move the supported Kubernetes versions to the prerequisites sections in installation docs

### DIFF
--- a/docs/kyma/04-01-overview.md
+++ b/docs/kyma/04-01-overview.md
@@ -52,7 +52,7 @@ A profile is defined globally for the whole Kyma installation. It's not possible
 
 To install Kyma with any of the predefined profiles, follow the instructions described in the [cluster Kyma installation](#installation-install-kyma-on-a-cluster) document and set a profile with the `--profile` flag, as described in the [Install Kyma](#installation-install-kyma-on-a-cluster-install-kyma) section.
 
->**NOTE:** You can also set profiles during the [Kyma upgrade operation](#installation-upgrade-kyma).
+>**NOTE:** You can also set profiles on a running cluster during the [Kyma upgrade operation](#installation-upgrade-kyma).
 
 ## Installation guides
 

--- a/docs/kyma/04-03-cluster-installation.md
+++ b/docs/kyma/04-03-cluster-installation.md
@@ -15,7 +15,7 @@ This installation guide explains how you can quickly deploy Kyma on a cluster wi
   GKE
   </summary>
 
-- Kubernetes cluster running on Google Cloud Platform (GCP) v1.18
+- Kubernetes cluster in v1.18 running on Google Cloud Platform (GCP)
 - [Kyma CLI](https://github.com/kyma-project/cli)
 - [Google Cloud Platform](https://console.cloud.google.com/) (GCP) project with Kubernetes Engine API enabled
 - [kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl/) 1.16.3 or higher
@@ -29,7 +29,7 @@ This installation guide explains how you can quickly deploy Kyma on a cluster wi
   AKS
   </summary>
 
-- Kubernetes cluster running on Azure v1.19
+- Kubernetes cluster in v1.19 running on Azure
 - [Kyma CLI](https://github.com/kyma-project/cli)
 - [Microsoft Azure](https://azure.microsoft.com) account
 - [kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl/) 1.16.3 or higher
@@ -43,7 +43,7 @@ This installation guide explains how you can quickly deploy Kyma on a cluster wi
   Gardener
   </summary>
 
-- Gardener cluster running on AWS, Azure, or GCP v1.19
+- Gardener cluster in v1.19 running on AWS, Azure, or GCP
 - [Kyma CLI](https://github.com/kyma-project/cli)
 - [Gardener](https://gardener.cloud/) account
 - [Google Cloud Platform](https://console.cloud.google.com/) (GCP) project

--- a/docs/kyma/04-03-cluster-installation.md
+++ b/docs/kyma/04-03-cluster-installation.md
@@ -3,14 +3,9 @@ title: Install Kyma on a cluster
 type: Installation
 ---
 
-This installation guide explains how you can quickly deploy Kyma on a cluster with a wildcard DNS provided by [`xip.io`](http://xip.io) using a GitHub release of your choice.
+This installation guide explains how you can quickly deploy Kyma on a cluster with a wildcard DNS provided by [xip.io](http://xip.io) using a GitHub release of your choice.
 
-These are the supported Kubernetes cluster versions:
-- Azure - AKS - 1.19
-- Google Cloud Platform - GKE - 1.18
-- GARDENER on AWS, Azure or GCP - 1.19
-
->**TIP:** An xip.io domain is not recommended for production. If you want to expose the Kyma cluster on your own domain, follow the [installation guide](#installation-install-kyma-with-your-own-domain). To install Kyma using your own image instead of a GitHub release, follow the [instructions](#installation-use-your-own-kyma-installer-image).
+>**TIP:** The xip.io domain is not recommended for production. If you want to expose the Kyma cluster on your own domain, follow the [installation guide](#installation-install-kyma-with-your-own-domain). To install Kyma using your own image instead of a GitHub release, follow the [instructions](#installation-use-your-own-kyma-installer-image).
 
 ## Prerequisites
 
@@ -20,6 +15,7 @@ These are the supported Kubernetes cluster versions:
   GKE
   </summary>
 
+- Kubernetes cluster in Google Cloud Platform (GCP) v1.18
 - [Kyma CLI](https://github.com/kyma-project/cli)
 - [Google Cloud Platform](https://console.cloud.google.com/) (GCP) project with Kubernetes Engine API enabled
 - [kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl/) 1.16.3 or higher
@@ -33,6 +29,7 @@ These are the supported Kubernetes cluster versions:
   AKS
   </summary>
 
+- Kubernetes cluster in Azure v1.19
 - [Kyma CLI](https://github.com/kyma-project/cli)
 - [Microsoft Azure](https://azure.microsoft.com) account
 - [kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl/) 1.16.3 or higher
@@ -46,6 +43,7 @@ These are the supported Kubernetes cluster versions:
   Gardener
   </summary>
 
+- Gardener cluster in AWS, Azure or GCP v1.19
 - [Kyma CLI](https://github.com/kyma-project/cli)
 - [Gardener](https://gardener.cloud/) account
 - [Google Cloud Platform](https://console.cloud.google.com/) (GCP) project

--- a/docs/kyma/04-03-cluster-installation.md
+++ b/docs/kyma/04-03-cluster-installation.md
@@ -43,7 +43,7 @@ This installation guide explains how you can quickly deploy Kyma on a cluster wi
   Gardener
   </summary>
 
-- Gardener cluster in AWS, Azure or GCP v1.19
+- Gardener cluster in AWS, Azure, or GCP v1.19
 - [Kyma CLI](https://github.com/kyma-project/cli)
 - [Gardener](https://gardener.cloud/) account
 - [Google Cloud Platform](https://console.cloud.google.com/) (GCP) project

--- a/docs/kyma/04-03-cluster-installation.md
+++ b/docs/kyma/04-03-cluster-installation.md
@@ -15,7 +15,7 @@ This installation guide explains how you can quickly deploy Kyma on a cluster wi
   GKE
   </summary>
 
-- Kubernetes cluster in Google Cloud Platform (GCP) v1.18
+- Kubernetes cluster running on Google Cloud Platform (GCP) v1.18
 - [Kyma CLI](https://github.com/kyma-project/cli)
 - [Google Cloud Platform](https://console.cloud.google.com/) (GCP) project with Kubernetes Engine API enabled
 - [kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl/) 1.16.3 or higher
@@ -29,7 +29,7 @@ This installation guide explains how you can quickly deploy Kyma on a cluster wi
   AKS
   </summary>
 
-- Kubernetes cluster in Azure v1.19
+- Kubernetes cluster running on Azure v1.19
 - [Kyma CLI](https://github.com/kyma-project/cli)
 - [Microsoft Azure](https://azure.microsoft.com) account
 - [kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl/) 1.16.3 or higher
@@ -43,7 +43,7 @@ This installation guide explains how you can quickly deploy Kyma on a cluster wi
   Gardener
   </summary>
 
-- Gardener cluster in AWS, Azure, or GCP v1.19
+- Gardener cluster running on AWS, Azure, or GCP v1.19
 - [Kyma CLI](https://github.com/kyma-project/cli)
 - [Gardener](https://gardener.cloud/) account
 - [Google Cloud Platform](https://console.cloud.google.com/) (GCP) project

--- a/docs/kyma/04-03-cluster-installation.md
+++ b/docs/kyma/04-03-cluster-installation.md
@@ -15,7 +15,7 @@ This installation guide explains how you can quickly deploy Kyma on a cluster wi
   GKE
   </summary>
 
-- Kubernetes cluster in v1.18 running on Google Cloud Platform (GCP)
+- Kubernetes cluster v1.18
 - [Kyma CLI](https://github.com/kyma-project/cli)
 - [Google Cloud Platform](https://console.cloud.google.com/) (GCP) project with Kubernetes Engine API enabled
 - [kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl/) 1.16.3 or higher
@@ -29,7 +29,7 @@ This installation guide explains how you can quickly deploy Kyma on a cluster wi
   AKS
   </summary>
 
-- Kubernetes cluster in v1.19 running on Azure
+- Kubernetes cluster v1.19
 - [Kyma CLI](https://github.com/kyma-project/cli)
 - [Microsoft Azure](https://azure.microsoft.com) account
 - [kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl/) 1.16.3 or higher
@@ -43,7 +43,7 @@ This installation guide explains how you can quickly deploy Kyma on a cluster wi
   Gardener
   </summary>
 
-- Gardener cluster in v1.19 running on AWS, Azure, or GCP
+- Kubernetes cluster v1.19
 - [Kyma CLI](https://github.com/kyma-project/cli)
 - [Gardener](https://gardener.cloud/) account
 - [Google Cloud Platform](https://console.cloud.google.com/) (GCP) project


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/master/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

The supported Kubernetes cluster versions for each provider are enlisted in the second paragraph of the [installation doc](https://kyma-project.io/docs/master/root/kyma#installation-install-kyma-on-a-cluster). The better place for them would be probably the respective prerequisite section of each provider. 

Changes proposed in this pull request:

- Move the supported Kubernetes versions to the respective prerequisites sections of each provider
- Provide some cosmetic changes to the installation docs

**Related issue(s)**
https://github.com/kyma-project/kyma/issues/10060