### PR TITLE
Perform cleanup for Impersonate-Group header in request

### DIFF
--- a/components/apiserver-proxy/internal/proxy/proxy.go
+++ b/components/apiserver-proxy/internal/proxy/proxy.go
@@ -81,6 +81,7 @@ func (h *kubeRBACProxy) Handle(w http.ResponseWriter, req *http.Request) bool {
 	}
 
 	req.Header.Set("Impersonate-User", r.User.GetName())
+	h.cleanupImpersonateGroupHeader(req)
 	for _, gr := range r.User.GetGroups() {
 		req.Header.Add("Impersonate-Group", gr)
 	}
@@ -88,6 +89,10 @@ func (h *kubeRBACProxy) Handle(w http.ResponseWriter, req *http.Request) bool {
 	h.metrics.RequestCounterVec.With(prometheus.Labels{"code": fmt.Sprint(http.StatusOK), "method": req.Method}).Inc()
 
 	return true
+}
+
+func (h *kubeRBACProxy) cleanupImpersonateGroupHeader(req *http.Request) {
+	req.Header.Set("Impersonate-Group", "")
 }
 
 func newKubeRBACProxyAuthorizerAttributesGetter(authzConfig *authz.Config) authorizer.RequestAttributesGetter {

--- a/components/apiserver-proxy/internal/proxy/proxy.go
+++ b/components/apiserver-proxy/internal/proxy/proxy.go
@@ -92,7 +92,7 @@ func (h *kubeRBACProxy) Handle(w http.ResponseWriter, req *http.Request) bool {
 }
 
 func (h *kubeRBACProxy) cleanupImpersonateGroupHeader(req *http.Request) {
-	req.Header.Set("Impersonate-Group", "")
+	req.Header.Del("Impersonate-Group")
 }
 
 func newKubeRBACProxyAuthorizerAttributesGetter(authzConfig *authz.Config) authorizer.RequestAttributesGetter {

--- a/components/apiserver-proxy/internal/proxy/proxy_test.go
+++ b/components/apiserver-proxy/internal/proxy/proxy_test.go
@@ -29,6 +29,7 @@ func TestProxyWithOIDCSupport(t *testing.T) {
 		Authorization: &authz.Config{},
 	}
 
+	maliciousGroup := "malicious-group"
 	fakeUser := user.DefaultInfo{Name: "Foo Bar", Groups: []string{"foo-bars"}}
 	authenticator := fakeOIDCAuthenticator(t, &fakeUser)
 	metrics, _ := monitoring.NewProxyMetrics()
@@ -56,8 +57,8 @@ func TestProxyWithOIDCSupport(t *testing.T) {
 					t.Errorf("User in the response header does not match authenticated user. Expected : %s, received : %s ", fakeUser.GetName(), user)
 				}
 
-				if strings.Contains(groups, "malicious-group") {
-					t.Errorf("Groups should not contain %s injected in the request", "malicious-group")
+				if strings.Contains(groups, maliciousGroup) {
+					t.Errorf("Groups should not contain %s injected in the request", maliciousGroup)
 				}
 
 				if groups != strings.Join(fakeUser.GetGroups(), cfg.Authentication.Header.GroupSeparator) {

--- a/components/apiserver-proxy/internal/proxy/proxy_test.go
+++ b/components/apiserver-proxy/internal/proxy/proxy_test.go
@@ -55,8 +55,13 @@ func TestProxyWithOIDCSupport(t *testing.T) {
 				if user != fakeUser.GetName() {
 					t.Errorf("User in the response header does not match authenticated user. Expected : %s, received : %s ", fakeUser.GetName(), user)
 				}
+
+				if strings.Contains(groups, "malicious-group") {
+					t.Errorf("Groups should not contain %s injected in the request", "malicious-group")
+				}
+
 				if groups != strings.Join(fakeUser.GetGroups(), cfg.Authentication.Header.GroupSeparator) {
-					t.Errorf("Groupsr in the response header does not match authenticated user groups. Expected : %s, received : %s ", fakeUser.GetName(), groups)
+					t.Errorf("Groups in the response header does not match authenticated user groups. Expected : %s, received : %s ", fakeUser.GetGroups(), groups)
 				}
 			}
 		})
@@ -114,7 +119,7 @@ func setupTestScenario() []testCase {
 		{
 			description: "Request with invalid Token should be authenticated and rejected with 401",
 			given: given{
-				req:        fakeJWTRequest("GET", "/accounts", "Bearer INVALID"),
+				req:        fakeJWTRequest("GET", "/accounts", "Bearer INVALID", "malicious-group"),
 				authorizer: denier{},
 			},
 			expected: expected{
@@ -124,7 +129,7 @@ func setupTestScenario() []testCase {
 		{
 			description: "Request with valid token, should return 200 due to sufficient permissions",
 			given: given{
-				req:        fakeJWTRequest("GET", "/accounts", "Bearer VALID"),
+				req:        fakeJWTRequest("GET", "/accounts", "Bearer VALID", "malicious-group"),
 				authorizer: approver{},
 			},
 			expected: expected{
@@ -136,9 +141,10 @@ func setupTestScenario() []testCase {
 	return testScenario
 }
 
-func fakeJWTRequest(method, path, token string) *http.Request {
+func fakeJWTRequest(method, path, token, groups string) *http.Request {
 	req := requestFor(method, path)
 	req.Header.Add("Authorization", token)
+	req.Header.Add("Impersonate-Group", groups)
 
 	return req
 }

--- a/components/apiserver-proxy/internal/proxy/proxy_test.go
+++ b/components/apiserver-proxy/internal/proxy/proxy_test.go
@@ -57,7 +57,7 @@ func TestProxyWithOIDCSupport(t *testing.T) {
 					t.Errorf("User in the response header does not match authenticated user. Expected : %s, received : %s ", fakeUser.GetName(), user)
 				}
 
-				if strings.Contains(groups, maliciousGroup) {
+				if strings.Contains(v.req.Header.Get("Impersonate-Group"), maliciousGroup) {
 					t.Errorf("Groups should not contain %s injected in the request", maliciousGroup)
 				}
 


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Request coming to `apiserver-proxy` component can contain `impersonate-group` header. We manage to prepare it on our own, depending on the user's groups. In order to not pass any additional data, we should make sure that a cleanup is performed.

Changes proposed in this pull request:

- before adding user's groups perform a cleanup on the header

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
