### PR TITLE
Central application gateway simplify API

### DIFF
--- a/components/central-application-gateway/README.md
+++ b/components/central-application-gateway/README.md
@@ -75,7 +75,7 @@ As a result, the Central Application Gateway:
 #### Standalone mode for Compass - simplified API
 
 The standalone mode can also be used for Compass bundles with a single API definition.
-This means that `{API_DEFINITION_NAME}` should be removed from the URL and its pattern looks like
+This means that `{API_DEFINITION_NAME}` should be removed from the URL and its pattern looks like:
 ```
 {APPLICATION_NAME}/{API_BUNDLE_NAME}/{TARGET_API_PATH}
 ```

--- a/components/central-application-gateway/README.md
+++ b/components/central-application-gateway/README.md
@@ -101,8 +101,9 @@ As a result, the Central Application Gateway:
    ```
 
 #### Handling ambiguous API definition names
+
 A combination of `{API_BUNDLE_NAME}` and `{API_DEFINITION_NAME}` which are extracted from an Application CRD should be unique for a given application.
-Invocation of endpoints with duplicate names will result in **400 Bad Request** failure. In such a case one of the names should be changed to avoid ambiguity.
+Invocation of endpoints with duplicate names will result in a **400 Bad Request** failure. In such a case, one of the names should be changed to avoid ambiguity.
 
 ## Development
 

--- a/components/central-application-gateway/README.md
+++ b/components/central-application-gateway/README.md
@@ -79,7 +79,7 @@ This means that `{API_DEFINITION_NAME}` should be removed from the URL and its p
 ```
 {APPLICATION_NAME}/{API_BUNDLE_NAME}/{TARGET_API_PATH}
 ```
-**Invocation of service bundles configured with multiple API definitions will result in 400 Bad Request failure.**
+> **NOTE:** Invocation of service bundles configured with multiple API definitions will result in **400 Bad Request** failure.
 
 ### Compass mode
 The proxy API exposes the following endpoint:

--- a/components/central-application-gateway/README.md
+++ b/components/central-application-gateway/README.md
@@ -52,7 +52,7 @@ The Central Application Gateway has the following parameters:
 ## API
 The Central Application Gateway exposes:
 - an external API implementing a health endpoint for liveness and readiness probes
-- 2 internal APIs implementing a proxy handler accessible via a service of type ClusterIP
+- 2 internal APIs implementing a proxy handler accessible via a service of type `ClusterIP`
 
 ### Standalone (legacy) mode
 The proxy API exposes the following endpoint:

--- a/components/central-application-gateway/README.md
+++ b/components/central-application-gateway/README.md
@@ -38,8 +38,7 @@ To start the Central Application Gateway, run this command:
 ```
 
 The Central Application Gateway has the following parameters:
-- **disableLegacyConnectivity** is the flag for disabling the default legacy mode and enabling the Compass mode. The default value is `false`.
-- **proxyPort** is the port that acts as a proxy for the calls from services and Functions to an external solution in the default standalone (legacy) mode. The default port is `8080`.
+- **proxyPort** is the port that acts as a proxy for the calls from services and Functions to an external solution in the default standalone (legacy) mode or Compass bundles with a single API definition. The default port is `8080`.
 - **proxyPortCompass** is the port that acts as a proxy for the calls from services and Functions to an external solution in the Compass mode. The default port is `8082`.
 - **externalAPIPort** is the port that exposes the API which allows checking the component status. The default port is `8081`.
 - **namespace** is the Namespace in which the Central Application Gateway is deployed. The default Namespace is `kyma-system`.
@@ -53,10 +52,10 @@ The Central Application Gateway has the following parameters:
 ## API
 The Central Application Gateway exposes:
 - an external API implementing a health endpoint for liveness and readiness probes
-- an internal API implementing a proxy handler accessible via a service of type ClusterIP
+- 2 internal APIs implementing a proxy handler accessible via a service of type ClusterIP
 
 ### Standalone (legacy) mode
-If  **disableLegacyConnectivity** is `false`, the proxy API exposes the following endpoint:
+The proxy API exposes the following endpoint:
 ```bash
 {APPLICATION_NAME}/{SERVICE_NAME}/{TARGET_API_PATH}
 ``` 
