### PR TITLE
Improve event-service build performance

### DIFF
--- a/components/event-service/Dockerfile
+++ b/components/event-service/Dockerfile
@@ -1,4 +1,4 @@
-FROM eu.gcr.io/kyma-project/test-infra/buildpack-golang-toolbox:v20190930-d28d219 as builder
+FROM eu.gcr.io/kyma-project/external/golang:1.16.0-alpine as builder
 
 ARG DOCK_PKG_DIR=/workspace/go/src/github.com/kyma-project/kyma/components/event-service
 

--- a/components/event-service/Makefile
+++ b/components/event-service/Makefile
@@ -1,6 +1,5 @@
 APP_NAME = event-service
 APP_PATH = components/$(APP_NAME)
-BUILDPACK = eu.gcr.io/kyma-project/test-infra/buildpack-golang-toolbox:v20190930-d28d219
 SCRIPTS_DIR = $(realpath $(shell pwd)/../..)/common/makefiles
 
 # COMPONENT_DIR is a local path to component
@@ -9,4 +8,4 @@ include $(SCRIPTS_DIR)/generic-make-go.mk
 MAIN_PATH = ./cmd/eventservice/eventgateway.go
 
 release:
-	$(MAKE) gomod-release
+	$(MAKE) gomod-release-local


### PR DESCRIPTION
**Description**

This change improves build time by around 50%. For details please check parent issue

Changes proposed in this pull request:

- makefile switched to `gomod-release-local` (removes additional docker layer)
- golang image bumped to the newest available version - because we can! :)

**Related issue(s)**
https://github.com/kyma-project/test-infra/issues/3273
