### PR TITLE
Rephrase runtime references

### DIFF
--- a/docs/serverless/03-03-registries.md
+++ b/docs/serverless/03-03-registries.md
@@ -13,11 +13,11 @@ Serverless supports two ways of connecting to an external registry:
 
   In this scenario, you can use Kyma overrides to change the default values supplied by the installation mechanism.
 
-- [You can switch to an external registry in the runtime](#tutorials-switch-to-an-external-docker-registry).
+- [You can switch to an external registry at runtime](#tutorials-switch-to-an-external-docker-registry-at-runtime).
 
   In this scenario, you can change the registry on the fly, with Kyma already installed on your cluster. This option gives you way more flexibility and control over the choice of an external registry for your Functions.
 
-## Switching registries in the runtime
+## Switching registries at runtime
 
 When you install Kyma with the default internal registry, Helm creates the `serverless-registry-config-default` Secret in the `kyma-system` Namespace. This Secret contains credentials used by Kubernetes to pull deployed Functions' images from the internal registry. These credentials also allow Kaniko to push any images to the registry each time a Function is created or updated.
 

--- a/docs/serverless/03-05-supported-webhooks.md
+++ b/docs/serverless/03-05-supported-webhooks.md
@@ -14,7 +14,7 @@ The defaulting webhook:
 - Sets default values for CPU and memory requests and limits for a Function.
 - Sets default values for CPU and memory requests and limits for a Kubernetes Job responsible for building the Function's image.
 - Adds the maximum and the minimum number of replicas, if not specified already in the Function CR.
-- Sets the default runtime `nodejs12` unless specified otherwise.
+- Sets the default `nodejs12` runtime unless specified otherwise.
 
    | Parameter       | Default value |
    | ----------------- | ------------- |
@@ -74,9 +74,9 @@ It checks the following conditions for these CRs:
 
 ## Admission webhook
 
-There is also the admission webhook that is only triggered in the scenario when you switch in the runtime from one registry to another.
+There is also the admission webhook that is only triggered in the scenario when you switch at runtime from one registry to another.
 
-To switch registries in the runtime, you must create or update a Secret CR that complies with [specific requirements](#details-switching-registries-in-the-runtime). This Secret CR, among other details, contains a username and password to the registry. The admission webhook encodes these credentials to base64, a format that is required by Kaniko - the Function's job building tool - to access the registry and push a Function's image to it. These encoded credentials also allow Kubernetes to pull images of deployed Functions from the registry. The admission webhook adds these credentials to the created Secret CR. They take the form of the `.dockerconfigjson` entry with a valid value. The admission webhook also updates this entry's value each time the username and password change.
+To switch registries at runtime, you must create or update a Secret CR that complies with [specific requirements](#details-switching-registries-at-runtime). This Secret CR, among other details, contains a username and password to the registry. The admission webhook encodes these credentials to base64, a format that is required by Kaniko - the Function's job building tool - to access the registry and push a Function's image to it. These encoded credentials also allow Kubernetes to pull images of deployed Functions from the registry. The admission webhook adds these credentials to the created Secret CR. They take the form of the `.dockerconfigjson` entry with a valid value. The admission webhook also updates this entry's value each time the username and password change.
 
 ### Requirements
 

--- a/docs/serverless/08-07-switch-to-external-registry.md
+++ b/docs/serverless/08-07-switch-to-external-registry.md
@@ -1,9 +1,9 @@
 ---
-title: Switch to an external Docker registry in the runtime
+title: Switch to an external Docker registry at runtime
 type: Tutorials
 ---
 
-This tutorial shows how you can [switch to an external Docker registry](#details-internal-and-external-registries-switching-registries-in-the-runtime) in a specific Namespace, with Serverless already installed on your cluster. This example relies on the `default` Namespace but you can use any other. You will create a Secret custom resource (CR) with credentials to one of these registries:
+This tutorial shows how you can [switch to an external Docker registry](#details-internal-and-external-registries-switching-registries-at-runtime) in a specific Namespace, with Serverless already installed on your cluster. This example relies on the `default` Namespace but you can use any other. You will create a Secret custom resource (CR) with credentials to one of these registries:
 
 - [Docker Hub](https://hub.docker.com/)
 - [Google Container Registry (GCR)](https://cloud.google.com/container-registry)
@@ -74,7 +74,7 @@ data:
 EOF
 ```
 
-> **CAUTION:** If you want to create a cluster-wide Secret, you must create it in the `kyma-system` Namespace and add the `serverless.kyma-project.io/config: credentials` label. Read more about [requirements for Secret CRs](#details-switching-registries-in-the-runtime).
+> **CAUTION:** If you want to create a cluster-wide Secret, you must create it in the `kyma-system` Namespace and add the `serverless.kyma-project.io/config: credentials` label. Read more about [requirements for Secret CRs](#details-switching-registries-at-runtime).
 
 ### Test the registry switch
 


### PR DESCRIPTION


**Description**

Changes proposed in this pull request:

- Change phrasing in Serverless docs: `in the runtime` -> `at runtime`