@@ -73,16 +72,25 @@ As a result, the Central Application Gateway:
    ```bash
    {TARGET_URL_EXTRACTED_FROM_APPLICATION_CRD}/basesites
 
+#### Standalone mode for Compass - simplified API
+
+The standalone mode can also be used for Compass bundles with a single API definition.
+This means that `{API_DEFINITION_NAME}` should be removed from the URL and its pattern looks like
+```
+{APPLICATION_NAME}/{API_BUNDLE_NAME}/{TARGET_API_PATH}
+```
+**Invocation of service bundles configured with multiple API definitions will result in 400 Bad Request failure.**
+
 ### Compass mode
-If **disableLegacyConnectivity** is `true`, the proxy API exposes the following endpoint:
+The proxy API exposes the following endpoint:
 ```bash
 {APPLICATION_NAME}/{API_BUNDLE_NAME}/{API_DEFINITION_NAME}/{TARGET_API_PATH}
-``` 
+```
 
 For instance, if the user registered the `cc-occ` API bundle with the `commerce-webservices` API definition in the `ec` application, they can send a request to the following URL:
 ```bash
 http://central-application-gateway:8082/ec/cc-occ/commerce-webservices/basesites
-``` 
+```
 
 As a result, the Central Application Gateway:
 1. Looks for the `cc-occ` service and the `commerce-webservices` entry in the `ec` Application CRD and extracts the target URL path along with the authentication configuration
@@ -90,6 +98,11 @@ As a result, the Central Application Gateway:
 3. Sends the request to the following path: 
    ```bash
    {TARGET_URL_EXTRACTED_FROM_APPLICATION_CRD}/basesites
