### PR TITLE
Kcproxy optional

### DIFF
--- a/resources/kiali/templates/kyma-additions/kcproxy-deployment.yaml
+++ b/resources/kiali/templates/kyma-additions/kcproxy-deployment.yaml
@@ -1,3 +1,4 @@
+{{if .Values.kcproxy.enabled}}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -32,7 +33,7 @@ spec:
         name: kcproxy
         command: ["/keycloak-gatekeeper"]
         args:
-        - --discovery-url=https://dex.{{ .Values.global.ingress.domainName }}
+        - --discovery-url=https://dex.{{ .Values.global.ingress.domainName }}    # Hardgecoded -> rausziehen in values  yaml
         - --skip-openid-provider-tls-verify={{ not .Values.kcproxy.config.tlsVerify }}
         - --client-id=$(CLIENT_ID)
         - --client-secret=$(CLIENT_SECRET)
@@ -96,3 +97,4 @@ spec:
         {{- end }}
         resources:
 {{ toYaml .Values.kcproxy.resources | indent 10 }}
+{{end}}

--- a/resources/kiali/templates/kyma-additions/kcproxy-deployment.yaml
+++ b/resources/kiali/templates/kyma-additions/kcproxy-deployment.yaml
@@ -33,7 +33,7 @@ spec:
         name: kcproxy
         command: ["/keycloak-gatekeeper"]
         args:
-        - --discovery-url={{tpl .Values.kcproxy.config.discoveryUrl}}
+        - --discovery-url={{tpl .Values.kcproxy.config.discoveryUrl .}}
         - --skip-openid-provider-tls-verify={{ not .Values.kcproxy.config.tlsVerify }}
         - --client-id=$(CLIENT_ID)
         - --client-secret=$(CLIENT_SECRET)

--- a/resources/kiali/templates/kyma-additions/kcproxy-deployment.yaml
+++ b/resources/kiali/templates/kyma-additions/kcproxy-deployment.yaml
@@ -33,7 +33,7 @@ spec:
         name: kcproxy
         command: ["/keycloak-gatekeeper"]
         args:
-        - --discovery-url=https://dex.{{ .Values.global.ingress.domainName }}    # Hardgecoded -> rausziehen in values  yaml
+        - --discovery-url={{tpl .Values.kcproxy.config.discoveryUrl}}
         - --skip-openid-provider-tls-verify={{ not .Values.kcproxy.config.tlsVerify }}
         - --client-id=$(CLIENT_ID)
         - --client-secret=$(CLIENT_SECRET)

--- a/resources/kiali/templates/kyma-additions/kcproxy-secret.yaml
+++ b/resources/kiali/templates/kyma-additions/kcproxy-secret.yaml
@@ -1,3 +1,4 @@
+{{if .Values.kcproxy.enabled}}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -9,3 +10,4 @@ data:
   CLIENT_ID: {{ .Values.kcproxy.config.clientId | b64enc | quote }}
   CLIENT_SECRET: {{ .Values.kcproxy.config.clientSecret | b64enc | quote }}
   ENCRYPTION_KEY: {{ randAlphaNum 32 | b64enc | quote }}
+{{end}}

--- a/resources/kiali/templates/kyma-additions/kcproxy-service.yaml
+++ b/resources/kiali/templates/kyma-additions/kcproxy-service.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ template "kiali-server.name" . }}-secured # Denn brauchen wir ned
+  name: {{ template "kiali-server.name" . }}-secured
   labels:
       {{- include "kiali-server.labels" . | nindent 4 }}
 spec:

--- a/resources/kiali/templates/kyma-additions/kcproxy-service.yaml
+++ b/resources/kiali/templates/kyma-additions/kcproxy-service.yaml
@@ -1,7 +1,8 @@
+{{if .Values.kcproxy.enabled}}
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ template "kiali-server.name" . }}-secured
+  name: {{ template "kiali-server.name" . }}-secured # Denn brauchen wir ned
   labels:
       {{- include "kiali-server.labels" . | nindent 4 }}
 spec:
@@ -12,3 +13,4 @@ spec:
       name: http
   selector:
       app: {{ template "kiali-server.name" . }}-kcproxy
