### PR TITLE
Improve handling of "NotFound" condition when deleting pods

### DIFF
--- a/resources/istio/files/istio-proxy-reset.sh
+++ b/resources/istio/files/istio-proxy-reset.sh
@@ -31,27 +31,6 @@ retry() {
     done
 }
 
-
-# A function that deletes the object and handles NotFound condition as a success.
-tryDelete() {
-    local namespace=$1
-    local kind=$2
-    local name=$3
-
-    local code
-    local result
-
-    result=$(kubectl -n "${namespace}" delete "${kind}" "${name}" 2>&1); code=$?
-
-    if [[ ${code} -eq 1 && ${result} == *"NotFound"* ]]
-    then
-        echo "        Delete operation failed with: \"${result}\". Handling as a success (the ${kind}/${name} is gone)"
-        return 0
-    fi
-
-    return ${code}
-}
-
 # Deletes a pod
 deletePod() {
     local namespace=$1
@@ -59,7 +38,7 @@ deletePod() {
 
     if [[ "${dryRun}" == "false" ]]; then
         echo "    Deleting pod: ${namespace}/${podName}"
-        retry "${retriesCount}" tryDelete "${namespace}" pod "${podName}"
+        retry "${retriesCount}" kubectl -n "${namespace}" delete pod "${podName}"1 --ignore-not-found=true
         sleep "${sleepAfterPodDeleted}"
     else
         echo "    [dryrun]" kubectl -n "${namespace}" delete pod "${podName}"

--- a/resources/istio/files/istio-proxy-reset.sh
+++ b/resources/istio/files/istio-proxy-reset.sh
@@ -38,7 +38,7 @@ deletePod() {
 
     if [[ "${dryRun}" == "false" ]]; then
         echo "    Deleting pod: ${namespace}/${podName}"
-        retry "${retriesCount}" kubectl -n "${namespace}" delete pod "${podName}"1 --ignore-not-found=true
+        retry "${retriesCount}" kubectl -n "${namespace}" delete pod "${podName}" --ignore-not-found=true
         sleep "${sleepAfterPodDeleted}"
     else
         echo "    [dryrun]" kubectl -n "${namespace}" delete pod "${podName}"

--- a/resources/istio/files/istio-proxy-reset.sh
+++ b/resources/istio/files/istio-proxy-reset.sh
@@ -133,7 +133,6 @@ if [[ -z "${PODS_FILE}" ]]; then
 
     echo "Getting pods data into file: ${PODS_FILE}"
     allPods=$(retry "${retriesCount}" kubectl get po -A -o json)
-    allPods=$(retry "${retriesCount}" kubectl get po -n padu -o json)
     echo "${allPods}" > "${PODS_FILE}"
 fi
 

--- a/resources/istio/templates/istio-proxy-reset.yaml
+++ b/resources/istio/templates/istio-proxy-reset.yaml
@@ -65,17 +65,19 @@ spec:
           image: eu.gcr.io/kyma-project/tpi/k8s-tools:20210407-86c769bd
           env:
           - name: ISTIO_PROXY_IMAGE_PREFIX
-            value: {{ .Values.kyma.proxyResetJob.commonIstioProxyImagePrefix }}
+            value: {{ .Values.kyma.proxyResetJob.commonIstioProxyImagePrefix | quote }}
           - name: ISTIO_PROXY_IMAGE_VERSION
-            value: {{ .Chart.Version }}
+            value: {{ .Chart.Version | quote }}
           - name: RETRIES_COUNT
-            value: "{{ .Values.kyma.proxyResetJob.retriesCount }}"
+            value: {{ .Values.kyma.proxyResetJob.retriesCount | quote }}
           - name: DRY_RUN
-            value: "{{ .Values.kyma.proxyResetJob.dryRun }}"
+            value: {{ .Values.kyma.proxyResetJob.dryRun | quote }}
           - name: EXIT_CODE
-            value: "{{ .Values.kyma.proxyResetJob.exitCode }}"
+            value: {{ .Values.kyma.proxyResetJob.exitCode | quote }}
+          - name: SLEEP_AFTER_POD_DELETED
+            value: {{ .Values.kyma.proxyResetJob.sleepAfterPodDeleted | quote }}
           - name: HOME
-            value: /tmp
+            value: "/tmp"
           command:
             - /bin/bash
             - -c

--- a/resources/istio/values.yaml
+++ b/resources/istio/values.yaml
@@ -14,9 +14,10 @@ kyma:
     tag: "20210407-86c769bd"
   proxyResetJob:
     commonIstioProxyImagePrefix: "eu.gcr.io/kyma-project/external/istio/proxyv2"
-    retriesCount: "5"
-    dryRun: "false"
-    exitCode: "0"
+    retriesCount: 5
+    dryRun: false
+    sleepAfterPodDeleted: 1
+    exitCode: 0
   securityContext:
     allowPrivilegeEscalation: false
     capabilities:


### PR DESCRIPTION
**Description**

Follow-up to https://github.com/kyma-project/kyma/pull/11067.

Make it a success when "NotFound" error is returned by kubectl on an attempt to delete a Pod.

Changes proposed in this pull request:

- Changed Pod delete logic
- Introduce configurable sleep time after a Pod is deleted
- Quote all environment variables

**Related issue(s)**
See also https://github.com/kyma-project/kyma/pull/11067