### PR TITLE
Deprecate nodejs10 function runtime in docs

### DIFF
--- a/docs/serverless/03-01-function-specification.md
+++ b/docs/serverless/03-01-function-specification.md
@@ -5,6 +5,8 @@ type: Details
 
 Serverless in Kyma allows you to create Functions in both Node.js (v10 & v12) and Python (v3.8). Although the Function's interface is unified, its specification differs depending on the runtime used to run the Function.
 
+>**CAUTION:** Node.js 10 runtime is deprecated, so use Node.js 12 instead.
+
 ## Signature
 
 Function's code is represented by a handler that is a method that processes events. When your Function is invoked, it runs this handler method to process a given request and return a response.

--- a/docs/serverless/03-02-available-runtimes.md
+++ b/docs/serverless/03-02-available-runtimes.md
@@ -5,6 +5,8 @@ type: Details
 
 Functions support multiple languages through the use of runtimes. To use a chosen runtime, add its name and version as a value in the **spec.runtime** field of the [Function custom resource (CR)](#custom-resource-function). If this value is not specified, it defaults to `nodejs12`. Dependencies for a Node.js Function should be specified using the [`package.json`](https://docs.npmjs.com/creating-a-package-json-file) file format. Dependencies for a Python Function should follow the format used by [pip](https://packaging.python.org/key_projects/#pip).
 
+>**CAUTION:** Node.js 10 runtime is deprecated, please use Node.js 12.
+
 See sample Functions for all available runtimes:
 
 <div tabs name="available-runtimes" group="available-runtimes">
@@ -43,10 +45,8 @@ EOF
   </details>
   <details>
   <summary label="nodejs10">
-  Node.js 10
+  Node.js 10 (Deprecated)
   </summary>
-
->**CAUTION:** Node.js 10 runtime is deprecated, please use Node.js 12.
 
 ```yaml
 cat <<EOF | kubectl apply -f -

--- a/docs/serverless/03-02-available-runtimes.md
+++ b/docs/serverless/03-02-available-runtimes.md
@@ -5,7 +5,7 @@ type: Details
 
 Functions support multiple languages through the use of runtimes. To use a chosen runtime, add its name and version as a value in the **spec.runtime** field of the [Function custom resource (CR)](#custom-resource-function). If this value is not specified, it defaults to `nodejs12`. Dependencies for a Node.js Function should be specified using the [`package.json`](https://docs.npmjs.com/creating-a-package-json-file) file format. Dependencies for a Python Function should follow the format used by [pip](https://packaging.python.org/key_projects/#pip).
 
->**CAUTION:** Node.js 10 runtime is deprecated, please use Node.js 12.
+>**CAUTION:** Node.js 10 runtime is deprecated, so use Node.js 12 instead.
 
 See sample Functions for all available runtimes:
 

--- a/docs/serverless/03-02-available-runtimes.md
+++ b/docs/serverless/03-02-available-runtimes.md
@@ -46,6 +46,8 @@ EOF
   Node.js 10
   </summary>
 
+>**CAUTION:** Node.js 10 runtime is deprecated, please use Node.js 12.
+
 ```yaml
 cat <<EOF | kubectl apply -f -
 apiVersion: serverless.kyma-project.io/v1alpha1

--- a/docs/serverless/06-01-function-cr.md
+++ b/docs/serverless/06-01-function-cr.md
@@ -114,7 +114,7 @@ This table lists all the possible parameters of a given resource together with t
 | **spec.buildResources.limits.memory**         |       No       | Defines the maximum amount of memory available for the Job's Pod to use.      |
 | **spec.buildResources.requests.cpu**          |       No       | Specifies the number of CPUs requested by the build Job's Pod to operate.       |
 | **spec.buildResources.requests.memory**       |       No       | Specifies the amount of memory requested by the build Job's Pod to operate.               |
-| **spec.runtime**                         |       No       | Specifies the runtime of the Function. The available values are `nodejs12`, `nodejs10`, and `python38`. It is set to `nodejs12` unless specified otherwise.  |
+| **spec.runtime**                         |       No       | Specifies the runtime of the Function. The available values are `nodejs12`, `python38` and deprecated `nodejs10`. It is set to `nodejs12` unless specified otherwise.  |
 | **spec.type**                          |      No       | Defines that you use a Git repository as the source of Function's code and dependencies. It must be set to `git`. |
 | **spec.source**                          |      Yes       | Provides the Function's full source code or the name of the Git directory in which the code and dependencies are stored.     |
 | **spec.baseDir**                          |      No       | Specifies the relative path to the Git directory that contains the source code from which the Function will be built​. |


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/master/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- mark nodejs10 runtime as deprecated in the docs

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
https://github.com/kyma-project/kyma/issues/10752