### PR TITLE
Add liveness and readiness probes to application-operator

### DIFF
--- a/resources/application-connector/charts/application-operator/templates/controller.yaml
+++ b/resources/application-connector/charts/application-operator/templates/controller.yaml
@@ -36,8 +36,16 @@ spec:
       containers:
       - name: {{ .Chart.Name }}
         ports:
-          - containerPort: 8090
+          - containerPort: {{ .Values.controller.args.healthPort }}
             name: http-health
+      livenessProbe:
+        httpGet:
+          port: {{ .Values.controller.args.healthPort }}
+          path: "/healthz"
+      readinessProbe:
+        httpGet:
+          port: {{ .Values.controller.args.healthPort }}
+          path: "/healthz"
         args:
         - "/manager"
         - "--appName={{ .Values.controller.args.appName }}"

--- a/resources/application-connector/charts/application-operator/templates/controller.yaml
+++ b/resources/application-connector/charts/application-operator/templates/controller.yaml
@@ -38,14 +38,14 @@ spec:
         ports:
           - containerPort: {{ .Values.controller.args.healthPort }}
             name: http-health
-      livenessProbe:
-        httpGet:
-          port: {{ .Values.controller.args.healthPort }}
-          path: "/healthz"
-      readinessProbe:
-        httpGet:
-          port: {{ .Values.controller.args.healthPort }}
-          path: "/healthz"
+        livenessProbe:
+          httpGet:
+            port: {{ .Values.controller.args.healthPort }}
+            path: "/healthz"
+        readinessProbe:
+          httpGet:
+            port: {{ .Values.controller.args.healthPort }}
+            path: "/healthz"
         args:
         - "/manager"
         - "--appName={{ .Values.controller.args.appName }}"

--- a/resources/application-connector/charts/application-operator/templates/controller.yaml
+++ b/resources/application-connector/charts/application-operator/templates/controller.yaml
@@ -42,16 +42,16 @@ spec:
           httpGet:
             port: {{ .Values.controller.args.healthPort }}
             path: "/healthz"
-          initialDelaySeconds: 50
-          timeoutSeconds: 1
-          periodSeconds: 10
+          initialDelaySeconds: {{ .Values.controller.livenessProbe.initialDelaySeconds }}
+          timeoutSeconds: {{ .Values.controller.livenessProbe.timeoutSeconds }}
+          periodSeconds: {{ .Values.controller.livenessProbe.periodSeconds }}
         readinessProbe:
           httpGet:
             port: {{ .Values.controller.args.healthPort }}
             path: "/healthz"
-          initialDelaySeconds: 10
-          timeoutSeconds: 1
-          periodSeconds: 2
+          initialDelaySeconds: {{ .Values.controller.readinessProbe.initialDelaySeconds }}
+          timeoutSeconds: {{ .Values.controller.readinessProbe.timeoutSeconds }}
+          periodSeconds: {{ .Values.controller.readinessProbe.periodSeconds }}
         args:
         - "/manager"
         - "--appName={{ .Values.controller.args.appName }}"

--- a/resources/application-connector/charts/application-operator/templates/controller.yaml
+++ b/resources/application-connector/charts/application-operator/templates/controller.yaml
@@ -42,10 +42,16 @@ spec:
           httpGet:
             port: {{ .Values.controller.args.healthPort }}
             path: "/healthz"
+          initialDelaySeconds: 50
+          timeoutSeconds: 1
+          periodSeconds: 10
         readinessProbe:
           httpGet:
             port: {{ .Values.controller.args.healthPort }}
             path: "/healthz"
+          initialDelaySeconds: 10
+          timeoutSeconds: 1
+          periodSeconds: 2
         args:
         - "/manager"
         - "--appName={{ .Values.controller.args.appName }}"

--- a/resources/application-connector/charts/application-operator/values.yaml
+++ b/resources/application-connector/charts/application-operator/values.yaml
@@ -15,6 +15,14 @@ controller:
     requests:
       cpu: 100m
       memory: 128Mi
+  livenessProbe:
+    initialDelaySeconds: 50
+    timeoutSeconds: 1
+    periodSeconds: 10
+  readinessProbe:
+    initialDelaySeconds: 10
+    timeoutSeconds: 1
+    periodSeconds: 2
 
 tests:
   enabled: true


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

A new way of monitoring Kyma runtime availability requires readiness probes to be configured for all workloads (deployments, stateful sets, daemon sets). application-operator already had a health check endpoint, but it was not used as a probe.

Changes proposed in this pull request:

- Use existing health check endpoint as a liveness/readiness probe (similar to the `compass-runtime-agent`)

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
