### PR TITLE
fixing fast-integration upgrade-test

### DIFF
--- a/tests/fast-integration/test/2-commerce-mock.js
+++ b/tests/fast-integration/test/2-commerce-mock.js
@@ -10,18 +10,11 @@ const {
   checkAppGatewayResponse,
   sendEventAndCheckResponse,
   cleanMockTestFixture,
+  checkInClusterEventDelivery,
 } = require("./fixtures/commerce-mock");
 const {
   printRestartReport,
   getContainerRestartsForAllNamespaces,
-  eventingSubscription,
-  waitForFunction,
-  waitForSubscription,
-  k8sApply,
-  genRandom,
-  retryPromise,
-  debug,
-  waitForVirtualService,
 } = require("../utils");
 
 describe("CommerceMock tests", function () {
@@ -42,35 +35,8 @@ describe("CommerceMock tests", function () {
     });
   });
 
-  it("lastorder function should be ready", async function () {
-    await waitForFunction("lastorder", testNamespace);
-  });
-
-  it("In-cluster event subscription should be ready", async function () {
-    await k8sApply([eventingSubscription(
-      `sap.kyma.custom.inapp.order.received.v1`,
-      `http://lastorder.${testNamespace}.svc.cluster.local`,
-      "order-received",
-      testNamespace)]);
-      await waitForSubscription("order-received", testNamespace);
-      await waitForSubscription("order-created", testNamespace);
-    });
-
   it("in-cluster event should be delivered", async function () {
-    const eventId = "event-"+genRandom(5);
-    const vs = await waitForVirtualService(testNamespace, "lastorder");
-    const mockHost = vs.spec.hosts[0];
-  
-    // send event using function query parameter send=true
-    await retryPromise(() => axios.post(`https://${mockHost}`, { id: eventId }, {params:{send:true}}), 10, 1000)
-    // verify if event was received using function query parameter inappevent=eventId
-    await retryPromise(async () => {
-      debug("Waiting for event: ",eventId);
-      let response = await axios.get(`https://${mockHost}`, { params: { inappevent: eventId } })
-      expect(response).to.have.nested.property("data.id", eventId, "The same event id expected in the result");
-      expect(response).to.have.nested.property("data.shipped", true, "Order should have property shipped");
-    }, 10, 1000);
-    
+    await checkInClusterEventDelivery(testNamespace);
   });
 
   it("function should reach Commerce mock API through app gateway", async function () {

--- a/tests/fast-integration/upgrade-test/upgrade-test-tests.js
+++ b/tests/fast-integration/upgrade-test/upgrade-test-tests.js
@@ -1,4 +1,5 @@
 const {
+  checkInClusterEventDelivery,
   checkAppGatewayResponse,
   sendEventAndCheckResponse,
 } = require("../test/fixtures/commerce-mock");
@@ -11,9 +12,14 @@ describe("Upgrade test tests", function () {
   this.timeout(10 * 60 * 1000);
   this.slow(5000);
   let initialRestarts = null;
+  const testNamespace = "test";
 
   it("Listing all pods in cluster", async function () {
     initialRestarts = await getContainerRestartsForAllNamespaces();
+  });
+
+  it("in-cluster event should be delivered", async function () {
+    await checkInClusterEventDelivery(testNamespace);
   });
 
   it("function should reach Commerce mock API through app gateway", async function () {


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- moved the "waitForFunction("lastorder") into the comerce-mock fixture as it was missing for upgrade tests
- moved the in-cluster eventing setup into the commerce-mock fixture to have it included for the upgrade test
- moved the in-cluster eventing verification into a nice ensure-function to have it included in the upgrade test
- increased the timeout for serviceclass waiting as it was not enough on azure

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
