### PR TITLE
Additional message in case of undefined restartCount parent

### DIFF
--- a/tests/fast-integration/utils/index.js
+++ b/tests/fast-integration/utils/index.js
@@ -654,11 +654,21 @@ const printRestartReport = (prevPodList = [], afterTestPodList = []) => {
               afterTestPod,
               status.image
             );
+
+            let restartsTillTestStart = 0
+            let message = ""
+            if(!afterTestContainerStatus || !status) {
+              restartsTillTestStart = -1
+              message = "Container removed during report generation"              
+            } else {
+              restartsTillTestStart  = afterTestContainerStatus.restartCount - status.restartCount
+            }
+            
             return {
               name: status.name,
               image: status.image,
-              restartsTillTestStart:
-                afterTestContainerStatus.restartCount - status.restartCount,
+              restartsTillTestStart: restartsTillTestStart,
+              info: message
             };
           })
           .filter((status) => {


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Additional log info that should help locating troublesome containers after failed fast-integration runs.

**Related issue(s)**

https://github.com/kyma-project/kyma/issues/11379