### PR TITLE
disable exposure of observability tools for new installer

### DIFF
--- a/installation/resources/values.yaml
+++ b/installation/resources/values.yaml
@@ -1,0 +1,30 @@
+tracing:
+  kcproxy:
+    enabled: false
+  virtualservice:
+    enabled: false
+kiali:
+  kcproxy:
+    enabled: false
+  virtualservice:
+    enabled: false
+logging:
+  logui:
+    enabled: false
+  loki:
+    virtualservice:
+      enabled: false
+monitoring:
+  alertmanager:
+    enabled: false
+  grafana:
+    virtualservice:
+      enabled: false
+    kyma:
+      console:
+        enabled: false
+      authProxy:
+        enabled: false
+    env:
+      GF_AUTH_ANONYMOUS_ENABLED: "true"
+      GF_AUTH_GENERIC_OAUTH_ENABLED: "false"

--- a/resources/kiali/templates/kyma-additions/virtualservice.yaml
+++ b/resources/kiali/templates/kyma-additions/virtualservice.yaml
@@ -1,3 +1,4 @@
+{{ if .Values.virtualservice.enabled }}
 apiVersion: networking.istio.io/v1alpha3
 kind: VirtualService
 metadata:
@@ -20,3 +21,4 @@ spec:
         {{- end}}
         port:
           number: {{ .Values.kiali.spec.server.port }}
+{{- end }}

--- a/resources/kiali/values.yaml
+++ b/resources/kiali/values.yaml
@@ -25,7 +25,8 @@ global:
     namespaceAdminGroup: runtimeNamespaceAdmin
   tracing:
     enabled: true
-
+virtualservice:
+    enabled: true
 kcproxy:
   enabled: true
   replicaCount: 1

--- a/resources/logging/Chart.yaml
+++ b/resources/logging/Chart.yaml
@@ -6,7 +6,7 @@ home: https://kyma-project.io
 icon: https://github.com/kyma-project/kyma/blob/main/logo.png?raw=true
 dependencies:
   - name: logui
-    condition: loki.enabled
+    condition: logui.enabled
   - name: fluent-bit
     condition: fluent-bit.enabled
   - name: loki

--- a/resources/logging/charts/loki/templates/kyma-additions/authorizationpolicy.yaml
+++ b/resources/logging/charts/loki/templates/kyma-additions/authorizationpolicy.yaml
@@ -13,6 +13,7 @@ spec:
     matchLabels:
       app: {{ template "loki.name" . }}
   rules:
+{{- if .Values.virtualservice.enabled }}
   # log-ui requests having a JWT token can query deprecated API
   - from:
     - source:
@@ -26,6 +27,7 @@ spec:
     - key: request.auth.claims[groups]
       values: [{{ template "kyma.auth.groups" . }}]
     {{- end }}
+{{- end }}
   # Grafana having SA can query v1 API
   - from:
     - source:

--- a/resources/logging/charts/loki/templates/kyma-additions/requestautentication.yaml
+++ b/resources/logging/charts/loki/templates/kyma-additions/requestautentication.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.virtualservice.enabled }}
 apiVersion: security.istio.io/v1beta1
 kind: RequestAuthentication
 metadata:
@@ -14,3 +15,4 @@ spec:
   jwtRules:	
   - issuer: https://dex.{{ .Values.global.ingress.domainName }}
     jwksUri: http://dex-service.kyma-system.svc.cluster.local:5556/keys
+{{- end }}

--- a/resources/logging/charts/loki/templates/kyma-additions/virtualservice.yaml
+++ b/resources/logging/charts/loki/templates/kyma-additions/virtualservice.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.virtualservice.enabled }}
 apiVersion: networking.istio.io/v1alpha3
 kind: VirtualService
 metadata:
@@ -26,3 +27,4 @@ spec:
       - authorization
   gateways:
   - {{ .Values.global.istio.gateway.namespace }}/{{ .Values.global.istio.gateway.name }}
+{{- end }}

--- a/resources/logging/charts/loki/values.yaml
+++ b/resources/logging/charts/loki/values.yaml
@@ -279,6 +279,8 @@ kyma:
   auth:
     useKymaGroups: false
     groups: ""
+virtualservice:
+  enabled: true
 grafana:
   datasource:
     derivedFields: |

--- a/resources/tracing/templates/kyma-additions/virtualservice.yaml
+++ b/resources/tracing/templates/kyma-additions/virtualservice.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.virtualservice.enabled }}
 apiVersion: networking.istio.io/v1alpha3
 kind: VirtualService
 metadata:
@@ -19,3 +20,4 @@ spec:
         {{end}}
         port:
           number: {{ .Values.jaeger.kyma.uiPort }}
+{{- end }}

--- a/resources/tracing/values.yaml
+++ b/resources/tracing/values.yaml
@@ -112,7 +112,8 @@ global:
     namespaceAdminGroup: runtimeNamespaceAdmin
   tracing:
     enabled: true
-
+virtualservice:
+  enabled: true
 kcproxy:
   enabled: true
   replicaCount: 1


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**
With the new way of installation and the unavilability of dex, the observability tools cannot be exposed anymore by default. That PR disables the exposure by making the exposure configurable and introduction of a new central values.yaml file for collecting all the settings relevant for the new installation.

Changes proposed in this pull request:

- configurable kiali exposure
- configurable jaeger-ui exposure
- configurable loki exposure
- new central values.yaml file to be picked up by the new installer

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
Relates to https://github.com/kyma-project/cli/issues/892