### PR TITLE
add pre-condtition for affinity attribute in ory's deployment.yaml

### DIFF
--- a/resources/ory/charts/gcloud-sqlproxy/templates/deployment.yaml
+++ b/resources/ory/charts/gcloud-sqlproxy/templates/deployment.yaml
@@ -100,8 +100,10 @@ spec:
       terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds }}
       nodeSelector:
 {{ toYaml .Values.nodeSelector | indent 8 }}
+{{- if .Values.affinity }}
       affinity:
 {{ toYaml .Values.affinity | indent 8 }}
+{{- end }}
       tolerations:
 {{ toYaml .Values.tolerations | indent 8 }}
 {{- end }}


### PR DESCRIPTION
try to fix the below error when execute the `helm install` 
```
    - component: ory
      log: |-
        Helm upgrade of release "ory" failed: error validating "": error validating data: ValidationError(Deployment.spec.template.spec.affinity): invalid type for io.k8s.api.core.v1.Affinity: got "string", expected "map".
        Finding last known deployed revision to rollback to.
        Performing rollback to last known deployed revision: 295
        Helm rollback of release "ory" was successfull
      occurrences: 1
    state: Error
    url: ""
    version: ""
```