### PR TITLE
Add the link to Busola console to allowlist

### DIFF
--- a/milv.config.yaml
+++ b/milv.config.yaml
@@ -96,3 +96,6 @@ files:
   - path: "./kyma/docs/security/08-06-generate-kubeconfig.md"
     config:
       external-links-to-ignore: ["https://configurations-generator.{YOUR_CLUSTER_DOMAIN"]
+  - path: "./kyma/components/busola-migrator/README.md "
+    config:
+      external-links-to-ignore: ["https://busola.main.hasselhoff.shoot.canary.k8s-hana.ondemand.com"]

--- a/milv.config.yaml
+++ b/milv.config.yaml
@@ -96,6 +96,6 @@ files:
   - path: "./kyma/docs/security/08-06-generate-kubeconfig.md"
     config:
       external-links-to-ignore: ["https://configurations-generator.{YOUR_CLUSTER_DOMAIN"]
-  - path: "./kyma/components/busola-migrator/README.md "
+  - path: "./kyma/components/busola-migrator/README.md"
     config:
       external-links-to-ignore: ["https://busola.main.hasselhoff.shoot.canary.k8s-hana.ondemand.com"]


### PR DESCRIPTION

**Description**

Changes proposed in this pull request:

- Add `https://busola.main.hasselhoff.shoot.canary.k8s-hana.ondemand.com"` to allowlist as the [`kyma-governance-nightly`](https://status.build.kyma-project.io/log?job=kyma-governance-nightly&id=1384718772413140993) governance job kept returning the `connection refused ` message.
