### PR TITLE
Update the publishers images with the subscribed endpoint fix for empty event-sources

### DIFF
--- a/resources/eventing/charts/event-publisher-nats/values.yaml
+++ b/resources/eventing/charts/event-publisher-nats/values.yaml
@@ -9,7 +9,7 @@ image:
   # name is the name of the container image for the event-publisher-nats
   name: "event-publisher-nats"
   # tag is the container tag of the event-publisher-nats image
-  tag: "0ece7d31"
+  tag: "e84f55a9"
   # pullPolicy is the pullPolicy for the event-publisher-nats image
   pullPolicy: "IfNotPresent"
 

--- a/resources/eventing/charts/event-publisher-proxy/values.yaml
+++ b/resources/eventing/charts/event-publisher-proxy/values.yaml
@@ -9,7 +9,7 @@ image:
   # name is the name of the container image for the event-publisher-proxy
   name: "event-publisher-proxy"
   # tag is the container tag of the event-publisher-proxy image
-  tag: "0ece7d31"
+  tag: "e84f55a9"
   # pullPolicy is the pullPolicy for the event-publisher-proxy image
   pullPolicy: "IfNotPresent"
 


### PR DESCRIPTION
**Description**

Update the publishers images with the subscribed endpoint fix for empty event-sources.

**Related issue(s)**
https://github.com/kyma-project/kyma/pull/10902