+{{end}}

--- a/resources/kiali/templates/kyma-additions/virtualservice.yaml
+++ b/resources/kiali/templates/kyma-additions/virtualservice.yaml
@@ -6,17 +6,17 @@ metadata:
   labels:
     {{- include "kiali-server.labels" . | nindent 4 }}
 spec:
-  gateways:
-  - {{ .Values.global.istio.gateway.namespace }}/{{ .Values.global.istio.gateway.name }}
   hosts:
   - kiali.{{ .Values.global.ingress.domainName }}
+  gateways:
+  - {{ .Values.global.istio.gateway.namespace }}/{{ .Values.global.istio.gateway.name }}
   http:
   - route:
     - destination:
+        {{- if .Values.kcproxy.enabled}}
+        host: {{ template "kiali-server.name" . }}-secured
+        {{- else}}
+        host: {{ template "kiali-server.name" . }}-server
+        {{- end}}
         port:
           number: {{ .Values.kiali.spec.server.port }}
-        {{if .Values.kcproxy.enabled}}
-        host: {{ template "kiali-server.name" . }}-secured
-        {{else}}
-        host: {{ template "kiali-server.name" . }}
-        {{end}}

--- a/resources/kiali/templates/kyma-additions/virtualservice.yaml
+++ b/resources/kiali/templates/kyma-additions/virtualservice.yaml
@@ -15,4 +15,8 @@ spec:
     - destination:
         port:
           number: {{ .Values.kiali.spec.server.port }}
+        {{if .Values.kcproxy.enabled}}
         host: {{ template "kiali-server.name" . }}-secured
+        {{else}}
+        host: {{ template "kiali-server.name" . }}
+        {{end}}

--- a/resources/kiali/values.yaml
+++ b/resources/kiali/values.yaml
@@ -27,6 +27,7 @@ global:
     enabled: true
 
 kcproxy:
+  enabled: false
   replicaCount: 1
   port: 3000
   config:

--- a/resources/kiali/values.yaml
+++ b/resources/kiali/values.yaml
@@ -33,6 +33,7 @@ kcproxy:
   config:
     clientId: "kiali"
     clientSecret: "hiFWLWqIxw5d3gl"
+    discoveryUrl: https://dex.{{ .Values.global.ingress.domainName }}
     tlsVerify: false
     resources:
       uri: "/*"

--- a/resources/kiali/values.yaml
+++ b/resources/kiali/values.yaml
@@ -27,7 +27,7 @@ global:
     enabled: true
 
 kcproxy:
-  enabled: false
+  enabled: true
   replicaCount: 1
   port: 3000
   config:

--- a/resources/tracing/templates/kyma-additions/kcproxy-deployment.yaml
+++ b/resources/tracing/templates/kyma-additions/kcproxy-deployment.yaml
@@ -34,7 +34,7 @@ spec:
         name: kcproxy
         command: ["/keycloak-gatekeeper"]
         args:
-        - --discovery-url={{tpl .Values.kcproxy.config.discoveryUrl}}
+        - --discovery-url={{tpl .Values.kcproxy.config.discoveryUrl .}}
         - --skip-openid-provider-tls-verify={{ not .Values.kcproxy.config.tlsVerify }}
         - --client-id=$(CLIENT_ID)
         - --client-secret=$(CLIENT_SECRET)

--- a/resources/tracing/templates/kyma-additions/kcproxy-deployment.yaml
+++ b/resources/tracing/templates/kyma-additions/kcproxy-deployment.yaml
@@ -1,3 +1,4 @@
+{{if .Values.kcproxy.enabled}}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -33,7 +34,7 @@ spec:
         name: kcproxy
         command: ["/keycloak-gatekeeper"]
         args:
-        - --discovery-url=https://dex.{{ .Values.global.ingress.domainName }}
+        - --discovery-url={{tpl .Values.kcproxy.config.discoveryUrl}}
         - --skip-openid-provider-tls-verify={{ not .Values.kcproxy.config.tlsVerify }}
         - --client-id=$(CLIENT_ID)
         - --client-secret=$(CLIENT_SECRET)
