### PR TITLE
Add Python 3.9 to the list of supported Serverless runtimes

### DIFF
--- a/docs/01-overview/02-main-areas/serverless/svls-02-from-code-to-function.md
+++ b/docs/01-overview/02-main-areas/serverless/svls-02-from-code-to-function.md
@@ -6,7 +6,7 @@ Pick the programming language for the Function and decide where you want to keep
 
 ## Runtimes
 
-Functions support multiple languages by using the underlying execution environments known as runtimes. Currently, you can create both Node.js (12 & 14) and Python (3.8) Functions in Kyma.
+Functions support multiple languages by using the underlying execution environments known as runtimes. Currently, you can create both Node.js (12 & 14) and Python (3.8 & 3.9) Functions in Kyma.
 
 >**TIP:** See [sample Functions](../../../05-technical-reference/svls-01-sample-functions.md) for each available runtime.
 

--- a/docs/01-overview/02-main-areas/serverless/svls-04-development-toolkit.md
+++ b/docs/01-overview/02-main-areas/serverless/svls-04-development-toolkit.md
@@ -10,6 +10,6 @@ To start developing your first Functions, you need:
 - [**kubectl**](https://kubernetes.io/docs/reference/kubectl/kubectl/), the Kubernetes command-line tool, for running commands against clusters
 - Development environment of your choice:
    - **Kyma CLI** to easily initiate inline Functions or Git Functions locally, run, test, and later apply them on the clusters
-   - **Node.js** (v12 or v14) or **Python** (3.8)
+   - **Node.js** (v12 or v14) or **Python** (v3.8 or v3.9)
    - **IDE** as the source code editor
    - **Busola** to manage Functions and related workloads through the user interface

--- a/docs/05-technical-reference/06-custom-resources/svls-01-function.md
+++ b/docs/05-technical-reference/06-custom-resources/svls-01-function.md
@@ -113,7 +113,7 @@ This table lists all the possible parameters of a given resource together with t
 | **spec.buildResources.limits.memory**         |       No       | Defines the maximum amount of memory available for the Job's Pod to use.      |
 | **spec.buildResources.requests.cpu**          |       No       | Specifies the number of CPUs requested by the build Job's Pod to operate.       |
 | **spec.buildResources.requests.memory**       |       No       | Specifies the amount of memory requested by the build Job's Pod to operate.               |
-| **spec.runtime**                         |       No       | Specifies the runtime of the Function. The available values are `nodejs12`, `python38` and `nodejs14`. It is set to `nodejs14` unless specified otherwise.  |
+| **spec.runtime**                         |       No       | Specifies the runtime of the Function. The available values are `nodejs12`, `nodejs14`, `python38`, and `python39`. It is set to `nodejs14` unless specified otherwise.  |
 | **spec.type**                          |      No       | Defines that you use a Git repository as the source of Function's code and dependencies. It must be set to `git`. |
 | **spec.source**                          |      Yes       | Provides the Function's full source code or the name of the Git directory in which the code and dependencies are stored.     |
 | **spec.baseDir**                          |      No       | Specifies the relative path to the Git directory that contains the source code from which the Function will be built​. |

--- a/docs/05-technical-reference/svls-01-sample-functions.md
+++ b/docs/05-technical-reference/svls-01-sample-functions.md
@@ -98,6 +98,30 @@ spec:
     requests==2.24.0
 EOF
 ```
+</details>
+
+<details>
+  <summary label="python39">
+  Python 3.9
+  </summary>
+
+```yaml
+cat <<EOF | kubectl apply -f -
+apiVersion: serverless.kyma-project.io/v1alpha1
+kind: Function
+metadata:
+  name: test-function-python39
+spec:
+  runtime: python39
+  source: |
+    import requests
+    def main(event, context):
+        r = requests.get('https://swapi.dev/api/people/13')
+        return r.json()
+  deps: |
+    requests==2.24.0
+EOF
+```
 
 </details>
 </div>

--- a/docs/05-technical-reference/svls-04-git-source-type.md
+++ b/docs/05-technical-reference/svls-04-git-source-type.md
@@ -2,7 +2,7 @@
 title: Git source type
 ---
 
-Depending on a runtime you use to build your Function (Node.js 12, Node.js 14, or Python 3.8), your Git repository must contain at least a directory with these files:
+Depending on a runtime you use to build your Function (Node.js 12, Node.js 14, Python 3.8, or Python 3.9), your Git repository must contain at least a directory with these files:
 
 - `handler.js` or `handler.py` with Function's code
 - `package.json` or `requirements.txt` with Function's dependencies

--- a/docs/05-technical-reference/svls-06-function-configuration-file.md
+++ b/docs/05-technical-reference/svls-06-function-configuration-file.md
@@ -125,7 +125,7 @@ See all parameter descriptions.
 | ---------------------------------------- | :------------: | ---------| ---------| ------- |
 | **name**              | Yes | Function | | Specifies the name of your Function.         |
 | **namespace**             | No | Function | `default` | Defines the Namespace in which the Function is created.        |
-| **runtime**             | Yes | Function | | Specifies the execution environment for your Function. The available values are `nodejs12`, `nodejs14`, and `python38`.      |
+| **runtime**             | Yes | Function | | Specifies the execution environment for your Function. The available values are `nodejs12`, `nodejs14`, `python38`, and `python39`.      |
 | **labels**             | No | Function | | Specifies the Function's Pod labels. |
 | **source**            | Yes | Function | | Provides details on the type and location of your Function's source code and dependencies.         |
 | **source.sourceType**            | Yes | Function | | Defines whether you use either inline code or a Git repository as the source of the Function's code and dependencies. It must be set either to `inline` or `git`.         |

--- a/docs/05-technical-reference/svls-08-function-specification.md
+++ b/docs/05-technical-reference/svls-08-function-specification.md
@@ -2,7 +2,7 @@
 title: Function's specification
 ---
 
-Serverless in Kyma allows you to create Functions in both Node.js (v12 & v14) and Python (v3.8). Although the Function's interface is unified, its specification differs depending on the runtime used to run the Function.
+Serverless in Kyma allows you to create Functions in both Node.js (v12 & v14) and Python (v3.8 & v3.9). Although the Function's interface is unified, its specification differs depending on the runtime used to run the Function.
 
 ## Signature
 
@@ -129,7 +129,7 @@ See the detailed descriptions of these fields:
 |-------|-------------|
 | **function-name** | Name of the invoked Function |
 | **timeout** | Time, in seconds, after which the system cancels the request to invoke the Function |
-| **runtime** | Environment used to run the Function. You can use `nodejs12`, `nodejs14`, or `python3.8`. |
+| **runtime** | Environment used to run the Function. You can use `nodejs12`, `nodejs14`, `python38`, or `python39`. |
 | **memory-limit** | Maximum amount of memory assigned to run a Function |  
 
 ## HTTP requests


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Added the new runtime (Python 3.9) to Serverless docs

**Related issue(s)**
See also https://github.com/kyma-project/kyma/issues/11299

Similar changes, but for the `main` branch, are performed in [PR 11498](https://github.com/kyma-project/kyma/pull/11498) by @moelsayed. 