### PR TITLE
Set temp override for Kubernetes min version in Serverless webhook

### DIFF
--- a/resources/serverless/charts/webhook/templates/deployment.yaml
+++ b/resources/serverless/charts/webhook/templates/deployment.yaml
@@ -69,6 +69,8 @@ spec:
               {{ include "tplValue" ( dict "value" .Values.container.envs.metricsDomain "context" . ) | nindent 14 }}
             - name: CONFIG_OBSERVABILITY_NAME
               {{ include "tplValue" ( dict "value" .Values.container.envs.configObservabilityName "context" . ) | nindent 14 }}
+            - name: KUBERNETES_MIN_VERSION # TODO: Delete this env after all CI pipelines are using k8s >1.17.0
+              value: "1.16.0"
     {{- if .Values.global.priorityClassName }}
       priorityClassName: {{ .Values.global.priorityClassName }}
     {{- end }}


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

After bumping serverless webhook dependencies the chart can no longer be installed on Kubernetes <1.17. Since some of our pipelines are still using 1.16.5 we decided to temporarily override the Kubernetes min version setting to unblock the installation before the pipelines are upgraded to a more recent K8s version. This environment variable should be removed once all pipelines installing serverless chart will be upgraded to Kubernetes 1.17.

Changes proposed in this pull request:

- Set temp override for Kubernetes min version in Serverless webhook

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
