### PR TITLE
Add readiness probes to OAuth2 proxies

### DIFF
--- a/resources/kiali/templates/kyma-additions/auth-proxy-deployment.yaml
+++ b/resources/kiali/templates/kyma-additions/auth-proxy-deployment.yaml
@@ -60,6 +60,10 @@ spec:
           httpGet:
             path: /ping
             port: http
+        readinessProbe:
+          httpGet:
+            path: /ping
+            port: http
         {{- if .Values.authProxy.securityContext }}
         securityContext:
 {{ toYaml .Values.authProxy.securityContext | nindent 10 }}

--- a/resources/monitoring/charts/grafana/templates/kyma-additions/auth-proxy-deployment.yaml
+++ b/resources/monitoring/charts/grafana/templates/kyma-additions/auth-proxy-deployment.yaml
@@ -65,6 +65,10 @@ spec:
           httpGet:
             path: /ping
             port: http
+        readinessProbe:
+          httpGet:
+            path: /ping
+            port: http
         {{- if .Values.kyma.authProxy.securityContext }}
         securityContext:
 {{ toYaml .Values.kyma.authProxy.securityContext | nindent 10 }}

--- a/resources/tracing/templates/kyma-additions/auth-proxy-deployment.yaml
+++ b/resources/tracing/templates/kyma-additions/auth-proxy-deployment.yaml
@@ -61,6 +61,10 @@ spec:
           httpGet:
             path: /ping
             port: http
+        readinessProbe:
+          httpGet:
+            path: /ping
+            port: http
         {{- if .Values.authProxy.securityContext }}
         securityContext:
 {{ toYaml .Values.authProxy.securityContext | nindent 10 }}


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- Adds readiness probes. The upstream chart also includes one: https://github.com/oauth2-proxy/manifests/blob/main/helm/oauth2-proxy/templates/deployment.yaml

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
