### PR TITLE
Disable processing of egress traffic by Istio in eventing-nats-controller(1.23)

### DIFF
--- a/resources/eventing/charts/nats-controller/templates/deployment.yaml
+++ b/resources/eventing/charts/nats-controller/templates/deployment.yaml
@@ -12,6 +12,9 @@ spec:
     type: RollingUpdate
   template:
     metadata:
+      annotations:
+        traffic.sidecar.istio.io/excludeOutboundIPRanges: 0.0.0.0/0
+        traffic.sidecar.istio.io/includeOutboundIPRanges: '*'
       labels: {{- include "nats-controller.selectorLabels" . | nindent 8 }}
     spec:
       serviceAccountName: {{ include "nats-controller.fullname" . }}


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**
With Kyma 1.23 installed only on Azure clusters, we could observe that eventing-nats-controller was not able to communicate with API Server after ~5 minutes of being idle. So the behaviour is similar to this older [issue](https://github.com/kubernetes/client-go/issues/527).

Versions:
- k8s.io/client-go v0.19.3 in eventing-nats-controller
- Istio 1.9.5
- Kubernetes 1.18.18

Changes proposed in this pull request:

- Bypass Istio for outbound traffic on eventing-nats-controller.

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
See also #11645