### PR TITLE
Fix fast-integration tests for new nats

### DIFF
--- a/tests/fast-integration/installer/index.js
+++ b/tests/fast-integration/installer/index.js
@@ -363,7 +363,7 @@ async function uninstallKyma(options) {
 
 /**
  * Install Kyma on kubernetes cluster with current kubeconfig
- * @param {Object} options List of installation options
+ * @param {{skipComponents: string, newEventing: boolean}} options List of installation options
  * @param {string} options.resourcesPath Path to the resources folder with Kyma charts 
  * @param {string} options.istioVersion Istio version, eg. 1.8.2
  * @param {boolean} options.isUpgrade Upgrade existing installation

--- a/tests/fast-integration/test/1-install.js
+++ b/tests/fast-integration/test/1-install.js
@@ -4,6 +4,10 @@ describe("Installation", function () {
   this.timeout(10 * 60 * 1000);
 
   it("Kyma should successfully install", async function () {
-    await installKyma();
+    const options = {
+      skipComponents: 'tracing,kiali,knative-eventing,knative-provisioner-natss,nats-streaming,event-sources',
+      newEventing: true
+    };
+    await installKyma(options);
   });
 });

--- a/tests/fast-integration/test/fixtures/commerce-mock/lastorder-function.yaml
+++ b/tests/fast-integration/test/fixtures/commerce-mock/lastorder-function.yaml
@@ -63,32 +63,13 @@ kind: ApplicationMapping
 metadata:
   name: commerce
 ---
-apiVersion: eventing.knative.dev/v1alpha1
-kind: Trigger
-metadata:
-  labels:
-    function: lastorder
-  name: function-lastorder
-spec:
-  broker: default
-  filter:
-    attributes:
-      eventtypeversion: v1
-      source: commerce
-      type: order.created
-  subscriber:
-    ref:
-      apiVersion: v1
-      kind: Service
-      name: lastorder
----
 apiVersion: eventing.kyma-project.io/v1alpha1
 kind: Subscription
 metadata:
   name: function-lastorder
 spec:
   filter:
-    dialect: beb,
+    dialect: nats,
     filters:
     - eventSource:
         property: source

--- a/tests/fast-integration/test/fixtures/commerce-mock/lastorder-function.yaml
+++ b/tests/fast-integration/test/fixtures/commerce-mock/lastorder-function.yaml
@@ -69,7 +69,6 @@ metadata:
   name: function-lastorder
 spec:
   filter:
-    dialect: nats,
     filters:
     - eventSource:
         property: source
@@ -79,8 +78,6 @@ spec:
         property: type
         type: exact
         value: sap.kyma.custom.commerce.order.created.v1
-  protocol: BEB
-  protocolsettings:
-    exemptHandshake: true
-    qos: AT-LEAST-ONCE
+  protocol: "nats"
+  protocolsettings: {}
   sink: http://lastorder.test.svc.cluster.local


### PR DESCRIPTION

**Description**

This PR applies the necessary changes to make fast-integration work with new nats backend. 

- Install.js is receiving an options object to skip the installation of knative related components

This PR should be merged when we switch to new nats solution from knative.