### PR TITLE
Rename master to main (leftovers)

### DIFF
--- a/resources/serverless/charts/k3s-tests/README.md
+++ b/resources/serverless/charts/k3s-tests/README.md
@@ -8,4 +8,4 @@ This project contains a chart with the test Job for the Function Controller.
 
 > **CAUTION:** This chart should not be installed with Kyma.
 
-This chart is installed in the `pre-master-serverless-integration-k3s` Prow job. The `values.yaml` file must have the same shape as [`values.yaml`](../../values.yaml) in the parent chart to properly inject required fields.
+This chart is installed in the `pre-main-serverless-integration-k3s` Prow job. The `values.yaml` file must have the same shape as [`values.yaml`](../../values.yaml) in the parent chart to properly inject required fields.

--- a/tests/fast-integration/README.md
+++ b/tests/fast-integration/README.md
@@ -125,8 +125,8 @@ We have several pipelines that use fast-integration tests. See the list of pipel
 
 Pipeline | Description | Infrastructure
 --|--|--|
-[pre-master-kyma-integration-k3s](https://status.build.kyma-project.io/?job=pre-master-kyma-integration-k3s) | Job that runs on every PR before the merge to the `main` branch. | k3s
-[post-master-kyma-integration-k3s](https://status.build.kyma-project.io/?job=post-master-kyma-integration-k3s) | Job that runs on every PR after it is merged to the `main` branch. | k3s
+[pre-main-kyma-integration-k3s](https://status.build.kyma-project.io/?job=pre-main-kyma-integration-k3s) | Job that runs on every PR before the merge to the `main` branch. | k3s
+[post-main-kyma-integration-k3s](https://status.build.kyma-project.io/?job=post-main-kyma-integration-k3s) | Job that runs on every PR after it is merged to the `main` branch. | k3s
 [kyma-integration-k3s](https://status.build.kyma-project.io/?job=kyma-integration-k3s) | Job that periodicially runs the fast-integration tests. | k3s
 [kyma-integration-production-gardener-azure](https://status.build.kyma-project.io/?job=kyma-integration-production-gardener-azure) | Periodic job that tests the production profile in Kyma. | Gardener, Azure
 [kyma-integration-evaluation-gardener-azure](https://status.build.kyma-project.io/?job=kyma-integration-evaluation-gardener-azure) | Periodic job that tests the evaluation profile in Kyma. | Gardener, Azure


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Changed `master` to `main` in docs (leftovers)

**Related issue(s)**
See issue https://github.com/kyma-project/community/issues/515