+   ```
+
+#### Handling ambiguous API definition names
+A combination of `{API_BUNDLE_NAME}` and `{API_DEFINITION_NAME}` which are extracted from an Application CRD should be unique for a given application.
+Invocation of endpoints with duplicate names will result in **400 Bad Request** failure. In such a case one of the names should be changed to avoid ambiguity.
 
 ## Development
 

--- a/components/central-application-gateway/cmd/applicationgateway/applicationproxy.go
+++ b/components/central-application-gateway/cmd/applicationgateway/applicationproxy.go
@@ -23,6 +23,7 @@ import (
 	log "github.com/sirupsen/logrus"
 	"k8s.io/client-go/kubernetes"
 	restclient "k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/clientcmd"
 )
 
 func main() {
@@ -36,7 +37,7 @@ func main() {
 	options := parseArgs()
 	log.Infof("Options: %s", options)
 
-	k8sConfig, err := restclient.InClusterConfig()
+	k8sConfig, err := clientcmd.BuildConfigFromFlags(options.apiServerURL, options.kubeConfig)
 	if err != nil {
 		log.Fatalf("Error reading in cluster config: %s", err.Error())
 	}

--- a/components/central-application-gateway/cmd/applicationgateway/applicationproxy.go
+++ b/components/central-application-gateway/cmd/applicationgateway/applicationproxy.go
@@ -1,10 +1,13 @@
 package main
 
 import (
+	"context"
+	"net"
 	"net/http"
 	"os"
+	"os/signal"
 	"strconv"
-	"sync"
+	"syscall"
 	"time"
 
 	"github.com/kyma-project/kyma/components/application-operator/pkg/client/clientset/versioned"
@@ -20,10 +23,15 @@ import (
 	"github.com/kyma-project/kyma/components/central-application-gateway/pkg/apperrors"
 	"github.com/kyma-project/kyma/components/central-application-gateway/pkg/authorization"
 	"github.com/kyma-project/kyma/components/central-application-gateway/pkg/httptools"
+	"github.com/oklog/run"
 	log "github.com/sirupsen/logrus"
 	"k8s.io/client-go/kubernetes"
 	restclient "k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
+)
+
+const (
+	shutdownTimeout = 2 * time.Second
 )
 
 func main() {
@@ -88,25 +96,54 @@ func main() {
 		WriteTimeout: time.Duration(options.requestTimeout) * time.Second,
 	}
 
-	// TODO: handle case when server fails
-	wg := &sync.WaitGroup{}
+	var g run.Group
 
-	wg.Add(2)
-	go func() {
-		log.Fatal(externalSrv.ListenAndServe())
-	}()
+	addHttpServerToRunGroup("external-api", &g, externalSrv)
+	addHttpServerToRunGroup("proxy-kyma-os", &g, internalSrv)
+	addHttpServerToRunGroup("proxy-kyma-mps", &g, internalSrvCompass)
+	addInterruptSignalToRunGroup(&g)
 
-	if options.disableLegacyConnectivity {
-		go func() {
-			log.Fatal(internalSrvCompass.ListenAndServe())
-		}()
-	} else {
-		go func() {
-			log.Fatal(internalSrv.ListenAndServe())
-		}()
+	err = g.Run()
+	if err != nil && err != http.ErrServerClosed {
+		log.Fatal(err)
 	}
+}
 
-	wg.Wait()
+func addHttpServerToRunGroup(name string, g *run.Group, srv *http.Server) {
+	log.Infof("Starting %s HTTP server on %s", name, srv.Addr)
+	ln, err := net.Listen("tcp", srv.Addr)
+	if err != nil {
+		log.Fatalf("Unable to start %s HTTP server: '%s'", name, err.Error())
+	}
+	g.Add(func() error {
+		defer log.Infof("Server %s finished", name)
+		return srv.Serve(ln)
+	}, func(error) {
+		log.Infof("Shutting down %s HTTP server on %s", name, srv.Addr)
+
+		ctx, cancel := context.WithTimeout(context.Background(), shutdownTimeout)
+		defer cancel()
+		err = srv.Shutdown(ctx)
+		if err != nil && err != http.ErrServerClosed {
+			log.Warnf("HTTP server shutdown %s failed: %s", name, err.Error())
+		}
+	})
+}
+
+func addInterruptSignalToRunGroup(g *run.Group) {
+	cancelInterrupt := make(chan struct{})
+	g.Add(func() error {
+		c := make(chan os.Signal, 1)
+		signal.Notify(c, syscall.SIGINT, syscall.SIGTERM)
+		select {
+		case <-cancelInterrupt:
+		case sig := <-c:
+			log.Infof("received signal %s", sig)
+		}
+		return nil
+	}, func(error) {
+		close(cancelInterrupt)
+	})
 }
 
 func newInternalHandler(serviceDefinitionService metadata.ServiceDefinitionService, options *options) http.Handler {

--- a/components/central-application-gateway/cmd/applicationgateway/options.go
+++ b/components/central-application-gateway/cmd/applicationgateway/options.go
@@ -21,8 +21,8 @@ type options struct {
 
 func parseArgs() *options {
 	externalAPIPort := flag.Int("externalAPIPort", 8081, "External API port.")
-	proxyPort := flag.Int("proxyPort", 8080, "Proxy port for Kyma OS or MPS with single service entry")
-	proxyPortCompass := flag.Int("proxyPortCompass", 8088, "Proxy port for Kyma MPS.")
+	proxyPort := flag.Int("proxyPort", 8080, "Proxy port for Kyma OS or MPS bundles with a single API definition")
+	proxyPortCompass := flag.Int("proxyPortCompass", 8082, "Proxy port for Kyma MPS.")
 	namespace := flag.String("namespace", "kyma-system", "Namespace used by the Application Gateway")
 	requestTimeout := flag.Int("requestTimeout", 1, "Timeout for services.")
 	skipVerify := flag.Bool("skipVerify", false, "Flag for skipping certificate verification for proxy target.")

--- a/components/central-application-gateway/cmd/applicationgateway/options.go
+++ b/components/central-application-gateway/cmd/applicationgateway/options.go
@@ -6,24 +6,22 @@ import (
 )
 
 type options struct {
-	disableLegacyConnectivity bool
-	externalAPIPort           int
-	proxyPort                 int
-	proxyPortCompass          int
-	namespace                 string
-	requestTimeout            int
-	skipVerify                bool
-	proxyTimeout              int
-	requestLogging            bool
-	proxyCacheTTL             int
-	kubeConfig                string
-	apiServerURL              string
+	externalAPIPort  int
+	proxyPort        int
+	proxyPortCompass int
+	namespace        string
+	requestTimeout   int
+	skipVerify       bool
+	proxyTimeout     int
+	requestLogging   bool
+	proxyCacheTTL    int
+	kubeConfig       string
+	apiServerURL     string
 }
 
 func parseArgs() *options {
-	disableLegacyConnectivity := flag.Bool("disableLegacyConnectivity", false, "Flag determining what HTTP handler will be used")
 	externalAPIPort := flag.Int("externalAPIPort", 8081, "External API port.")
-	proxyPort := flag.Int("proxyPort", 8080, "Proxy port for Kyma OS.")
+	proxyPort := flag.Int("proxyPort", 8080, "Proxy port for Kyma OS or MPS with single service entry")
 	proxyPortCompass := flag.Int("proxyPortCompass", 8088, "Proxy port for Kyma MPS.")
 	namespace := flag.String("namespace", "kyma-system", "Namespace used by the Application Gateway")
 	requestTimeout := flag.Int("requestTimeout", 1, "Timeout for services.")
@@ -37,24 +35,23 @@ func parseArgs() *options {
 	flag.Parse()
 
 	return &options{
-		disableLegacyConnectivity: *disableLegacyConnectivity,
-		externalAPIPort:           *externalAPIPort,
-		proxyPort:                 *proxyPort,
-		proxyPortCompass:          *proxyPortCompass,
-		namespace:                 *namespace,
-		requestTimeout:            *requestTimeout,
-		skipVerify:                *skipVerify,
-		proxyTimeout:              *proxyTimeout,
-		requestLogging:            *requestLogging,
-		proxyCacheTTL:             *proxyCacheTTL,
-		kubeConfig:                *kubeConfig,
-		apiServerURL:              *apiServerURL,
+		externalAPIPort:  *externalAPIPort,
+		proxyPort:        *proxyPort,
+		proxyPortCompass: *proxyPortCompass,
+		namespace:        *namespace,
+		requestTimeout:   *requestTimeout,
+		skipVerify:       *skipVerify,
+		proxyTimeout:     *proxyTimeout,
+		requestLogging:   *requestLogging,
+		proxyCacheTTL:    *proxyCacheTTL,
+		kubeConfig:       *kubeConfig,
+		apiServerURL:     *apiServerURL,
 	}
 }
 
 func (o *options) String() string {
-	return fmt.Sprintf("--disableLegacyConnectivity=%t --externalAPIPort=%d --proxyPort=%d --proxyPortCompass=%d --namespace=%s --requestTimeout=%d --skipVerify=%v --proxyTimeout=%d"+
+	return fmt.Sprintf("--externalAPIPort=%d --proxyPort=%d --proxyPortCompass=%d --namespace=%s --requestTimeout=%d --skipVerify=%v --proxyTimeout=%d"+
 		" --requestLogging=%t --proxyCacheTTL=%d --kubeConfig=%s --apiServerURL=%s",
-		o.disableLegacyConnectivity, o.externalAPIPort, o.proxyPort, o.proxyPortCompass, o.namespace, o.requestTimeout, o.skipVerify, o.proxyTimeout,
+		o.externalAPIPort, o.proxyPort, o.proxyPortCompass, o.namespace, o.requestTimeout, o.skipVerify, o.proxyTimeout,
 		o.requestLogging, o.proxyCacheTTL, o.kubeConfig, o.apiServerURL)
 }

--- a/components/central-application-gateway/cmd/applicationgateway/options.go
+++ b/components/central-application-gateway/cmd/applicationgateway/options.go
@@ -16,6 +16,8 @@ type options struct {
 	proxyTimeout              int
 	requestLogging            bool
 	proxyCacheTTL             int
+	kubeConfig                string
+	apiServerURL              string
 }
 
 func parseArgs() *options {
@@ -29,6 +31,8 @@ func parseArgs() *options {
 	proxyTimeout := flag.Int("proxyTimeout", 10, "Timeout for proxy call.")
 	requestLogging := flag.Bool("requestLogging", false, "Flag for logging incoming requests.")
 	proxyCacheTTL := flag.Int("proxyCacheTTL", 120, "TTL, in seconds, for proxy cache of Remote API information")
+	kubeConfig := flag.String("kubeConfig", "", "Path to a kubeconfig. Only required if out-of-cluster.")
+	apiServerURL := flag.String("apiServerURL", "", "The address of the Kubernetes API server. Overrides any value in kubeconfig. Only required if out-of-cluster.")
 
 	flag.Parse()
 
@@ -43,12 +47,14 @@ func parseArgs() *options {
 		proxyTimeout:              *proxyTimeout,
 		requestLogging:            *requestLogging,
 		proxyCacheTTL:             *proxyCacheTTL,
+		kubeConfig:                *kubeConfig,
+		apiServerURL:              *apiServerURL,
 	}
 }
 
 func (o *options) String() string {
 	return fmt.Sprintf("--disableLegacyConnectivity=%t --externalAPIPort=%d --proxyPort=%d --proxyPortCompass=%d --namespace=%s --requestTimeout=%d --skipVerify=%v --proxyTimeout=%d"+
-		" --requestLogging=%t --proxyCacheTTL=%d",
+		" --requestLogging=%t --proxyCacheTTL=%d --kubeConfig=%s --apiServerURL=%s",
 		o.disableLegacyConnectivity, o.externalAPIPort, o.proxyPort, o.proxyPortCompass, o.namespace, o.requestTimeout, o.skipVerify, o.proxyTimeout,
-		o.requestLogging, o.proxyCacheTTL)
+		o.requestLogging, o.proxyCacheTTL, o.kubeConfig, o.apiServerURL)
 }

--- a/components/central-application-gateway/go.mod
+++ b/components/central-application-gateway/go.mod
@@ -5,6 +5,7 @@ go 1.14
 require (
 	github.com/gorilla/mux v1.8.0
 	github.com/kyma-project/kyma/components/application-operator v0.0.0-20210624133846-3e1e71e9f682
+	github.com/oklog/run v1.1.0
 	github.com/patrickmn/go-cache v2.1.0+incompatible
 	github.com/sirupsen/logrus v1.8.1
 	github.com/stretchr/testify v1.7.0

--- a/components/central-application-gateway/go.sum
+++ b/components/central-application-gateway/go.sum
@@ -438,6 +438,7 @@ github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:
 github.com/imdario/mergo v0.3.5/go.mod h1:2EnlNZ0deacrJVfApfmtdGgDfMuh/nq6Ok1EcJh5FfA=
 github.com/imdario/mergo v0.3.6/go.mod h1:2EnlNZ0deacrJVfApfmtdGgDfMuh/nq6Ok1EcJh5FfA=
 github.com/imdario/mergo v0.3.10/go.mod h1:jmQim1M+e3UYxmgPu/WyfjB3N3VflVyUjjjwH0dnCYA=
+github.com/imdario/mergo v0.3.11 h1:3tnifQM4i+fbajXKBHXWEH+KvNHqojZ778UH75j3bGA=
 github.com/imdario/mergo v0.3.11/go.mod h1:jmQim1M+e3UYxmgPu/WyfjB3N3VflVyUjjjwH0dnCYA=
 github.com/imdario/mergo v0.3.12/go.mod h1:jmQim1M+e3UYxmgPu/WyfjB3N3VflVyUjjjwH0dnCYA=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=

--- a/components/central-application-gateway/go.sum
+++ b/components/central-application-gateway/go.sum
@@ -440,6 +440,7 @@ github.com/imdario/mergo v0.3.6/go.mod h1:2EnlNZ0deacrJVfApfmtdGgDfMuh/nq6Ok1EcJ
 github.com/imdario/mergo v0.3.10/go.mod h1:jmQim1M+e3UYxmgPu/WyfjB3N3VflVyUjjjwH0dnCYA=
 github.com/imdario/mergo v0.3.11 h1:3tnifQM4i+fbajXKBHXWEH+KvNHqojZ778UH75j3bGA=
 github.com/imdario/mergo v0.3.11/go.mod h1:jmQim1M+e3UYxmgPu/WyfjB3N3VflVyUjjjwH0dnCYA=
+github.com/imdario/mergo v0.3.12 h1:b6R2BslTbIEToALKP7LxUvijTsNI9TAe80pLWN2g/HU=
 github.com/imdario/mergo v0.3.12/go.mod h1:jmQim1M+e3UYxmgPu/WyfjB3N3VflVyUjjjwH0dnCYA=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
 github.com/influxdata/influxdb1-client v0.0.0-20191209144304-8bf82d3c094d/go.mod h1:qj24IKcXYK6Iy9ceXlo3Tc+vtHo9lIhSX5JddghvEPo=
@@ -570,6 +571,8 @@ github.com/nxadm/tail v1.4.4/go.mod h1:kenIhsEOeOJmVchQTgglprH7qJGnHDVpk1VPCcaMI
 github.com/nxadm/tail v1.4.8/go.mod h1:+ncqLTQzXmGhMZNUePPaPqPvBxHAIsmXswZKocGu+AU=
 github.com/oklog/oklog v0.3.2/go.mod h1:FCV+B7mhrz4o+ueLpx+KqkyXRGMWOYEvfiXtdGtbWGs=
 github.com/oklog/run v1.0.0/go.mod h1:dlhp/R75TPv97u0XWUtDeV/lRKWPKSdTuV0TZvrmrQA=
+github.com/oklog/run v1.1.0 h1:GEenZ1cK0+q0+wsJew9qUg/DyD8k3JzYsZAi5gYi2mA=
+github.com/oklog/run v1.1.0/go.mod h1:sVPdnTZT1zYwAJeCMu2Th4T21pA3FPOQRfWjQlk7DVU=
 github.com/oklog/ulid v1.3.1/go.mod h1:CirwcVhetQ6Lv90oh/F+FBtV6XMibvdAFo93nm5qn4U=
 github.com/olekukonko/tablewriter v0.0.0-20170122224234-a0225b3f23b5/go.mod h1:vsDQFd/mU46D+Z4whnwzcISnGGzXWMclvtLoiIKAKIo=
 github.com/olekukonko/tablewriter v0.0.1/go.mod h1:vsDQFd/mU46D+Z4whnwzcISnGGzXWMclvtLoiIKAKIo=

--- a/components/central-application-gateway/internal/metadata/servicedefservice.go
+++ b/components/central-application-gateway/internal/metadata/servicedefservice.go
@@ -78,5 +78,9 @@ func handleError(err apperrors.AppError, notFoundMessage, internalErrorMEssage s
 		return apperrors.NotFound(notFoundMessage)
 	}
 	log.Error(internalErrorMEssage)
+
+	if err.Code() == apperrors.CodeWrongInput {
+		return apperrors.WrongInput(internalErrorMEssage)
+	}
 	return apperrors.Internal(internalErrorMEssage)
 }

--- a/resources/application-connector/charts/central-application-gateway/templates/deployment.yaml
+++ b/resources/application-connector/charts/central-application-gateway/templates/deployment.yaml
@@ -35,7 +35,6 @@ spec:
         imagePullPolicy: {{ .Values.deployment.image.pullPolicy }}
         args:
           - "/applicationgateway"
-          - "--disableLegacyConnectivity={{ .Values.global.disableLegacyConnectivity }}"
           - "--proxyPort={{ .Values.deployment.args.proxyPort }}"
           - "--proxyPortCompass={{ .Values.deployment.args.proxyPortCompass }}"
           - "--externalAPIPort={{ .Values.deployment.args.externalAPIPort }}"
@@ -65,12 +64,9 @@ spec:
             cpu: {{ .Values.deployment.resources.requests.cpu }}
             memory: {{ .Values.deployment.resources.requests.memory }}
         ports:
-      {{- if .Values.global.disableLegacyConnectivity }}
-          - containerPort: {{ .Values.deployment.args.proxyPortCompass }}
-            name: http-proxy
-      {{- else}}
           - containerPort: {{ .Values.deployment.args.proxyPort }}
             name: http-proxy
-      {{- end }}
+          - containerPort: {{ .Values.deployment.args.proxyPortCompass }}
+            name: http-proxy-mps
           - containerPort: {{ .Values.deployment.args.externalAPIPort }}
             name: http-api-port

--- a/resources/application-connector/charts/central-application-gateway/templates/service.yaml
+++ b/resources/application-connector/charts/central-application-gateway/templates/service.yaml
@@ -17,13 +17,12 @@ spec:
     - port: {{ .Values.service.externalapi.port }}
       protocol: TCP
       name: http-api-port
-  {{- if .Values.global.disableLegacyConnectivity }}
-    - port: {{ .Values.service.proxy.portCompass }}
-  {{- else}}
     - port: {{ .Values.service.proxy.port }}
-  {{- end }}
       protocol: TCP
       name: http-proxy
+    - port: {{ .Values.service.proxy.portCompass }}
+      protocol: TCP
+      name: http-proxy-mps
   selector:
     app: {{ .Chart.Name }}
     release: {{ .Release.Name }}

--- a/resources/application-connector/values.yaml
+++ b/resources/application-connector/values.yaml
@@ -74,7 +74,7 @@ global:
   central_application_connectivity_validator:
     version: "PR-11558"
   central_application_gateway:
-    version: "PR-11558"
+    version: "PR-11624"
 
 application_connectivity_certs_setup_job:
   secrets:


### PR DESCRIPTION
**Description**

1. Central application gateway serves simultaneously on 2 port OS / MPS
2. OS part uses only service display name in the URL
3. MPS part uses service display name and entry name in the URL
4. In both cases (OS, MPS) if multiple configuration entries are found, service responds with 400 Bad Request  