### PR TITLE
Upgrade Istio resource to 1.10.0 version

### DIFF
--- a/resources/istio/Chart.yaml
+++ b/resources/istio/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: istio
-version: 1.9.5-distroless
-appVersion: 1.9.5
+version: 1.10.0-distroless
+appVersion: 1.10.0
 tillerVersion: ">=2.7.2-0"
 description: Helm chart for all istio components
 keywords:

--- a/resources/istio/files/istio-operator-cluster-evaluation.yaml
+++ b/resources/istio/files/istio-operator-cluster-evaluation.yaml
@@ -129,6 +129,8 @@ spec:
       enabled: true
       k8s:
         env:
+        - name: PILOT_ENABLE_INBOUND_PASSTHROUGH
+          value: false
         - name: PILOT_TRACE_SAMPLING
           value: "100"
         - name: PILOT_HTTP10

--- a/resources/istio/files/istio-operator-cluster-evaluation.yaml
+++ b/resources/istio/files/istio-operator-cluster-evaluation.yaml
@@ -129,8 +129,6 @@ spec:
       enabled: true
       k8s:
         env:
-        - name: PILOT_ENABLE_INBOUND_PASSTHROUGH
-          value: false
         - name: PILOT_TRACE_SAMPLING
           value: "100"
         - name: PILOT_HTTP10

--- a/resources/istio/files/istio-operator-cluster-evaluation.yaml
+++ b/resources/istio/files/istio-operator-cluster-evaluation.yaml
@@ -301,6 +301,7 @@ spec:
       replicaCount: 1
       traceSampling: 1
     sidecarInjectorWebhook:
+      useLegacySelectors: true
       enableNamespacesByDefault: true
       objectSelector:
         autoInject: true

--- a/resources/istio/files/istio-operator-cluster-production.yaml
+++ b/resources/istio/files/istio-operator-cluster-production.yaml
@@ -299,6 +299,7 @@ spec:
       replicaCount: 1
       traceSampling: 1
     sidecarInjectorWebhook:
+      useLegacySelectors: true
       enableNamespacesByDefault: true
       objectSelector:
         autoInject: true

--- a/resources/istio/files/istio-operator-cluster-production.yaml
+++ b/resources/istio/files/istio-operator-cluster-production.yaml
@@ -129,6 +129,8 @@ spec:
       enabled: true
       k8s:
         env:
+        - name: PILOT_ENABLE_INBOUND_PASSTHROUGH
+          value: false
         - name: PILOT_TRACE_SAMPLING
           value: "100"
         - name: PILOT_HTTP10

--- a/resources/istio/files/istio-operator-cluster-production.yaml
+++ b/resources/istio/files/istio-operator-cluster-production.yaml
@@ -213,10 +213,6 @@ spec:
         type: LoadBalancer
         zvpn: {}
     global:
-      arch:
-        amd64: 2
-        ppc64le: 2
-        s390x: 2
       configValidation: true
       defaultNodeSelector: {}
       defaultPodDisruptionBudget:

--- a/resources/istio/files/istio-operator-cluster-production.yaml
+++ b/resources/istio/files/istio-operator-cluster-production.yaml
@@ -129,8 +129,6 @@ spec:
       enabled: true
       k8s:
         env:
-        - name: PILOT_ENABLE_INBOUND_PASSTHROUGH
-          value: false
         - name: PILOT_TRACE_SAMPLING
           value: "100"
         - name: PILOT_HTTP10

--- a/resources/istio/files/istio-operator-cluster.yaml
+++ b/resources/istio/files/istio-operator-cluster.yaml
@@ -127,8 +127,6 @@ spec:
       enabled: true
       k8s:
         env:
-        - name: PILOT_ENABLE_INBOUND_PASSTHROUGH
-          value: false
         - name: PILOT_TRACE_SAMPLING
           value: "100"
         - name: PILOT_HTTP10

--- a/resources/istio/files/istio-operator-cluster.yaml
+++ b/resources/istio/files/istio-operator-cluster.yaml
@@ -210,10 +210,6 @@ spec:
         type: LoadBalancer
         zvpn: {}
     global:
-      arch:
-        amd64: 2
-        ppc64le: 2
-        s390x: 2
       configValidation: true
       defaultNodeSelector: {}
       defaultPodDisruptionBudget:

--- a/resources/istio/files/istio-operator-cluster.yaml
+++ b/resources/istio/files/istio-operator-cluster.yaml
@@ -127,6 +127,8 @@ spec:
       enabled: true
       k8s:
         env:
+        - name: PILOT_ENABLE_INBOUND_PASSTHROUGH
+          value: false
         - name: PILOT_TRACE_SAMPLING
           value: "100"
         - name: PILOT_HTTP10

--- a/resources/istio/files/istio-operator-cluster.yaml
+++ b/resources/istio/files/istio-operator-cluster.yaml
@@ -296,6 +296,7 @@ spec:
       replicaCount: 1
       traceSampling: 1
     sidecarInjectorWebhook:
+      useLegacySelectors: true
       enableNamespacesByDefault: true
       objectSelector:
         autoInject: true

--- a/resources/istio/files/istio-operator-minikube-evaluation.yaml
+++ b/resources/istio/files/istio-operator-minikube-evaluation.yaml
@@ -223,10 +223,6 @@ spec:
         type: NodePort
         zvpn: {}
     global:
