### PR TITLE
Increase timeout for the pre-master-serverless-integration-k3s pipeline

### DIFF
--- a/resources/serverless/values.yaml
+++ b/resources/serverless/values.yaml
@@ -41,7 +41,7 @@ tests:
 
   image:
     repository: "eu.gcr.io/kyma-project/function-controller-test"
-    tag: "f3bfca27"
+    tag: "PR-10737"
     pullPolicy: IfNotPresent
   disableConcurrency: false
   restartPolicy: Never

--- a/tests/function-controller/testsuite/scenarios/light_runtimes.go
+++ b/tests/function-controller/testsuite/scenarios/light_runtimes.go
@@ -47,7 +47,7 @@ func SimpleFunctionTest(restConfig *rest.Config, cfg testsuite.Config, logf *log
 		Log:         logf,
 	}
 
-	nodejs12Cfg, err := runtimes.NewFunctionSimpleConfig("nodejs12", genericContainer.WithLogger(python38Logger))
+	nodejs12Cfg, err := runtimes.NewFunctionSimpleConfig("nodejs12", genericContainer.WithLogger(nodejs12Logger))
 	if err != nil {
 		return nil, errors.Wrapf(err, "while creating nodejs12 config")
 	}

--- a/tests/function-controller/testsuite/teststep/check.go
+++ b/tests/function-controller/testsuite/teststep/check.go
@@ -46,8 +46,8 @@ func (h HTTPCheck) Run() error {
 	// the language specific server may not start yet
 	// there may also be some problems with istio sidecars etc
 	backoff := wait.Backoff{
-		Steps:    6,
-		Duration: 250 * time.Millisecond,
+		Steps:    10,
+		Duration: 500 * time.Millisecond,
 		Factor:   2.0,
 		Jitter:   0.1,
 	}


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/master/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- increase the timeout in python38 scenario
- fix logging in nodejs12 scenario

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
https://github.com/kyma-project/kyma/issues/10717