### PR TITLE
Avoid restarting eventing-controller if NATS cluster was restarted

### DIFF
--- a/components/eventing-controller/pkg/handlers/nats.go
+++ b/components/eventing-controller/pkg/handlers/nats.go
@@ -134,7 +134,7 @@ func (n *Nats) DeleteSubscription(subscription *eventingv1alpha1.Subscription) e
 				}
 			}
 			if v.IsValid() {
-				if err := v.Unsubscribe();  err != nil {
+				if err := v.Unsubscribe(); err != nil {
 					return errors.Wrapf(err, "failed to unsubscribe")
 				}
 			} else {
@@ -198,7 +198,7 @@ func convertMsgToCE(msg *nats.Msg) (*cev2event.Event, error) {
 }
 
 func getKeyPrefix(sub *eventingv1alpha1.Subscription) string {
-	namespacedName := types.NamespacedName {
+	namespacedName := types.NamespacedName{
 		Namespace: sub.Namespace,
 		Name:      sub.Name,
 	}
@@ -220,7 +220,7 @@ func getSubject(filter *eventingv1alpha1.BebFilter, cleaner eventtype.Cleaner) (
 }
 
 func getKymaSubscriptionNamespacedName(key string, sub *nats.Subscription) types.NamespacedName {
-	nsn := types.NamespacedName {}
+	nsn := types.NamespacedName{}
 	nnvalues := strings.Split(strings.TrimSuffix(strings.TrimSuffix(key, sub.Subject), "."), string(types.Separator))
 	nsn.Namespace = nnvalues[0]
 	nsn.Name = nnvalues[1]

--- a/components/eventing-controller/pkg/handlers/nats_test.go
+++ b/components/eventing-controller/pkg/handlers/nats_test.go
@@ -4,10 +4,11 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"github.com/avast/retry-go"
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/avast/retry-go"
 
 	. "github.com/onsi/gomega"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -266,10 +267,9 @@ func TestIsValidSubscription(t *testing.T) {
 	// TODO: the controller should react and inject Kyma subscriptions into NATS for all "invalid" subscriptions
 	// the associated Nats subscription should be valid again
 	/*
-	err = checkIsValid(natsSub, t)
-	g.Expect(err).To(BeNil())
+		err = checkIsValid(natsSub, t)
+		g.Expect(err).To(BeNil())
 	*/
-
 
 }
 

--- a/components/eventing-controller/pkg/handlers/nats_test.go
+++ b/components/eventing-controller/pkg/handlers/nats_test.go
@@ -228,22 +228,19 @@ func TestIsValidSubscription(t *testing.T) {
 	natsSub := natsClient.subscriptions[key]
 	g.Expect(natsSub).To(Not(BeNil()))
 
-	// the associated Nats subscription should be valid
-	g.Expect(natsSub.IsValid()).To(BeTrue())
-
 	// check the mapping of Kyma subscription and Nats subscription
 	nsn := getKymaSubscriptionNamespacedName(key, natsSub)
 	g.Expect(nsn.Namespace).To(BeIdenticalTo(sub.Namespace))
 	g.Expect(nsn.Name).To(BeIdenticalTo(sub.Name))
 
+	// the associated Nats subscription should be valid
+	g.Expect(natsSub.IsValid()).To(BeTrue())
+
 	// check that no invalid subscriptions exist
-	inactiveNsn := natsClient.GetInvalidSubscriptions()
-	g.Expect(len(*inactiveNsn)).To(BeZero())
+	invalidNsn := natsClient.GetInvalidSubscriptions()
+	g.Expect(len(*invalidNsn)).To(BeZero())
 
 	natsClient.connection.Close()
-
-	// the associated Nats subscription should be valid
-	g.Expect(natsSub.IsValid()).To(BeFalse())
 
 	// the associated Nats subscription should not be valid anymore
 	err = checkIsNotValid(natsSub, t)
@@ -257,19 +254,16 @@ func TestIsValidSubscription(t *testing.T) {
 	g.Expect(err).To(BeNil())
 
 	// check that only one invalid subscription exist
-	inactiveNsn = natsClient.GetInvalidSubscriptions()
-	g.Expect(len(*inactiveNsn)).To(BeIdenticalTo(1))
+	invalidNsn = natsClient.GetInvalidSubscriptions()
+	g.Expect(len(*invalidNsn)).To(BeIdenticalTo(1))
 
-	// Restart Nats server
+	// restart Nats server
 	natsServer = eventingtesting.RunNatsServerOnPort(natsPort)
 	defer natsServer.Shutdown()
 
-	// TODO: the controller should react and inject Kyma subscriptions into NATS for all "invalid" subscriptions
-	// the associated Nats subscription should be valid again
-	/*
-		err = checkIsValid(natsSub, t)
-		g.Expect(err).To(BeNil())
-	*/
+	// check that only one invalid subscription still exist, the controller is not running...
+	invalidNsn = natsClient.GetInvalidSubscriptions()
+	g.Expect(len(*invalidNsn)).To(BeIdenticalTo(1))
 
 }
 

--- a/components/eventing-controller/pkg/handlers/nats_test.go
+++ b/components/eventing-controller/pkg/handlers/nats_test.go
@@ -183,11 +183,10 @@ func TestIsValidSubscription(t *testing.T) {
 	subscriberPort := 8080
 	subscriberReceiveURL := fmt.Sprintf("http://127.0.0.1:%d/store", subscriberPort)
 
-	// Start Nats server
+	// Start NATS server
 	natsServer := eventingtesting.RunNatsServerOnPort(natsPort)
-	//defer natsServer.Shutdown()
 
-	// Create Nats client
+	// Create NATS client
 	natsURL := natsServer.ClientURL()
 	natsClient := Nats{
 		subscriptions: make(map[string]*nats.Subscription),
@@ -200,7 +199,7 @@ func TestIsValidSubscription(t *testing.T) {
 	}
 	err := natsClient.Initialize(env.Config{})
 	if err != nil {
-		t.Fatalf("failed to connect to Nats Server: %v", err)
+		t.Fatalf("failed to connect to NATS Server: %v", err)
 	}
 
 	// Prepare event-type cleaner
@@ -218,18 +217,18 @@ func TestIsValidSubscription(t *testing.T) {
 
 	// get filter
 	filter := sub.Spec.Filter.Filters[0]
-	subject, err := getSubject(filter, cleaner)
+	subject, err := createSubject(filter, cleaner)
 	g.Expect(err).ShouldNot(HaveOccurred())
 	g.Expect(subject).To(Not(BeEmpty()))
 
 	// get internal key
-	key := getKey(sub, subject)
+	key := createKey(sub, subject)
 	g.Expect(key).To(Not(BeEmpty()))
 	natsSub := natsClient.subscriptions[key]
 	g.Expect(natsSub).To(Not(BeNil()))
 
 	// check the mapping of Kyma subscription and Nats subscription
-	nsn := getKymaSubscriptionNamespacedName(key, natsSub)
+	nsn := createKymaSubscriptionNamespacedName(key, natsSub)
 	g.Expect(nsn.Namespace).To(BeIdenticalTo(sub.Namespace))
 	g.Expect(nsn.Name).To(BeIdenticalTo(sub.Name))
 
@@ -242,14 +241,14 @@ func TestIsValidSubscription(t *testing.T) {
 
 	natsClient.connection.Close()
 
-	// the associated Nats subscription should not be valid anymore
+	// the associated NATS subscription should not be valid anymore
 	err = checkIsNotValid(natsSub, t)
 	g.Expect(err).To(BeNil())
 
 	// shutdown NATS
 	natsServer.Shutdown()
 
-	// the associated Nats subscription should not be valid anymore
+	// the associated NATS subscription should not be valid anymore
 	err = checkIsNotValid(natsSub, t)
 	g.Expect(err).To(BeNil())
 
@@ -257,7 +256,7 @@ func TestIsValidSubscription(t *testing.T) {
 	invalidNsn = natsClient.GetInvalidSubscriptions()
 	g.Expect(len(*invalidNsn)).To(BeIdenticalTo(1))
 
-	// restart Nats server
+	// restart NATS server
 	natsServer = eventingtesting.RunNatsServerOnPort(natsPort)
 	defer natsServer.Shutdown()
 

--- a/components/eventing-controller/reconciler/subscription-nats/reconciler.go
+++ b/components/eventing-controller/reconciler/subscription-nats/reconciler.go
@@ -3,6 +3,10 @@ package subscription_nats
 import (
 	"context"
 	"fmt"
+	"net/url"
+	"os"
+	"reflect"
+
 	"github.com/go-logr/logr"
 	eventingv1alpha1 "github.com/kyma-project/kyma/components/eventing-controller/api/v1alpha1"
 	"github.com/kyma-project/kyma/components/eventing-controller/pkg/application"
@@ -13,9 +17,6 @@ import (
 	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/client-go/tools/record"
-	"net/url"
-	"os"
-	"reflect"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -89,7 +90,7 @@ func (r *Reconciler) SetupUnmanaged(mgr ctrl.Manager) error {
 		return err
 	}
 
-	p := predicate.Funcs {
+	p := predicate.Funcs{
 		CreateFunc: func(e event.CreateEvent) bool {
 			if e.Object.GetName() == NATSFirstInstanceName && e.Object.GetNamespace() == NATSNamespace {
 				return true
@@ -282,12 +283,12 @@ func (r Reconciler) assertProtocolValidity(protocol string) error {
 func (r Reconciler) syncInvalidSubscriptions(ctx context.Context) (ctrl.Result, error) {
 	handler, _ := r.Backend.(*handlers.Nats)
 	invalidSubs := handler.GetInvalidSubscriptions()
-	for _,v := range *invalidSubs {
+	for _, v := range *invalidSubs {
 		r.Log.Info("found invalid subscription", "namespace", v.Namespace, "name", v.Name)
 		sub := &eventingv1alpha1.Subscription{}
 		err := r.Client.Get(ctx, v, sub)
 		if err != nil {
-			r.Log.Error(err, "failed to get invalid subscription","namespace", v.Namespace, "name", v.Name)
+			r.Log.Error(err, "failed to get invalid subscription", "namespace", v.Namespace, "name", v.Name)
 			continue
 		}
 		// mark the subscription to be not ready, it will throw a new reconcile call

--- a/components/eventing-controller/reconciler/subscription-nats/reconciler.go
+++ b/components/eventing-controller/reconciler/subscription-nats/reconciler.go
@@ -3,10 +3,6 @@ package subscription_nats
 import (
 	"context"
 	"fmt"
-	"net/url"
-	"os"
-	"reflect"
-
 	"github.com/go-logr/logr"
 	eventingv1alpha1 "github.com/kyma-project/kyma/components/eventing-controller/api/v1alpha1"
 	"github.com/kyma-project/kyma/components/eventing-controller/pkg/application"
@@ -17,11 +13,16 @@ import (
 	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/client-go/tools/record"
+	"net/url"
+	"os"
+	"reflect"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	"sigs.k8s.io/controller-runtime/pkg/source"
 )
 
@@ -42,6 +43,10 @@ var (
 
 const (
 	NATSProtocol = "NATS"
+	// NATSFirstInstanceName the name of first instance of NATS cluster
+	NATSFirstInstanceName = "eventing-nats-1"
+	// NATSNamespace namespace of NATS cluster
+	NATSNamespace = "kyma-system"
 )
 
 func NewReconciler(ctx context.Context, client client.Client, applicationLister *application.Lister, cache cache.Cache,
@@ -80,7 +85,32 @@ func (r *Reconciler) SetupUnmanaged(mgr ctrl.Manager) error {
 	}
 
 	if err := ctru.Watch(&source.Kind{Type: &eventingv1alpha1.Subscription{}}, &handler.EnqueueRequestForObject{}); err != nil {
-		r.Log.Error(err, "unable to watch pods")
+		r.Log.Error(err, "unable to watch subscriptions")
+		return err
+	}
+
+	p := predicate.Funcs {
+		CreateFunc: func(e event.CreateEvent) bool {
+			if e.Object.GetName() == NATSFirstInstanceName && e.Object.GetNamespace() == NATSNamespace {
+				return true
+			}
+			return false
+		},
+		DeleteFunc: func(e event.DeleteEvent) bool {
+			if e.Object.GetName() == NATSFirstInstanceName && e.Object.GetNamespace() == NATSNamespace {
+				return true
+			}
+			return false
+		},
+		UpdateFunc: func(e event.UpdateEvent) bool {
+			return false
+		},
+		GenericFunc: func(e event.GenericEvent) bool {
+			return false
+		},
+	}
+	if err := ctru.Watch(&source.Kind{Type: &corev1.Pod{}}, &handler.EnqueueRequestForObject{}, p); err != nil {
+		r.Log.Error(err, "unable to watch eventing-nats-1 pod")
 		return err
 	}
 
@@ -95,8 +125,13 @@ func (r *Reconciler) SetupUnmanaged(mgr ctrl.Manager) error {
 }
 
 func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
-	r.Log.Info("received subscription reconciliation request", "namespace", req.Namespace, "name",
-		req.Name)
+
+	if req.Name == NATSFirstInstanceName && req.Namespace == NATSNamespace {
+		r.Log.Info("received watch request", "namespace", req.Namespace, "name", req.Name)
+		return r.syncInvalidSubscriptions(ctx)
+	}
+
+	r.Log.Info("received subscription reconciliation request", "namespace", req.Namespace, "name", req.Name)
 
 	actualSubscription := &eventingv1alpha1.Subscription{}
 	result := ctrl.Result{}
@@ -242,4 +277,24 @@ func (r Reconciler) assertProtocolValidity(protocol string) error {
 		return fmt.Errorf("invalid protocol: %s", protocol)
 	}
 	return nil
+}
+
+func (r Reconciler) syncInvalidSubscriptions(ctx context.Context) (ctrl.Result, error) {
+	handler, _ := r.Backend.(*handlers.Nats)
+	invalidSubs := handler.GetInvalidSubscriptions()
+	for _,v := range *invalidSubs {
+		r.Log.Info("found invalid subscription", "namespace", v.Namespace, "name", v.Name)
+		sub := &eventingv1alpha1.Subscription{}
+		err := r.Client.Get(ctx, v, sub)
+		if err != nil {
+			r.Log.Error(err, "failed to get invalid subscription","namespace", v.Namespace, "name", v.Name)
+			continue
+		}
+		// mark the subscription to be not ready, it will throw a new reconcile call
+		if err := r.syncSubscriptionStatus(ctx, sub, false, "invalid subscription"); err != nil {
+			r.Log.Error(err, "failed to save status for invalid subscription", "namespace", v.Namespace, "name", v.Name)
+			return ctrl.Result{}, err
+		}
+	}
+	return ctrl.Result{}, nil
 }

--- a/components/eventing-controller/reconciler/subscription-nats/reconciler.go
+++ b/components/eventing-controller/reconciler/subscription-nats/reconciler.go
@@ -282,8 +282,8 @@ func (r Reconciler) assertProtocolValidity(protocol string) error {
 
 func (r Reconciler) syncInvalidSubscriptions(ctx context.Context) (ctrl.Result, error) {
 	handler, _ := r.Backend.(*handlers.Nats)
-	invalidSubs := handler.GetInvalidSubscriptions()
-	for _, v := range *invalidSubs {
+	namespacedName := handler.GetInvalidSubscriptions()
+	for _, v := range *namespacedName {
 		r.Log.Info("found invalid subscription", "namespace", v.Namespace, "name", v.Name)
 		sub := &eventingv1alpha1.Subscription{}
 		err := r.Client.Get(ctx, v, sub)

--- a/resources/eventing/charts/controller/templates/clusterrole.yaml
+++ b/resources/eventing/charts/controller/templates/clusterrole.yaml
@@ -8,6 +8,7 @@ rules:
   - ""
   resources:
   - services
+  - pods
   verbs:
   - list
   - get

--- a/resources/eventing/charts/controller/values.yaml
+++ b/resources/eventing/charts/controller/values.yaml
@@ -15,7 +15,7 @@ image:
   # name is the name of the container image for the eventing-controller
   name: "eventing-controller"
   # tag is the container tag of the eventing-controller image
-  tag: "PR-11480"
+  tag: "PR-11494"
   # pullPolicy is the pullPolicy for the eventing-controller image
   pullPolicy: "IfNotPresent"
 


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- The controller is  reacting now for K8S events  related to the lifecycle of NATS cluster instance
- The Kyma subscriptions are injected now at restarting of NATS cluster
- The eventing controller should not be  manually restarted if NATS cluster was restarted

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
See: https://github.com/kyma-project/kyma/issues/11376