### PR TITLE
Ensure QoS for helpers Pods in ORY chart

### DIFF
--- a/resources/ory/charts/oathkeeper/templates/job.yaml
+++ b/resources/ory/charts/oathkeeper/templates/job.yaml
@@ -84,6 +84,13 @@ spec:
             runAsGroup: 101
             runAsNonRoot: true
             runAsUser: 100
+          resources:
+            limits:
+              memory: 192Mi
+              cpu: 100m
+            requests:
+              memory: 192Mi
+              cpu: 100m
       containers:
         - command:
             - /bin/bash
@@ -104,6 +111,13 @@ spec:
             runAsGroup: 65534
             runAsNonRoot: true
             runAsUser: 65534
+          resources:
+            limits:
+              memory: 128Mi
+              cpu: 100m
+            requests:
+              memory: 128Mi
+              cpu: 100m
           volumeMounts:
           - name: {{ include "oathkeeper.name" . }}-keys-volume
             mountPath: /etc/secrets

--- a/resources/ory/charts/oathkeeper/templates/job.yaml
+++ b/resources/ory/charts/oathkeeper/templates/job.yaml
@@ -87,10 +87,10 @@ spec:
           resources:
             limits:
               memory: 192Mi
-              cpu: 100m
+              cpu: 400m
             requests:
               memory: 192Mi
-              cpu: 100m
+              cpu: 200m
       containers:
         - command:
             - /bin/bash

--- a/resources/ory/templates/job-secret-migration.yaml
+++ b/resources/ory/templates/job-secret-migration.yaml
@@ -104,10 +104,10 @@ spec:
           runAsUser: 65534
         resources:
           limits:
-            memory: 96Mi
+            memory: 128Mi
             cpu: 100m
           requests:
-            memory: 96Mi
+            memory: 128Mi
             cpu: 100m
     {{- if .Values.global.priorityClassName }}
       priorityClassName: {{ .Values.global.priorityClassName }}

--- a/resources/ory/templates/job-secret-migration.yaml
+++ b/resources/ory/templates/job-secret-migration.yaml
@@ -102,6 +102,13 @@ spec:
           runAsGroup: 65534
           runAsNonRoot: true
           runAsUser: 65534
+        resources:
+          limits:
+            memory: 96Mi
+            cpu: 100m
+          requests:
+            memory: 96Mi
+            cpu: 100m
     {{- if .Values.global.priorityClassName }}
       priorityClassName: {{ .Values.global.priorityClassName }}
     {{- end }}


### PR DESCRIPTION
**Description**

OOM issues in different CI jobs frequently target `ory` Pods
It's a target for OOM because it has no resources configured.

Changes proposed in this pull request:

- Configure resources for `ory-mechanism-migration*` Pod
- Configure resources for for `ory-oathkeeper-helper-keys-job*` Pod
