### PR TITLE
Add flag to toggle SM broker credentials rotation

### DIFF
--- a/resources/service-manager-proxy/templates/deployment.yaml
+++ b/resources/service-manager-proxy/templates/deployment.yaml
@@ -47,6 +47,8 @@ spec:
           mountPath: {{ .Values.file.location }}
           readOnly: true
         env:
+        - name: BROKER_CREDENTIALS_ENABLED
+          value: {{ .Values.config.brokerCredentials.enabled }}
         - name: K8S_SECRET_NAME
           value: {{ template "service-broker-proxy.fullname" . }}-regsecret
         - name: K8S_SECRET_NAMESPACE

--- a/resources/service-manager-proxy/templates/deployment.yaml
+++ b/resources/service-manager-proxy/templates/deployment.yaml
@@ -47,8 +47,6 @@ spec:
           mountPath: {{ .Values.file.location }}
           readOnly: true
         env:
-        - name: BROKER_CREDENTIALS_ENABLED
-          value: {{ .Values.config.brokerCredentials.enabled }}
         - name: K8S_SECRET_NAME
           value: {{ template "service-broker-proxy.fullname" . }}-regsecret
         - name: K8S_SECRET_NAMESPACE
@@ -63,6 +61,8 @@ spec:
             secretKeyRef:
               name: {{ template "service-broker-proxy.fullname" . }}-regsecret
               key: password
+        - name: APP_BROKER_CREDENTIALS_ENABLED
+          value: '{{ .Values.config.app.broker_credentials_enabled }}'
         - name: APP_URL
           {{- if .Values.config.app.url }}
           value: {{ .Values.config.app.url }}

--- a/resources/service-manager-proxy/values.yaml
+++ b/resources/service-manager-proxy/values.yaml
@@ -1,10 +1,8 @@
 config:
-  # brokerCredentials allows to disable credentials rotation
-  brokerCredentials:
-    enabled: false
   app:
     legacy_url: null
     url: null
+    broker_credentials_enabled: true
   authn:
     client_id: null
     password: admin
@@ -41,7 +39,7 @@ image:
   pullPolicy: IfNotPresent
   pullsecret: null
   repository: eu.gcr.io/kyma-project/external/quay.io/service-manager/sb-proxy-k8s
-  tag: v0.8.15
+  tag: v0.8.16
 replicaCount: 1
 securityContext: { }
 service:

--- a/resources/service-manager-proxy/values.yaml
+++ b/resources/service-manager-proxy/values.yaml
@@ -1,4 +1,7 @@
 config:
+  # brokerCredentials allows to disable credentials rotation
+  brokerCredentials:
+    enabled: false
   app:
     legacy_url: null
     url: null
@@ -24,10 +27,16 @@ config:
     request_timeout: 2m
     skip_ssl_validation: false
     url: http://service-manager.dev.cfdev.sh
+
 file:
   format: yml
   location: /etc/config
   name: application
+
+sm:
+  password: admin
+  user: admin
+
 image:
   pullPolicy: IfNotPresent
   pullsecret: null
@@ -38,9 +47,6 @@ securityContext: { }
 service:
   port: 80
   type: ClusterIP
-sm:
-  password: admin
-  user: admin
 
 resources:
   limits:


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/master/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**
Aligning chart with latest version from [service-broker-proxy-k8s/#124](https://github.com/Peripli/service-broker-proxy-k8s/pull/124)

Changes proposed in this pull request:

- Added `BROKER_CREDENTIALS_ENABLED` env variable which toggles SM broker credentials rotation

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
