### PR TITLE
Improve event-sources build performance

### DIFF
--- a/components/event-sources/Makefile
+++ b/components/event-sources/Makefile
@@ -1,6 +1,5 @@
 APP_NAME = event-sources
 APP_PATH = components/event-sources
-BUILDPACK = eu.gcr.io/kyma-project/test-infra/buildpack-golang-toolbox:v20200423-1d9d6590
 SCRIPTS_DIR = ../../common/makefiles
 
 # COMPONENT_DIR is a local path to component
@@ -8,7 +7,7 @@ include $(SCRIPTS_DIR)/generic-make-go.mk
 
 # Override to use go modules
 release:
-	$(MAKE) gomod-release
+	$(MAKE) gomod-release-local
 
 # This target patch opencensus lib (add required method). This patch is required by knative.dev/eventing
 gomod-deps-local:: vendor/go.opencensus.io/trace/trace.go.patched
@@ -33,8 +32,8 @@ cmds_clean = $(foreach cmd,$(cmds),$(cmd).clean)
 # produce goals to push images for each cmd program ("bin1.image.push bin2.image.push ...")
 cmds_images_push = $(foreach img,$(cmds_images),$(img).push)
 
-MOUNT_TARGETS = $(cmds)
-$(foreach t,$(MOUNT_TARGETS),$(eval $(call buildpack-mount,$(t))))
+#MOUNT_TARGETS = $(cmds)
+#$(foreach t,$(MOUNT_TARGETS),$(eval $(call buildpack-mount,$(t))))
 
 .PHONY: clean
 clean: $(cmds_clean) resolve_clean licenses_clean

--- a/components/event-sources/Makefile
+++ b/components/event-sources/Makefile
@@ -70,7 +70,7 @@ test-local: gomod-vendor-local $(patched_trace)
 .PHONY: $(cmds_images) $(cmds_images_push)
 
 # override image goals from common Makefile because we need to build several images
-build-image: gomod-deps $(patched_trace) $(cmds_images) ;
+build-image: gomod-deps-local $(patched_trace) $(cmds_images) ;
 push-image: $(cmds_images_push) ;
 
 # Example:

--- a/components/event-sources/cmd/controller-manager/Dockerfile
+++ b/components/event-sources/cmd/controller-manager/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.14-alpine as builder
+FROM eu.gcr.io/kyma-project/external/golang:1.16.0-alpine as builder
 
 ARG DOCK_PKG_DIR=/go/src/github.com/kyma-project/kyma/components/event-sources
 

--- a/components/event-sources/cmd/http-adapter/Dockerfile
+++ b/components/event-sources/cmd/http-adapter/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.14-alpine as builder
+FROM eu.gcr.io/kyma-project/external/golang:1.16.0-alpine as builder
 
 ARG DOCK_PKG_DIR=/go/src/github.com/kyma-project/kyma/components/event-sources
 


### PR DESCRIPTION
**Description**

This change improves build time by around 50%. For details please check parent issue

Changes proposed in this pull request:

- makefile switched to `gomod-release-local` (removes additional docker layer)
- golang image bumped to the newest available version - because we can! :)

**Related issue(s)**
https://github.com/kyma-project/test-infra/issues/3273
