### PR TITLE
Update to version 1.9.5

### DIFF
--- a/components/istio-installer/Dockerfile
+++ b/components/istio-installer/Dockerfile
@@ -2,7 +2,7 @@ FROM eu.gcr.io/kyma-project/tpi/k8s-tools:20210504-12243229
 
 LABEL source=git@github.com:kyma-project/kyma.git
 
-ENV ISTIOCTL_VERSION 1.9.1
+ENV ISTIOCTL_VERSION 1.9.5
 ENV YQ_VERSION 3.1.1
 
 RUN curl -L https://github.com/istio/istio/releases/download/${ISTIOCTL_VERSION}/istioctl-${ISTIOCTL_VERSION}-linux-amd64.tar.gz -o istioctl.tar.gz &&\


### PR DESCRIPTION
**Description**

Prepare istio-installer image for version Istio version 1.9.5
Changes proposed in this pull request:

- Update istio-installer version


**Related issue(s)**
See also: https://github.com/kyma-project/kyma/pull/11262