### PR TITLE
Upgrade Service Manager proxy image to the newest version

### DIFF
--- a/resources/service-manager-proxy/values.yaml
+++ b/resources/service-manager-proxy/values.yaml
@@ -39,7 +39,7 @@ image:
   pullPolicy: IfNotPresent
   pullsecret: null
   repository: eu.gcr.io/kyma-project/external/quay.io/service-manager/sb-proxy-k8s
-  tag: v0.8.16
+  tag: v0.8.17
 replicaCount: 1
 securityContext: { }
 service:


### PR DESCRIPTION
**Description**

New version of Service Manager proxy appeared which allows use of websockets for syncing offerings.

Changes proposed in this pull request:

- replace Service Manager proxy image with the newest image version.

**Related issue(s)**
#11217 