### PR TITLE
Upgrade Istio to 1.9.5

### DIFF
--- a/resources/istio/Chart.yaml
+++ b/resources/istio/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: istio
-version: 1.9.1-distroless
-appVersion: 1.9.1
+version: 1.9.5-distroless
+appVersion: 1.9.5
 tillerVersion: ">=2.7.2-0"
 description: Helm chart for all istio components
 keywords:

--- a/resources/istio/values.yaml
+++ b/resources/istio/values.yaml
@@ -33,7 +33,7 @@ kyma:
 istio:
   installer:
     image: eu.gcr.io/kyma-project/istio-installer
-    tag: "8d072ec7"
+    tag: "4039a61f"
   securityContext:
     runAsUser: 65534
     runAsNonRoot: true


### PR DESCRIPTION
**Description**

There are several security vulnerabilities discovered since Istio version 1.9.1: [link](https://istio.io/latest/news/security/)
This PR introduces all fixes by bumping Istio to 1.9.5

Changes proposed in this pull request:

- Bump Istio version to 1.9.5