### PR TITLE
Improve uaa-activator build performance

### DIFF
--- a/components/uaa-activator/Dockerfile
+++ b/components/uaa-activator/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.13-alpine as builder
+FROM eu.gcr.io/kyma-project/external/golang:1.16.0-alpine as builder
 
 WORKDIR /go/src/github.com/kyma-project/kyma/components/uaa-activator
 

--- a/components/uaa-activator/Makefile
+++ b/components/uaa-activator/Makefile
@@ -1,6 +1,5 @@
 APP_NAME = uaa-activator
 APP_PATH = components/$(APP_NAME)
-BUILDPACK = eu.gcr.io/kyma-project/test-infra/buildpack-golang-toolbox:v20190930-d28d219
 SCRIPTS_DIR = $(realpath $(shell pwd)/../..)/common/makefiles
 
 include $(SCRIPTS_DIR)/generic-make-go.mk
@@ -9,4 +8,4 @@ ENTRYPOINT:=main.go
 VERIFY_IGNORE := /vendor\|/automock\|/testdata\|/pkg
 
 release:
-	$(MAKE) gomod-release
+	$(MAKE) gomod-release-local


### PR DESCRIPTION
**Description**

This change improves build time by around 50%. For details please check parent issue

Changes proposed in this pull request:

- makefile switched to `gomod-release-local` (removes additional docker layer)
- golang image bumped to the newest available version - because we can! :)

**Related issue(s)**
https://github.com/kyma-project/test-infra/issues/3273
