### PR TITLE
Disable AlertManager Alert

### DIFF
--- a/resources/monitoring/templates/prometheus/rules-1.14/prometheus.yaml
+++ b/resources/monitoring/templates/prometheus/rules-1.14/prometheus.yaml
@@ -94,6 +94,7 @@ spec:
 {{- if .Values.defaultRules.additionalRuleLabels }}
 {{ toYaml .Values.defaultRules.additionalRuleLabels | indent 8 }}
 {{- end }}
+{{- if .Values.alertmanager.enabled }}
     - alert: PrometheusNotConnectedToAlertmanagers
       annotations:
         description: Prometheus {{`{{`}}$labels.namespace{{`}}`}}/{{`{{`}}$labels.pod{{`}}`}} is not connected to any Alertmanagers.
@@ -105,6 +106,7 @@ spec:
       for: 10m
       labels:
         severity: warning
+{{- end }}
 {{- if .Values.defaultRules.additionalRuleLabels }}
 {{ toYaml .Values.defaultRules.additionalRuleLabels | indent 8 }}
 {{- end }}


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**
In Kyma 2.0: Prometheus is firing alerts for missing AlertManager. AlertManager is not being deployed on Kyma 2.0 by default. 

Following alert is firing:
`max_over_time(prometheus_notifications_alertmanagers_discovered{job="monitoring-prometheus",namespace="kyma-system"}[5m]) < 1
`

Changes proposed in this pull request:

- Disable this alerting rule when AlertManager is not deployed


**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
