### PR TITLE
Add pod antiaffinity to NATS cluster

### DIFF
--- a/resources/eventing/charts/nats/templates/40-cr.yaml
+++ b/resources/eventing/charts/nats/templates/40-cr.yaml
@@ -22,3 +22,14 @@ spec:
   natsConfig:
     debug: true
     trace: true
+  template:
+    spec:
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - podAffinityTerm:
+                labelSelector:
+                  matchLabels:
+                    nats_cluster: eventing-nats
+                topologyKey: kubernetes.io/hostname
+              weight: 100


### PR DESCRIPTION
**Description**

During K8s cluster upgrade, sometimes the NATS operator does not seem to be able to recover the NATS cluster.
https://github.tools.sap/kyma/backlog/issues/1549
#11439 

Changes proposed in this pull request:

- Add "soft" pod-anti-affinity to the eventing nats cluster.
- Upgrade NATS operator version.
