### PR TITLE
Set owner references for publisher deployment

### DIFF
--- a/components/eventing-controller/go.mod
+++ b/components/eventing-controller/go.mod
@@ -19,7 +19,7 @@ require (
 	github.com/onsi/gomega v1.10.5
 	github.com/ory/oathkeeper-maester v0.1.0
 	github.com/pkg/errors v0.9.1
-	github.com/stretchr/testify v1.7.0
+	github.com/stretchr/testify v1.7.0 // indirect
 	go.uber.org/zap v1.16.0
 	golang.org/x/oauth2 v0.0.0-20200107190931-bf48bf16ab8d
 	golang.org/x/tools v0.1.0 // indirect

--- a/components/eventing-controller/pkg/deployment/controller_deployment.go
+++ b/components/eventing-controller/pkg/deployment/controller_deployment.go
@@ -1,0 +1,6 @@
+package deployment
+
+const (
+	ControllerNamespace = "kyma-system"
+	ControllerName      = "eventing-controller"
+)

--- a/components/eventing-controller/reconciler/backend/reconciler_test.go
+++ b/components/eventing-controller/reconciler/backend/reconciler_test.go
@@ -424,7 +424,7 @@ func ensureEventingBackendCreated(ctx context.Context, name, namespace string) {
 }
 
 func ensureControllerDeploymentCreated(ctx context.Context) *[]metav1.OwnerReference {
-	By(fmt.Sprintf("Ensuring an Eventing-Controller Deployment is created"))
+	By("Ensuring an Eventing-Controller Deployment is created")
 	deployment := reconcilertesting.WithEventingControllerDeployment()
 
 	err := k8sClient.Create(ctx, deployment)

--- a/components/eventing-controller/reconciler/backend/reconciler_test.go
+++ b/components/eventing-controller/reconciler/backend/reconciler_test.go
@@ -12,6 +12,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes/scheme"
 
@@ -202,6 +203,18 @@ var _ = AfterSuite(func() {
 })
 
 var _ = Describe("Backend Reconciliation Tests", func() {
+	var ownerReferences *[]metav1.OwnerReference
+
+	When("Creating a controller deployment", func() {
+		It("Should return an non empty owner to be used as a reference in publisher deployemnt", func() {
+			ctx := context.Background()
+			ensureNamespaceCreated(ctx, kymaSystemNamespace)
+			ownerReferences = ensureControllerDeploymentCreated(ctx)
+			// Expect
+			Eventually(controllerDeploymentGetter(ctx), timeout, pollingInterval).ShouldNot(BeNil())
+			Expect((*ownerReferences)[0].UID).ShouldNot(BeEmpty())
+		})
+	})
 
 	When("Creating a Eventing Backend and no secret labeled for BEB is found", func() {
 		It("Should start with NATS", func() {
@@ -233,6 +246,13 @@ var _ = Describe("Backend Reconciliation Tests", func() {
 					BebSecretName:               "",
 					BebSecretNamespace:          "",
 				}))
+		})
+		It("Should check that the owner of publisher deployment is the controller deployment", func() {
+			ctx := context.Background()
+			ensurePublisherProxyIsReady(ctx)
+			// Expect
+			Eventually(eventingOwnerReferencesGetter(ctx, "eventing-publisher-proxy", kymaSystemNamespace), timeout, pollingInterval).
+				Should(Equal(ownerReferences))
 		})
 	})
 
@@ -276,6 +296,13 @@ var _ = Describe("Backend Reconciliation Tests", func() {
 					BebSecretName:               bebSecret1name,
 					BebSecretNamespace:          kymaSystemNamespace,
 				}))
+		})
+		It("Should check that the owner of publisher deployment is the controller deployment", func() {
+			ctx := context.Background()
+			ensurePublisherProxyIsReady(ctx)
+			// Expect
+			Eventually(eventingOwnerReferencesGetter(ctx, "eventing-publisher-proxy", kymaSystemNamespace), timeout, pollingInterval).
+				Should(Equal(ownerReferences))
 		})
 	})
 
@@ -396,6 +423,24 @@ func ensureEventingBackendCreated(ctx context.Context, name, namespace string) {
 	}
 }
 
