### PR TITLE
Increase memory limit for eventing controller

### DIFF
--- a/resources/eventing/charts/controller/values.yaml
+++ b/resources/eventing/charts/controller/values.yaml
@@ -24,7 +24,7 @@ podSecurityContext:
 resources:
   limits:
     cpu: 100m
-    memory: 128Mi
+    memory: 192Mi
   requests:
     cpu: 30m
     memory: 32Mi

--- a/resources/eventing/charts/controller/values.yaml
+++ b/resources/eventing/charts/controller/values.yaml
@@ -21,6 +21,14 @@ image:
 
 podSecurityContext:
 
+resources:
+  limits:
+    cpu: 100m
+    memory: 128Mi
+  requests:
+    cpu: 30m
+    memory: 64Mi
+
 bebSecret:
   nameSuffix: "-beb-oauth2"
 

--- a/resources/eventing/charts/controller/values.yaml
+++ b/resources/eventing/charts/controller/values.yaml
@@ -27,7 +27,7 @@ resources:
     memory: 128Mi
   requests:
     cpu: 30m
-    memory: 64Mi
+    memory: 32Mi
 
 bebSecret:
   nameSuffix: "-beb-oauth2"


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/master/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- increase memory limit from 96MB to 192MB  for eventing controller in evaluation profile to hopefully avoid `applicationtest` OOM errors:

![Screenshot 2021-03-02 at 11 20 50](https://user-images.githubusercontent.com/5176598/109634294-5db67600-7b49-11eb-8efb-10e9fc58443d.png)


**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
https://github.com/kyma-project/test-infra/issues/3300