### PR TITLE
Improve compass-runtime-agent build performance

### DIFF
--- a/components/compass-runtime-agent/Dockerfile
+++ b/components/compass-runtime-agent/Dockerfile
@@ -1,11 +1,7 @@
-FROM eu.gcr.io/kyma-project/external/golang:1.14.8-alpine as builder
+FROM eu.gcr.io/kyma-project/external/golang:1.16.0-alpine as builder
 
 ARG DOCK_PKG_DIR=/compass-runtime-agent
 WORKDIR $DOCK_PKG_DIR
-
-COPY go.mod .
-COPY go.sum .
-RUN go mod download
 
 COPY ./licenses/ /app/licenses
 COPY . $DOCK_PKG_DIR
@@ -15,7 +11,7 @@ RUN echo "nobody:x:65534:5534:nobody:/:" > /etc_passwd
 RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -o compass-runtime-agent ./cmd
 
 
-FROM eu.gcr.io/kyma-project/external/alpine:3.12.0 as certs
+FROM eu.gcr.io/kyma-project/external/alpine:3.13.2 as certs
 RUN apk add -U --no-cache ca-certificates
 
 FROM scratch

--- a/components/compass-runtime-agent/Makefile
+++ b/components/compass-runtime-agent/Makefile
@@ -1,7 +1,5 @@
 APP_NAME = compass-runtime-agent
 APP_PATH = components/$(APP_NAME)
-BUILDPACK = eu.gcr.io/kyma-project/test-infra/buildpack-golang-kubebuilder2:v20200506-76a53983
-
 SCRIPTS_DIR = $(realpath $(shell pwd)/../..)/common/makefiles
 
 override ENTRYPOINT = cmd/
@@ -10,29 +8,8 @@ include $(SCRIPTS_DIR)/generic-make-go.mk
 
 VERIFY_IGNORE := /vendor\|/mocks
 
-verify:: mod-verify
-
-resolve-local:
-	GO111MODULE=on go mod vendor -v
-
-ensure-local:
-	@echo "Go modules present in component - omitting."
-
-dep-status:
-	@echo "Go modules present in component - omitting."
-
-dep-status-local:
-	@echo "Go modules present in component - omitting."
-
-mod-verify-local:
-	GO111MODULE=on go mod verify 
-
-test-local:
-	GO111MODULE=on go test ./... 
-
-$(eval $(call buildpack-cp-ro,resolve)) 
-$(eval $(call buildpack-mount,mod-verify)) 
-$(eval $(call buildpack-mount,test))
+release:
+	$(MAKE) gomod-release-local
 
 .PHONY: path-to-referenced-charts
 path-to-referenced-charts:


### PR DESCRIPTION
**Description**

This change improves build time by around 50%. For details please check parent issue

Changes proposed in this pull request:

- makefile switched to `gomod-release-local` (removes additional docker layer)
- alpine version bumped to the newest available version - fixes sec vulnerabilities
- golang image bumped to the newest available version - because we can! :)

**Related issue(s)**
https://github.com/kyma-project/test-infra/issues/3273
