### PR TITLE
istio tracing config is set to 100

### DIFF
--- a/resources/istio/files/istio-operator-cluster-evaluation.yaml
+++ b/resources/istio/files/istio-operator-cluster-evaluation.yaml
@@ -129,8 +129,6 @@ spec:
       enabled: true
       k8s:
         env:
-        - name: PILOT_TRACE_SAMPLING
-          value: "100"
         - name: PILOT_HTTP10
           value: "1"
         - name: POD_NAME
@@ -177,6 +175,7 @@ spec:
     defaultConfig:
       proxyMetadata: {}
       tracing:
+        sampling: 100
         zipkin:
           address: "{{ .Values.global.tracing.zipkinAddress }}"
     enablePrometheusMerge: false
@@ -295,25 +294,9 @@ spec:
       keepaliveMaxServerConnectionAge: 30m
       nodeSelector: {}
       replicaCount: 1
-      traceSampling: 1
     sidecarInjectorWebhook:
       enableNamespacesByDefault: true
       objectSelector:
         autoInject: true
         enabled: false
       rewriteAppHTTPProbe: true
-    telemetry:
-      enabled: true
-      v2:
-        enabled: true
-        metadataExchange:
-          wasmEnabled: false
-        prometheus:
-          enabled: true
-          wasmEnabled: false
-        stackdriver:
-          configOverride: {}
-          enabled: false
-          logging: false
-          monitoring: false
-          topology: false

--- a/resources/istio/files/istio-operator-cluster-production.yaml
+++ b/resources/istio/files/istio-operator-cluster-production.yaml
@@ -129,8 +129,6 @@ spec:
       enabled: true
       k8s:
         env:
-        - name: PILOT_TRACE_SAMPLING
-          value: "100"
         - name: PILOT_HTTP10
           value: "1"
         - name: POD_NAME
@@ -177,6 +175,7 @@ spec:
     defaultConfig:
       proxyMetadata: {}
       tracing:
+        sampling: 1
         zipkin:
           address: "{{ .Values.global.tracing.zipkinAddress }}"
     enablePrometheusMerge: false
@@ -297,25 +296,9 @@ spec:
       keepaliveMaxServerConnectionAge: 30m
       nodeSelector: {}
       replicaCount: 1
-      traceSampling: 1
     sidecarInjectorWebhook:
       enableNamespacesByDefault: true
       objectSelector:
         autoInject: true
         enabled: false
       rewriteAppHTTPProbe: true
-    telemetry:
-      enabled: true
-      v2:
-        enabled: true
-        metadataExchange:
-          wasmEnabled: false
-        prometheus:
-          enabled: true
-          wasmEnabled: false
-        stackdriver:
-          configOverride: {}
-          enabled: false
-          logging: false
-          monitoring: false
-          topology: false

--- a/resources/istio/files/istio-operator-cluster-production.yaml
+++ b/resources/istio/files/istio-operator-cluster-production.yaml
@@ -175,7 +175,7 @@ spec:
     defaultConfig:
       proxyMetadata: {}
       tracing:
-        sampling: 1
+        # sampling: 1 # use the istio default (which is 1) to support override by pilot env variable at runtime
         zipkin:
           address: "{{ .Values.global.tracing.zipkinAddress }}"
     enablePrometheusMerge: false

--- a/resources/istio/files/istio-operator-cluster.yaml
+++ b/resources/istio/files/istio-operator-cluster.yaml
@@ -172,7 +172,7 @@ spec:
     defaultConfig:
       proxyMetadata: {}
       tracing:
-        sampling: 1
+        # sampling: 1 # use the istio default (which is 1) to support override by pilot env variable at runtime
         zipkin:
           address: "{{ .Values.global.tracing.zipkinAddress }}"
     enablePrometheusMerge: false

--- a/resources/istio/files/istio-operator-cluster.yaml
+++ b/resources/istio/files/istio-operator-cluster.yaml
@@ -127,8 +127,6 @@ spec:
       enabled: true
       k8s:
         env:
-        - name: PILOT_TRACE_SAMPLING
-          value: "100"
         - name: PILOT_HTTP10
           value: "1"
         - name: POD_NAME
@@ -174,6 +172,7 @@ spec:
     defaultConfig:
       proxyMetadata: {}
       tracing:
+        sampling: 1
         zipkin:
           address: "{{ .Values.global.tracing.zipkinAddress }}"
     enablePrometheusMerge: false
