### PR TITLE
Update istio version, kiali and tracing overrides

### DIFF
--- a/tests/fast-integration/installer/config-istio.yaml
+++ b/tests/fast-integration/installer/config-istio.yaml
@@ -3,7 +3,7 @@ kind: IstioOperator
 spec:
   # TODO: find some way to override that file with our specific images
   hub: eu.gcr.io/kyma-project/external/istio
-  tag: 1.8.2-distroless
+  tag: 1.10.0-distroless
   components:
     egressGateways:
       - enabled: false

--- a/tests/fast-integration/installer/index.js
+++ b/tests/fast-integration/installer/index.js
@@ -26,7 +26,7 @@ const {
 } = require("../utils");
 const notDeployed = "not-deployed";
 const kymaCrds = require("./kyma-crds");
-const defaultIstioVersion = "1.8.2";
+const defaultIstioVersion = "1.10.0";
 
 
 async function waitForNodesToBeReady(timeout = "180s") {
@@ -106,7 +106,7 @@ function skipHelmTest(r) {
   return !(r.metadata.annotations && r.metadata.annotations["helm.sh/hook"] && r.metadata.annotations["helm.sh/hook"].includes("test-success"));
 }
 function skipNull(r) {
-  return (r!=null);
+  return (r != null);
 }
 
 async function applyRelease(
@@ -184,6 +184,8 @@ async function chartList(options) {
   if (isGardener == "true") {
     registryOverrides = `dockerRegistry.enableInternal=true,global.ingress.domainName=${domain}`
   }
+  const kialiOverrides = overrides + ',kiali.kcproxy.enabled=false,kiali.virtualservice.enabled=false';
+  const tracingOverrides = overrides + ',tracing.kcproxy.enabled=false,tracing.virtualservice.enabled=false';
 
   const kymaCharts = [
     {
@@ -255,12 +257,12 @@ async function chartList(options) {
     {
       release: "kiali",
       namespace: "kyma-system",
-      values: `${overrides}`,
+      values: `${kialiOverrides}`,
     },
     {
       release: "tracing",
       namespace: "kyma-system",
-      values: `${overrides}`,
+      values: `${tracingOverrides}`,
     },
     {
       release: "logging",

--- a/tests/fast-integration/utils/index.js
+++ b/tests/fast-integration/utils/index.js
@@ -452,6 +452,21 @@ function waitForDeployment(name, namespace = "default", timeout = 90000) {
   );
 }
 
+function waitForStatefulSet(name, namespace = "default", timeout = 90000) {
+  return waitForK8sObject(
+    `/apis/apps/v1/namespaces/${namespace}/statefulsets`,
+    {},
+    (_type, _apiObj, watchObj) => {
+      return (
+        watchObj.object.metadata.name === name &&
+        watchObj.object.status.readyReplicas>0
+      );
+    },
+    timeout,
+    `Waiting for StatefulSet ${name} timeout (${timeout} ms)`
+  );
+}
+
 function waitForVirtualService(namespace, apiRuleName, timeout = 20000) {
   const path = `/apis/networking.istio.io/v1beta1/namespaces/${namespace}/virtualservices`;
   const query = {
@@ -960,6 +975,7 @@ module.exports = {
   waitForServiceBindingUsage,
   waitForVirtualService,
   waitForDeployment,
+  waitForStatefulSet,
   waitForTokenRequest,
   waitForCompassConnection,
   waitForFunction,


### PR DESCRIPTION
**Description**
Few fixe
Changes proposed in this pull request:

- update fast-integration test installer to use istio 1.10
- add overrides for tracing and kiali to work without dex
- wait for deployments and statefulsets to be ready when installed without helm

