### PR TITLE
Fix containerd self-signed certificates issue

### DIFF
--- a/resources/cluster-essentials/templates/psp-privileged-hostPID.yaml
+++ b/resources/cluster-essentials/templates/psp-privileged-hostPID.yaml
@@ -1,0 +1,29 @@
+---
+apiVersion: policy/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  name: 003-kyma-privileged-hostpid
+  annotations:
+    helm.sh/hook: "pre-upgrade, pre-install"
+    helm.sh/hook-weight: "0"
+    helm.sh/hook-delete-policy: "before-hook-creation"
+spec:
+  allowPrivilegeEscalation: true
+  allowedCapabilities:
+  - '*'
+  hostPorts:
+  - max: 65535
+    min: 1024
+  privileged: true
+  hostNetwork: true
+  hostPID: true
+  fsGroup:
+    rule: RunAsAny
+  seLinux:
+    rule: RunAsAny
+  runAsUser:
+    rule: RunAsAny
+  supplementalGroups:
+    rule: RunAsAny
+  volumes:
+    - "*"

--- a/resources/cluster-essentials/templates/rbac-clusterrole.yaml
+++ b/resources/cluster-essentials/templates/rbac-clusterrole.yaml
@@ -16,6 +16,20 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
+  name: kyma:psp:privileged-hostpid
+  annotations:
+    helm.sh/hook: "pre-upgrade, pre-install"
+    helm.sh/hook-weight: "0"
+    helm.sh/hook-delete-policy: "before-hook-creation"
+rules:
+- apiGroups: ["policy"] # "" indicates the core API group
+  resources: ["podsecuritypolicies"]
+  verbs: ["use"]
+  resourceNames: ["003-kyma-privileged-hostpid"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
   name: kyma:psp:unprivileged
   annotations:
     helm.sh/hook: "pre-upgrade, pre-install"

--- a/resources/serverless/templates/daemonset-certs-configmap.yaml
+++ b/resources/serverless/templates/daemonset-certs-configmap.yaml
@@ -43,13 +43,22 @@ data:
       exit 0
     fi
 
-    echo "Certificate is self-signed, patching Docker..."
-    DIR="/kube-etc/docker/certs.d/registry.{{ .Values.global.ingress.domainName }}"
-    if [ ! -d "${DIR}" ]; then
-      mkdir -p "${DIR}"
-    fi
+    CONTAINER_RUNTIME=$(kubectl get nodes -o jsonpath='{.items[0].status.nodeInfo.containerRuntimeVersion}'| cut -d: -f 1)
 
-    cat "${CERT_FILE}" > "${DIR}/ca.crt"
+    if [ "${CONTAINER_RUNTIME}" = "docker" ]; then
+      echo "Certificate is self-signed, patching Docker..."
+      DIR="/kube-etc/docker/certs.d/registry.{{ .Values.global.ingress.domainName }}"
+      if [ ! -d "${DIR}" ]; then
+        mkdir -p "${DIR}"
+      fi
+
+      cat "${CERT_FILE}" > "${DIR}/ca.crt"
+    else
+      echo "Certificate is self-signed, patching Containerd..."
+      TMPDIR=$(mktemp -u)
+      # GKE nodes have /usr/local/ mounted read-only. So we need to override the default localcertsdir
+      nsenter --mount=/proc/1/ns/mnt -- sh -c "mkdir $TMPDIR && echo \"${DECODED_CERT}\" > $TMPDIR/ca.crt && update-ca-certificates --localcertsdir $TMPDIR && systemctl restart containerd"
+    fi
     echo "Done."
     exit 0
 {{- end }}

--- a/resources/serverless/templates/daemonset-certs.yaml
+++ b/resources/serverless/templates/daemonset-certs.yaml
@@ -19,6 +19,8 @@ spec:
         sidecar.istio.io/inject: "false"
     spec:
       serviceAccountName: {{ template "fullname" . }}-self-signed-cert
+      hostPID: true
+      hostNetwork: true
       initContainers:
         - name: inject-certs
           securityContext:

--- a/resources/serverless/templates/daemonset-service-account.yaml
+++ b/resources/serverless/templates/daemonset-service-account.yaml
@@ -15,7 +15,7 @@ metadata:
     {{- include "tplValue" ( dict "value" .Values.global.commonLabels "context" . ) | nindent 4 }}
 rules:
 - apiGroups: [""]
-  resources: ["secrets"]
+  resources: ["secrets", "nodes"]
   verbs: ["get", "list"]
 ---
 kind: ClusterRoleBinding
@@ -32,4 +32,17 @@ roleRef:
   kind: ClusterRole
   name: {{ template "fullname" . }}-self-signed-cert
   apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+ name: {{ template "fullname" . }}-self-signed-cert-privileged-hostpid
+roleRef:
+ kind: ClusterRole
+ name: kyma:psp:privileged-hostpid
+ apiGroup: rbac.authorization.k8s.io
+subjects:
+- kind: ServiceAccount
+  name: {{ template "fullname" . }}-self-signed-cert
+  namespace: kyma-system
 {{- end }}

--- a/resources/serverless/values.yaml
+++ b/resources/serverless/values.yaml
@@ -110,8 +110,9 @@ pod:
 containers:
   daemonset:
     initContainerSecurityContext:
-      privileged: false
-      allowPrivilegeEscalation: false
+      # need this for containerd support
+      privileged: true
+      allowPrivilegeEscalation: true
       runAsUser: 0
     containerSecurityContext:
       privileged: false


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**
Provides a workaround to run serverless with internal registry with self-signed certificates on containerd nodes. 

Changes proposed in this pull request:
- Run the injection script in a privileged container
- Add new privileged PSP with hostPID/network allowed
- Add related clusterrole/clusterrolebinding to use it
- Update the certs injection script to handle both containerd and docker.
- Allow the injection SA to get/list nodes

**Related issue(s)**
#10842
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
