### PR TITLE
Change cookie names for OAuth2 Proxy deployments

### DIFF
--- a/resources/kiali/templates/kyma-additions/auth-proxy-deployment.yaml
+++ b/resources/kiali/templates/kyma-additions/auth-proxy-deployment.yaml
@@ -40,7 +40,7 @@ spec:
         - --upstream=http://{{ template "kiali-server.name" . }}-server:{{ .Values.kiali.spec.server.port }}
         - --cookie-secure=true
         - --cookie-domain=kiali.{{ .Values.global.ingress.domainName }}
-        - --cookie-name=KYMA_KIALI_TOKEN
+        - --cookie-name=KYMA_KIALI_OAUTH2_PROXY_TOKEN
         - --silence-ping-logging=true
         - --reverse-proxy=true
         - --auth-logging={{ .Values.authProxy.config.authLogging }}

--- a/resources/monitoring/charts/grafana/templates/kyma-additions/auth-proxy-deployment.yaml
+++ b/resources/monitoring/charts/grafana/templates/kyma-additions/auth-proxy-deployment.yaml
@@ -45,7 +45,7 @@ spec:
         - --upstream=http://{{ template "grafana.fullname" . }}:{{ .Values.service.port }}
         - --cookie-secure=true
         - --cookie-domain=grafana.{{ .Values.global.ingress.domainName }}
-        - --cookie-name=KYMA_GRAFANA_TOKEN
+        - --cookie-name=KYMA_GRAFANA_OAUTH2_PROXY_TOKEN
         - --silence-ping-logging=true
         - --reverse-proxy=true
         - --auth-logging={{ .Values.kyma.authProxy.config.authLogging }}

--- a/resources/tracing/templates/kyma-additions/auth-proxy-deployment.yaml
+++ b/resources/tracing/templates/kyma-additions/auth-proxy-deployment.yaml
@@ -41,7 +41,7 @@ spec:
         - --upstream=http://{{ template "jaeger-operator.fullname" . }}-jaeger-query:{{ .Values.jaeger.kyma.uiPort }}
         - --cookie-secure=true
         - --cookie-domain=jaeger.{{ .Values.global.ingress.domainName }}
-        - --cookie-name=KYMA_JAEGER_TOKEN
+        - --cookie-name=KYMA_JAEGER_OAUTH2_PROXY_TOKEN
         - --silence-ping-logging=true
         - --reverse-proxy=true
         - --auth-logging={{ .Values.authProxy.config.authLogging }}


### PR DESCRIPTION
To avoid problems with logging in to services that ran keycloak-proxy before.

<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- Change cookie names for OAuth2 Proxy deployments

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
See also #11181 
