### PR TITLE
Fix the Trigger a Function with events AC tutorial

### DIFF
--- a/docs/application-connector/08-06-trigger-lambda-with-event.md
+++ b/docs/application-connector/08-06-trigger-lambda-with-event.md
@@ -176,7 +176,7 @@ To create a simple Function and trigger it with an event, you must first registe
    ```bash
    curl -X POST -H "Content-Type: application/json" https://gateway.{CLUSTER_DOMAIN}/$APP_NAME/v1/events -k --cert {CERT_FILE_NAME}.crt --key {KEY_FILE_NAME}.key -d \
    '{
-       "event-type": "$EVENT",
+       "event-type": "'$EVENT'",
        "event-type-version": "v1",
        "event-id": "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
        "event-time": "2018-10-16T15:00:00Z",

--- a/docs/application-connector/08-06-trigger-lambda-with-event.md
+++ b/docs/application-connector/08-06-trigger-lambda-with-event.md
@@ -19,7 +19,7 @@ To create a simple Function and trigger it with an event, you must first registe
    ```bash
    export NAMESPACE={YOUR_NAMESPACE}
    export APP_NAME={YOUR_APPLICATION_NAME}
-   export EVENT={YOUR_EVENT}
+   export EVENT={YOUR_EVENT_TYPE}
    ```
 
 2. Register a service with events in the desired Application. Use the example AsyncAPI specification.

--- a/docs/application-connector/08-06-trigger-lambda-with-event.md
+++ b/docs/application-connector/08-06-trigger-lambda-with-event.md
@@ -145,8 +145,6 @@ To create a simple Function and trigger it with an event, you must first registe
 
 6. Create a Subscription to allow events to trigger the Function.
 
-> **NOTE:** In the Subscription CR, provide `$APP_NAME` without any special characters like dashes (`-`) or dots (`.`). For example, use `commercemock` instead of `commerce-mock`.
-
    ```bash
    cat <<EOF | kubectl apply -f -
    apiVersion: eventing.kyma-project.io/v1alpha1
@@ -155,7 +153,7 @@ To create a simple Function and trigger it with an event, you must first registe
      labels:
        function: my-events-function
      name: function-my-events-function-exampleevent-v1
-     namespace: ${NAMESPACE}
+     namespace: $NAMESPACE
    spec:
      filter:
        filters:
@@ -166,10 +164,10 @@ To create a simple Function and trigger it with an event, you must first registe
          eventType:
            property: type
            type: exact
-           value: sap.kyma.custom.${APP_NAME}.${EVENT}.v1
+           value: sap.kyma.custom.$APP_NAME.$EVENT.v1
      protocol: ""
      protocolsettings: {}
-     sink: http://my-events-function.${NAMESPACE}.svc.cluster.local
+     sink: http://my-events-function.$NAMESPACE.svc.cluster.local
    EOF
    ```
 

--- a/docs/application-connector/08-06-trigger-lambda-with-event.md
+++ b/docs/application-connector/08-06-trigger-lambda-with-event.md
@@ -155,21 +155,21 @@ To create a simple Function and trigger it with an event, you must first registe
      labels:
        function: my-events-function
      name: function-my-events-function-exampleevent-v1
-     namespace: $NAMESPACE
+     namespace: ${NAMESPACE}
    spec:
      filter:
-      filters:
-        - eventSource:
+       filters:
+       - eventSource:
            property: source
            type: exact
            value: ""
          eventType:
            property: type
            type: exact
-           value: sap.kyma.custom.$APP_NAME.$EVENT.v1
+           value: sap.kyma.custom.${APP_NAME}.${EVENT}.v1
      protocol: ""
      protocolsettings: {}
-     sink: http://my-events-function.$NAMESPACE.svc.cluster.local
+     sink: http://my-events-function.${NAMESPACE}.svc.cluster.local
    EOF
    ```
 


### PR DESCRIPTION
**Description**

Following recent changes to Eventing in Kyma, the Application Connector tutorials were modified. 
During AC tutorial testing for 1.21-RC1, it turned out that these modifications included some bugs. This PR fixes them. 

Changes proposed in this pull request:

- Specify that in `export EVENT` you must export the event type (and not the whole payload, for example)
- Fix indentation in the Subscription code snippet
- Remove the NOTE panel as the endpoint used in the tutorial strips the app name of `-` and `.` itself
- Put `"$EVENT"` in ticks (`'`) in the event payload

**Related issue(s)**
#9311 
