### PR TITLE
Replace original cert-manager's images with Kyma external images

### DIFF
--- a/resources/cert-manager/values.yaml
+++ b/resources/cert-manager/values.yaml
@@ -39,7 +39,7 @@ strategy: {}
 featureGates: ""
 
 image:
-  repository: quay.io/jetstack/cert-manager-controller
+  repository: eu.gcr.io/kyma-project/external/quay.io/jetstack/cert-manager-controller:v1.1.0
   # You can manage a registry with
   # registry: quay.io
   # repository: jetstack/cert-manager-controller
@@ -243,7 +243,7 @@ webhook:
   podLabels: {}
 
   image:
-    repository: quay.io/jetstack/cert-manager-webhook
+    repository: eu.gcr.io/kyma-project/external/quay.io/jetstack/cert-manager-webhook:v1.1.0
     # You can manage a registry with
     # registry: quay.io
     # repository: jetstack/cert-manager-webhook
@@ -330,7 +330,7 @@ cainjector:
   podLabels: {}
 
   image:
-    repository: quay.io/jetstack/cert-manager-cainjector
+    repository: eu.gcr.io/kyma-project/external/quay.io/jetstack/cert-manager-cainjector:v1.1.0
     # You can manage a registry with
     # registry: quay.io
     # repository: jetstack/cert-manager-cainjector


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/master/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- swap three cert-manager's images to the ones pushed into the Kyma external artifactory
- merged external-images PR: https://github.com/kyma-project/test-infra/pull/3292
- build containing refs to the new images: https://storage.googleapis.com/kyma-prow-logs/logs/post-master-test-infra-image-syncer-run/1360219417429938176/build-log.txt

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
Implements #10336 