### PR TITLE
Add liveness and readiness probes to api gateway

### DIFF
--- a/resources/api-gateway/templates/deployment.yaml
+++ b/resources/api-gateway/templates/deployment.yaml
@@ -56,6 +56,15 @@ spec:
           ports:
           - containerPort: {{ .Values.config.ports.metrics }}
             name: metrics
+          #TODO: temporary solution, replace with a health endpoint
+          livenessProbe:
+            httpGet:
+              port: {{ .Values.config.ports.metrics }}
+              path: "/metrics"
+          readinessProbe:
+            httpGet:
+              port: {{ .Values.config.ports.metrics }}
+              path: "/metrics"
       serviceAccountName: {{ include "api-gateway.name" . }}-account
       nodeSelector:
       {{- with .Values.config.nodeSelector }}


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

A new way of monitoring Kyma runtime availability requires readiness probes to be configured for all workloads (deployments, stateful sets, daemon sets). api-gateway does not expose a health check endpoint, so as a temporary workaround, the metrics endpoint will be used for this purpose.

Changes proposed in this pull request:

- Use existing metrics endpoint as a liveness/readiness probe

**Related issue(s)**
 See also #11726 