### PR TITLE
Fix links to Gardener documentation

### DIFF
--- a/docs/kyma/04-03-cluster-installation.md
+++ b/docs/kyma/04-03-cluster-installation.md
@@ -159,7 +159,7 @@ This installation guide explains how you can quickly deploy Kyma on a cluster wi
 
     * For GCP:
       * Create a project in Gardener.
-      * Add a [new service account and roles](https://gardener.cloud/documentation/guides/administer_shoots/gardener_gcp).
+      * Add a [new service account and roles](https://gardener.cloud/docs/guides/administer_shoots/gardener_gcp).
       * Add the GCP Secret under **Secrets** in the Gardener dashboard.
       * Add the service account and download Gardener's `kubeconfig` file.
 

--- a/docs/security/10-03-certificates-gardener.md
+++ b/docs/security/10-03-certificates-gardener.md
@@ -3,7 +3,7 @@ title: Issues with certificates on Gardener
 type: Troubleshooting
 ---
 
-During installation on Gardener, Kyma requests domain SSL certificates using the Gardener's [`Certificate`](https://gardener.cloud/documentation/guides/administer_shoots/request_cert/#request-a-certificate-via-certificate) custom resource to ensure secure communication through both Kyma UI and Kubernetes CLI.
+During installation on Gardener, Kyma requests domain SSL certificates using the Gardener's [`Certificate`](https://gardener.cloud/docs/guides/administer_shoots/request_cert/#request-a-certificate-via-certificate) custom resource to ensure secure communication through both Kyma UI and Kubernetes CLI.
 
 This process can result in the following issues:
 


### PR DESCRIPTION
**Description**

Two links to Gardener documentation stopped working, as the URL now contains a `docs` bit instead of the previous `documentation` part. This PR fixes them.

Changes proposed in this pull request:

- Fix the link to Gardener's guide on [Requesting a certificate via Certificate](https://gardener.cloud/docs/guides/administer_shoots/request_cert/#request-a-certificate-via-certificate) in [`10-03-certificates-gardener.md`](https://github.com/kyma-project/kyma/blob/main/docs/security/10-03-certificates-gardener.md)
- Fix the link to Gardener's guide on [Creating a Kubernetes cluster on GCP with Gardener](https://gardener.cloud/docs/guides/administer_shoots/request_cert/#request-a-certificate-via-certificate) in [`04-03-cluster-installation.md`](https://github.com/kyma-project/kyma/blob/main/docs/kyma/04-03-cluster-installation.md)

**Related build error log**
[kyma-governance-nightly #1414796889462673408](https://status.build.kyma-project.io/view/gs/kyma-prow-logs/logs/kyma-governance-nightly/1414796889462673408)
