### PR TITLE
Fix replicas vs PDB settings in evaluation profile

### DIFF
--- a/resources/cluster-essentials/charts/pod-preset/templates/webhook/deploy.yaml
+++ b/resources/cluster-essentials/charts/pod-preset/templates/webhook/deploy.yaml
@@ -64,7 +64,7 @@ kind: PodDisruptionBudget
 metadata:
   name: {{ template "pod-preset.fullname" . }}-pdb
 spec:
-  minAvailable: 1
+  minAvailable: {{ .Values.webhook.pdb.minAvailable }}
   selector:
     matchLabels:
       app: {{ template "pod-preset.name" . }}-webhook

--- a/resources/cluster-essentials/charts/pod-preset/values.yaml
+++ b/resources/cluster-essentials/charts/pod-preset/values.yaml
@@ -9,6 +9,7 @@ webhook:
   verbosity: 6
   pdb:
     enabled: false
+    minAvailable: 0
   timeout: 10
   resources:
     requests:

--- a/resources/cluster-essentials/profile-evaluation.yaml
+++ b/resources/cluster-essentials/profile-evaluation.yaml
@@ -3,7 +3,7 @@ pod-preset:
     replicaCount: 1
     timeout: "10"
     pdb:
-      enabled: "false"
+      enabled: false
     resources:
       requests:
         cpu: 20m

--- a/resources/cluster-essentials/profile-production.yaml
+++ b/resources/cluster-essentials/profile-production.yaml
@@ -3,7 +3,8 @@ pod-preset:
     replicaCount: 2
     timeout: "15"
     pdb:
-      enabled: "true"
+      enabled: true
+      minAvailable: 1
     resources:
       requests:
         cpu: 50m

--- a/resources/istio/files/istio-operator-cluster-evaluation.yaml
+++ b/resources/istio/files/istio-operator-cluster-evaluation.yaml
@@ -215,7 +215,7 @@ spec:
       configValidation: true
       defaultNodeSelector: {}
       defaultPodDisruptionBudget:
-        enabled: true
+        enabled: false
       defaultResources:
         requests:
           cpu: 10m

--- a/resources/istio/files/istio-operator-cluster-production.yaml
+++ b/resources/istio/files/istio-operator-cluster-production.yaml
@@ -150,7 +150,7 @@ spec:
           timeoutSeconds: 5
         hpaSpec:
           maxReplicas: 5
-          minReplicas: 1
+          minReplicas: 2
           scaleTargetRef:
             apiVersion: apps/v1
             kind: Deployment
@@ -284,7 +284,7 @@ spec:
     pilot:
       autoscaleEnabled: true
       autoscaleMax: 5
-      autoscaleMin: 1
+      autoscaleMin: 2
       configMap: true
       configNamespace: istio-config
       cpu:
@@ -295,7 +295,6 @@ spec:
       image: pilot
       keepaliveMaxServerConnectionAge: 30m
       nodeSelector: {}
-      replicaCount: 1
     sidecarInjectorWebhook:
       enableNamespacesByDefault: true
       objectSelector:

--- a/resources/istio/files/istio-operator-minikube-evaluation.yaml
+++ b/resources/istio/files/istio-operator-minikube-evaluation.yaml
@@ -226,7 +226,7 @@ spec:
       configValidation: true
       defaultNodeSelector: {}
       defaultPodDisruptionBudget:
-        enabled: true
+        enabled: false
       defaultResources:
         requests:
           cpu: 10m


### PR DESCRIPTION
**Description**

Cherry-pick of https://github.com/kyma-project/kyma/pull/11544

On clusters with evaluation profile, `istiod`, `istio-ingressgateway` and `cluster-essentials-podpreset-webhook` have PDB configured with `minAvailable: 1` while these workloads are being run with 1 replica only. This blocks pod eviction, which effectively blocks node drain during maintenance activities (such as Gardener K8S cluster upgrades).

Changes proposed in this pull request:

- Have configurable value for `cluster-essentials-podpreset-webhook` PDB `minAvailable` field. Fix disabling the PDB in evaluation profile.
- Disable all Istio PDBs in evaluation profile
- Have at least 2 replicas of istiod in production profile by default, with PDB `minAvailable: 1`
