### PR TITLE
Cleanup kyma-operator makefile

### DIFF
--- a/components/kyma-operator/Dockerfile
+++ b/components/kyma-operator/Dockerfile
@@ -1,4 +1,4 @@
-FROM eu.gcr.io/kyma-project/test-infra/buildpack-golang-toolbox:v20200117-d3885041 as builder
+FROM eu.gcr.io/kyma-project/external/golang:1.16.0-alpine as builder
 
 ENV BASE_APP_DIR /workspace/go/src/github.com/kyma-project/kyma/components/kyma-operator
 WORKDIR ${BASE_APP_DIR}
@@ -6,7 +6,8 @@ WORKDIR ${BASE_APP_DIR}
 #
 # Copy files
 #
-
+COPY go.mod ${BASE_APP_DIR}
+COPY go.sum ${BASE_APP_DIR}
 COPY ./vendor/ ${BASE_APP_DIR}/vendor/
 COPY ./pkg/ ${BASE_APP_DIR}/pkg/
 COPY ./cmd/ ${BASE_APP_DIR}/cmd/

--- a/components/kyma-operator/Makefile
+++ b/components/kyma-operator/Makefile
@@ -1,40 +1,12 @@
 APP_NAME = kyma-operator
 APP_PATH = components/$(APP_NAME)
-BUILDPACK = eu.gcr.io/kyma-project/test-infra/buildpack-golang-toolbox:v20200117-d3885041
 SCRIPTS_DIR = $(realpath $(shell pwd)/../..)/common/makefiles
 override ENTRYPOINT := ./cmd/operator/main.go
 
 include $(SCRIPTS_DIR)/generic-make-go.mk
 
-verify:: vet mod-verify
-
-# Skip dep commands
-
-ensure-local:
-	@echo "Go modules present in component - omitting."
-
-dep-status:
-	@echo "Go modules present in component - omitting."
-
-dep-status-local:
-	@echo "Go modules present in component - omitting."
-
-# go mod
-
-resolve-local:
-	GO111MODULE=on go mod vendor -v
-
-mod-verify-local:
-	GO111MODULE=on go mod verify
-
-test-local:
-	GO111MODULE=on go test -coverprofile=/tmp/artifacts/cover.out ./...
-	@echo -n "Total coverage: "
-	@go tool cover -func=/tmp/artifacts/cover.out | grep total | awk '{print $$3}'
-
-$(eval $(call buildpack-mount,resolve))
-$(eval $(call buildpack-mount,mod-verify))
-$(eval $(call buildpack-mount,test))
+release:
+	$(MAKE) gomod-release-local
 
 .PHONY: clean
 clean:


### PR DESCRIPTION
**Description**

This change improves build time by around 50%. For details please check parent issue

Changes proposed in this pull request:

- makefile switched to `gomod-release-local` (removes additional docker layer)
- golang image bumped to the newest available version - because we can! :)

**Related issue(s)**
https://github.com/kyma-project/test-infra/issues/3273