@@ -294,25 +293,9 @@ spec:
       keepaliveMaxServerConnectionAge: 30m
       nodeSelector: {}
       replicaCount: 1
-      traceSampling: 1
     sidecarInjectorWebhook:
       enableNamespacesByDefault: true
       objectSelector:
         autoInject: true
         enabled: false
       rewriteAppHTTPProbe: true
-    telemetry:
-      enabled: true
-      v2:
-        enabled: true
-        metadataExchange:
-          wasmEnabled: false
-        prometheus:
-          enabled: true
-          wasmEnabled: false
-        stackdriver:
-          configOverride: {}
-          enabled: false
-          logging: false
-          monitoring: false
-          topology: false

--- a/resources/istio/files/istio-operator-minikube-evaluation.yaml
+++ b/resources/istio/files/istio-operator-minikube-evaluation.yaml
@@ -135,8 +135,6 @@ spec:
       enabled: true
       k8s:
         env:
-          - name: PILOT_TRACE_SAMPLING
-            value: "100"
           - name: PILOT_HTTP10
             value: "1"
           - name: POD_NAME
@@ -188,9 +186,11 @@ spec:
     defaultConfig:
       proxyMetadata: {}
       tracing:
+        sampling: 100
         zipkin:
           address: "{{ .Values.global.tracing.zipkinAddress }}"
     enablePrometheusMerge: false
+    enableTracing: {{ .Values.global.tracing.enabled }}
   values:
     base:
       enableCRDTemplates: false
@@ -306,25 +306,9 @@ spec:
       keepaliveMaxServerConnectionAge: 30m
       nodeSelector: {}
       replicaCount: 1
-      traceSampling: 1
     sidecarInjectorWebhook:
       enableNamespacesByDefault: true
       objectSelector:
         autoInject: true
         enabled: false
       rewriteAppHTTPProbe: true
-    telemetry:
-      enabled: true
-      v2:
-        enabled: true
-        metadataExchange:
-          wasmEnabled: false
-        prometheus:
-          enabled: true
-          wasmEnabled: false
-        stackdriver:
-          configOverride: {}
-          enabled: false
-          logging: false
-          monitoring: false
-          topology: false

--- a/resources/istio/files/istio-operator-minikube.yaml
+++ b/resources/istio/files/istio-operator-minikube.yaml
@@ -185,7 +185,7 @@ spec:
     defaultConfig:
       proxyMetadata: {}
       tracing:
-        sampling: 1
+        # sampling: 1 # use the istio default (which is 1) to support override by pilot env variable at runtime
         zipkin:
           address: "{{ .Values.global.tracing.zipkinAddress }}"
     enablePrometheusMerge: false

--- a/resources/istio/files/istio-operator-minikube.yaml
+++ b/resources/istio/files/istio-operator-minikube.yaml
@@ -135,8 +135,6 @@ spec:
       enabled: true
       k8s:
         env:
-        - name: PILOT_TRACE_SAMPLING
-          value: "100"
         - name: PILOT_HTTP10
           value: "1"
         - name: POD_NAME
@@ -187,9 +185,11 @@ spec:
     defaultConfig:
       proxyMetadata: {}
       tracing:
+        sampling: 1
         zipkin:
           address: "{{ .Values.global.tracing.zipkinAddress }}"
     enablePrometheusMerge: false
+    enableTracing: {{ .Values.global.tracing.enabled }}
   values:
     base:
       enableCRDTemplates: false
@@ -304,25 +304,9 @@ spec:
       keepaliveMaxServerConnectionAge: 30m
       nodeSelector: {}
       replicaCount: 1
-      traceSampling: 1
     sidecarInjectorWebhook:
       enableNamespacesByDefault: true
       objectSelector:
         autoInject: true
         enabled: false
       rewriteAppHTTPProbe: true
-    telemetry:
-      enabled: true
-      v2:
-        enabled: true
-        metadataExchange:
-          wasmEnabled: false
-        prometheus:
-          enabled: true
-          wasmEnabled: false
-        stackdriver:
-          configOverride: {}
-          enabled: false
-          logging: false
-          monitoring: false
-          topology: false


### PR DESCRIPTION


<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

The istio tracing config is ambigious sampling rate settings leading to on overall effect of sampling all requests. That is way too much for a productive system, it was set to 1 in the past.

Furthermore, the config uses deprecated elements which prevents an effective override of the trace config

Changes proposed in this pull request:

- removed outdated tracing config from all profiles
- configured the sampling rate with one setting only
- configured a sampling rate of 100 for the evaluation profile, otherwise 1

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
