### PR TITLE
Disable version info from grafana in case of anonymous users

### DIFF
--- a/resources/monitoring/charts/grafana/values.yaml
+++ b/resources/monitoring/charts/grafana/values.yaml
@@ -321,6 +321,7 @@ env:
   # https://grafana.com/docs/grafana/latest/auth/overview/
   GF_AUTH_ANONYMOUS_ENABLED: "false"
   GF_AUTH_ANONYMOUS_ORG_ROLE: "Editor"
+  GF_AUTH_ANONYMOUS_HIDE_VERSION: "true"
   GF_AUTH_OAUTH_AUTO_LOGIN: "true"
   GF_AUTH_DISABLE_LOGIN_FORM: "true"
   GF_AUTH_PROXY_ENABLED: "false"


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/master/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

In the anonymous not logged in views the grafana version info gets exposed as part of the html sources. This should be disabled to not have potential leaks of internals. Setting the HIDE_VERSION flag will fix that problem, see https://github.com/grafana/grafana/blob/1b149523edc2f9add9dc4f816e4895b827db1b83/conf/defaults.ini#L367

Changes proposed in this pull request:

- Setting the HIDE_VERSION flag by default, having it configurable
- ...
- ...

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