+func ensureControllerDeploymentCreated(ctx context.Context) *[]metav1.OwnerReference {
+	By(fmt.Sprintf("Ensuring an Eventing-Controller Deployment is created"))
+	deployment := reconcilertesting.WithEventingControllerDeployment()
+
+	err := k8sClient.Create(ctx, deployment)
+	if !k8serrors.IsAlreadyExists(err) {
+		Expect(err).Should(BeNil())
+	}
+
+	return &[]metav1.OwnerReference{
+		*metav1.NewControllerRef(deployment, schema.GroupVersionKind{
+			Group:   appsv1.SchemeGroupVersion.Group,
+			Version: appsv1.SchemeGroupVersion.Version,
+			Kind:    "Deployment",
+		}),
+	}
+}
+
 func ensurePublisherProxyIsReady(ctx context.Context) {
 	d, err := publisherProxyDeploymentGetter(ctx)()
 	Expect(err).ShouldNot(HaveOccurred())
@@ -467,6 +512,34 @@ func getPublisherProxySecret(ctx context.Context) AsyncAssertion {
 		}
 		return secret
 	}, timeout, pollingInterval)
+}
+
+func controllerDeploymentGetter(ctx context.Context) func() (*appsv1.Deployment, error) {
+	lookupKey := types.NamespacedName{
+		Namespace: deployment.ControllerNamespace,
+		Name:      deployment.ControllerName,
+	}
+	dep := new(appsv1.Deployment)
+	return func() (*appsv1.Deployment, error) {
+		if err := k8sClient.Get(ctx, lookupKey, dep); err != nil {
+			return nil, err
+		}
+		return dep, nil
+	}
+}
+
+func eventingOwnerReferencesGetter(ctx context.Context, name, namespace string) func() (*[]metav1.OwnerReference, error) {
+	lookupKey := types.NamespacedName{
+		Namespace: namespace,
+		Name:      name,
+	}
+	deployment := new(appsv1.Deployment)
+	return func() (*[]metav1.OwnerReference, error) {
+		if err := k8sClient.Get(ctx, lookupKey, deployment); err != nil {
+			return nil, err
+		}
+		return &deployment.OwnerReferences, nil
+	}
 }
 
 type TestCommander struct {

--- a/components/eventing-controller/testing/test_helpers.go
+++ b/components/eventing-controller/testing/test_helpers.go
@@ -4,6 +4,11 @@ import (
 	"fmt"
 	"net/http"
 
+	"github.com/kyma-project/kyma/components/eventing-controller/pkg/deployment"
+
+	"github.com/kyma-project/kyma/components/eventing-controller/utils"
+	appsv1 "k8s.io/api/apps/v1"
+
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
@@ -292,5 +297,37 @@ func WithEventingBackend(name, ns string) *eventingv1alpha1.EventingBackend {
 		},
 		Spec:   eventingv1alpha1.EventingBackendSpec{},
 		Status: eventingv1alpha1.EventingBackendStatus{},
+	}
+}
+
+func WithEventingControllerDeployment() *appsv1.Deployment {
+	labels := map[string]string{
+		"app.kubernetes.io/name": "value",
+	}
+	return &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      deployment.ControllerName,
+			Namespace: deployment.ControllerNamespace,
+			Labels:    labels,
+		},
+		Spec: appsv1.DeploymentSpec{
+			Replicas: utils.Int32Ptr(1),
+			Selector: metav1.SetAsLabelSelector(labels),
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:   deployment.ControllerName,
+					Labels: labels,
+				},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Name:  deployment.ControllerName,
+							Image: "eventing-controller-pod-image",
+						},
+					},
+				},
+			},
+		},
+		Status: appsv1.DeploymentStatus{},
 	}
 }

--- a/resources/eventing/charts/controller/values.yaml
+++ b/resources/eventing/charts/controller/values.yaml
@@ -15,7 +15,7 @@ image:
   # name is the name of the container image for the eventing-controller
   name: "eventing-controller"
   # tag is the container tag of the eventing-controller image
-  tag: "PR-11252"
+  tag: "PR-11390"
   # pullPolicy is the pullPolicy for the eventing-controller image
   pullPolicy: "IfNotPresent"
 


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- Dynamically set the owner reference for publisher deployment to be the eventing-controller deployment


**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
See: https://github.com/orgs/kyma-project/projects/3#card-61593021