### PR TITLE
Fix eventing health probes coming outside of Istio mesh

### DIFF
--- a/resources/eventing/charts/event-publisher-nats/templates/service.yaml
+++ b/resources/eventing/charts/event-publisher-nats/templates/service.yaml
@@ -21,7 +21,12 @@ spec:
   type: ClusterIP
   selector: {{- include "event-publisher-nats.selectorLabels" . | nindent 4 }}
   ports:
-    - protocol: TCP
+    - name: metrics
+      protocol: TCP
       port: 80
       targetPort: {{ .Values.metrics.service.port }}
+    - name: proxy-status
+      protocol: TCP
+      port: {{ .Values.global.istio.proxy.statusPort }}
+      targetPort: {{ .Values.global.istio.proxy.statusPort }}
 {{- end }}

--- a/resources/eventing/charts/event-publisher-nats/templates/service.yaml
+++ b/resources/eventing/charts/event-publisher-nats/templates/service.yaml
@@ -21,10 +21,19 @@ spec:
   type: ClusterIP
   selector: {{- include "event-publisher-nats.selectorLabels" . | nindent 4 }}
   ports:
-    - name: metrics
-      protocol: TCP
+    - protocol: TCP
       port: 80
       targetPort: {{ .Values.metrics.service.port }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "event-publisher-nats.serviceName" . }}-health
+  labels: {{- include "event-publisher-nats.labels" . | nindent 4 }}
+spec:
+  type: ClusterIP
+  selector: {{- include "event-publisher-nats.selectorLabels" . | nindent 4 }}
+  ports:
     - name: proxy-status
       protocol: TCP
       port: {{ .Values.global.istio.proxy.statusPort }}

--- a/resources/eventing/charts/event-publisher-proxy/templates/service.yaml
+++ b/resources/eventing/charts/event-publisher-proxy/templates/service.yaml
@@ -21,10 +21,23 @@ spec:
   type: ClusterIP
   selector: {{- include "event-publisher-proxy.selectorLabels" . | nindent 4 }}
   ports:
-    - name: metrics
-      protocol: TCP
+    - protocol: TCP
       port: 80
       targetPort: {{ .Values.metrics.service.port }}
+    - name: proxy-status
+      protocol: TCP
+      port: {{ .Values.global.istio.proxy.statusPort }}
+      targetPort: {{ .Values.global.istio.proxy.statusPort }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "event-publisher-proxy.fullname" . }}-health
+  labels: {{- include "event-publisher-proxy.labels" . | nindent 4 }}
+spec:
+  type: ClusterIP
+  selector: {{- include "event-publisher-proxy.selectorLabels" . | nindent 4 }}
+  ports:
     - name: proxy-status
       protocol: TCP
       port: {{ .Values.global.istio.proxy.statusPort }}

--- a/resources/eventing/charts/event-publisher-proxy/templates/service.yaml
+++ b/resources/eventing/charts/event-publisher-proxy/templates/service.yaml
@@ -24,18 +24,4 @@ spec:
     - protocol: TCP
       port: 80
       targetPort: {{ .Values.metrics.service.port }}
----
-apiVersion: v1
-kind: Service
-metadata:
-  name: {{ include "event-publisher-proxy.fullname" . }}-health
-  labels: {{- include "event-publisher-proxy.labels" . | nindent 4 }}
-spec:
-  type: ClusterIP
-  selector: {{- include "event-publisher-proxy.selectorLabels" . | nindent 4 }}
-  ports:
-    - name: proxy-status
-      protocol: TCP
-      port: {{ .Values.global.istio.proxy.statusPort }}
-      targetPort: {{ .Values.global.istio.proxy.statusPort }}
 {{- end }}

--- a/resources/eventing/charts/event-publisher-proxy/templates/service.yaml
+++ b/resources/eventing/charts/event-publisher-proxy/templates/service.yaml
@@ -24,10 +24,6 @@ spec:
     - protocol: TCP
       port: 80
       targetPort: {{ .Values.metrics.service.port }}
-    - name: proxy-status
-      protocol: TCP
-      port: {{ .Values.global.istio.proxy.statusPort }}
-      targetPort: {{ .Values.global.istio.proxy.statusPort }}
 ---
 apiVersion: v1
 kind: Service

--- a/resources/eventing/charts/event-publisher-proxy/templates/service.yaml
+++ b/resources/eventing/charts/event-publisher-proxy/templates/service.yaml
@@ -21,7 +21,12 @@ spec:
   type: ClusterIP
   selector: {{- include "event-publisher-proxy.selectorLabels" . | nindent 4 }}
   ports:
-    - protocol: TCP
+    - name: metrics
+      protocol: TCP
       port: 80
       targetPort: {{ .Values.metrics.service.port }}
+    - name: proxy-status
+      protocol: TCP
+      port: {{ .Values.global.istio.proxy.statusPort }}
+      targetPort: {{ .Values.global.istio.proxy.statusPort }}
 {{- end }}

