### PR TITLE
Cleanup Overrides - Adapt Production Profil and Base Chart

### DIFF
--- a/resources/logging/charts/fluent-bit/values.yaml
+++ b/resources/logging/charts/fluent-bit/values.yaml
@@ -133,7 +133,7 @@ existingConfigMap: ""
 ## Custom configuration for Kyma alerting rules
 prometheusRules:
   ## Adds the specified filter to NoOutputBytesProcessed alert for Fluent Bit
-  fluentBitAlertFilter: ""
+  fluentBitAlertFilter: "name='loki-output'"
 
 # Fluentbit configuration section
 # https://docs.fluentbit.io/manual/administration/configuring-fluent-bit/configuration-file
@@ -230,7 +230,7 @@ config:
   outputs:
     loki:
       enabled: true
-      alias:
+      alias: "loki-output"
       match: "loki.*"
       serviceName: "logging-loki"
       servicePort: 3100

--- a/resources/logging/charts/fluent-bit/values.yaml
+++ b/resources/logging/charts/fluent-bit/values.yaml
@@ -80,8 +80,8 @@ readinessProbe:
 
 resources:
   limits:
-    cpu: 100m
-    memory: 192Mi
+    cpu: 400m
+    memory: 256Mi
   requests:
     cpu: 20m
     memory: 50Mi

--- a/resources/logging/profile-evaluation.yaml
+++ b/resources/logging/profile-evaluation.yaml
@@ -13,6 +13,8 @@ loki:
 
 fluent-bit:
   resources:
+    limits:
+      cpu: 50m
     requests:
       cpu: 20m
       memory: 40Mi

--- a/resources/logging/profile-evaluation.yaml
+++ b/resources/logging/profile-evaluation.yaml
@@ -13,8 +13,6 @@ loki:
 
 fluent-bit:
   resources:
-    limits:
-      cpu: 50m
     requests:
       cpu: 20m
       memory: 40Mi

--- a/resources/monitoring/profile-production.yaml
+++ b/resources/monitoring/profile-production.yaml
@@ -20,7 +20,7 @@ prometheus-istio:
   server:
     resources:
       limits:
-        memory: 4Gi
+        memory: 1000m
 
 prometheusOperator:
   resources:
@@ -34,3 +34,12 @@ prometheusOperator:
 alertmanager:
   alertmanagerSpec:
     retention: 240h
+
+kube-state-metrics:
+  resources:
+    requests:
+      cpu: "50m"
+      memory: "128Mi"
+    limits:
+      cpu: "500m"
+      memory: "1Gi"

--- a/resources/monitoring/profile-production.yaml
+++ b/resources/monitoring/profile-production.yaml
@@ -22,6 +22,15 @@ prometheus-istio:
       limits:
         memory: 4Gi
 
+prometheusOperator:
+  resources:
+    requests:
+      cpu: "50m"
+      memory: "128Mi"
+    limits:
+      cpu: "500m"
+      memory: "1Gi"
+
 alertmanager:
   alertmanagerSpec:
     retention: 240h

--- a/resources/monitoring/profile-production.yaml
+++ b/resources/monitoring/profile-production.yaml
@@ -16,12 +16,6 @@ prometheus:
             requests:
               storage: 20Gi
 
-prometheus-istio:
-  server:
-    resources:
-      limits:
-        memory: 1000m
-
 prometheusOperator:
   resources:
     requests:


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Regrading [this Issue](https://github.tools.sap/kyma/backlog/issues/1440) we should adapt the OS and Skr to reduce the amount of overrides.

Changes proposed in this pull request:

- Adopt the filter, alias, and limits in `fluent-bit` chart
- Removed cpu limit on production profile, since it is now in the chart itself
- Adopt `prometheusOperator` and `kube-state-metrics` in production profile 

**Related issue(s)**
[#1440](https://github.tools.sap/kyma/backlog/issues/1440)