-      arch:
-        amd64: 2
-        ppc64le: 2
-        s390x: 2
       configValidation: true
       defaultNodeSelector: {}
       defaultPodDisruptionBudget:

--- a/resources/istio/files/istio-operator-minikube-evaluation.yaml
+++ b/resources/istio/files/istio-operator-minikube-evaluation.yaml
@@ -135,6 +135,8 @@ spec:
       enabled: true
       k8s:
         env:
+          - name: PILOT_ENABLE_INBOUND_PASSTHROUGH
+            value: false
           - name: PILOT_TRACE_SAMPLING
             value: "100"
           - name: PILOT_HTTP10

--- a/resources/istio/files/istio-operator-minikube-evaluation.yaml
+++ b/resources/istio/files/istio-operator-minikube-evaluation.yaml
@@ -135,8 +135,6 @@ spec:
       enabled: true
       k8s:
         env:
-          - name: PILOT_ENABLE_INBOUND_PASSTHROUGH
-            value: false
           - name: PILOT_TRACE_SAMPLING
             value: "100"
           - name: PILOT_HTTP10

--- a/resources/istio/files/istio-operator-minikube-evaluation.yaml
+++ b/resources/istio/files/istio-operator-minikube-evaluation.yaml
@@ -308,6 +308,7 @@ spec:
       replicaCount: 1
       traceSampling: 1
     sidecarInjectorWebhook:
+      useLegacySelectors: true
       enableNamespacesByDefault: true
       objectSelector:
         autoInject: true

--- a/resources/istio/files/istio-operator-minikube.yaml
+++ b/resources/istio/files/istio-operator-minikube.yaml
@@ -306,6 +306,7 @@ spec:
       replicaCount: 1
       traceSampling: 1
     sidecarInjectorWebhook:
+      useLegacySelectors: true
       enableNamespacesByDefault: true
       objectSelector:
         autoInject: true

--- a/resources/istio/files/istio-operator-minikube.yaml
+++ b/resources/istio/files/istio-operator-minikube.yaml
@@ -222,10 +222,6 @@ spec:
         type: NodePort
         zvpn: {}
     global:
-      arch:
-        amd64: 2
-        ppc64le: 2
-        s390x: 2
       configValidation: true
       defaultNodeSelector: {}
       defaultPodDisruptionBudget:

--- a/resources/istio/files/istio-operator-minikube.yaml
+++ b/resources/istio/files/istio-operator-minikube.yaml
@@ -135,8 +135,6 @@ spec:
       enabled: true
       k8s:
         env:
-        - name: PILOT_ENABLE_INBOUND_PASSTHROUGH
-          value: false
         - name: PILOT_TRACE_SAMPLING
           value: "100"
         - name: PILOT_HTTP10

--- a/resources/istio/files/istio-operator-minikube.yaml
+++ b/resources/istio/files/istio-operator-minikube.yaml
@@ -135,6 +135,8 @@ spec:
       enabled: true
       k8s:
         env:
+        - name: PILOT_ENABLE_INBOUND_PASSTHROUGH
+          value: false
         - name: PILOT_TRACE_SAMPLING
           value: "100"
         - name: PILOT_HTTP10

--- a/resources/istio/values.yaml
+++ b/resources/istio/values.yaml
@@ -33,7 +33,7 @@ kyma:
 istio:
   installer:
     image: eu.gcr.io/kyma-project/istio-installer
-    tag: "49659ad2"
+    tag: "5894b75c"
   securityContext:
     runAsUser: 65534
     runAsNonRoot: true

--- a/resources/ory/charts/hydra/charts/hydra-maester/templates/deployment.yaml
+++ b/resources/ory/charts/hydra/charts/hydra-maester/templates/deployment.yaml
@@ -36,7 +36,7 @@ spec:
           command:
             - /manager
           args:
-            - --metrics-addr=127.0.0.1:{{ .Values.port.metrics }}
+            - --metrics-addr=0.0.0.0:{{ .Values.port.metrics }}
             - --hydra-url=http://{{ include "hydra-maester.adminService" . }}
             - --hydra-port={{ .Values.adminService.port | default 4445 }}
             - --sync-period={{ .Values.config.syncPeriod }}


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**
For security & support reasons we should be up to date with the latest Istio release.
https://istio.io/latest/news/releases/1.10.x/announcing-1.10/change-notes/
https://istio.io/latest/news/releases/1.10.x/announcing-1.10/upgrade-notes/

Changes proposed in this pull request:

- Upgrade Istio to 1.10.0 version.
- Remove deprecated global.arch settings in favour of the Kubernetes affinity rules.
- Change the services that bind to the _lo_ interface, to bind to all interfaces.
- Temporary use of legacy selectors option, as the follow up we will tweak our istio scripts to align with the new selector logic.

From 1.10 Istio changed the networking behaviour for the inbound traffic, the proxy no longer redirects the traffic to the _lo_ interface and forwards it to the application on _eth0_.
For more info, please refer to the docs [#1](https://istio.io/latest/blog/2021/upcoming-networking-changes) and [#2](https://istio.io/latest/news/releases/1.10.x/announcing-1.10/upgrade-notes/#inbound-forwarding-configuration).


**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
Fixes #11423 