### PR TITLE
Split up Logging chart rules  to respective subcharts

### DIFF
--- a/resources/logging/charts/fluent-bit/templates/kyma-additions/fluent-bit.rules.yaml
+++ b/resources/logging/charts/fluent-bit/templates/kyma-additions/fluent-bit.rules.yaml
@@ -9,7 +9,7 @@ spec:
   groups:
   - name: fluent-bit.rules
     - alert: NoOutputBytesProcessed
-      expr: rate(fluentbit_output_proc_bytes_total{ {{ .Values.kymaRules.fluentBitAlertFilter }} }[5m]) == 0
+      expr: rate(fluentbit_output_proc_bytes_total{ {{ .Values.prometheusRules.fluentBitAlertFilter }} }[5m]) == 0
       annotations:
         description: Fluent Bit instance {{ `{{ $labels.instance }}` }}'s output plugin {{ `{{ $labels.name }}` }} has not processed any
           bytes for at least 15 minutes.

--- a/resources/logging/charts/fluent-bit/templates/kyma-additions/fluent-bit.rules.yaml
+++ b/resources/logging/charts/fluent-bit/templates/kyma-additions/fluent-bit.rules.yaml
@@ -7,7 +7,8 @@ metadata:
 {{ include "fluent-bit.labels" . | indent 4 }}
 spec:
   groups:
-  - name: fluent-bit.rules
+  - name: loki.rules
+    rules:
     - alert: NoOutputBytesProcessed
       expr: rate(fluentbit_output_proc_bytes_total{ {{ .Values.prometheusRules.fluentBitAlertFilter }} }[5m]) == 0
       annotations:

--- a/resources/logging/charts/fluent-bit/templates/kyma-additions/fluent-bit.rules.yaml
+++ b/resources/logging/charts/fluent-bit/templates/kyma-additions/fluent-bit.rules.yaml
@@ -1,0 +1,20 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: {{ printf "%s-%s" (include "fluent-bit.fullname" .) "kyma-fluent-bit.rules" | trunc 63 | trimSuffix "-" }}
+  labels:
+    app: {{ template "fluent-bit.name" . }}
+{{ include "fluent-bit.labels" . | indent 4 }}
+spec:
+  groups:
+  - name: fluent-bit.rules
+    - alert: NoOutputBytesProcessed
+      expr: rate(fluentbit_output_proc_bytes_total{ {{ .Values.kymaRules.fluentBitAlertFilter }} }[5m]) == 0
+      annotations:
+        description: Fluent Bit instance {{ `{{ $labels.instance }}` }}'s output plugin {{ `{{ $labels.name }}` }} has not processed any
+          bytes for at least 15 minutes.
+        summary: No Output Bytes Processed
+      for: 15m
+      labels:
+        severity: critical   
+

--- a/resources/logging/charts/fluent-bit/values.yaml
+++ b/resources/logging/charts/fluent-bit/values.yaml
@@ -130,6 +130,11 @@ updateStrategy: {}
 # Make use of a pre-defined configmap instead of the one templated here
 existingConfigMap: ""
 
+## Custom configuration for Kyma alerting rules
+kymaRules:
+  ## Adds the specified filter to NoOutputBytesProcessed alert for Fluent Bit
+  fluentBitAlertFilter: ""
+
 # Fluentbit configuration section
 # https://docs.fluentbit.io/manual/administration/configuring-fluent-bit/configuration-file
 config:

--- a/resources/logging/charts/fluent-bit/values.yaml
+++ b/resources/logging/charts/fluent-bit/values.yaml
@@ -131,7 +131,7 @@ updateStrategy: {}
 existingConfigMap: ""
 
 ## Custom configuration for Kyma alerting rules
-kymaRules:
+prometheusRules:
   ## Adds the specified filter to NoOutputBytesProcessed alert for Fluent Bit
   fluentBitAlertFilter: ""
 

