### PR TITLE
Improve ServiceCatalog stability in fast-integration tests

### DIFF
--- a/components/application-broker/internal/syncer/broker_syncer.go
+++ b/components/application-broker/internal/syncer/broker_syncer.go
@@ -79,6 +79,7 @@ func (r *ServiceBrokerSync) SyncBroker(namespace string) error {
 	brokerClient := r.serviceBrokerGetter.ServiceBrokers(namespace)
 	name := nsbroker.NamespacedBrokerName
 
+	r.log.Infof("Syncing ServiceBroker in %s namespace", namespace)
 	for i := 0; i < maxSyncRetries; i++ {
 		broker, err := brokerClient.Get(name, v1.GetOptions{})
 		if err != nil {

--- a/components/application-broker/internal/syncer/controller.go
+++ b/components/application-broker/internal/syncer/controller.go
@@ -164,7 +164,6 @@ func (c *Controller) processNextItem() bool {
 	switch {
 	case err == nil:
 		c.queue.Forget(key)
-
 		c.scRelistRequester.RequestRelist()
 		c.log.Infof("Relist requested after successful processing of the %q", strKey)
 

--- a/resources/application-connector/values.yaml
+++ b/resources/application-connector/values.yaml
@@ -58,7 +58,7 @@ global:
   application_registry_tests:
     version: "d556963d"
   application_broker:
-    version: "52f52cc9"
+    version: "PR-10908"
   application_connectivity_certs_setup_job:
     version: "34011b0f"
   application_connectivity_validator:

--- a/tests/fast-integration/test/fixtures/commerce-mock/index.js
+++ b/tests/fast-integration/test/fixtures/commerce-mock/index.js
@@ -71,7 +71,12 @@ function serviceInstanceObj(name, serviceClassExternalName) {
   return {
     apiVersion: "servicecatalog.k8s.io/v1beta1",
     kind: "ServiceInstance",
-    metadata: { name },
+    metadata: {
+      name: name,
+      annotations: {
+        "app": "test",
+      },
+    },
     spec: { serviceClassExternalName },
   };
 }
@@ -426,7 +431,12 @@ async function ensureCommerceMockLocalTestFixture(mockNamespace, targetNamespace
   const serviceBinding = {
     apiVersion: "servicecatalog.k8s.io/v1beta1",
     kind: "ServiceBinding",
-    metadata: { name: "commerce-binding" },
+    metadata: {
+      name: "commerce-binding",
+      annotations: {
+        "app": "test",
+      },
+    },
     spec: {
       instanceRef: { name: "commerce-webservices" },
     },

--- a/tests/fast-integration/test/fixtures/getting-started-guides/redis-addon-sb-si.yaml
+++ b/tests/fast-integration/test/fixtures/getting-started-guides/redis-addon-sb-si.yaml
@@ -12,6 +12,8 @@ kind: ServiceInstance
 metadata:
   name: redis-service
   namespace: orders-service
+  annotations:
+    app: "test"
 spec:
   serviceClassExternalName: redis
   servicePlanExternalName: micro
@@ -23,6 +25,8 @@ kind: ServiceBinding
 metadata:
   name: orders-service
   namespace: orders-service
+  annotations:
+    app: "test"
 spec:
   instanceRef:
     name: redis-service


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/master/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

This PR solves 2 problems:

- Added dummy annotations to Service catalog resources as a workaround for this issue: https://github.com/kubernetes-sigs/service-catalog/issues/2825 to prevent controller-manager [crashes](https://status.build.kyma-project.io/view/gcs/kyma-prow-logs/logs/kyma-integration-evaluation-gardener-azure/1372353369854709760):
```
=========RESTART REPORT========
- name: service-catalog-catalog-controller-manager-68cdf64c7-t7bct
  containerRestarts:
    - name: controller-manager
      image: >-
        eu.gcr.io/kyma-project/external/quay.io/kubernetes-service-catalog/service-catalog:v0.3.1-6-ge839d22-dirty
      restartsTillTestStart: 1
===============================
```
^ happens on every [build](https://status.build.kyma-project.io/?job=kyma-integration-evaluation-gardener-azure)

-  The second problem actually fails tests and is related to the not correctly working logic with ServiceBroker removal in the Application Broker which makes required ServiceClasses unavailable. The fix for this is to wait and ensure ServiceBroker deletion before we start to process another mapping.

Additionally:
- Changed the queue configuration to reconcile slower.
- Added logs to the application broker to improve traceability

**Results**

The result of these fixes can be observed on my custom pipeline which is installing kyma and executing fast-integration tests from this [PR](https://github.com/kyma-project/test-infra/pull/3413):

https://status.build.kyma-project.io/?job=polskikiel_test_of_prowjob_kyma-integration-evaluation-gardener 
Starting from this [job](https://status.build.kyma-project.io/view/gcs/kyma-prow-logs/logs/polskikiel_test_of_prowjob_kyma-integration-evaluation-gardener/1372885761723994112) started at 13.20 on Friday fixes were applied.


 
**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
#10886