### PR TITLE
Restart auth-proxy pods when Helm values change

### DIFF
--- a/resources/kiali/templates/kyma-additions/auth-proxy-deployment.yaml
+++ b/resources/kiali/templates/kyma-additions/auth-proxy-deployment.yaml
@@ -15,6 +15,8 @@ spec:
     metadata:
       labels:
         app: {{ template "kiali-server.fullname" . }}-auth-proxy
+      annotations:
+        checksum/config: {{ tpl (toYaml .Values) . | sha256sum }}
     spec:
       {{- if .Values.global.isLocalEnv }}
       hostNetwork: true   #only for minikube

--- a/resources/monitoring/charts/grafana/templates/kyma-additions/auth-proxy-deployment.yaml
+++ b/resources/monitoring/charts/grafana/templates/kyma-additions/auth-proxy-deployment.yaml
@@ -20,6 +20,8 @@ spec:
       labels:
         app.kubernetes.io/instance: {{ .Release.Name }}
         app.kubernetes.io/name: auth-proxy
+      annotations:
+        checksum/config: {{ tpl (toYaml .Values) . | sha256sum }}
     spec:
       {{- if .Values.global.isLocalEnv }}
       hostNetwork: true   #only for minikube

--- a/resources/tracing/templates/kyma-additions/auth-proxy-deployment.yaml
+++ b/resources/tracing/templates/kyma-additions/auth-proxy-deployment.yaml
@@ -16,6 +16,8 @@ spec:
       labels:
         app.kubernetes.io/name: {{ template "jaeger-operator.fullname" . }}
         app.kubernetes.io/component: auth-proxy
+      annotations:
+        checksum/config: {{ tpl (toYaml .Values) . | sha256sum }}
     spec:
       {{- if .Values.global.isLocalEnv }}
       hostNetwork: true   #only for minikube


### PR DESCRIPTION
Annotate OAuth2 Proxy pods with hash over Helm values to enforce restart
if values change.

<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- Annotate OAuth2 Proxy pods with hash over Helm values to enforce restart if values change.

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->