### PR TITLE
Ensure Kyma priority class is applied before everything else during install and upgrade

### DIFF
--- a/resources/cluster-essentials/templates/crd-install-job.yaml
+++ b/resources/cluster-essentials/templates/crd-install-job.yaml
@@ -58,5 +58,5 @@ spec:
       {{- end }}
       {{ end }}
     {{- if .Values.global.priorityClassName }}
-      priorityClassName: kyma-installer
+      priorityClassName: {{ .Values.global.priorityClassName }}
     {{- end }}

--- a/resources/cluster-essentials/templates/priorityclass.yaml
+++ b/resources/cluster-essentials/templates/priorityclass.yaml
@@ -3,6 +3,9 @@ apiVersion: scheduling.k8s.io/v1
 kind: PriorityClass
 metadata:
   name: {{ .Values.global.priorityClassName }}
+  annotations:
+    "helm.sh/hook": "pre-install, pre-upgrade"
+    "helm.sh/hook-weight": "-5"
 value: {{ .Values.global.priorityClassValue }}
 globalDefault: false
 description: "Global (default) scheduling priority of Kyma components. Must not be blocked by unschedulable user workloads."


### PR DESCRIPTION
**Description**

Make sure priority class is the first resource applied by Helm to avoid present and future hook failures due to non-existent priority class resource.

