### PR TITLE
Migrate observability resources to new api versions

### DIFF
--- a/resources/logging/charts/logui/templates/rbac.yaml
+++ b/resources/logging/charts/logui/templates/rbac.yaml
@@ -8,7 +8,7 @@ metadata:
     app: {{ template "logui.name" . }}
 ---
 kind: Role
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: {{ template "logui.fullname" . }}
   namespace:  {{ .Release.Namespace }}
@@ -22,7 +22,7 @@ rules:
   {{- end }}
 ---
 kind: RoleBinding
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: {{ template "logui.fullname" . }}
   namespace:  {{ .Release.Namespace }}

--- a/resources/logging/charts/logui/templates/rbac.yaml
+++ b/resources/logging/charts/logui/templates/rbac.yaml
@@ -8,7 +8,7 @@ metadata:
     app: {{ template "logui.name" . }}
 ---
 kind: Role
-apiVersion: rbac.authorization.k8s.io/v1
+apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
   name: {{ template "logui.fullname" . }}
   namespace:  {{ .Release.Namespace }}
@@ -22,7 +22,7 @@ rules:
   {{- end }}
 ---
 kind: RoleBinding
-apiVersion: rbac.authorization.k8s.io/v1
+apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
   name: {{ template "logui.fullname" . }}
   namespace:  {{ .Release.Namespace }}

--- a/resources/monitoring/charts/grafana/templates/_helpers.tpl
+++ b/resources/monitoring/charts/grafana/templates/_helpers.tpl
@@ -108,7 +108,7 @@ Return the appropriate apiVersion for rbac.
 {{- if .Capabilities.APIVersions.Has "rbac.authorization.k8s.io/v1" }}
 {{- print "rbac.authorization.k8s.io/v1" -}}
 {{- else -}}
-{{- print "rbac.authorization.k8s.io/v1beta1" -}}
+{{- print "rbac.authorization.k8s.io/v1" -}}
 {{- end -}}
 {{- end -}}
 

--- a/resources/monitoring/charts/prometheus-istio/templates/_helpers.tpl
+++ b/resources/monitoring/charts/prometheus-istio/templates/_helpers.tpl
@@ -199,7 +199,7 @@ Return the appropriate apiVersion for rbac.
 {{- if .Capabilities.APIVersions.Has "rbac.authorization.k8s.io/v1" }}
 {{- print "rbac.authorization.k8s.io/v1" -}}
 {{- else -}}
-{{- print "rbac.authorization.k8s.io/v1beta1" -}}
+{{- print "rbac.authorization.k8s.io/v1" -}}
 {{- end -}}
 {{- end -}}
 


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- Migrate `(Cluster)Roles` and `(Cluster)RoleBindings` to "rbac.authorization.k8s.io/v1" since "rbac.authorization.k8s.io/v1beta1" is deprecated and will be removed in k8s v1.22.

**Related issue(s)**
See also #10497
