### PR TITLE
dynamic configuration for grafana datasources

### DIFF
--- a/docs/monitoring/03-02-istio.md
+++ b/docs/monitoring/03-02-istio.md
@@ -15,7 +15,7 @@ See the diagram for a broader view of how the Istio-related instance fits into t
 
 ![Istio Monitoring](./assets/monitoring-istio.svg)
 
-By default, `minitoring-prometheus-istio-server` is not provided as a data source in Grafana. However, this can be enabled by adding the override: 
+By default, `monitoring-prometheus-istio-server` is not provided as a data source in Grafana. However, this can be enabled by adding the override: 
 
  ```bash
 cat <<EOF | kubectl apply -f -
@@ -30,7 +30,7 @@ metadata:
     component: monitoring
     kyma-project.io/installation: ""
 data:
-    grafana.dataSources.prometheusIstio.enabled: "true"
+    prometheus-istio.grafana.datasource.enabled: "true"
 EOF
 ```
 

--- a/resources/logging/charts/fluent-bit/templates/kyma-additions/grafana-dashboard.yaml
+++ b/resources/logging/charts/fluent-bit/templates/kyma-additions/grafana-dashboard.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: fluent-bit-dashboard
+  name: {{ template "fluent-bit.fullname" . }}-grafana-dashboard
   labels:
     grafana_dashboard: "1"
     {{- include "fluent-bit.labels" . | nindent 4 }}
@@ -1385,7 +1385,7 @@ data:
                 }
                 }
             ],
-            "refresh": "5s",
+            "refresh": "10s",
             "schemaVersion": 22,
             "style": "dark",
             "tags": ["logging","kyma"],
@@ -1393,7 +1393,7 @@ data:
                 "list": []
             },
             "time": {
-                "from": "now-15m",
+                "from": "now-1h",
                 "to": "now"
             },
             "timepicker": {

--- a/resources/logging/charts/loki/templates/kyma-additions/grafana-datasource.yaml
+++ b/resources/logging/charts/loki/templates/kyma-additions/grafana-datasource.yaml
@@ -1,0 +1,28 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ template "loki.fullname" . }}-grafana-datasource
+  labels:
+    grafana_datasource: "1"
+    app: {{ template "loki.name" . }}
+    chart: {{ template "loki.chart" . }}
+    release: {{ .Release.Name }}
+data:
+    loki-datasource.yaml: |-
+      apiVersion: 1
+      datasources:
+      - name: Loki
+        type: loki
+        access: proxy
+        url: http://{{ template "loki.fullname" . }}.{{ .Release.Namespace }}:{{ .Values.service.port }}
+        editable: true
+        jsonData:
+          maxLines: 1000
+{{- if .Values.global.tracing.enabled }}
+          derivedFields:
+          - datasourceUid: Jaeger
+            matcherRegex: "traceId=(\\w+)"
+            name: TraceID
+            # url will be interpreted as query for the datasource
+            url: "$${__value.raw}"
+{{- end }}

--- a/resources/logging/charts/loki/templates/kyma-additions/grafana-datasource.yaml
+++ b/resources/logging/charts/loki/templates/kyma-additions/grafana-datasource.yaml
@@ -20,9 +20,5 @@ data:
           maxLines: 1000
 {{- if .Values.global.tracing.enabled }}
           derivedFields:
-          - datasourceUid: Jaeger
-            matcherRegex: "traceId=(\\w+)"
-            name: TraceID
-            # url will be interpreted as query for the datasource
-            url: "$${__value.raw}"
+            {{- tpl .Values.grafana.datasource.derivedFields . | nindent 10}}
 {{- end }}

--- a/resources/logging/charts/loki/values.yaml
+++ b/resources/logging/charts/loki/values.yaml
@@ -279,3 +279,10 @@ kyma:
   auth:
     useKymaGroups: false
     groups: ""
+grafana:
+  datasource:
+    derivedFields: |
+      - datasourceUid: Jaeger
+        matcherRegex: "traceId=(\\w+)"
+        name: TraceID
+        url: "$${__value.raw}"