--- a/resources/eventing/charts/nats-controller/templates/deployment.yaml
+++ b/resources/eventing/charts/nats-controller/templates/deployment.yaml
@@ -33,6 +33,7 @@ spec:
             limits:
               cpu: {{ .Values.resources.limits.cpu }}
               memory: {{ .Values.resources.limits.memory }}
+          # TODO: probe on metrics endpoint is a temporary workaround, should be cleaned up by https://github.com/kyma-project/kyma/issues/9769
           livenessProbe:
             failureThreshold: 3
             httpGet:

--- a/resources/eventing/charts/nats-controller/templates/deployment.yaml
+++ b/resources/eventing/charts/nats-controller/templates/deployment.yaml
@@ -33,6 +33,16 @@ spec:
             limits:
               cpu: {{ .Values.resources.limits.cpu }}
               memory: {{ .Values.resources.limits.memory }}
+          livenessProbe:
+            failureThreshold: 3
+            httpGet:
+              path: /metrics
+              port: 8080
+              scheme: HTTP
+            initialDelaySeconds: 60
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 3
     {{- if .Values.global.priorityClassName }}
       priorityClassName: {{ .Values.global.priorityClassName }}
     {{- end }}

--- a/resources/eventing/charts/nats-controller/templates/deployment.yaml
+++ b/resources/eventing/charts/nats-controller/templates/deployment.yaml
@@ -33,16 +33,6 @@ spec:
             limits:
               cpu: {{ .Values.resources.limits.cpu }}
               memory: {{ .Values.resources.limits.memory }}
-          livenessProbe:
-            failureThreshold: 3
-            httpGet:
-              path: /metrics
-              port: 8080
-              scheme: HTTP
-            initialDelaySeconds: 60
-            periodSeconds: 10
-            successThreshold: 1
-            timeoutSeconds: 3
     {{- if .Values.global.priorityClassName }}
       priorityClassName: {{ .Values.global.priorityClassName }}
     {{- end }}

--- a/resources/eventing/charts/nats-controller/templates/service.yaml
+++ b/resources/eventing/charts/nats-controller/templates/service.yaml
@@ -8,7 +8,12 @@ spec:
   type: ClusterIP
   selector: {{- include "nats-controller.selectorLabels" . | nindent 4 }}
   ports:
-    - protocol: TCP
+    - name: metrics
+      protocol: TCP
       port: 80
       targetPort: 8080
+    - name: proxy-status
+      protocol: TCP
+      port: {{ .Values.global.istio.proxy.statusPort }}
+      targetPort: {{ .Values.global.istio.proxy.statusPort }}
 {{- end }}

--- a/resources/eventing/charts/nats-controller/templates/service.yaml
+++ b/resources/eventing/charts/nats-controller/templates/service.yaml
@@ -8,12 +8,7 @@ spec:
   type: ClusterIP
   selector: {{- include "nats-controller.selectorLabels" . | nindent 4 }}
   ports:
-    - name: metrics
-      protocol: TCP
+    - protocol: TCP
       port: 80
       targetPort: 8080
-    - name: proxy-status
-      protocol: TCP
-      port: {{ .Values.global.istio.proxy.statusPort }}
-      targetPort: {{ .Values.global.istio.proxy.statusPort }}
 {{- end }}

--- a/resources/eventing/charts/nats-controller/templates/service.yaml
+++ b/resources/eventing/charts/nats-controller/templates/service.yaml
@@ -11,4 +11,18 @@ spec:
     - protocol: TCP
       port: 80
       targetPort: 8080
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "nats-controller.fullname" . }}-health
+  labels: {{- include "nats-controller.labels" . | nindent 4 }}
+spec:
+  type: ClusterIP
+  selector: {{- include "nats-controller.selectorLabels" . | nindent 4 }}
+  ports:
+    - name: proxy-status
+      protocol: TCP
+      port: {{ .Values.global.istio.proxy.statusPort }}
+      targetPort: {{ .Values.global.istio.proxy.statusPort }}
 {{- end }}

--- a/resources/eventing/values.yaml
+++ b/resources/eventing/values.yaml
@@ -14,6 +14,10 @@ global:
     # backend defines the provisioned eventing backend, either NATS or BEB
     backend: nats
 
+  istio:
+    proxy:
+      statusPort: 15020
+
   # eventTypePrefix is the prefix of the eventType
   # note that the eventType format is: eventTypePrefix.applicationName.eventName.eventVersion
   # for example: sap.kyma.custom.myapp.order.created.v1 (where the eventName is order.created)


### PR DESCRIPTION
**Description**

Define liveness probes for `eventing-nats-controller`, based on the controller metrics endpoint

Expose istio proxy status port on `eventing-nats-controller-metrics` and `eventing-event-publisher-proxy-metrics` Services, so that the health endpoints could be probed outside of the Istio mesh after istio probe-rewrite through:

- `eventing-event-publisher-proxy-health.kyma-system:15020/app-health/event-publisher-nats/readyz`
- `eventing-nats-controller-health.kyma-system:15020/app-health/nats-controller/livez`

