### PR TITLE
Change certificates gateway namespace

### DIFF
--- a/resources/certificates/values.yaml
+++ b/resources/certificates/values.yaml
@@ -24,7 +24,7 @@ global:
   istio:
     gateway:
       name: kyma-gateway
-      namespace: kyma-system
+      namespace: istio-system
 
 securityContext:
   allowPrivilegeEscalation: false


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**
Currently, the upgrade from kyma 1.x to 2.0 fails with the error:
```
ERROR	cli/logs.go:56	[helm/client.go] Error: rendered manifests contain a resource that already exists. Unable to continue with install: Gateway "kyma-gateway" in namespace "kyma-system" exists and cannot be imported into the current release: invalid ownership metadata; annotation validation error: key "meta.helm.sh/release-name" must equal "certificates": current value is "core"; annotation validation error: key "meta.helm.sh/release-namespace" must equal "istio-system": current value is "kyma-system"
```
The kyma cli already has a [job](https://github.com/kyma-project/hydroform/blob/e8a55f4dea3dc44aa0100b4d1576479e740a7fcd/parallel-install/pkg/jobmanager/certificatesJobs.go) to fix this. But it conflicts with the [current](https://github.com/kyma-project/kyma/blob/22ea3bd0903d1afca5e42c01fcb7c8c2525afd33/resources/certificates/values.yaml#L27) `values.yaml` file in the certificates chart. This PR fixes this.

Changes proposed in this pull request:

- change certificates gateway namespace to `istio-system`


**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