--- a/resources/logging/values.yaml
+++ b/resources/logging/values.yaml
@@ -42,3 +42,5 @@ global:
     gateway:
       name: kyma-gateway
       namespace: kyma-system
+  tracing:
+    enabled: true

--- a/resources/monitoring/charts/grafana/templates/kyma-additions/backendmodule.yaml
+++ b/resources/monitoring/charts/grafana/templates/kyma-additions/backendmodule.yaml
@@ -5,5 +5,7 @@
 apiVersion: ui.kyma-project.io/v1alpha1
 kind: BackendModule
 metadata:
-  name: grafana
+  name: {{ template "grafana.fullname" . }}
+  labels:
+    {{- include "grafana.labels" . | nindent 4 }}
 {{- end }}

--- a/resources/monitoring/charts/grafana/templates/kyma-additions/grafana-dashboard.yaml
+++ b/resources/monitoring/charts/grafana/templates/kyma-additions/grafana-dashboard.yaml
@@ -1,10 +1,10 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: grafana-dashboard
+  name: {{ template "grafana.fullname" . }}-grafana-dashboard
   labels:
+    {{- include "grafana.labels" . | nindent 4 }}
     grafana_dashboard: "1"
-    app: monitoring-grafana
 data:
   grafana-dashboard.json: |-
     {

--- a/resources/monitoring/charts/grafana/templates/kyma-additions/logs-microfrontend.yaml
+++ b/resources/monitoring/charts/grafana/templates/kyma-additions/logs-microfrontend.yaml
@@ -5,7 +5,7 @@
 apiVersion: "ui.kyma-project.io/v1alpha1"
 kind: ClusterMicroFrontend
 metadata:
-  name: {{ template "grafana.name" . }}-logs
+  name: {{ template "grafana.fullname" . }}-logs
   labels:
     {{- include "grafana.labels" . | nindent 4 }}
 spec:

--- a/resources/monitoring/charts/grafana/templates/kyma-additions/metrics-microfrontend.yaml
+++ b/resources/monitoring/charts/grafana/templates/kyma-additions/metrics-microfrontend.yaml
@@ -5,7 +5,7 @@
 apiVersion: "ui.kyma-project.io/v1alpha1"
 kind: ClusterMicroFrontend
 metadata:
-  name: {{ template "grafana.name" . }}-metrics
+  name: {{ template "grafana.fullname" . }}-metrics
   labels:
     {{- include "grafana.labels" . | nindent 4 }}
 spec:

--- a/resources/monitoring/charts/prometheus-istio/templates/kyma-additions/grafana-datasource.yaml
+++ b/resources/monitoring/charts/prometheus-istio/templates/kyma-additions/grafana-datasource.yaml
@@ -1,0 +1,18 @@
+{{- if .Values.grafana.datasource.enabled }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ template "prometheus.server.fullname" . }}-grafana-datasource
+  labels:
+    {{- include "prometheus.server.labels" . | nindent 4 }}
+    grafana_datasource: "1"
+data:
+    prometheus-istio-datasource.yaml: |-
+      apiVersion: 1
+      datasources:
+      - name: Prometheus-Istio
+        type: prometheus
+        access: proxy
+        url: http://{{ template "prometheus.server.fullname" . }}.{{ .Release.Namespace }}:{{ .Values.server.service.servicePort }}
+        editable: true
+{{- end }}

--- a/resources/monitoring/charts/prometheus-istio/values.yaml
+++ b/resources/monitoring/charts/prometheus-istio/values.yaml
@@ -1316,3 +1316,7 @@ networkPolicy:
 
 # Force namespace of namespaced resources
 forceNamespace: null
+
+grafana:
+  datasource:
+    enabled: false

--- a/resources/monitoring/templates/grafana/configmaps-datasources.yaml
+++ b/resources/monitoring/templates/grafana/configmaps-datasources.yaml
@@ -32,15 +32,6 @@ data:
 {{- end }}
 {{- end }}
 {{- end }}
