### PR TITLE
Add the AC chart documentation and describe the central_connectivity_validator.enabled parameter

### DIFF
--- a/docs/application-connector/05-00-application-connector.md
+++ b/docs/application-connector/05-00-application-connector.md
@@ -1,0 +1,18 @@
+---
+title: Application Connector chart
+type: Configuration
+---
+
+To configure the Application Connector (AC) chart, override the default values of its `values.yaml` file. This document describes parameters that you can configure.
+
+>**TIP:** To learn more about how to use overrides in Kyma, see the following documents:
+>* [Helm overrides for Kyma installation](/root/kyma/#configuration-helm-overrides-for-kyma-installation)
+>* [Top-level charts overrides](/root/kyma/#configuration-helm-overrides-for-kyma-installation-top-level-charts-overrides)
+
+## Configurable parameters
+
+This table lists the configurable parameters, their descriptions, and default values:
+
+| Parameter | Description | Default value |
+|-----------|-------------|---------------|
+| **central_connectivity_validator.enabled** | Specifies whether to use Central Connectivity Validator for Application Operator. If enabled, it removes the existing per-Application Gateways and installs the Central Connectivity Validator chart. | `false` |

--- a/docs/application-connector/05-00-application-connector.md
+++ b/docs/application-connector/05-00-application-connector.md
@@ -16,3 +16,7 @@ This table lists the configurable parameters, their descriptions, and default va
 | Parameter | Description | Default value |
 |-----------|-------------|---------------|
 | **central_connectivity_validator.enabled** | Specifies whether to use Central Connectivity Validator for Application Operator. If enabled, it removes the existing per-Application Gateways and installs the Central Connectivity Validator chart. | `false` |
+| **global.disableLegacyConnectivity** | Disables the default standalone (legacy) connectivity components and enables the Compass mode. | `false` |
+| **global.isLocalEnv** | Specifies whether the component is run locally or on a cluster. Used in Connector Service and Application Registry. | `false` |
+| **global.log.format** | Specifies the logging format. Used in Application Operator. | `json` |
+| **global.log.level** | Specifies the logging level. Used in Application Operator. | `warn` |


### PR DESCRIPTION
**Description**

With the addition of Central Connectivity Validator, a new parameter was added that can be configured in the Application Connector (AC) chart. It needs to be documented. 

Changes proposed in this pull request:

- Add the AC chart documentation 
- Describe the **central_connectivity_validator.enabled** parameter together with other AC parameters

**Related PR(s)**
#11173 
