### PR TITLE
Remove waiting for service-catalog resources deletion in e2e upgrade test

### DIFF
--- a/tests/end-to-end/upgrade/chart/upgrade/values.yaml
+++ b/tests/end-to-end/upgrade/chart/upgrade/values.yaml
@@ -7,7 +7,7 @@ subscriberimage:
 
 image:
   dir:
-  version: c682d636
+  version: "PR-10949"
 
   pullPolicy: "IfNotPresent"
 

--- a/tests/end-to-end/upgrade/pkg/tests/service-catalog/app_broker.go
+++ b/tests/end-to-end/upgrade/pkg/tests/service-catalog/app_broker.go
@@ -140,7 +140,6 @@ func (f *appBrokerFlow) TestResources() error {
 		f.deleteApplicationMapping,
 		f.deleteApplication,
 		f.deleteChannel,
-		f.waitForClassesRemoved,
 		f.undeployEnvTester,
 	} {
 		err := fn()
@@ -166,6 +165,7 @@ func (f *appBrokerFlow) logReport() {
 }
 
 func (f *appBrokerFlow) deleteApplication() error {
+	f.log.Infof("Removing Application %s", applicationName)
 	return f.appConnectorInterface.ApplicationconnectorV1alpha1().Applications().Delete(applicationName, &metav1.DeleteOptions{})
 }
 
@@ -188,6 +188,7 @@ func (f *appBrokerFlow) createChannel() error {
 }
 
 func (f *appBrokerFlow) deleteChannel() error {
+	f.log.Infof("Removing Channel %s", applicationName)
 	return f.messagingInterface.Channels(integrationNamespace).Delete(applicationName, &metav1.DeleteOptions{})
 }
 
@@ -350,6 +351,7 @@ func (f *appBrokerFlow) deleteEventsServiceInstance() error {
 }
 
 func (f *appBrokerFlow) deleteApplicationMapping() error {
+	f.log.Infof("Removing Application Mapping %s", applicationName)
 	return f.appBrokerInterface.ApplicationconnectorV1alpha1().ApplicationMappings(f.namespace).Delete(applicationName, &metav1.DeleteOptions{})
 }
 
@@ -362,19 +364,6 @@ func (f *appBrokerFlow) waitForInstances() error {
 	err = f.waitForInstance(eventsServiceID)
 
 	return err
-}
-
-func (f *appBrokerFlow) waitForClassesRemoved() error {
-	return f.wait(5*time.Second, func() (bool, error) {
-		classes, err := f.scInterface.ServicecatalogV1beta1().ServiceClasses(f.namespace).List(metav1.ListOptions{})
-		if err != nil {
-			return false, err
-		}
-		if len(classes.Items) == 0 {
-			return true, nil
-		}
-		return false, nil
-	})
 }
 
 func (f *appBrokerFlow) waitForClassAndPlans() error {
@@ -454,7 +443,7 @@ func (f *appBrokerFlow) waitForEnvTester() error {
 }
 
 func (f *appBrokerFlow) undeployEnvTester() error {
-	f.log.Info("Removing deployment environment variable tester")
+	f.log.Infof("Removing deployment %s", appEnvTester)
 	return f.deleteDeployment(appEnvTester)
 }
 

--- a/tests/end-to-end/upgrade/pkg/tests/service-catalog/base_flow.go
+++ b/tests/end-to-end/upgrade/pkg/tests/service-catalog/base_flow.go
@@ -283,6 +283,7 @@ func (f *baseFlow) waitForInstanceRemoved(name string) error {
 		instance, err := f.scInterface.ServicecatalogV1beta1().ServiceInstances(f.namespace).Get(name, metav1.GetOptions{})
 		if err != nil {
 			if errors.IsNotFound(err) {
+				f.log.Infof("Service instances in namespace %s not found - all deleted", f.namespace)
 				return true, nil
 			}
 			f.log.Warnf(err.Error())


### PR DESCRIPTION

<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/master/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**
In e2e upgrade test we're waiting for `ClusterServiceClass` removal, which leads to random failures.

Changes proposed in this pull request:

- Do not wait for service-catalog CR removal

**Related issue(s)**
#10646 
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
