### PR TITLE
Upgrade test

### DIFF
--- a/tests/fast-integration/test/fixtures/commerce-mock/index.js
+++ b/tests/fast-integration/test/fixtures/commerce-mock/index.js
@@ -130,7 +130,7 @@ async function registerAllApis(mockHost) {
             "content-type": "application/json",
             origin: `https://${mockHost}`,
           },
-          timeout: 5000
+          timeout: 30000
         }
       ).catch((err) => {
         throw convertAxiosError(err, "Error during Commerce Mock API registration");

--- a/tests/fast-integration/test/fixtures/commerce-mock/index.js
+++ b/tests/fast-integration/test/fixtures/commerce-mock/index.js
@@ -114,7 +114,7 @@ async function sendEventAndCheckResponse() {
 
 async function registerAllApis(mockHost) {
   debug("Listing Commerce Mock local APIs")
-  const localApis = axios.get(`https://${mockHost}/local/apis`, { timeout: 5000 }).catch((err) => {
+  const localApis = await axios.get(`https://${mockHost}/local/apis`, { timeout: 5000 }).catch((err) => {
     throw convertAxiosError(err, "API registration error - commerce mock local API not available");
   });
   debug("Commerce Mock local APIs received")

--- a/tests/fast-integration/test/fixtures/commerce-mock/index.js
+++ b/tests/fast-integration/test/fixtures/commerce-mock/index.js
@@ -25,6 +25,7 @@ const {
   k8sAppsApi,
   k8sDynamicApi,
   deleteNamespaces,
+  debug,
 } = require("../../../utils");
 
 const commerceMockYaml = fs.readFileSync(
@@ -112,6 +113,7 @@ async function sendEventAndCheckResponse() {
 }
 
 async function registerAllApis(mockHost) {
+  debug("Listing Commerce Mock local APIs")
   const localApis = await retryPromise(
     () => axios.get(`https://${mockHost}/local/apis`, { timeout: 5000 }).catch((err) => {
       throw convertAxiosError(err, "API registration error - commerce mock local API not available");
@@ -120,6 +122,7 @@ async function registerAllApis(mockHost) {
     1,
     3000
   );
+  debug("Commerce Mock local APIs received")
   const filteredApis = localApis.data.filter((api) => (api.name.includes("Commerce Webservices") || api.name.includes("Events")));
   for (let api of filteredApis) {
     await retryPromise(
@@ -143,6 +146,7 @@ async function registerAllApis(mockHost) {
       3000
     );
   }
+  debug("Verifying if APIs are properly registered")
 
   const remoteApis = await axios
     .get(`https://${mockHost}/remote/apis`)
@@ -150,6 +154,7 @@ async function registerAllApis(mockHost) {
       throw convertAxiosError(err, "Commerce Mock registered apis not available");
     });
   expect(remoteApis.data).to.have.lengthOf.at.least(2);
+  debug("Commerce APIs registered");
   return remoteApis;
 }
 
@@ -176,7 +181,9 @@ async function connectMock(mockHost, targetNamespace) {
     baseUrl: `https://${mockHost}`,
     insecure: true,
   };
+  debug("Token URL", tokenObj.status.url);
   await connectCommerceMock(mockHost, pairingBody);
+  debug("Commerce mock connected");
 }
 
 async function connectCommerceMock(mockHost, tokenData) {

--- a/tests/fast-integration/test/fixtures/commerce-mock/index.js
+++ b/tests/fast-integration/test/fixtures/commerce-mock/index.js
@@ -93,18 +93,18 @@ async function sendEventAndCheckResponse() {
       return axios
         .get(`https://lastorder.${host}`, { timeout: 5000 })
         .then((res) => {
-          expect(res.data).to.have.nested.property("event.data.orderCode","567");        
+          expect(res.data).to.have.nested.property("event.data.orderCode", "567");
           // See: https://github.com/kyma-project/kyma/issues/10720
-          expect(res.data).to.have.nested.property("event.ce-type").that.contains("order.created"); 
-          expect(res.data).to.have.nested.property("event.ce-source"); 
-          expect(res.data).to.have.nested.property("event.ce-eventtypeversion","v1");
-          expect(res.data).to.have.nested.property("event.ce-specversion","1.0");
+          expect(res.data).to.have.nested.property("event.ce-type").that.contains("order.created");
+          expect(res.data).to.have.nested.property("event.ce-source");
+          expect(res.data).to.have.nested.property("event.ce-eventtypeversion", "v1");
+          expect(res.data).to.have.nested.property("event.ce-specversion", "1.0");
           expect(res.data).to.have.nested.property("event.ce-id");
           expect(res.data).to.have.nested.property("event.ce-time");
           return res;
         })
-        .catch((e) => { 
-          throw convertAxiosError(e, "Error during request to function lastorder") 
+        .catch((e) => {
+          throw convertAxiosError(e, "Error during request to function lastorder")
         });
     },
     30,
@@ -114,37 +114,26 @@ async function sendEventAndCheckResponse() {
 
 async function registerAllApis(mockHost) {
   debug("Listing Commerce Mock local APIs")
-  const localApis = await retryPromise(
-    () => axios.get(`https://${mockHost}/local/apis`, { timeout: 5000 }).catch((err) => {
-      throw convertAxiosError(err, "API registration error - commerce mock local API not available");
-    }
-    ),
-    1,
-    3000
-  );
+  axios.get(`https://${mockHost}/local/apis`, { timeout: 5000 }).catch((err) => {
+    throw convertAxiosError(err, "API registration error - commerce mock local API not available");
+  });
   debug("Commerce Mock local APIs received")
   const filteredApis = localApis.data.filter((api) => (api.name.includes("Commerce Webservices") || api.name.includes("Events")));
   for (let api of filteredApis) {
-    await retryPromise(
-      async () => {
-        await axios
-          .post(
-            `https://${mockHost}/local/apis/${api.id}/register`,
-            {},
-            {
-              headers: {
-                "content-type": "application/json",
-                origin: `https://${mockHost}`,
-              },
-              timeout: 5000
-            }
-          ).catch((err) => {
-            throw convertAxiosError(err, "Error during Commerce Mock API registration");
-          });
-      },
-      10,
-      3000
-    );
+    await axios
+      .post(
+        `https://${mockHost}/local/apis/${api.id}/register`,
+        {},
+        {
+          headers: {
+            "content-type": "application/json",
+            origin: `https://${mockHost}`,
+          },
+          timeout: 5000
+        }
+      ).catch((err) => {
+        throw convertAxiosError(err, "Error during Commerce Mock API registration");
+      });
   }
   debug("Verifying if APIs are properly registered")
 

--- a/tests/fast-integration/test/fixtures/commerce-mock/index.js
+++ b/tests/fast-integration/test/fixtures/commerce-mock/index.js
@@ -114,12 +114,13 @@ async function sendEventAndCheckResponse() {
 
 async function registerAllApis(mockHost) {
   debug("Listing Commerce Mock local APIs")
-  axios.get(`https://${mockHost}/local/apis`, { timeout: 5000 }).catch((err) => {
+  const localApis = axios.get(`https://${mockHost}/local/apis`, { timeout: 5000 }).catch((err) => {
     throw convertAxiosError(err, "API registration error - commerce mock local API not available");
   });
   debug("Commerce Mock local APIs received")
   const filteredApis = localApis.data.filter((api) => (api.name.includes("Commerce Webservices") || api.name.includes("Events")));
   for (let api of filteredApis) {
+    debug("Registering", api.name)
     await axios
       .post(
         `https://${mockHost}/local/apis/${api.id}/register`,


### PR DESCRIPTION
- Increase the timeout for API registration from 5 to 30 seconds.
- Remove retries inside the API registration function as an entire function is retried already