### PR TITLE
generic-make-go: change pull-licenses to local

### DIFF
--- a/common/makefiles/generic-make-go.mk
+++ b/common/makefiles/generic-make-go.mk
@@ -85,7 +85,7 @@ release:
 release-dep: resolve dep-status verify build-image push-image
 
 .PHONY: build-image push-image
-build-image: pull-licenses
+build-image: pull-licenses-local
 	docker build -t $(IMG_NAME) .
 push-image: post-pr-tag-image
 	docker tag $(IMG_NAME) $(IMG_NAME):$(TAG)
@@ -99,7 +99,7 @@ ifdef DOCKER_POST_PR_TAG
 endif
 
 # Targets mounting sources to buildpack
-MOUNT_TARGETS = build resolve ensure dep-status check-imports imports check-fmt fmt errcheck vet generate pull-licenses gqlgen
+MOUNT_TARGETS = build resolve ensure dep-status check-imports imports check-fmt fmt errcheck vet generate gqlgen
 $(foreach t,$(MOUNT_TARGETS),$(eval $(call buildpack-mount,$(t))))
 
 build-local:
@@ -179,6 +179,8 @@ check-gqlgen:
 		exit 1; \
 	fi;
 
+pull-licenses: pull-licenses-local
+
 pull-licenses-local:
 ifdef LICENSE_PULLER_PATH
 	bash $(LICENSE_PULLER_PATH)
@@ -191,6 +193,7 @@ COPY_TARGETS = test
 $(foreach t,$(COPY_TARGETS),$(eval $(call buildpack-cp-ro,$(t))))
 
 test-local:
+	mkdir -p /tmp/artifacts
 	go test -coverprofile=/tmp/artifacts/cover.out ./...
 	@echo -n "Total coverage: "
 	@go tool cover -func=/tmp/artifacts/cover.out | grep total | awk '{print $$3}'


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/master/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- change `pull-licenses` to `pull-licenses-local`, to allow us to skip downloading buildpack image in next PRs 
- generate `/tmp/artifacts` for `test-local`, since we want to skip Docker run if possible, which was generating that folder automatically before `test-local` was called

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
kyma-project/test-infra#3273