### PR TITLE
Improve application-registry build performance

### DIFF
--- a/components/application-registry/Dockerfile
+++ b/components/application-registry/Dockerfile
@@ -1,13 +1,9 @@
-FROM eu.gcr.io/kyma-project/external/golang:1.14.8-alpine as builder
+FROM eu.gcr.io/kyma-project/external/golang:1.16.0-alpine as builder
 
 RUN apk add -U --no-cache ca-certificates
 
 ARG DOCK_PKG_DIR=/go/src/github.com/kyma-project/kyma/components/application-registry
 WORKDIR $DOCK_PKG_DIR
-
-COPY go.mod .
-COPY go.sum .
-RUN go mod download
 
 COPY ./licenses/ /app/licenses
 COPY . $DOCK_PKG_DIR

--- a/components/application-registry/Makefile
+++ b/components/application-registry/Makefile
@@ -1,6 +1,5 @@
 APP_NAME = application-registry
 APP_PATH = components/$(APP_NAME)
-BUILDPACK = eu.gcr.io/kyma-project/test-infra/buildpack-golang-toolbox:v20200423-1d9d6590
 SCRIPTS_DIR = $(realpath $(shell pwd)/../..)/common/makefiles
 
 override ENTRYPOINT = cmd/applicationregistry/
@@ -9,29 +8,8 @@ include $(SCRIPTS_DIR)/generic-make-go.mk
 
 VERIFY_IGNORE := /vendor\|/mocks
 
-verify:: mod-verify
-
-resolve-local:
-	GO111MODULE=on go mod vendor -v
-
-ensure-local:
-	@echo "Go modules present in component - omitting."
-
-dep-status:
-	@echo "Go modules present in component - omitting."
-
-dep-status-local:
-	@echo "Go modules present in component - omitting."
-
-mod-verify-local:
-	GO111MODULE=on go mod verify
-
-test-local:
-	GO111MODULE=on go test ./...
-
-$(eval $(call buildpack-cp-ro,resolve))
-$(eval $(call buildpack-mount,mod-verify))
-$(eval $(call buildpack-mount,test))
+release:
+	$(MAKE) gomod-release-local
 
 .PHONY: path-to-referenced-charts
 path-to-referenced-charts:


### PR DESCRIPTION
**Description**

This change improves build time by around 50%. For details please check parent issue

Changes proposed in this pull request:

- makefile switched to `gomod-release-local` (removes additional docker layer)
- alpine version bumped to the newest available version - fixes sec vulnerabilities
- golang image bumped to the newest available version - because we can! :)

**Related issue(s)**
https://github.com/kyma-project/test-infra/issues/3273
