### PR TITLE
Fix links in documentation

### DIFF
--- a/components/event-sources/README.md
+++ b/components/event-sources/README.md
@@ -20,7 +20,7 @@ $ make
 
 ### Run the controller inside the cluster
 
-To deploy the controller inside a cluster, make sure you have `ko` installed and configured according to the [usage instructions](https://github.com/google/ko#usage), then run:
+To deploy the controller inside a cluster, make sure you have `ko` installed and configured according to the [instructions](https://github.com/google/ko#setup), then run:
 
 ```console
 $ ko apply -f config/

--- a/components/eventing-controller/README.md
+++ b/components/eventing-controller/README.md
@@ -13,8 +13,8 @@ This component contains controllers for various CustomResourceDefinitions relate
 
 ### Installation
 
-- To deploy the controllers inside a cluster, make sure you have `ko` installed and configured according to the [usage instructions](https://github.com/google/ko#usage).
- 
+- To deploy the controllers inside a cluster, make sure you have `ko` installed and configured according to the [instructions](https://github.com/google/ko#setup).
+
 - For `controller`, run:
 
     ```sh


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/master/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- Fix links in documentation which gave a[ prow job error ](https://storage.googleapis.com/kyma-prow-logs/logs/kyma-governance-nightly/1365149865088126976/build-log.txt) because the anchor is not called `usage` anymore. 

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
