### PR TITLE
Use kyma-installer priority class for CRD install job

### DIFF
--- a/resources/cluster-essentials/templates/crd-install-job.yaml
+++ b/resources/cluster-essentials/templates/crd-install-job.yaml
@@ -58,5 +58,5 @@ spec:
       {{- end }}
       {{ end }}
     {{- if .Values.global.priorityClassName }}
-      priorityClassName: {{ .Values.global.priorityClassName }}
+      priorityClassName: kyma-installer
     {{- end }}


### PR DESCRIPTION
**Description**

CRD install job is a pre-install helm hook, and when Kyma is installed the first time the priority class created by the same cluster-essentials chart is not yet deployed when the job runs.

Cherry pick of https://github.com/kyma-project/kyma/pull/10791
