### PR TITLE
Update Istio-installer to 1.10.2

### DIFF
--- a/components/istio-installer/Dockerfile
+++ b/components/istio-installer/Dockerfile
@@ -2,7 +2,7 @@ FROM eu.gcr.io/kyma-project/tpi/k8s-tools:20210610-d25e85b1
 
 LABEL source=git@github.com:kyma-project/kyma.git
 
-ENV ISTIOCTL_VERSION 1.10.0
+ENV ISTIOCTL_VERSION 1.10.2
 ENV YQ_VERSION 3.1.1
 
 RUN curl -L https://github.com/istio/istio/releases/download/${ISTIOCTL_VERSION}/istioctl-${ISTIOCTL_VERSION}-linux-amd64.tar.gz -o istioctl.tar.gz &&\


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- Bump Istio to the newest version 1.10.2, mitigating [CVE-2021-34824](https://istio.io/latest/news/security/istio-security-2021-007/), which we are currently using: [link](https://github.com/kyma-project/kyma/search?q=credentialName)
