### PR TITLE
Bump image for service-manager-proxy

### DIFF
--- a/resources/service-manager-proxy/values.yaml
+++ b/resources/service-manager-proxy/values.yaml
@@ -39,7 +39,7 @@ image:
   pullPolicy: IfNotPresent
   pullsecret: null
   repository: eu.gcr.io/kyma-project/external/quay.io/service-manager/sb-proxy-k8s
-  tag: v0.8.18
+  tag: v0.9.0
 replicaCount: 1
 securityContext: { }
 service:


### PR DESCRIPTION
**Description**

Bump service-manager-proxy image from v0.8.18 to v0.9.0

**Related issue(s)**
[test-infra](https://github.com/kyma-project/test-infra/pull/3831)