### PR TITLE
Add alias to Loki address in local case

### DIFF
--- a/resources/logging/templates/tests/test.yaml
+++ b/resources/logging/templates/tests/test.yaml
@@ -30,6 +30,7 @@ spec:
           hostnames:
             - "oauth2.{{ .Values.global.ingress.domainName }}"
             - "dex.{{ .Values.global.ingress.domainName }}"
+            - "loki.{{ .Values.global.ingress.domainName }}"
       {{ end }}
       restartPolicy: Never
       containers:


### PR DESCRIPTION
**Description**

Wen logging test are executed on local minikube installation the requests to loki address fails, as domain name cannot be resolved. 
The error that is thrown is the following:
```
2021/03/29 17:08:26 cannot query loki for logs: cannot send HTTP request to https://loki.kyma.local/api/prom/query?query={container="count"}&start=1617037701834791419: Get "https://loki.kyma.local/api/prom/query?query={container=\"count\"}&start=1617037701834791419": dial tcp: lookup loki.kyma.local on 10.96.0.10:53: no such host
```

Changes proposed in this pull request:

- Add alias to Loki address in local minikube scenario
