### PR TITLE
Improve apiserver-proxy build performance

### DIFF
--- a/components/apiserver-proxy/Dockerfile
+++ b/components/apiserver-proxy/Dockerfile
@@ -9,7 +9,6 @@ WORKDIR ${BASE_APP_DIR}
 #
 
 COPY . ${BASE_APP_DIR}
-RUN go mod download
 
 #
 # Build app
@@ -18,7 +17,7 @@ RUN go mod download
 RUN CGO_ENABLED=0 GOOS=linux go build -v -o app ${BASE_APP_DIR}/cmd/proxy/main.go
 RUN mkdir /app && mv ./app /app/app && mv ${BASE_APP_DIR}/licenses /app/licenses
 
-FROM alpine:3.12
+FROM alpine:3.13.2
 LABEL source = git@github.com:kyma-project/kyma.git
 WORKDIR /app
 

--- a/components/apiserver-proxy/Dockerfile
+++ b/components/apiserver-proxy/Dockerfile
@@ -1,4 +1,4 @@
-FROM eu.gcr.io/kyma-project/test-infra/buildpack-golang-toolbox:v20200117-d3885041 as builder
+FROM eu.gcr.io/kyma-project/external/golang:1.16.0-alpine as builder
 
 ENV BASE_APP_DIR /workspace/go/src/github.com/kyma-project/kyma/components/apiserver-proxy
 WORKDIR ${BASE_APP_DIR}

--- a/components/apiserver-proxy/Makefile
+++ b/components/apiserver-proxy/Makefile
@@ -1,35 +1,13 @@
 APP_NAME = apiserver-proxy
 APP_PATH = components/$(APP_NAME)
-BUILDPACK = eu.gcr.io/kyma-project/test-infra/buildpack-golang-toolbox:v20200423-1d9d6590
 SCRIPTS_DIR = $(realpath $(shell pwd)/../..)/common/makefiles
 
 include $(SCRIPTS_DIR)/generic-make-go.mk
 
 VERIFY_IGNORE := /vendor\|/mocks
 
-verify:: mod-verify
-
-resolve-local:
-	GO111MODULE=on go mod vendor -v
-
-ensure-local:
-	@echo "Go modules present in component - omitting."
-
-dep-status:
-	@echo "Go modules present in component - omitting."
-
-dep-status-local:
-	@echo "Go modules present in component - omitting."
-
-mod-verify-local:
-	GO111MODULE=on go mod verify
-
-test-local:
-	GO111MODULE=on go test ./...
-
-$(eval $(call buildpack-cp-ro,resolve))
-$(eval $(call buildpack-mount,mod-verify))
-$(eval $(call buildpack-mount,test))
+release:
+	$(MAKE) gomod-release-local
 
 .PHONY: path-to-referenced-charts
 path-to-referenced-charts:


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/master/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

This change improves build time by around 50%. For details please check parent issue

Changes proposed in this pull request:

- makefile switched to `gomod-release-local` (removes additional docker layer)
- alpine version bumped to the newest available version - fixes sec vulnerabilities
- golang image bumped to the newest available version - because we can! :)

**Related issue(s)**
https://github.com/kyma-project/test-infra/issues/3273