### PR TITLE
Restrict fluent-bit pod permissions

### DIFF
--- a/resources/logging/charts/fluent-bit/values.yaml
+++ b/resources/logging/charts/fluent-bit/values.yaml
@@ -54,7 +54,8 @@ securityContext:
 service:
   type: ClusterIP
   port: 2020
-  labels: {}
+  labels: 
+    {}
   annotations:
     {}
     # prometheus.io/path: "/api/v1/metrics/prometheus"

--- a/resources/logging/charts/fluent-bit/values.yaml
+++ b/resources/logging/charts/fluent-bit/values.yaml
@@ -14,7 +14,6 @@ image:
 imagePullSecrets: []
 nameOverride: ""
 fullnameOverride: ""
-
 serviceAccount:
   create: true
   annotations: {}
@@ -29,7 +28,8 @@ podSecurityPolicy:
 podSecurityContext:
   {}
   # fsGroup: 2000
-dnsConfig: {}
+dnsConfig:
+  {}
   # nameservers:
   #   - 1.2.3.4
   # searches:
@@ -42,9 +42,11 @@ dnsConfig: {}
 securityContext:
   allowPrivilegeEscalation: false
   privileged: false
-  # capabilities:
-  #   drop:
-  #   - ALL
+  capabilities:
+    drop:
+      - ALL
+    add:
+      - FOWNER
   # readOnlyRootFilesystem: true
   # runAsNonRoot: true
   # runAsUser: 1000
@@ -52,8 +54,7 @@ securityContext:
 service:
   type: ClusterIP
   port: 2020
-  labels:
-    {}
+  labels: {}
   annotations:
     {}
     # prometheus.io/path: "/api/v1/metrics/prometheus"
@@ -122,7 +123,8 @@ extraVolumeMounts: ""
 #   - name: volume
 #     mountPath: /var/tmp
 
-updateStrategy: {}
+updateStrategy:
+  {}
   # type: RollingUpdate
   # rollingUpdate:
   #   maxUnavailable: 1
@@ -138,7 +140,7 @@ prometheusRules:
 # Fluentbit configuration section
 # https://docs.fluentbit.io/manual/administration/configuring-fluent-bit/configuration-file
 config:
-  # Secret values that will be included in a Secret mounted to the Fluent Bit Pods. 
+  # Secret values that will be included in a Secret mounted to the Fluent Bit Pods.
   secrets:
     #MY_ES_PASSWD: "1234"
   service:
@@ -156,11 +158,11 @@ config:
       enabled: true
       alias:
       tag: loki.*
-      tagRegex: 
+      tagRegex:
       path: /var/log/containers/*.log
       # If enabled, it appends the name of the monitored file as part of the record. The value assigned becomes the key in the map.
       pathKey:
-      excludePath: 
+      excludePath:
       #	Set the initial buffer size to read files data. This value is used too to increase buffer size. The value must be according to the Unit Size specification. Default: 32k
       bufferChunkSize:
       # Set the limit of the buffer size per monitored file. When a buffer needs to be increased (e.g: very long lines), this value is used to restrict how much the memory buffer can grow. If reading a file exceed this limit, the file is removed from the monitored file list. The value must be according to the Unit Size specification. Default: Buffer_Chunk_Size
@@ -344,7 +346,7 @@ config:
   ## https://docs.fluentbit.io/manual/pipeline/parsers
   parsers:
     additional: ""
-  
+
   # extra can be used to pass extra configuration to Fluent Bit. Find below a sample configuration.
   extra: #|
   #  [FILTER]
@@ -353,10 +355,9 @@ config:
   #  [OUTPUT]
   #      Name              test
   #      Match             *
-  
+
   script: #|
   # myScript() {}
-
 # Defines an entry to add an external service to the service mesh
 # By default, the fluent-bit daemon will be part of the service-mesh (having istio sidecar injection enabled). In some cases the sidecar doesn't allow access to external services through https using none standard ports (not 443 or 8443)
 # A typical error message will look like 'routines:ssl3_get_record:wrong version number'. In such cases, add an entry for the external service like below


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**
Fluentbit is distributed as a container which must run in the workload cluster as root user in order to collect logs from other containers on the same node. By getting access to that container you can get access to the node file system.

Changes proposed in this pull request:

- as suggested [here](https://github.com/fluent/fluent-bit/issues/872): root access is needed but the permissions can be restricted to file access


**How it was tested:**
- the logs of the fluent-bit pod were checked
- in Grafana, the traffic in the logging board was compared to another cluster

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
https://github.tools.sap/kyma/backlog/issues/1560