### PR TITLE
Migrate serverless admission webhooks to v1

### DIFF
--- a/resources/serverless/charts/webhook/templates/webhooks.yaml
+++ b/resources/serverless/charts/webhook/templates/webhooks.yaml
@@ -1,33 +1,35 @@
-apiVersion: admissionregistration.k8s.io/v1beta1
+apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
 metadata:
   name: validation.webhook.serverless.kyma-project.io
   labels:
     {{- include "tplValue" ( dict "value" .Values.commonLabels "context" . ) | nindent 4 }}
 webhooks:
-  - admissionReviewVersions:
-      - v1beta1
-    clientConfig:
+  - clientConfig:
       service:
         name: {{ template "webhook.fullname" . }}
         namespace: {{ .Release.Namespace }}
     failurePolicy: Fail
     sideEffects: None
+    matchPolicy: Exact
+    timeoutSeconds: 30
+    admissionReviewVersions: ["v1", "v1beta1"]
     name: validation.webhook.serverless.kyma-project.io
 ---
-apiVersion: admissionregistration.k8s.io/v1beta1
+apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingWebhookConfiguration
 metadata:
   name: defaulting.webhook.serverless.kyma-project.io
   labels:
     {{- include "tplValue" ( dict "value" .Values.commonLabels "context" . ) | nindent 4 }}
 webhooks:
-  - admissionReviewVersions:
-      - v1beta1
-    clientConfig:
+  - clientConfig:
       service:
         name: {{ template "webhook.fullname" . }}
         namespace: {{ .Release.Namespace }}
     failurePolicy: Fail
     sideEffects: None
+    matchPolicy: Exact
+    timeoutSeconds: 30
+    admissionReviewVersions: ["v1", "v1beta1"]
     name: defaulting.webhook.serverless.kyma-project.io

--- a/resources/serverless/templates/admission_webhook.yaml
+++ b/resources/serverless/templates/admission_webhook.yaml
@@ -18,7 +18,7 @@ data:
   tls.crt: {{ b64enc $cert.Cert }}
   tls.key: {{ b64enc $cert.Key }}
 ---
-apiVersion: admissionregistration.k8s.io/v1beta1
+apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingWebhookConfiguration
 metadata:
   name: mutating.secrets 
@@ -31,6 +31,10 @@ webhooks:
       path: /mutate-v1-secret
       port: {{ .Values.services.manager.https.port }}
   failurePolicy: Fail
+  matchPolicy: Exact
+  timeoutSeconds: 30
+  sideEffects: None
+  admissionReviewVersions: ["v1", "v1beta1"]
   name: mutating.secret.serverless.k8s.io
   objectSelector:
     matchLabels:


### PR DESCRIPTION
**Description**
Changes proposed in this pull request:

- Migrate serverless admission webhooks to v1 ([API changes](https://kubernetes.io/docs/reference/using-api/deprecation-guide/#webhook-resources-v122))

**Related issue(s)**
https://github.com/kyma-project/kyma/issues/11170