### PR TITLE
Skr svcat install example resources

### DIFF
--- a/tests/fast-integration/skr-svcat-migration-test/deploy-sample-resources.js
+++ b/tests/fast-integration/skr-svcat-migration-test/deploy-sample-resources.js
@@ -211,46 +211,6 @@ async function deploy() {
   })
 }
 
-// async function getSecrets(secretNames) {
-
-//   await secretNames
-
-// }
-
-async function checkSecrets() {
-  let allSecrets = await getSecrets("default")
-
-  let reference = [
-    "hb-redis-micro",
-    "func-sb-svcat-auditlog-management-1",
-    "func-sb-svcat-auditlog-api-1",
-    "inst-sb-svcat-auditlog-api-1",
-    "inst-sb-svcat-auditlog-management-1",
-    "func-sb-svcat-html5-apps-repo-1",
-    "inst-sb-svcat-html5-apps-repo-1",
-    "func-sb-redis-function-1",
-    "inst-sb-redis-function-1"
-  ]
-  
-  allSecrets.forEach(async function(secretName){
-    let s = await getSecret(secretName, "default")
-    // s = JSON.parse(s)
-    console.log(s.metadata.name)
-  })
-
-}
-
-checkSecrets()
-
-async function getPodPresets([]) {
-
-}
-async function checkPodPresets([]) {
-
-}
-
-
-// deploy()
 module.exports = {
   deploy,
   destroy,

--- a/tests/fast-integration/skr-svcat-migration-test/deploy-sample-resources.js
+++ b/tests/fast-integration/skr-svcat-migration-test/deploy-sample-resources.js
@@ -1,0 +1,261 @@
+const { join } = require("path");
+const {
+    kubectlApply,
+    kubectlDeleteDir,
+    waitForPodWithLabel,
+    waitForFunction,
+    waitForServiceInstance,
+    waitForServiceBinding,
+    waitForServiceBindingUsage,
+    waitForClusterAddonsConfiguration,
+    getSecret,
+    getSecrets,
+    debug,
+  } = require("../utils");
+const {
+  performance,
+} = require('perf_hooks');
+
+async function installResource(manifest, resource, name, namespace) {
+
+  try {
+    debug(`Applying ${resource} manifest ${manifest}`)
+    await kubectlApply(manifest);
+  } catch (error) {
+    throw new Error(`Failed to apply resource ${name}: ${manifest}.`)
+  }
+
+  try {
+    switch (resource) {
+      case "serviceInstance":
+        debug(`Waiting for ${resource} ${name}`)
+        await waitForServiceInstance(name, namespace)
+        break;
+      case "function":
+        debug(`Waiting for ${resource} ${name}`)
+        await waitForFunction(name, namespace)
+        break;
+      case "servicebinding":
+        debug(`Waiting for ${resource} ${name}`)
+        await waitForServiceBinding(name, namespace)
+        break;
+      case "servicebindingusage":
+        debug(`Waiting for ${resource} ${name}`)
+        await waitForServiceBindingUsage(name, namespace)
+        break;
+      default:
+        debug("Not waiting for resource installation.")
+        break;
+    }
+  } catch (error) {
+    console.log(error)
+    throw new Error(`Failed to wait for resource ${resource} with name ${name}.`)
+  }
+
+}
+
+async function installRedisExample(options) {
+  // console.time('installRedisExample')
+  let t0 = performance.now()
+
+  options = options || {};
+  
+  debug(`Waiting for pod with label app=helm-broker...`)
+  await waitForPodWithLabel("app", "helm-broker", "kyma-system");
+
+  const clusteraddonconfigurationPath = options.resourcesPath || join(__dirname, "fixtures", "01_clusteraddonconfiguration.yaml");
+  debug(`Applying manifest ${clusteraddonconfigurationPath}`)
+  await kubectlApply(clusteraddonconfigurationPath);
+  await waitForClusterAddonsConfiguration("redis-addon")
+  
+  // Deploying redis instance with function and servicebindings
+  const serviceInstanceManifestPath = options.resourcesPath || join(__dirname, "fixtures", "02_serviceinstance_redis.yaml");
+  const functionManifestPath = options.resourcesPath || join(__dirname, "fixtures", "03_function_redis.yaml");
+  const funcSBManifestPath = options.resourcesPath || join(__dirname, "fixtures", "04_func-sb_redis.yaml");
+  const instSBManifestPath = options.resourcesPath || join(__dirname, "fixtures", "04_inst-sb_redis.yaml");
+  const sbuManifestPath = options.resourcesPath || join(__dirname, "fixtures", "05_sbu_redis.yaml");
+  
+  await installResource(serviceInstanceManifestPath, "serviceInstance", "hb-instbind-redis-1", "default")
+  await installResource(functionManifestPath, "function", "hb-instbind-redis-1", "default")
+  await installResource(funcSBManifestPath, "servicebinding", "func-sb-redis-function-1", "default")
+  await installResource(instSBManifestPath, "servicebinding", "inst-sb-redis-function-1", "default")
+  await installResource(sbuManifestPath, "servicebindingusage", "hb-instbind-redis-1", "default")
+  
+  // return console.timeEnd('installRedisExample')
+  let t1 = performance.now()
+  console.log(`Finished deployment of Redis in ${t1-t0} ms`)
+  return {resource: "Redis", duration: t1-t0}
+}
+
+async function installAuditlogExample(options) {
+  // console.time('installAuditlogExample')
+  let t0 = performance.now()
+  
+  options = options || {};
+  
+  const serviceInstanceManifestPath = options.resourcesPath || join(__dirname, "fixtures", "02_serviceinstance_auditlog.yaml");
+  const functionManifestPath = options.resourcesPath || join(__dirname, "fixtures", "03_function_auditlog.yaml");
+  const funcSBManifestPath = options.resourcesPath || join(__dirname, "fixtures", "04_func-sb_auditlog.yaml");
+  const instSBManifestPath = options.resourcesPath || join(__dirname, "fixtures", "04_inst-sb_auditlog.yaml");
+  const sbuManifestPath = options.resourcesPath || join(__dirname, "fixtures", "05_sbu_auditlog.yaml");
+  
+  await installResource(serviceInstanceManifestPath, "serviceInstance", "svcat-auditlog-api-1", "default")
+  await installResource(functionManifestPath, "function", "svcat-auditlog-api-1", "default")
+  await installResource(funcSBManifestPath, "servicebinding", "func-sb-svcat-auditlog-api-1", "default")
+  await installResource(instSBManifestPath, "servicebinding", "inst-sb-svcat-auditlog-api-1", "default")
+  await installResource(sbuManifestPath, "servicebindingusage", "func-sbu-svcat-auditlog-api-1", "default")
+  
+  // return console.timeEnd('installAuditlogExample')
+  let t1 = performance.now()
+  console.log(`Finished deployment of Audit-Log in ${t1-t0} ms`)
+  return {resource: "Audit-Log", duration: t1-t0}
+}
+
+async function installHTML5AppsRepoExample(options) {
+  // console.time('installHTML5AppsRepoExample')
+  let t0 = performance.now()
+
+  options = options || {};
+  
+  const serviceInstanceManifestPath = options.resourcesPath || join(__dirname, "fixtures", "02_serviceinstance_html5appsrepo.yaml");
+  const functionManifestPath = options.resourcesPath || join(__dirname, "fixtures", "03_function_html5appsrepo.yaml");
+  const funcSBManifestPath = options.resourcesPath || join(__dirname, "fixtures", "04_func-sb_html5appsrepo.yaml");
+  const instSBManifestPath = options.resourcesPath || join(__dirname, "fixtures", "04_inst-sb_html5appsrepo.yaml");
+  const sbuManifestPath = options.resourcesPath || join(__dirname, "fixtures", "05_sbu_html5appsrepo.yaml");
+  
+  await installResource(serviceInstanceManifestPath, "serviceInstance", "svcat-html5-apps-repo-1", "default")
+  await installResource(functionManifestPath, "function", "svcat-html5-apps-repo-1", "default")
+  await installResource(funcSBManifestPath, "servicebinding", "func-sb-svcat-html5-apps-repo-1", "default")
+  await installResource(instSBManifestPath, "servicebinding", "inst-sb-svcat-html5-apps-repo-1", "default")
+  await installResource(sbuManifestPath, "servicebindingusage", "func-sbu-svcat-html5-apps-repo-1", "default")
+  
+  // return console.timeEnd('installHTML5AppsRepoExample')
+  let t1 = performance.now()
+  console.log(`Finished deployment of HTML5-Apps-Repo in ${t1-t0} ms`)
+  return {resource: "HTML5-Apps-Repo", duration: t1-t0}
+}
+
+async function installAuditManagementExample(options) {
+  // console.time('installAuditManagementExample')
+  let t0 = performance.now()
+
+  options = options || {};
+  
+  const serviceInstanceManifestPath = options.resourcesPath || join(__dirname, "fixtures", "02_serviceinstance_auditlogmanagement.yaml");
+  const functionManifestPath = options.resourcesPath || join(__dirname, "fixtures", "03_function_auditlogmanagement.yaml");
+  const funcSBManifestPath = options.resourcesPath || join(__dirname, "fixtures", "04_func-sb_auditlogmanagement.yaml");
+  const instSBManifestPath = options.resourcesPath || join(__dirname, "fixtures", "04_inst-sb_auditlogmanagement.yaml");
+  const sbuManifestPath = options.resourcesPath || join(__dirname, "fixtures", "05_sbu_auditlogmanagement.yaml");
+  
+  await installResource(serviceInstanceManifestPath, "serviceInstance", "svcat-auditlog-management-1", "default")
+  await installResource(functionManifestPath, "function", "svcat-auditlog-management-1", "default")
+  await installResource(funcSBManifestPath, "servicebinding", "func-sb-svcat-auditlog-management-1", "default")
+  await installResource(instSBManifestPath, "servicebinding", "inst-sb-svcat-auditlog-management-1", "default")
+  await installResource(sbuManifestPath, "servicebindingusage", "func-sbu-svcat-auditlog-management-1", "default")
+  
+  // return console.timeEnd('installAuditManagementExample')
+  let t1 = performance.now()
+  console.log(`Finished deployment of Audit-Management in ${t1-t0} ms`)
+  return {resource: "Audit-Management", duration: t1-t0}
+}
+
+async function destroy() {  
+  try {
+    let path = join(__dirname, "fixtures")
+    debug(`Destroying all ressources from ${path}`)
+    await kubectlDeleteDir(path, "default")
+  } catch (err) {
+    throw new Error(`Error destroying ressources from ${path}`)
+  }
+}
+
+function sleep(ms) {
+  return new Promise(resolve => setTimeout(resolve, ms));
+}
+
+async function goodNight() {
+  console.log('Taking a break...');
+  await sleep(900000); //15min
+  console.log('Waking up...');
+}
+
+async function deploy() {
+  let times = []
+
+  await waitForPodWithLabel("app", "service-catalog-addons-service-binding-usage-controller", "kyma-system");
+  await waitForPodWithLabel("app", "service-catalog-ui", "kyma-system");
+  await waitForPodWithLabel("app", "service-catalog-catalog-controller-manager", "kyma-system");
+  await waitForPodWithLabel("app", "service-catalog-catalog-webhook", "kyma-system");
+  await waitForPodWithLabel("app", "service-broker-proxy-k8s", "kyma-system");
+
+  times.push(installRedisExample())
+  times.push(installAuditlogExample())
+  times.push(installHTML5AppsRepoExample())
+  times.push(installAuditManagementExample())
+  
+  Promise.all(times).then(function () {
+    console.log(`\nSuccessfully deployed all resources:`)
+    let items = arguments[0]
+    items.sort(function(a, b) {
+      if (a.duration < b.duration) {
+        return -1;
+      }
+      if (a.duration > b.duration) {
+        return 1;
+      }
+      return 0;
+    })
+    console.table(items, ["resource", "duration"])
+  }, function (error) {
+    console.log(error)
+  })
+}
+
+// async function getSecrets(secretNames) {
+
+//   await secretNames
+
+// }
+
+async function checkSecrets() {
+  let allSecrets = await getSecrets("default")
+
+  let reference = [
+    "hb-redis-micro",
+    "func-sb-svcat-auditlog-management-1",
+    "func-sb-svcat-auditlog-api-1",
+    "inst-sb-svcat-auditlog-api-1",
+    "inst-sb-svcat-auditlog-management-1",
+    "func-sb-svcat-html5-apps-repo-1",
+    "inst-sb-svcat-html5-apps-repo-1",
+    "func-sb-redis-function-1",
+    "inst-sb-redis-function-1"
+  ]
+  
+  allSecrets.forEach(async function(secretName){
+    let s = await getSecret(secretName, "default")
+    // s = JSON.parse(s)
+    console.log(s.metadata.name)
+  })
+
+}
+
+checkSecrets()
+
+async function getPodPresets([]) {
+
+}
+async function checkPodPresets([]) {
+
+}
+
+
+// deploy()
+module.exports = {
+  deploy,
+  destroy,
+  checkSecrets,
+  getPodPresets,
+  checkPodPresets,
+  goodNight
+};

--- a/tests/fast-integration/skr-svcat-migration-test/fixtures/01_clusteraddonconfiguration.yaml
+++ b/tests/fast-integration/skr-svcat-migration-test/fixtures/01_clusteraddonconfiguration.yaml
@@ -1,0 +1,7 @@
+apiVersion: addons.kyma-project.io/v1alpha1
+kind: ClusterAddonsConfiguration
+metadata:
+  name: redis-addon
+spec:
+  repositories:
+    - url: "https://github.com/kyma-project/addons/releases/download/0.14.0/index-testing.yaml"

--- a/tests/fast-integration/skr-svcat-migration-test/fixtures/02_serviceinstance_auditlog.yaml
+++ b/tests/fast-integration/skr-svcat-migration-test/fixtures/02_serviceinstance_auditlog.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: servicecatalog.k8s.io/v1beta1
+kind: ServiceInstance
+metadata:
+  name: svcat-auditlog-api-1
+spec:
+  clusterServiceClassExternalName: auditlog-api
+  clusterServicePlanExternalName: default
+#  externalID: 8443e7eb-a405-48e8-8b83-30f2f3dfae33

--- a/tests/fast-integration/skr-svcat-migration-test/fixtures/02_serviceinstance_auditlogmanagement.yaml
+++ b/tests/fast-integration/skr-svcat-migration-test/fixtures/02_serviceinstance_auditlogmanagement.yaml
@@ -1,0 +1,10 @@
+---
+apiVersion: servicecatalog.k8s.io/v1beta1
+kind: ServiceInstance
+metadata:
+  name: svcat-auditlog-management-1
+spec:
+  clusterServiceClassExternalName: auditlog-management
+  clusterServicePlanExternalName: default
+  clusterServicePlanRef:
+    name: e95e800c-f129-474f-b08e-fbfbe624abfd-3

--- a/tests/fast-integration/skr-svcat-migration-test/fixtures/02_serviceinstance_html5appsrepo.yaml
+++ b/tests/fast-integration/skr-svcat-migration-test/fixtures/02_serviceinstance_html5appsrepo.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: servicecatalog.k8s.io/v1beta1
+kind: ServiceInstance
+metadata:
+  name: svcat-html5-apps-repo-1
+spec:
+  clusterServiceClassExternalName: html5-apps-repo
+  clusterServicePlanExternalName: app-runtime
+#  externalID: 8443e7eb-a405-48e8-8b83-30f2f3dfae33

--- a/tests/fast-integration/skr-svcat-migration-test/fixtures/02_serviceinstance_redis.yaml
+++ b/tests/fast-integration/skr-svcat-migration-test/fixtures/02_serviceinstance_redis.yaml
@@ -1,0 +1,10 @@
+---
+apiVersion: servicecatalog.k8s.io/v1beta1
+kind: ServiceInstance
+metadata:
+  name: hb-instbind-redis-1
+spec:
+  clusterServiceClassExternalName: redis
+  clusterServicePlanExternalName: micro
+  parameters:
+    imagePullPolicy: Always

--- a/tests/fast-integration/skr-svcat-migration-test/fixtures/03_function_auditlog.yaml
+++ b/tests/fast-integration/skr-svcat-migration-test/fixtures/03_function_auditlog.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: serverless.kyma-project.io/v1alpha1
+kind: Function
+metadata:
+  name: svcat-auditlog-api-1
+spec:
+  runtime: nodejs12
+  source: |
+    module.exports = {
+      main: function(event, context) {
+        return 'Hello World!'
+      }
+    }

--- a/tests/fast-integration/skr-svcat-migration-test/fixtures/03_function_auditlogmanagement.yaml
+++ b/tests/fast-integration/skr-svcat-migration-test/fixtures/03_function_auditlogmanagement.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: serverless.kyma-project.io/v1alpha1
+kind: Function
+metadata:
+  name: svcat-auditlog-management-1
+spec:
+  runtime: nodejs12
+  source: |
+    module.exports = {
+      main: function(event, context) {
+        return 'Hello World!'
+      }
+    }

--- a/tests/fast-integration/skr-svcat-migration-test/fixtures/03_function_html5appsrepo.yaml
+++ b/tests/fast-integration/skr-svcat-migration-test/fixtures/03_function_html5appsrepo.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: serverless.kyma-project.io/v1alpha1
+kind: Function
+metadata:
+  name: svcat-html5-apps-repo-1
+spec:
+  runtime: nodejs12
+  source: |
+    module.exports = {
+      main: function(event, context) {
+        return 'Hello World!'
+      }
+    }

--- a/tests/fast-integration/skr-svcat-migration-test/fixtures/03_function_redis.yaml
+++ b/tests/fast-integration/skr-svcat-migration-test/fixtures/03_function_redis.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: serverless.kyma-project.io/v1alpha1
+kind: Function
+metadata:
+  name: hb-instbind-redis-1
+spec:
+  runtime: nodejs12
+  source: |
+    module.exports = {
+      main: function(event, context) {
+        return 'Hello World!'
+      }
+    }

--- a/tests/fast-integration/skr-svcat-migration-test/fixtures/04_func-sb_auditlog.yaml
+++ b/tests/fast-integration/skr-svcat-migration-test/fixtures/04_func-sb_auditlog.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: servicecatalog.k8s.io/v1beta1
+kind: ServiceBinding
+metadata:
+  name: func-sb-svcat-auditlog-api-1
+spec:
+  instanceRef:
+    name: svcat-auditlog-api-1

--- a/tests/fast-integration/skr-svcat-migration-test/fixtures/04_func-sb_auditlogmanagement.yaml
+++ b/tests/fast-integration/skr-svcat-migration-test/fixtures/04_func-sb_auditlogmanagement.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: servicecatalog.k8s.io/v1beta1
+kind: ServiceBinding
+metadata:
+  name: func-sb-svcat-auditlog-management-1
+spec:
+  instanceRef:
+    name: svcat-auditlog-management-1

--- a/tests/fast-integration/skr-svcat-migration-test/fixtures/04_func-sb_html5appsrepo.yaml
+++ b/tests/fast-integration/skr-svcat-migration-test/fixtures/04_func-sb_html5appsrepo.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: servicecatalog.k8s.io/v1beta1
+kind: ServiceBinding
+metadata:
+  name: func-sb-svcat-html5-apps-repo-1
+spec:
+  instanceRef:
+    name: svcat-html5-apps-repo-1

--- a/tests/fast-integration/skr-svcat-migration-test/fixtures/04_func-sb_redis.yaml
+++ b/tests/fast-integration/skr-svcat-migration-test/fixtures/04_func-sb_redis.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: servicecatalog.k8s.io/v1beta1
+kind: ServiceBinding
+metadata:
+  name: func-sb-redis-function-1
+spec:
+  instanceRef:
+    name: hb-instbind-redis-1

--- a/tests/fast-integration/skr-svcat-migration-test/fixtures/04_inst-sb_auditlog.yaml
+++ b/tests/fast-integration/skr-svcat-migration-test/fixtures/04_inst-sb_auditlog.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: servicecatalog.k8s.io/v1beta1
+kind: ServiceBinding
+metadata:
+  name: inst-sb-svcat-auditlog-api-1
+spec:
+  # externalID: a42a5dde-8bd8-4491-9cca-6a6343e97158
+  instanceRef:
+    name: svcat-auditlog-api-1

--- a/tests/fast-integration/skr-svcat-migration-test/fixtures/04_inst-sb_auditlogmanagement.yaml
+++ b/tests/fast-integration/skr-svcat-migration-test/fixtures/04_inst-sb_auditlogmanagement.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: servicecatalog.k8s.io/v1beta1
+kind: ServiceBinding
+metadata:
+  name: inst-sb-svcat-auditlog-management-1
+spec:
+  # externalID: a42a5dde-8bd8-4491-9cca-6a6343e97158
+  instanceRef:
+    name: svcat-auditlog-management-1

--- a/tests/fast-integration/skr-svcat-migration-test/fixtures/04_inst-sb_html5appsrepo.yaml
+++ b/tests/fast-integration/skr-svcat-migration-test/fixtures/04_inst-sb_html5appsrepo.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: servicecatalog.k8s.io/v1beta1
+kind: ServiceBinding
+metadata:
+  name: inst-sb-svcat-html5-apps-repo-1
+spec:
+  # externalID: a42a5dde-8bd8-4491-9cca-6a6343e97158
+  instanceRef:
+    name: svcat-html5-apps-repo-1

--- a/tests/fast-integration/skr-svcat-migration-test/fixtures/04_inst-sb_redis.yaml
+++ b/tests/fast-integration/skr-svcat-migration-test/fixtures/04_inst-sb_redis.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: servicecatalog.k8s.io/v1beta1
+kind: ServiceBinding
+metadata:
+  name: inst-sb-redis-function-1
+spec:
+  instanceRef:
+    name: hb-instbind-redis-1

--- a/tests/fast-integration/skr-svcat-migration-test/fixtures/05_sbu_auditlog.yaml
+++ b/tests/fast-integration/skr-svcat-migration-test/fixtures/05_sbu_auditlog.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: servicecatalog.kyma-project.io/v1alpha1
+kind: ServiceBindingUsage
+metadata:
+  name: func-sbu-svcat-auditlog-api-1
+spec:
+  serviceBindingRef:
+    name: func-sb-svcat-auditlog-api-1
+  usedBy:
+    kind: serverless-function
+    name: svcat-auditlog-api-1

--- a/tests/fast-integration/skr-svcat-migration-test/fixtures/05_sbu_auditlogmanagement.yaml
+++ b/tests/fast-integration/skr-svcat-migration-test/fixtures/05_sbu_auditlogmanagement.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: servicecatalog.kyma-project.io/v1alpha1
+kind: ServiceBindingUsage
+metadata:
+  name: func-sbu-svcat-auditlog-management-1
+spec:
+  serviceBindingRef:
+    name: func-sb-svcat-auditlog-management-1
+  usedBy:
+    kind: serverless-function
+    name: svcat-auditlog-management-1

--- a/tests/fast-integration/skr-svcat-migration-test/fixtures/05_sbu_html5appsrepo.yaml
+++ b/tests/fast-integration/skr-svcat-migration-test/fixtures/05_sbu_html5appsrepo.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: servicecatalog.kyma-project.io/v1alpha1
+kind: ServiceBindingUsage
+metadata:
+  name: func-sbu-svcat-html5-apps-repo-1
+spec:
+  serviceBindingRef:
+    name: func-sb-svcat-html5-apps-repo-1
+  usedBy:
+    kind: serverless-function
+    name: svcat-html5-apps-repo-1

--- a/tests/fast-integration/skr-svcat-migration-test/fixtures/05_sbu_redis.yaml
+++ b/tests/fast-integration/skr-svcat-migration-test/fixtures/05_sbu_redis.yaml
@@ -1,0 +1,14 @@
+---
+apiVersion: servicecatalog.kyma-project.io/v1alpha1
+kind: ServiceBindingUsage
+metadata:
+  name: hb-instbind-redis-1
+spec:
+  serviceBindingRef:
+    name: func-sb-redis-function-1
+  usedBy:
+    kind: serverless-function
+    name: hb-instbind-redis-1
+  parameters:
+    envPrefix:
+      name: "REDIS_"

--- a/tests/fast-integration/skr-svcat-migration-test/skr-svcat-migration-test.js
+++ b/tests/fast-integration/skr-svcat-migration-test/skr-svcat-migration-test.js
@@ -13,8 +13,10 @@ const {
   debug,
   genRandom,
   initializeK8sClient,
+  switchDebug,
 } = require("../utils");
 const t = require("./test-helpers");
+const sampleResources = require("./deploy-sample-resources");
 
 describe("SKR SVCAT migration test", function() {
   const keb = new KEBClient(KEBConfig.fromEnv());
@@ -29,7 +31,7 @@ describe("SKR SVCAT migration test", function() {
   const svcatPlatform = `svcat-${suffix}`
   const btpOperatorInstance = `btp-operator-${suffix}`
   const btpOperatorBinding = `btp-operator-binding-${suffix}`
-
+  switchDebug(on = true)
   debug(`RuntimeID ${runtimeID}`, `Runtime ${runtimeName}`, `Application ${appName}`, `Suffix ${suffix}`);
 
   this.timeout(60 * 60 * 1000 * 3); // 3h
@@ -49,8 +51,23 @@ describe("SKR SVCAT migration test", function() {
   it(`Should instantiate SM Instance and Binding`, async function() {
     btpOperatorCreds = await t.smInstanceBinding(smAdminCreds, svcatPlatform, btpOperatorInstance, btpOperatorBinding);
   });
+  it(`Should install sample service catalogue ressources`, async function() {
+    await sampleResources.deploy()
+  });
   it(`Should install BTP Operator helm chart`, async function() {
     await t.installBTPOperatorHelmChart(btpOperatorCreds);
+  });
+  it(`Should Sleep and wakeup properly`, async function() {
+    await sampleResources.goodNight()
+  });
+  
+  // Install BTP-Migrator and execute sc-removal
+  
+  // Sanity Check: secrets & presets still available?
+  // All other SVCAT resources removed?
+  
+  it(`Should destroy sample service catalogue ressources`, async function() {
+    await sampleResources.destroy()
   });
   it(`Should deprovision SKR`, async function() {
     await deprovisionSKR(keb, runtimeID);

--- a/tests/fast-integration/skr-svcat-migration-test/test-helpers.js
+++ b/tests/fast-integration/skr-svcat-migration-test/test-helpers.js
@@ -9,8 +9,11 @@ const {
 class SMCreds {
   static fromEnv() {
     return new SMCreds(
+      // TODO: rename to BTP_SM_ADMIN_CLIENTID
       getEnvOrThrow("BTP_OPERATOR_CLIENTID"),
+      // TODO: rename to BTP_SM_ADMIN_CLIENTID
       getEnvOrThrow("BTP_OPERATOR_CLIENTSECRET"),
+      // TODO: rename to BTP_SM_URL
       getEnvOrThrow("BTP_OPERATOR_URL")
     );
   }
@@ -46,8 +49,30 @@ async function smInstanceBinding(creds, svcatPlatform, btpOperatorInstance, btpO
     let args = [`login`, `-a`, creds.url, `--param`, `subdomain=e2etestingscmigration`, `--auth-flow`, `client-credentials`]
     await execa(`smctl`, args.concat([`--client-id`, creds.clientid, `--client-secret`, creds.clientsecret]));
 
-    args = [`register-platform`, svcatPlatform, `kubernetes`]
-    await execa(`smctl`, args);
+    // $ smctl register-platform <name> kubernetes -o json
+    // Output:
+    // {
+    //   "id": "<platform-id/cluster-id>",
+    //   "name": "<name>",
+    //   "type": "kubernetes",
+    //   "created_at": "...",
+    //   "updated_at": "...",
+    //   "credentials": {
+    //     "basic": {
+    //       "username": "...",
+    //       "password": "..."
+    //     }
+    //   },
+    //   "labels": {
+    //     "subaccount_id": [
+    //       "..."
+    //     ]
+    //   },
+    //   "ready": true
+    // }
+    args = [`register-platform`, svcatPlatform, `kubernetes`, `-o`, `json`]
+    let registerPlatformOut = await execa(`smctl`, args);
+    let platform = JSON.parse(registerPlatformOut.stdout)
 
     args = [`provision`, btpOperatorInstance, `service-manager`, `service-operator-access`, `--mode=sync`]
     await execa(`smctl`, args);
@@ -58,8 +83,8 @@ async function smInstanceBinding(creds, svcatPlatform, btpOperatorInstance, btpO
     let out = await execa(`smctl`, args);
     let b = JSON.parse(out.stdout)
     let c = b.items[0].credentials
-    //TODO figure out how to find clusterid
-    return {clientId:c.clientid,clientSecret:c.clientsecret,smURL:c.sm_url,url:c.url,clusterId:"TODO"};
+
+    return {clientId:c.clientid,clientSecret:c.clientsecret,smURL:c.sm_url,url:c.url,clusterId:platform.id};
   } catch(error) {
     if (error.stderr === undefined) {
       throw new Error(`failed to process output of "smctl ${args.join(' ')}": ${error}`);

--- a/tests/fast-integration/utils/index.js
+++ b/tests/fast-integration/utils/index.js
@@ -188,7 +188,7 @@ async function kubectlDeleteDir(dir, namespace) {
 }
 
 function kubectlDelete(file, namespace) {
-  console.log(`Deleting ${file}...`)
+  debug(`Deleting ${file}...`)
   const yaml = fs.readFileSync(file);
   const listOfSpecs = k8s.loadAllYaml(yaml);
   return k8sDelete(listOfSpecs, namespace);

--- a/tests/fast-integration/utils/index.js
+++ b/tests/fast-integration/utils/index.js
@@ -188,6 +188,7 @@ async function kubectlDeleteDir(dir, namespace) {
 }
 
 function kubectlDelete(file, namespace) {
+  console.log(`Deleting ${file}...`)
   const yaml = fs.readFileSync(file);
   const listOfSpecs = k8s.loadAllYaml(yaml);
   return k8sDelete(listOfSpecs, namespace);
@@ -243,6 +244,33 @@ async function getAllCRDs() {
   body.items.forEach(crd => stat[crd.spec.group] = stat[crd.spec.group] ? stat[crd.spec.group] + 1 : 1)
   return body.items
 
+}
+
+async function getClusteraddonsconfigurations() {
+  const path = '/apis/addons.kyma-project.io/v1alpha1/clusteraddonsconfigurations';
+  const response = await k8sDynamicApi.requestPromise({
+    url: k8sDynamicApi.basePath + path
+  });
+  const body = JSON.parse(response.body);
+  return body.items
+}
+
+async function getSecrets(namespace) {
+  const path = '`/api/v1/namespaces/${namespace}/secrets';
+  const response = await k8sDynamicApi.requestPromise({
+    url: k8sDynamicApi.basePath + path
+  });
+  const body = JSON.parse(response.body);
+  return body.items
+}
+
+async function getSecret(name, namespace) {
+  const path = `/api/v1/namespaces/${namespace}/secrets/${name}`;
+  const response = await k8sDynamicApi.requestPromise({
+    url: k8sDynamicApi.basePath + path
+  });
+  const body = JSON.parse(response.body);
+  return body
 }
 
 async function k8sApply(resources, namespace, patch = true) {
@@ -309,6 +337,18 @@ function waitForK8sObject(path, query, checkFn, timeout, timeoutMsg) {
       });
   });
   return result;
+}
+
+function waitForClusterAddonsConfiguration(name, timeout = 90000) {
+  return waitForK8sObject(
+    `/apis/addons.kyma-project.io/v1alpha1/clusteraddonsconfigurations`,
+    {},
+    (_type, _apiObj, watchObj) => {
+      return watchObj.object.metadata.name == name;
+    },
+    timeout,
+    `Waiting for ${name} ClusterAddonsConfiguration timeout (${timeout} ms)`
+  );
 }
 
 function waitForFunction(name, namespace = "default", timeout = 90000) {
@@ -981,6 +1021,7 @@ module.exports = {
   k8sApply,
   k8sDelete,
   waitForK8sObject,
+  waitForClusterAddonsConfiguration,
   waitForServiceClass,
   waitForServicePlanByServiceClass,
   waitForServiceInstance,
@@ -998,6 +1039,9 @@ module.exports = {
   deleteAllK8sResources,
   getAllResourceTypes,
   getAllCRDs,
+  getClusteraddonsconfigurations,
+  getSecret,
+  getSecrets,
   listResources,
   listResourceNames,
   k8sDynamicApi,


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

Deploys the following ressources as part of the BTP migration test:

```yaml
kubectl get serviceinstance,servicebinding,servicebindingusage,function | grep -v "service-catalog-auditlog-api"
NAME                                                                 CLASS                                     PLAN          STATUS             AGE
serviceinstance.servicecatalog.k8s.io/hb-instbind-redis-1            ClusterServiceClass/redis                 micro         Ready              2d20h
serviceinstance.servicecatalog.k8s.io/svcat-auditlog-api-1           ClusterServiceClass/auditlog-api          default       Ready              2d20h
serviceinstance.servicecatalog.k8s.io/svcat-auditlog-management-1    ClusterServiceClass/auditlog-management   default       Ready              2d20h
serviceinstance.servicecatalog.k8s.io/svcat-html5-apps-repo-1        ClusterServiceClass/html5-apps-repo       app-runtime   Ready              2d20h

NAME                                                                       SERVICE-INSTANCE              SECRET-NAME                           STATUS   AGE
servicebinding.servicecatalog.k8s.io/func-sb-redis-function-1              hb-instbind-redis-1           func-sb-redis-function-1              Ready    2d20h
servicebinding.servicecatalog.k8s.io/func-sb-svcat-auditlog-api-1          svcat-auditlog-api-1          func-sb-svcat-auditlog-api-1          Ready    2d20h
servicebinding.servicecatalog.k8s.io/func-sb-svcat-auditlog-management-1   svcat-auditlog-management-1   func-sb-svcat-auditlog-management-1   Ready    2d20h
servicebinding.servicecatalog.k8s.io/func-sb-svcat-html5-apps-repo-1       svcat-html5-apps-repo-1       func-sb-svcat-html5-apps-repo-1       Ready    2d20h
servicebinding.servicecatalog.k8s.io/inst-sb-redis-function-1              hb-instbind-redis-1           inst-sb-redis-function-1              Ready    2d20h
servicebinding.servicecatalog.k8s.io/inst-sb-svcat-auditlog-api-1          svcat-auditlog-api-1          inst-sb-svcat-auditlog-api-1          Ready    2d20h
servicebinding.servicecatalog.k8s.io/inst-sb-svcat-auditlog-management-1   svcat-auditlog-management-1   inst-sb-svcat-auditlog-management-1   Ready    2d20h
servicebinding.servicecatalog.k8s.io/inst-sb-svcat-html5-apps-repo-1       svcat-html5-apps-repo-1       inst-sb-svcat-html5-apps-repo-1       Ready    2d20h

NAME                                                                                      AGE
servicebindingusage.servicecatalog.kyma-project.io/func-sbu-svcat-auditlog-api-1          2d20h
servicebindingusage.servicecatalog.kyma-project.io/func-sbu-svcat-auditlog-management-1   2d20h
servicebindingusage.servicecatalog.kyma-project.io/func-sbu-svcat-html5-apps-repo-1       2d20h
servicebindingusage.servicecatalog.kyma-project.io/hb-instbind-redis-1                    2d20h

NAME                                                              CONFIGURED   BUILT   RUNNING   RUNTIME    VERSION   AGE
function.serverless.kyma-project.io/hb-instbind-redis-1           True         True    True      nodejs12   4         2d20h
function.serverless.kyma-project.io/svcat-auditlog-api-1          True         True    True      nodejs12   4         2d20h
function.serverless.kyma-project.io/svcat-auditlog-management-1   True         True    True      nodejs12   4         2d20h
function.serverless.kyma-project.io/svcat-html5-apps-repo-1       True         True    True      nodejs12   4         2d20h
```

**Related issue(s)**
prow job: kyma-project/test-infra#3913
epic: https://github.tools.sap/kyma/backlog/issues/1656