### PR TITLE
better way of configuring the Loki log level

### DIFF
--- a/resources/logging/charts/loki/values.yaml
+++ b/resources/logging/charts/loki/values.yaml
@@ -108,8 +108,8 @@ config:
 #    enable_api: true
 
 ## Additional Loki container arguments, e.g. log level (debug, info, warn, error)
-extraArgs: {}
-  # log.level: debug
+extraArgs:
+  log.level: info
 
 livenessProbe:
   httpGet:

--- a/resources/logging/profile-evaluation.yaml
+++ b/resources/logging/profile-evaluation.yaml
@@ -8,9 +8,8 @@ loki:
       memory: 128Mi
   persistence:
     enabled: false
-  config:
-    server:
-      log_level: warn
+  extraArgs:
+    log.level: warn
 
 fluent-bit:
   resources:

--- a/resources/logging/profile-production.yaml
+++ b/resources/logging/profile-production.yaml
@@ -2,9 +2,8 @@ loki:
   resources:
     limits:
       memory: 512Mi
-  config:
-    server:
-      log_level: warn
+  extraArgs:
+    log.level: warn
 
 fluent-bit:
   resources:


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/master/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**
The log level for Loki is configured with "warn" for the profiles. Unfortunately the used mechanism uses a property inside the Loki secret which is not convinient to change at runtime for imeediate level adjustments.
This PR proposes a different setting via the command args, which easily can be changed at runtime

Changes proposed in this pull request:

- Setting default log level to info using the extraArgs
- Switch profile adjustments to the new way
- ...

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