@@ -97,3 +98,4 @@ spec:
         {{- end }}
         resources:
 {{ toYaml .Values.kcproxy.resources | indent 10 }}
+{{end}}

--- a/resources/tracing/templates/kyma-additions/kcproxy-secret.yaml
+++ b/resources/tracing/templates/kyma-additions/kcproxy-secret.yaml
@@ -1,3 +1,4 @@
+{{if .Values.kcproxy.enabled}}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -8,3 +9,4 @@ data:
   CLIENT_ID: {{ .Values.kcproxy.config.clientId | b64enc | quote }}
   CLIENT_SECRET: {{ .Values.kcproxy.config.clientSecret | b64enc | quote }}
   ENCRYPTION_KEY: {{ randAlphaNum 32 | b64enc | quote }}
+{{end}}

--- a/resources/tracing/templates/kyma-additions/kcproxy-service.yaml
+++ b/resources/tracing/templates/kyma-additions/kcproxy-service.yaml
@@ -1,3 +1,4 @@
+{{if .Values.kcproxy.enabled}}
 apiVersion: v1
 kind: Service
 metadata:
@@ -13,3 +14,4 @@ spec:
   selector:
     app.kubernetes.io/name: {{ template "jaeger-operator.fullname" . }}
     app.kubernetes.io/component: kcproxy
+{{end}}

--- a/resources/tracing/templates/kyma-additions/kcproxy-virtualservice.yaml
+++ b/resources/tracing/templates/kyma-additions/kcproxy-virtualservice.yaml
@@ -1,3 +1,4 @@
+{{if .Values.kcproxy.enabled}}
 apiVersion: networking.istio.io/v1alpha3
 kind: VirtualService
 metadata:
@@ -15,3 +16,4 @@ spec:
         host: {{ template "jaeger-operator.fullname" . }}-jaeger-query-secured
         port:
           number: {{ .Values.jaeger.kyma.uiPort }}
+{{end}}

--- a/resources/tracing/templates/kyma-additions/kcproxy-virtualservice.yaml
+++ b/resources/tracing/templates/kyma-additions/kcproxy-virtualservice.yaml
@@ -1,4 +1,3 @@
-{{if .Values.kcproxy.enabled}}
 apiVersion: networking.istio.io/v1alpha3
 kind: VirtualService
 metadata:
@@ -13,7 +12,11 @@ spec:
   http:
   - route:
     - destination:
+        {{if .Values.kcproxy.enabled}}
         host: {{ template "jaeger-operator.fullname" . }}-jaeger-query-secured
+        {{else}}
+        host: {{ template "jaeger-operator.fullname" . }}-jaeger-query
+        {{end}}
         port:
           number: {{ .Values.jaeger.kyma.uiPort }}
-{{end}}
+

--- a/resources/tracing/templates/kyma-additions/virtualservice.yaml
+++ b/resources/tracing/templates/kyma-additions/virtualservice.yaml
@@ -19,4 +19,3 @@ spec:
         {{end}}
         port:
           number: {{ .Values.jaeger.kyma.uiPort }}
-

--- a/resources/tracing/values.yaml
+++ b/resources/tracing/values.yaml
@@ -114,11 +114,13 @@ global:
     enabled: true
 
 kcproxy:
+  enabled: false
   replicaCount: 1
   inPort: 10001
   config:
     clientId: "jaeger"
     clientSecret: "oiEWUWOIEwedfgg"
+    discoveryUrl: https://dex.{{ .Values.global.ingress.domainName }}
     tlsVerify: false
     resources:
       uri: "/*"

--- a/resources/tracing/values.yaml
+++ b/resources/tracing/values.yaml
@@ -114,7 +114,7 @@ global:
     enabled: true
 
 kcproxy:
-  enabled: false
+  enabled: true
   replicaCount: 1
   inPort: 10001
   config:


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/master/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

This PR changes authentication for the UIs of Kiali and Jaegger to optional. Default is set to enabled. Furthermore, 'discoveryurl' was moved to values.yaml to make the configuration more simple.

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
Resolves #10811 