### PR TITLE
Correct the default runtime in Serverless docs

### DIFF
--- a/docs/serverless/03-02-available-runtimes.md
+++ b/docs/serverless/03-02-available-runtimes.md
@@ -3,7 +3,7 @@ title: Runtimes
 type: Details
 ---
 
-Functions support multiple languages through the use of runtimes. To use a chosen runtime, add its name and version as a value in the **spec.runtime** field of the [Function custom resource (CR)](#custom-resource-function). If this value is not specified, it defaults to `nodejs12`. Dependencies for a Node.js Function should be specified using the [`package.json`](https://docs.npmjs.com/creating-a-package-json-file) file format. Dependencies for a Python Function should follow the format used by [pip](https://packaging.python.org/key_projects/#pip).
+Functions support multiple languages through the use of runtimes. To use a chosen runtime, add its name and version as a value in the **spec.runtime** field of the [Function custom resource (CR)](#custom-resource-function). If this value is not specified, it defaults to `nodejs14`. Dependencies for a Node.js Function should be specified using the [`package.json`](https://docs.npmjs.com/creating-a-package-json-file) file format. Dependencies for a Python Function should follow the format used by [pip](https://packaging.python.org/key_projects/#pip).
 
 See sample Functions for all available runtimes:
 

--- a/docs/serverless/03-05-supported-webhooks.md
+++ b/docs/serverless/03-05-supported-webhooks.md
@@ -14,7 +14,7 @@ The defaulting webhook:
 - Sets default values for CPU and memory requests and limits for a Function.
 - Sets default values for CPU and memory requests and limits for a Kubernetes Job responsible for building the Function's image.
 - Adds the maximum and the minimum number of replicas, if not specified already in the Function CR.
-- Sets the default `nodejs12` runtime unless specified otherwise.
+- Sets the default `nodejs14` runtime unless specified otherwise.
 
    | Parameter       | Default value |
    | ----------------- | ------------- |
@@ -28,7 +28,7 @@ The defaulting webhook:
    | **buildResources.limits.memory**  | `1100Mi`       |
    | **minReplicas**   | `1`           |
    | **maxReplicas**   | `1`           |
-   | **runtime**       | `nodejs12`    |
+   | **runtime**       | `nodejs14`    |
 
 > **NOTE:** Function's resources and replicas as well as resources for a Kubernetes Job are based on presets. Read about all [available presets](#details-available-presets) to find out more.
 


### PR DESCRIPTION

**Description**

Changes proposed in this pull request:

- Correct the default runtime in Serverless docs, from Node.js 12 to Node.js 14.