--- a/resources/logging/charts/loki/templates/_helpers.tpl
+++ b/resources/logging/charts/loki/templates/_helpers.tpl
@@ -43,6 +43,18 @@ Create the name of the service account
 {{- end -}}
 
 {{/*
+Common labels
+*/}}
+{{- define "loki.labels" -}}
+helm.sh/chart: {{ include "loki.chart" . }}
+{{ include "loki.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end -}}
+
+{{/*
 Create the app name of loki clients. Defaults to the same logic as "loki.fullname", and default client expects "promtail".
 */}}
 {{- define "client.name" -}}

--- a/resources/logging/charts/loki/templates/_helpers.tpl
+++ b/resources/logging/charts/loki/templates/_helpers.tpl
@@ -43,6 +43,14 @@ Create the name of the service account
 {{- end -}}
 
 {{/*
+Selector labels
+*/}}
+{{- define "loki.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "fluent-bit.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end -}}
+
+{{/*
 Common labels
 */}}
 {{- define "loki.labels" -}}
@@ -52,14 +60,6 @@ helm.sh/chart: {{ include "loki.chart" . }}
 app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 {{- end }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
-{{- end -}}
-
-{{/*
-Selector labels
-*/}}
-{{- define "fluent-bit.selectorLabels" -}}
-app.kubernetes.io/name: {{ include "fluent-bit.name" . }}
-app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end -}}
 
 {{/*

--- a/resources/logging/charts/loki/templates/_helpers.tpl
+++ b/resources/logging/charts/loki/templates/_helpers.tpl
@@ -55,6 +55,14 @@ app.kubernetes.io/managed-by: {{ .Release.Service }}
 {{- end -}}
 
 {{/*
+Selector labels
+*/}}
+{{- define "fluent-bit.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "fluent-bit.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end -}}
+
+{{/*
 Create the app name of loki clients. Defaults to the same logic as "loki.fullname", and default client expects "promtail".
 */}}
 {{- define "client.name" -}}

--- a/resources/logging/charts/loki/templates/kyma-additions/loki.rules.yaml
+++ b/resources/logging/charts/loki/templates/kyma-additions/loki.rules.yaml
@@ -36,4 +36,3 @@ spec:
         description: The {{ `{{ $labels.job }}` }} is experiencing {{ `{{ printf "%.2f" $value }}` }}% increase of panics.
       labels:
         severity: critical
-

--- a/resources/logging/charts/loki/templates/kyma-additions/loki.rules.yaml
+++ b/resources/logging/charts/loki/templates/kyma-additions/loki.rules.yaml
@@ -1,13 +1,13 @@
 apiVersion: monitoring.coreos.com/v1
 kind: PrometheusRule
 metadata:
-  name: {{ printf "%s-%s" (include "logging.fullname" .) "kyma-logging.rules" | trunc 63 | trimSuffix "-" }}
+  name: {{ printf "%s-%s" (include "loki.fullname" .) "kyma-loki.rules" | trunc 63 | trimSuffix "-" }}
   labels:
-    app: {{ template "logging.name" . }}
-{{ include "logging.labels" . | indent 4 }}
+    app: {{ template "loki.name" . }}
+{{ include "loki.labels" . | indent 4 }}
 spec:
   groups:
-  - name: logging.rules
+  - name: loki.rules
     rules:
     - alert: LoggingKBPSHigh
       expr: rate(loki_distributor_bytes_received_total[5m])/1024 > 1024
@@ -29,16 +29,7 @@ spec:
       labels:
         severity: critical
       annotations:
-        description: 'High percentage of failing requests for logging: Number of requests is {{`{{$value}}`}}%'
-    - alert: NoOutputBytesProcessed
-      expr: rate(fluentbit_output_proc_bytes_total{ {{ .Values.kymaRules.fluentBitAlertFilter }} }[5m]) == 0
-      annotations:
-        description: Fluent Bit instance {{ `{{ $labels.instance }}` }}'s output plugin {{ `{{ $labels.name }}` }} has not processed any
-          bytes for at least 15 minutes.
-        summary: No Output Bytes Processed
-      for: 15m
-      labels:
-        severity: critical   
+        description: 'High percentage of failing requests for logging: Number of requests is {{`{{$value}}`}}%'  
     - alert: LokiRequestPanics
       expr: sum(increase(loki_panic_total[10m])) by (namespace, job) > 0
       annotations:

--- a/resources/logging/values.yaml
+++ b/resources/logging/values.yaml
@@ -20,11 +20,6 @@ fluent-bit:
 loki:
   enabled: true
 
-## Custom configuration for Kyma alerting rules
-kymaRules:
-  ## Adds the specified filter to NoOutputBytesProcessed alert for Fluent Bit
-  fluentBitAlertFilter: ""
-
 global:
   containerRegistry:
     path: eu.gcr.io/kyma-project


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/master/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- Prometheus-Alerting-Rules of logging chart have been split to sub-charts (fluentbit and Loki)
- Splitting up helps with the situation when fluentbit or Loki is disabled, all rules of active charts can be applied without having to deal with deactivating certain Rules, since if the sub-charts are deactivated, the corresponding rules will also not be applied

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
