### PR TITLE
Remove the old migration guide

### DIFF
--- a/docs/migration-guides/1.18-1.19.md
+++ b/docs/migration-guides/1.18-1.19.md
@@ -1,7 +1,0 @@
-# Migrate from 1.18 to 1.19
-
-## Istio
-
-Kyma 1.19 comes with a new Istio version: 1.8.2. See what changes in the [official Istio upgrade notes](https://istio.io/latest/news/releases/1.8.x/announcing-1.8/).
-
-Ensure Istio sidecars for all Pods are in the proper version after the upgrade. See the [troubleshooting guide](https://kyma-project.io/docs/master/components/service-mesh#troubleshooting-incompatible-istio-sidecar-version-after-kyma-upgrade) for more information.


### PR DESCRIPTION

**Description**

Changes proposed in this pull request:

- Removed the `1.18-1.19.md` migration guide to clean up the guides before the 1.20 release.

