### PR TITLE
Change ETCD image in Helm Broker to alpine 3.3.15 based

### DIFF
--- a/resources/helm-broker/charts/etcd-stateful/values.yaml
+++ b/resources/helm-broker/charts/etcd-stateful/values.yaml
@@ -1,6 +1,6 @@
 etcd:
-  image: "eu.gcr.io/kyma-project/external/quay.io/coreos/etcd"
-  imageTag: "v3.3.25"
+  image: "eu.gcr.io/kyma-project/tpi/quay.io/coreos/etcd"
+  imageTag: "v3.3.25-051e9b55"
   secure: false
   resources:
     limits:


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**
`eu.gcr.io/kyma-project/tpi/quay.io/coreos/etcd:v3.3.25-051e9b55` is the etcd v3.3.25 image, but built on `alpine:3.3.15`:
https://github.com/kyma-project/third-party-images/tree/main/etcd

Changes proposed in this pull request:

- Changed etcd image directory and version

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
