### PR TITLE
Upgrade nats from 2.1.8 to 2.1.9

### DIFF
--- a/components/nats-operator/Dockerfile
+++ b/components/nats-operator/Dockerfile
@@ -1,4 +1,4 @@
-FROM connecteverything/nats-operator:0.7.6 as builder
+FROM natsio/nats-operator:0.8.2 as builder
 FROM alpine:3.13
 COPY --from=builder /usr/local/bin/nats-operator /usr/local/bin/nats-operator
 CMD ["nats-operator"]

--- a/resources/eventing/charts/nats/templates/40-cr.yaml
+++ b/resources/eventing/charts/nats/templates/40-cr.yaml
@@ -5,7 +5,7 @@ metadata:
   name: {{ include "nats.fullname" . }}
 spec:
   size: {{ .Values.clusterSize }}
-  version: "2.1.8"
+  version: "2.1.9"
   serverImage: "eu.gcr.io/kyma-project/external/nats"
   pod:
     {{- if .Values.enableMetrics }}

--- a/resources/eventing/charts/nats/values.yaml
+++ b/resources/eventing/charts/nats/values.yaml
@@ -18,7 +18,7 @@ resources:
     memory: 16Mi
 
 image:
-  tag: "8ee92eeb"
+  tag: "PR-11244"
   name: "nats-operator"
   pullPolicy: "IfNotPresent"
 


### PR DESCRIPTION
Use NATS 2.1.9 instead of 2.1.8

https://github.com/nats-io/nats-server/releases/tag/v2.1.9
https://github.com/nats-io/nats-operator/releases/tag/v0.8.2

After Version 0.8.0 the docker image repository was changed from connecteverything/nats-operator:0.8.0  to natsio/nats-operator:0.8.2
