### PR TITLE
Adding postgresql repl pwd to ory hydra credentials secret

### DIFF
--- a/resources/ory/files/secret-migration.sh
+++ b/resources/ory/files/secret-migration.sh
@@ -32,6 +32,12 @@ DB_USER="{{ .Values.global.postgresql.postgresqlUsername }}"
 DB_URL="ory-postgresql.{{ .Release.Namespace }}.svc.cluster.local:5432"
 DB_NAME="{{ .Values.global.postgresql.postgresqlDatabase }}"
 PASSWORD="{{ .Values.global.postgresql.postgresqlPassword }}"
+PASSWORDR="{{ .Values.global.postgresql.replicationPassword }}"
+PASSWORD_R_KEY="postgresql-replication-password"
+  if [[ -z "${PASSWORDR}" ]]; then
+	    communicate_missing_override "${PASSWORD_R_KEY}"
+	      PASSWORDR=$(get_from_file "${PASSWORD_R_KEY}" || generateRandomString 10)
+  fi
 PASSWORD_KEY="postgresql-password"
 if [[ -z "${PASSWORD}" ]]; then
   communicate_missing_override "${PASSWORD_KEY}"
@@ -80,6 +86,7 @@ DATA=$(cat << EOF
   ${SECRET_COOKIE_KEY}: $(echo -n "${COOKIE}" | base64 -w 0)
   {{- if .Values.global.ory.hydra.persistence.enabled }}
   ${PASSWORD_KEY}: $(echo -n "${PASSWORD}" | base64 -w 0)
+  ${PASSWORD_R_KEY}: $(echo -n "${PASSWORDR}" | base64 -w 0)
   {{- end }}
   {{- if .Values.global.ory.hydra.persistence.gcloud.enabled }}
   ${SERVICE_ACCOUNT_KEY}: $(echo -n "${SERVICE_ACCOUNT}")


### PR DESCRIPTION
Update secret-migration.sh 

If (Values.postgresql.replication.enabled) is true then ory-hydra-credential secret will have a PostgreSQL replication pwd other wise ory-hydra-credentials won't have a replication pwd.

<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- ...
- ...
- ...

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
