### PR TITLE
fixed jaeger CRD schema

### DIFF
--- a/installation/resources/crds/tracing/jaegers.jaegertracing.crd.yaml
+++ b/installation/resources/crds/tracing/jaegers.jaegertracing.crd.yaml
@@ -19,21 +19,16 @@ spec:
     - name: v1
       served: true
       storage: true
-      additionalPrinterColumns:
-      - jsonPath: .status.phase
-        description: Jaeger instance's status
-        name: Status
-        type: string
-      - jsonPath: .status.version
-        description: Jaeger Version
-        name: Version
-        type: string
-      subresources:
-        status: {}
       schema:
         openAPIV3Schema:
-          description: Temp desc
           type: object
-          properties:
-            spec:
-              type: object
+          x-kubernetes-preserve-unknown-fields: true
+      additionalPrinterColumns:
+        - jsonPath: .status.phase
+          description: Jaeger instance's status
+          name: Status
+          type: string
+        - jsonPath: .status.version
+          description: Jaeger Version
+          name: Version
+          type: string

--- a/resources/cluster-essentials/files/jaegers.jaegertracing.crd.yaml
+++ b/resources/cluster-essentials/files/jaegers.jaegertracing.crd.yaml
@@ -18,21 +18,16 @@ spec:
     - name: v1
       served: true
       storage: true
-      additionalPrinterColumns:
-      - jsonPath: .status.phase
-        description: Jaeger instance's status
-        name: Status
-        type: string
-      - jsonPath: .status.version
-        description: Jaeger Version
-        name: Version
-        type: string
-      subresources:
-        status: {}
       schema:
         openAPIV3Schema:
-          description: Temp desc
           type: object
-          properties:
-            spec:
-              type: object
+          x-kubernetes-preserve-unknown-fields: true
+      additionalPrinterColumns:
+        - jsonPath: .status.phase
+          description: Jaeger instance's status
+          name: Status
+          type: string
+        - jsonPath: .status.version
+          description: Jaeger Version
+          name: Version
+          type: string


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**
The schema definition for the jaegers CRD was declining any attribute so that the spec for a new resource was empty always.
I updated the CRD according to the upstream version https://github.com/jaegertracing/helm-charts/blob/main/charts/jaeger-operator/crds/crd.yaml

Changes proposed in this pull request:

- fixed schema definition of jaeger CRD
- ...
- ...

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
https://github.com/kyma-project/kyma/pull/11569