### PR TITLE
Use TLS mode SIMPLE in api-server DestinationRule

### DIFF
--- a/resources/istio/files/destination-rules.yaml
+++ b/resources/istio/files/destination-rules.yaml
@@ -11,3 +11,6 @@ spec:
     connectionPool:
       tcp:
         connectTimeout: "30s"
+    tls:
+      mode: SIMPLE
+      caCertificates: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- Disable mutual TLS for Kubernetes API Server as [documentation](https://kyma-project.io/docs/components/service-mesh#details-istio-setup-in-kyma-kyma-specific-configuration) suggests
- Use TLS mode SIMPLE instead and validate certificate with cluster internal certification authority

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
Resolves #11478
