### PR TITLE
[istio ingressgateway] add memory based HPA

### DIFF
--- a/resources/istio/files/istio-kyma-validate-test.sh
+++ b/resources/istio/files/istio-kyma-validate-test.sh
@@ -76,8 +76,19 @@ function check_sidecar_injector() {
   log "    Automatic injection policy is enabled" green
 }
 
+function require_ingressgateway_hpa() {
+    echo "--> Checking istio-ingresgateway HPA"
+    local targetMemHPA=$(kubectl -n istio-system get istiooperators.install.istio.io installed-state -o jsonpath="{.spec.components.ingressGateways[0].k8s.hpaSpec.metrics[?(@.resource.name=='memory')].resource.targetAverageUtilization}")
+    if [[ ${targetMemHPA} != "80" ]]; then
+       echo "   Memory based HPA needs to be set and targetAverageUtilization is 80" red
+       exit 1
+    fi
+    echo " Memory based HPA is has targetAverageUtilization set to 80" green
+}
+
 require_istio_system
 require_istio_version
+require_ingressgateway_hpa
 check_mtls_enabled
 check_sidecar_injector
 log "Istio is configured to run Kyma!" green

--- a/resources/istio/files/istio-operator-cluster-evaluation.yaml
+++ b/resources/istio/files/istio-operator-cluster-evaluation.yaml
@@ -68,6 +68,10 @@ spec:
               name: cpu
               targetAverageUtilization: 80
             type: Resource
+          - resource:
+              name: memory
+              targetAverageUtilization: 80
+            type: Resource
           minReplicas: 1
           scaleTargetRef:
             apiVersion: apps/v1

--- a/resources/istio/files/istio-operator-cluster-production.yaml
+++ b/resources/istio/files/istio-operator-cluster-production.yaml
@@ -69,6 +69,10 @@ spec:
               name: cpu
               targetAverageUtilization: 80
             type: Resource
+          - resource:
+              name: memory
+              targetAverageUtilization: 80
+            type: Resource
           scaleTargetRef:
             apiVersion: apps/v1
             kind: Deployment

--- a/resources/istio/files/istio-operator-cluster.yaml
+++ b/resources/istio/files/istio-operator-cluster.yaml
@@ -66,6 +66,10 @@ spec:
               name: cpu
               targetAverageUtilization: 80
             type: Resource
+          - resource:
+              name: memory
+              targetAverageUtilization: 80
+            type: Resource
           minReplicas: 1
           scaleTargetRef:
             apiVersion: apps/v1

--- a/resources/istio/files/istio-operator-minikube-evaluation.yaml
+++ b/resources/istio/files/istio-operator-minikube-evaluation.yaml
@@ -66,6 +66,10 @@ spec:
                 name: cpu
                 targetAverageUtilization: 80
               type: Resource
+            - resource:
+                name: memory
+                targetAverageUtilization: 80
+              type: Resource
           minReplicas: 1
           scaleTargetRef:
             apiVersion: apps/v1

--- a/resources/istio/files/istio-operator-minikube.yaml
+++ b/resources/istio/files/istio-operator-minikube.yaml
@@ -66,6 +66,10 @@ spec:
               name: cpu
               targetAverageUtilization: 80
             type: Resource
+          - resource:
+              name: memory
+              targetAverageUtilization: 80
+            type: Resource
           minReplicas: 1
           scaleTargetRef:
             apiVersion: apps/v1

--- a/resources/istio/templates/tests/istio-kyma-validate-rbac.yaml
+++ b/resources/istio/templates/tests/istio-kyma-validate-rbac.yaml
@@ -12,6 +12,9 @@ rules:
   - apiGroups: ["security.istio.io"]
     resources: ["peerauthentications"]
     verbs: ["get", "list"]
+  - apiGroups: ["install.istio.io"]
+    resources: ["istiooperators"]
+    verbs: ["get", "list"]
 ---
 apiVersion: v1
 kind: ServiceAccount


### PR DESCRIPTION
Envoy proxy can use large amount of memory in some cases [0],
hence HPA based on CPU util alone is not enough and the deployment
should also scale based on memory util to prevent/minimize OOM kills.

[0] #11303 

Resolves #11303 

<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->


**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
