### PR TITLE
Fix SecurityContext for Postgresql

### DIFF
--- a/resources/ory/charts/postgresql/templates/statefulset-slaves.yaml
+++ b/resources/ory/charts/postgresql/templates/statefulset-slaves.yaml
@@ -130,6 +130,12 @@ spec:
           {{- end }}
           {{- if .Values.securityContext.enabled }}
           securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+            privileged: false
+            runAsNonRoot: true
             runAsUser: {{ .Values.securityContext.runAsUser }}
           {{- end }}
           env:

--- a/resources/ory/charts/postgresql/templates/statefulset.yaml
+++ b/resources/ory/charts/postgresql/templates/statefulset.yaml
@@ -66,6 +66,7 @@ spec:
       {{- if .Values.securityContext.enabled }}
       securityContext:
         fsGroup: {{ .Values.securityContext.fsGroup }}
+        runAsNonRoot: true
       {{- end }}
       {{- if .Values.serviceAccount.enabled }}
       serviceAccountName: {{ default (include "postgresql.fullname" . ) .Values.serviceAccount.name }}
@@ -96,10 +97,14 @@ spec:
               {{- if and .Values.shmVolume.enabled .Values.shmVolume.chmod.enabled }}
               chmod -R 777 /dev/shm
               {{- end }}
-          {{- if eq ( toString ( .Values.volumePermissions.securityContext.runAsUser )) "auto" }}
           securityContext:
-          {{- else }}
-          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+            privileged: false
+            runAsNonRoot: true
+          {{- if ne ( toString ( .Values.volumePermissions.securityContext.runAsUser )) "auto" }}
             runAsUser: {{ .Values.volumePermissions.securityContext.runAsUser }}
           {{- end }}
           volumeMounts:
@@ -129,6 +134,12 @@ spec:
           {{- end }}
           {{- if .Values.securityContext.enabled }}
           securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+            privileged: false
+            runAsNonRoot: true
             runAsUser: {{ .Values.securityContext.runAsUser }}
           {{- end }}
           env:

--- a/resources/ory/charts/postgresql/values.yaml
+++ b/resources/ory/charts/postgresql/values.yaml
@@ -72,7 +72,8 @@ volumePermissions:
   ## pod securityContext.enabled=false and shmVolume.chmod.enabled=false
   ##
   securityContext:
-    runAsUser: 0
+    ## UID 11 is `operator` in Alpine. It belongs to "root" group so it has higher filesystem permissions necessary for init container, but it's not root.
+    runAsUser: 11
 
 ## Use an alternate scheduler, e.g. "stork".
 ## ref: https://kubernetes.io/docs/tasks/administer-cluster/configure-multiple-schedulers/


### PR DESCRIPTION
**Description**

Ensure non-privileged `securityContext` for ORY/Postgresql Pods.
Follow-up to: https://github.com/kyma-project/kyma/pull/10834

Changes proposed in this pull request:

- Fix securityContext for containers
- Use `operator` - UID=11 instead of `root` in init containers

**Related issue(s)**
See also: #9550, https://github.com/kyma-project/kyma/pull/10834