### PR TITLE
Change image `eu.gcr.io/kyma-project/test-infra/alpine-kubectl:v20200309-9a88ce97` to `eu.gcr.io/kyma-project/tpi/k8s-tools:20210504-12243229`.

### DIFF
--- a/tests/fast-integration/installer/charts/ingress-dns-cert/templates/job.yaml
+++ b/tests/fast-integration/installer/charts/ingress-dns-cert/templates/job.yaml
@@ -16,7 +16,7 @@ spec:
       restartPolicy: Never
       containers:
       - name: {{ .Release.Name }}
-        image: eu.gcr.io/kyma-project/test-infra/alpine-kubectl:v20200309-9a88ce97
+        image: eu.gcr.io/kyma-project/tpi/k8s-tools:20210504-12243229
         command: ["/bin/sh", ]
         args: ["-c","kubectl -n istio-system annotate service istio-ingressgateway dns.gardener.cloud/class=garden dns.gardener.cloud/dnsnames=*.$(GLOBAL_DOMAIN) --overwrite" ]
         env:
@@ -41,7 +41,7 @@ spec:
       restartPolicy: Never
       containers:
       - name: {{ .Release.Name }}-job1
-        image: eu.gcr.io/kyma-project/test-infra/alpine-kubectl:v20200309-9a88ce97
+        image: eu.gcr.io/kyma-project/tpi/k8s-tools:20210504-12243229
         command: ["/bin/sh", ]
         args: ["-c","kubectl create secret tls kyma-gateway-certs -n kyma-system --cert=/etc/kyma-gateway-certs/tls.crt --key=/etc/kyma-gateway-certs/tls.key --dry-run -oyaml |
   kubectl apply -f -"]
@@ -49,7 +49,7 @@ spec:
         - name: cert
           mountPath: /etc/kyma-gateway-certs/
       - name: {{ .Release.Name }}-job2
-        image: eu.gcr.io/kyma-project/test-infra/alpine-kubectl:v20200309-9a88ce97
+        image: eu.gcr.io/kyma-project/tpi/k8s-tools:20210504-12243229
         command: ["/bin/sh", ]
         args: ["-c","kubectl create secret generic ingress-tls-cert -n kyma-system --from-file=tls.crt=/etc/kyma-gateway-certs/tls.crt --dry-run -oyaml |
   kubectl apply -f -"]
@@ -57,7 +57,7 @@ spec:
         - name: cert
           mountPath: /etc/kyma-gateway-certs/
       - name: {{ .Release.Name }}-job3
-        image: eu.gcr.io/kyma-project/test-infra/alpine-kubectl:v20200309-9a88ce97
+        image: eu.gcr.io/kyma-project/tpi/k8s-tools:20210504-12243229
         command: ["/bin/sh", ]
         args: ["-c","kubectl create secret tls apiserver-proxy-tls-cert -n kyma-system --cert=/etc/kyma-gateway-certs/tls.crt --key=/etc/kyma-gateway-certs/tls.key --dry-run -oyaml |
   kubectl apply -f -"]


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**
Image `eu.gcr.io/kyma-project/test-infra/alpine-kubectl` is deprecated and removed from the test-infra repo. This PR changes image `eu.gcr.io/kyma-project/test-infra/alpine-kubectl:v20200309-9a88ce97` to `eu.gcr.io/kyma-project/tpi/k8s-tools:20210504-12243229`.

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
https://github.com/kyma-project/test-infra/issues/3647