-{{- if .Values.grafana.dataSources.loki.enabled }}
-{{ toYaml .Values.grafana.dataSources.loki.config | indent 4}}
-{{- end }}
-{{- if .Values.grafana.dataSources.jaeger.enabled }}
-{{ toYaml .Values.grafana.dataSources.jaeger.config | indent 4}}
-{{- end }}
-{{- if (and .Values.grafana.dataSources.prometheusIstio.enabled (index .Values "prometheus-istio").enabled )}}
-{{ toYaml .Values.grafana.dataSources.prometheusIstio.config | indent 4}}
-{{- end }}
 {{- if .Values.grafana.additionalDataSources }}
 {{ tpl (toYaml .Values.grafana.additionalDataSources | indent 4) . }}
 {{- end }}

--- a/resources/monitoring/templates/grafana/kyma-dashboards/alertmanager.yaml
+++ b/resources/monitoring/templates/grafana/kyma-dashboards/alertmanager.yaml
@@ -1,10 +1,10 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: alertmanager-dashboard
+  name: {{ template "kube-prometheus-stack.fullname" . }}-alertmanager-grafana-dashboard
   labels:
     grafana_dashboard: "1"
-    app: monitoring-grafana
+    app: {{ template "kube-prometheus-stack.name" $ }}-grafana
 data:
   alertmanager-dashboard.json: |-
     {

--- a/resources/monitoring/templates/grafana/kyma-dashboards/apiserver.yaml
+++ b/resources/monitoring/templates/grafana/kyma-dashboards/apiserver.yaml
@@ -1,10 +1,10 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: apiserver-dashboard
+  name: {{ template "kube-prometheus-stack.fullname" . }}-apiserver-grafana-dashboard
   labels:
     grafana_dashboard: "1"
-    app: monitoring-grafana
+    app: {{ template "kube-prometheus-stack.name" $ }}-grafana
 data:
   apiserver-dashboard.json: |-
     {

--- a/resources/monitoring/templates/grafana/kyma-dashboards/kubernetes-apiserver-per-client.yaml
+++ b/resources/monitoring/templates/grafana/kyma-dashboards/kubernetes-apiserver-per-client.yaml
@@ -1,10 +1,10 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: kubernetes-apiserver-per-client-dashboard
+  name: {{ template "kube-prometheus-stack.fullname" . }}-apiserver-per-client-grafana-dashboard
   labels:
     grafana_dashboard: "1"
-    app: monitoring-grafana
+    app: {{ template "kube-prometheus-stack.name" $ }}-grafana
 data:
   kubernetes-apiserver-per-client-dashboard.json: |-
     {

--- a/resources/monitoring/templates/grafana/kyma-dashboards/kyma-backends.yaml
+++ b/resources/monitoring/templates/grafana/kyma-dashboards/kyma-backends.yaml
@@ -1,10 +1,10 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: monitoring-kyma-backends-dashboard
+  name: {{ template "kube-prometheus-stack.fullname" . }}-kyma-backends-grafana-dashboard
   labels:
     grafana_dashboard: "1"
-    app: monitoring-grafana
+    app: {{ template "kube-prometheus-stack.name" $ }}-grafana
 data:
   kyma-backends-dashboard.json: |-
     {

--- a/resources/monitoring/templates/grafana/kyma-dashboards/kyma-controllers.yaml
+++ b/resources/monitoring/templates/grafana/kyma-dashboards/kyma-controllers.yaml
@@ -1,10 +1,10 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: monitoring-kyma-controllers-dashboard
+  name: {{ template "kube-prometheus-stack.fullname" . }}-kyma-controllers-grafana-dashboard
   labels:
     grafana_dashboard: "1"
-    app: monitoring-grafana
+    app: {{ template "kube-prometheus-stack.name" $ }}-grafana
 data:
   kyma-controllers-dashboard.json: |-
     {

--- a/resources/monitoring/templates/grafana/kyma-dashboards/kyma-frontends.yaml
+++ b/resources/monitoring/templates/grafana/kyma-dashboards/kyma-frontends.yaml
@@ -1,10 +1,10 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: monitoring-kyma-frontends-dashboard
+  name: {{ template "kube-prometheus-stack.fullname" . }}-kyma-frontends-grafana-dashboard
   labels:
     grafana_dashboard: "1"
-    app: monitoring-grafana
+    app: {{ template "kube-prometheus-stack.name" $ }}-grafana
 data:
   kyma-frontends-dashboard.json: |-
     {

--- a/resources/monitoring/templates/grafana/kyma-dashboards/pods.yaml
+++ b/resources/monitoring/templates/grafana/kyma-dashboards/pods.yaml
@@ -1,10 +1,10 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: monitoring-kyma-pods
+  name: {{ template "kube-prometheus-stack.fullname" . }}-kyma-pods-grafana-dashboard
   labels:
     grafana_dashboard: "1"
-    app: monitoring-grafana
+    app: {{ template "kube-prometheus-stack.name" $ }}-grafana
 data:
 data:
   pods.json: |-

--- a/resources/monitoring/values.yaml
+++ b/resources/monitoring/values.yaml
@@ -615,14 +615,14 @@ grafana:
     dashboards:
       enabled: true
       label: grafana_dashboard
-
+      searchNamespace: ALL
       ## Annotations for Grafana dashboard configmaps
       ##
       annotations: {}
     datasources:
       enabled: true
       defaultDatasourceEnabled: true
-
+      searchNamespace: ALL
       ## Annotations for Grafana datasource configmaps
       ##
       annotations: {}
@@ -642,35 +642,6 @@ grafana:
 
   ## Configure additional grafana datasources (passed through tpl)
   ## ref: http://docs.grafana.org/administration/provisioning/#datasources
-  
-
-  dataSources:
-    loki:
-      enabled: true
-      config:
-        - name: Loki
-          type: loki
-          access: proxy
-          url: http://logging-loki.kyma-system:3100
-          editable: true
-          jsonData:
-            maxLines: 1000
-    jaeger:
-      enabled: true
-      config:
-        - name: Jaeger
-          type: jaeger
-          access: proxy
-          url: http://tracing-jaeger-query.kyma-system:16686
-          editable: true
-    prometheusIstio:
-      enabled: false
-      config:
-        - name: Prometheus-Istio
-          type: prometheus
-          access: proxy
-          url: http://monitoring-prometheus-istio-server.kyma-system:80
-          editable: true
 
   additionalDataSources: []
   # - name: prometheus-sample

--- a/resources/tracing/templates/kyma-additions/grafana-dashboard.yaml
+++ b/resources/tracing/templates/kyma-additions/grafana-dashboard.yaml
@@ -1,10 +1,10 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: jaeger-dashboard
+  name: {{ include "jaeger-operator.fullname" . }}-grafana-dashboard
   labels:
+{{ include "jaeger-operator.labels" . | indent 4 }}
     grafana_dashboard: "1"
-    app: monitoring-grafana
 data:
   jaeger-dashboard.json: |-
         {

--- a/resources/tracing/templates/kyma-additions/grafana-datasource.yaml
+++ b/resources/tracing/templates/kyma-additions/grafana-datasource.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "jaeger-operator.fullname" . }}-grafana-datasource
+  labels:
+{{ include "jaeger-operator.labels" . | indent 4 }}
+    grafana_datasource: "1"
+data:
+    jaeger-datasource.yaml: |-
+      apiVersion: 1
+      datasources:
+      - name: Jaeger
+        type: jaeger
+        access: proxy
+        url: http://{{ include "jaeger-operator.fullname" . }}-jaeger-query.{{ .Release.Namespace }}:16686
+        editable: true


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/master/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**
Part of the Grafana helm chart is a mechanism to load the datasources configurations dynamically via a sidecar. Kyma leverages the feature already for dashboards. As kyma brings already 3 datasources we should leverage the feature here as well, locating the datasource configuration also in the component related to that (like the datasource for loki in the logging component)

Changes proposed in this pull request:

- Enabled the dynamic loading for all namespaces based on configmaps
- Migrated the three datasources into configmaps located in the related component
- Renamed existing dashboards configmaps to have "grafana" in the name as well
- Added a new derivedField to the loki datasource definition to support traceId integration to logs

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
