### PR TITLE
Bump apiserver-proxy and dex versions

### DIFF
--- a/resources/apiserver-proxy/values.yaml
+++ b/resources/apiserver-proxy/values.yaml
@@ -46,7 +46,7 @@ tests:
 global:
   apiserver_proxy:
     dir:
-    version: "6dfa4d9a"
+    version: "bfc3a894"
   apiserver_proxy_integration_tests:
     dir:
     version: "49659ad2"

--- a/resources/dex/Chart.yaml
+++ b/resources/dex/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-appVersion: "6ccd8edd"
+appVersion: "c366a60e"
 description: Kyma component 'dex'
 name: dex
 version: 1.0.0


### PR DESCRIPTION
**Description**
Bump Docker images versions used in Kyma
Changes proposed in this pull request:

- update apiserver-proxy Docker image version
- update dex Docker image version

**Related issue(s)**
See also: https://github.com/kyma-project/kyma/pull/11448, https://github.com/kyma-incubator/dex/pull/27, 