### PR TITLE
Improve service-binding-usage-controller build performance

### DIFF
--- a/components/service-binding-usage-controller/Dockerfile
+++ b/components/service-binding-usage-controller/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.14.4-alpine3.11 as builder
+FROM eu.gcr.io/kyma-project/external/golang:1.16.0-alpine as builder
 
 ENV SRC_DIR=/go/src/github.com/kyma-project/kyma/components/service-binding-usage-controller
 ADD . $SRC_DIR

--- a/components/service-binding-usage-controller/Makefile
+++ b/components/service-binding-usage-controller/Makefile
@@ -1,6 +1,5 @@
 APP_NAME = service-binding-usage-controller
 APP_PATH = components/$(APP_NAME)
-BUILDPACK = eu.gcr.io/kyma-project/test-infra/buildpack-golang-toolbox:v20200423-1d9d6590
 SCRIPTS_DIR = $(realpath $(shell pwd)/../..)/common/makefiles
 
 include $(SCRIPTS_DIR)/generic-make-go.mk
@@ -8,32 +7,5 @@ include $(SCRIPTS_DIR)/generic-make-go.mk
 ENTRYPOINT:=cmd/controller/main.go
 VERIFY_IGNORE := /vendor\|/automock\|/testdata\|/pkg
 
-verify:: mod-verify
-
-# Skip dep commands
-
-ensure-local:
-	@echo "Go modules present in component - omitting."
-
-dep-status:
-	@echo "Go modules present in component - omitting."
-
-dep-status-local:
-	@echo "Go modules present in component - omitting."
-
-# go mod
-
-resolve-local:
-	GO111MODULE=on go mod vendor -v
-
-mod-verify-local:
-	GO111MODULE=on go mod verify
-
-test-local:
-	GO111MODULE=on go test -coverprofile=/tmp/artifacts/cover.out ./...
-	@echo -n "Total coverage: "
-	@go tool cover -func=/tmp/artifacts/cover.out | grep total | awk '{print $$3}'
-
-$(eval $(call buildpack-mount,resolve))
-$(eval $(call buildpack-mount,mod-verify))
-$(eval $(call buildpack-mount,test))
+release:
+	$(MAKE) gomod-release-local


### PR DESCRIPTION
**Description**

This change improves build time by around 50%. For details please check parent issue

Changes proposed in this pull request:

- makefile switched to `gomod-release-local` (removes additional docker layer)
- golang image bumped to the newest available version - because we can! :)

**Related issue(s)**
https://github.com/kyma-project/test-infra/issues/3273
