### PR TITLE
Add liveness and readiness probes to prometheus operator

### DIFF
--- a/resources/monitoring/templates/prometheus-operator/deployment.yaml
+++ b/resources/monitoring/templates/prometheus-operator/deployment.yaml
@@ -1,5 +1,6 @@
 {{- /*
   Customization: .Values.resourceSelector.namespaces if statement is added to make comma separated namespace list work.
+  Liveness/readiness probes were added since they are missing in the upstream chart
 */ -}}
 {{- $namespace := printf "%s" (include "kube-prometheus-stack.namespace" .) }}
 {{- if .Values.prometheusOperator.enabled }}
@@ -107,6 +108,38 @@ spec:
           ports:
             - containerPort: 8080
               name: http
+          {{- end }}
+          {{- if .Values.prometheusOperator.livenessProbe.enabled }}
+          livenessProbe:
+            httpGet:
+              path: {{ .Values.prometheusOperator.livenessProbe.path }}
+              {{- if .Values.prometheusOperator.tls.enabled }}
+              port: https
+              {{- else }}
+              port: http
+              {{- end }}
+              scheme: HTTP
+            initialDelaySeconds: {{ .Values.prometheusOperator.livenessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.prometheusOperator.livenessProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.prometheusOperator.livenessProbe.timeoutSeconds }}
+            failureThreshold: {{ .Values.prometheusOperator.livenessProbe.failureThreshold }}
+            successThreshold: {{ .Values.prometheusOperator.livenessProbe.successThreshold }}
+          {{- end }}
+          {{- if .Values.prometheusOperator.readinessProbe.enabled }}
+          readinessProbe:
+            httpGet:
+              path: {{ .Values.prometheusOperator.readinessProbe.path }}
+              {{- if .Values.prometheusOperator.tls.enabled }}
+              port: https
+              {{- else }}
+              port: http
+              {{- end }}
+              scheme: HTTP
+            initialDelaySeconds: {{ .Values.prometheusOperator.readinessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.prometheusOperator.readinessProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.prometheusOperator.readinessProbe.timeoutSeconds }}
+            failureThreshold: {{ .Values.prometheusOperator.readinessProbe.failureThreshold }}
+            successThreshold: {{ .Values.prometheusOperator.readinessProbe.successThreshold }}
           {{- end }}
           resources:
 {{ toYaml .Values.prometheusOperator.resources | indent 12 }}

--- a/resources/monitoring/values.yaml
+++ b/resources/monitoring/values.yaml
@@ -20,7 +20,8 @@ global:
   rbac:
     create: true
     pspEnabled: true
-    pspAnnotations: {}
+    pspAnnotations:
+      {}
       ## Specify pod annotations
       ## Ref: https://kubernetes.io/docs/concepts/policy/pod-security-policy/#apparmor
       ## Ref: https://kubernetes.io/docs/concepts/policy/pod-security-policy/#seccomp
@@ -30,7 +31,7 @@ global:
       # seccomp.security.alpha.kubernetes.io/defaultProfileName: 'docker/default'
       # apparmor.security.beta.kubernetes.io/defaultProfileName: 'runtime/default'
 
-# disable slack and victorops alerting by default
+  # disable slack and victorops alerting by default
   alertTools:
     credentials:
       slack:
@@ -150,7 +151,6 @@ additionalPrometheusRulesMap: {}
 ## ref: https://prometheus.io/docs/alerting/alertmanager/
 ##
 alertmanager:
-
   ## Deploy alertmanager
   ##
   enabled: true
@@ -196,7 +196,6 @@ alertmanager:
   #         receiver: 'null'
   #   receivers:
   #     - name: 'null'
-
 
   ## Pass the Alertmanager configuration directives through Helm's templating
   ## engine. If the Alertmanager configuration contains Alertmanager templates,
@@ -245,7 +244,8 @@ alertmanager:
 
     ## Hosts must be provided if Ingress is enabled.
     ##
-    hosts: []
+    hosts:
+      []
       # - alertmanager.domain.com
 
     ## Paths to use for ingress rules - one path should match the alertmanagerSpec.routePrefix
@@ -378,9 +378,9 @@ alertmanager:
     ## 	metric relabel configs to apply to samples before ingestion.
     ##
     metricRelabelings:
-    - sourceLabels: [ __name__ ]
-      regex: ^(alertmanager_.*|go_goroutines|go_memstats_alloc_bytes|go_memstats_heap_alloc_bytes|go_memstats_heap_inuse_bytes|go_memstats_heap_sys_bytes|go_memstats_stack_inuse_bytes|process_cpu_seconds_total|process_max_fds|process_open_fds|process_resident_memory_bytes|process_start_time_seconds|process_virtual_memory_bytes)$
-      action: keep
+      - sourceLabels: [__name__]
+        regex: ^(alertmanager_.*|go_goroutines|go_memstats_alloc_bytes|go_memstats_heap_alloc_bytes|go_memstats_heap_inuse_bytes|go_memstats_heap_sys_bytes|go_memstats_stack_inuse_bytes|process_cpu_seconds_total|process_max_fds|process_open_fds|process_resident_memory_bytes|process_start_time_seconds|process_virtual_memory_bytes)$
+        action: keep
 
     # 	relabel configs to apply to samples before ingestion.
     ##
@@ -459,7 +459,6 @@ alertmanager:
     #       requests:
     #         storage: 50Gi
     #   selector: {}
-
 
     ## 	The external URL the Alertmanager instances will be available under. This is necessary to generate correct URLs. This is necessary if Alertmanager is not served from root of a DNS name.	string	false
     ##
@@ -557,9 +556,8 @@ alertmanager:
     portName: "web"
 
     ## ClusterAdvertiseAddress is the explicit address to advertise in cluster. Needs to be provided for non RFC1918 [1] (public) addresses. [1] RFC1918: https://tools.ietf.org/html/rfc1918
-##
+    ##
     clusterAdvertiseAddress: false
-
 
 ## Using default values from https://github.com/grafana/helm-charts/blob/main/charts/grafana/values.yaml
 ##
@@ -580,7 +578,8 @@ grafana:
 
     ## Annotations for Grafana Ingress
     ##
-    annotations: {}
+    annotations:
+      {}
       # kubernetes.io/ingress.class: nginx
       # kubernetes.io/tls-acme: "true"
 
@@ -652,7 +651,6 @@ grafana:
   #   url: https://{{ printf "%s-prometheus.svc" .Release.Name }}:9090
   #   version: 1
 
-
   ## Passed to grafana subchart and used by servicemonitor below
   ##
   service:
@@ -669,9 +667,9 @@ grafana:
     ## 	metric relabel configs to apply to samples before ingestion.
     ##
     metricRelabelings:
-    - sourceLabels: [ __name__ ]
-      regex: ^(http_request_total|grafana_.*|go_goroutines|go_memstats_alloc_bytes|go_memstats_heap_alloc_bytes|go_memstats_heap_inuse_bytes|go_memstats_heap_sys_bytes|go_memstats_stack_inuse_bytes|process_cpu_seconds_total|process_max_fds|process_open_fds|process_resident_memory_bytes|process_start_time_seconds|process_virtual_memory_bytes)$
-      action: keep
+      - sourceLabels: [__name__]
+        regex: ^(http_request_total|grafana_.*|go_goroutines|go_memstats_alloc_bytes|go_memstats_heap_alloc_bytes|go_memstats_heap_inuse_bytes|go_memstats_heap_sys_bytes|go_memstats_stack_inuse_bytes|process_cpu_seconds_total|process_max_fds|process_open_fds|process_resident_memory_bytes|process_start_time_seconds|process_virtual_memory_bytes)$
+        action: keep
 
     # 	relabel configs to apply to samples before ingestion.
     ##
@@ -716,9 +714,9 @@ kubeApiServer:
     ## 	metric relabel configs to apply to samples before ingestion.
     ##
     metricRelabelings:
-    - sourceLabels: [ __name__ ]
-      regex: ^(apiserver_audit_event_total|apiserver_audit_level_total|apiserver_audit_requests_rejected_total|apiserver_client_certificate_expiration_seconds_bucket|apiserver_registered_watchers|apiserver_request_total|apiserver_request_duration_seconds_bucket|apiserver_request_latencies_bucket|etcd_helper_cache_entry_total|etcd_helper_cache_hit_total|etcd_helper_cache_miss_total|etcd_request_cache_add_duration_seconds_bucket|etcd_request_cache_get_duration_seconds_bucket|go_goroutines|go_memstats_alloc_bytes|go_memstats_heap_alloc_bytes|go_memstats_heap_inuse_bytes|go_memstats_heap_sys_bytes|go_memstats_stack_inuse_bytes|kubernetes_build_info|process_cpu_seconds_total|process_max_fds|process_open_fds|process_resident_memory_bytes|process_start_time_seconds|process_virtual_memory_bytes|rest_client_request_latency_seconds_bucket|rest_client_requests_total|workqueue_adds_total|workqueue_depth|workqueue_queue_duration_seconds_bucket)$
-      action: keep
+      - sourceLabels: [__name__]
+        regex: ^(apiserver_audit_event_total|apiserver_audit_level_total|apiserver_audit_requests_rejected_total|apiserver_client_certificate_expiration_seconds_bucket|apiserver_registered_watchers|apiserver_request_total|apiserver_request_duration_seconds_bucket|apiserver_request_latencies_bucket|etcd_helper_cache_entry_total|etcd_helper_cache_hit_total|etcd_helper_cache_miss_total|etcd_request_cache_add_duration_seconds_bucket|etcd_request_cache_get_duration_seconds_bucket|go_goroutines|go_memstats_alloc_bytes|go_memstats_heap_alloc_bytes|go_memstats_heap_inuse_bytes|go_memstats_heap_sys_bytes|go_memstats_stack_inuse_bytes|kubernetes_build_info|process_cpu_seconds_total|process_max_fds|process_open_fds|process_resident_memory_bytes|process_start_time_seconds|process_virtual_memory_bytes|rest_client_request_latency_seconds_bucket|rest_client_requests_total|workqueue_adds_total|workqueue_depth|workqueue_queue_duration_seconds_bucket)$
+        action: keep
     # - action: keep
     #   regex: 'kube_(daemonset|deployment|pod|namespace|node|statefulset).+'
     #   sourceLabels: [__name__]
@@ -756,9 +754,9 @@ kubelet:
     ## Metric relabellings to apply to samples before ingestion
     ##
     cAdvisorMetricRelabelings:
-    - sourceLabels: [ __name__ ]
-      regex: ^(container_cpu_cfs_periods_total|container_cpu_cfs_throttled_periods_total|container_cpu_cfs_throttled_seconds_total|container_cpu_usage_seconds_total|container_fs_reads_bytes_total|container_fs_usage_bytes|container_fs_writes_bytes_total|container_memory_cache|container_memory_failcnt|container_memory_rss|container_memory_swap|container_memory_usage_bytes|container_memory_working_set_bytes|container_network_receive_bytes_total|container_network_receive_packets_dropped_total|container_network_receive_packets_total|container_network_transmit_bytes_total|container_network_transmit_packets_dropped_total|container_network_transmit_packets_total)$
-      action: keep
+      - sourceLabels: [__name__]
+        regex: ^(container_cpu_cfs_periods_total|container_cpu_cfs_throttled_periods_total|container_cpu_cfs_throttled_seconds_total|container_cpu_usage_seconds_total|container_fs_reads_bytes_total|container_fs_usage_bytes|container_fs_writes_bytes_total|container_memory_cache|container_memory_failcnt|container_memory_rss|container_memory_swap|container_memory_usage_bytes|container_memory_working_set_bytes|container_network_receive_bytes_total|container_network_receive_packets_dropped_total|container_network_receive_packets_total|container_network_transmit_bytes_total|container_network_transmit_packets_dropped_total|container_network_transmit_packets_total)$
+        action: keep
 
     ## Metric relabellings to apply to samples before ingestion
     ##
@@ -778,8 +776,8 @@ kubelet:
     #   metrics_path is required to match upstream rules and charts
     ##
     cAdvisorRelabelings:
-    - sourceLabels: [__metrics_path__]
-      targetLabel: metrics_path
+      - sourceLabels: [__metrics_path__]
+        targetLabel: metrics_path
     # - sourceLabels: [__meta_kubernetes_pod_node_name]
     #   separator: ;
     #   regex: ^(.*)$
@@ -808,16 +806,16 @@ kubelet:
     #   action: replace
 
     metricRelabelings:
-    - sourceLabels: [ __name__ ]
-      regex: ^(apiserver_client_certificate_expiration_seconds_bucket|go_goroutines|go_memstats_alloc_bytes|go_memstats_heap_alloc_bytes|go_memstats_heap_inuse_bytes|go_memstats_heap_sys_bytes|go_memstats_stack_inuse_bytes|kubelet_cgroup_manager_duration_seconds_bucket|kubelet_cgroup_manager_duration_seconds_count|kubelet_node_name|kubelet_pleg_relist_duration_seconds_bucket|kubelet_pleg_relist_duration_seconds_count|kubelet_pleg_relist_interval_seconds_bucket|kubelet_pod_start_duration_seconds_count|kubelet_pod_worker_duration_seconds_bucket|kubelet_pod_worker_duration_seconds_count|kubelet_running_container_count|kubelet_running_pod_count|kubelet_runtime_operations|kubelet_runtime_operations_total|kubelet_runtime_operations_errors_total|kubelet_volume_stats_available_bytes|kubelet_volume_stats_capacity_bytes|kubelet_volume_stats_inodes|kubernetes_build_info|process_cpu_seconds_total|process_max_fds|process_open_fds|process_resident_memory_bytes|process_start_time_seconds|process_virtual_memory_bytes|rest_client_requests_total)$
-      action: keep
+      - sourceLabels: [__name__]
+        regex: ^(apiserver_client_certificate_expiration_seconds_bucket|go_goroutines|go_memstats_alloc_bytes|go_memstats_heap_alloc_bytes|go_memstats_heap_inuse_bytes|go_memstats_heap_sys_bytes|go_memstats_stack_inuse_bytes|kubelet_cgroup_manager_duration_seconds_bucket|kubelet_cgroup_manager_duration_seconds_count|kubelet_node_name|kubelet_pleg_relist_duration_seconds_bucket|kubelet_pleg_relist_duration_seconds_count|kubelet_pleg_relist_interval_seconds_bucket|kubelet_pod_start_duration_seconds_count|kubelet_pod_worker_duration_seconds_bucket|kubelet_pod_worker_duration_seconds_count|kubelet_running_container_count|kubelet_running_pod_count|kubelet_runtime_operations|kubelet_runtime_operations_total|kubelet_runtime_operations_errors_total|kubelet_volume_stats_available_bytes|kubelet_volume_stats_capacity_bytes|kubelet_volume_stats_inodes|kubernetes_build_info|process_cpu_seconds_total|process_max_fds|process_open_fds|process_resident_memory_bytes|process_start_time_seconds|process_virtual_memory_bytes|rest_client_requests_total)$
+        action: keep
 
     # 	relabel configs to apply to samples before ingestion.
     #   metrics_path is required to match upstream rules and charts
     ##
     relabelings:
-    - sourceLabels: [__metrics_path__]
-      targetLabel: metrics_path
+      - sourceLabels: [__metrics_path__]
+        targetLabel: metrics_path
     # - sourceLabels: [__meta_kubernetes_pod_node_name]
     #   separator: ;
     #   regex: ^(.*)$
@@ -895,9 +893,9 @@ coreDns:
     ## 	metric relabel configs to apply to samples before ingestion.
     ##
     metricRelabelings:
-    - sourceLabels: [ __name__ ]
-      regex: ^(coredns_.*|go_goroutines|go_memstats_alloc_bytes|go_memstats_heap_alloc_bytes|go_memstats_heap_inuse_bytes|go_memstats_heap_sys_bytes|go_memstats_stack_inuse_bytes|process_cpu_seconds_total|process_max_fds|process_open_fds|process_resident_memory_bytes|process_start_time_seconds|process_virtual_memory_bytes)$
-      action: keep
+      - sourceLabels: [__name__]
+        regex: ^(coredns_.*|go_goroutines|go_memstats_alloc_bytes|go_memstats_heap_alloc_bytes|go_memstats_heap_inuse_bytes|go_memstats_heap_sys_bytes|go_memstats_stack_inuse_bytes|process_cpu_seconds_total|process_max_fds|process_open_fds|process_resident_memory_bytes|process_start_time_seconds|process_virtual_memory_bytes)$
+        action: keep
 
     # 	relabel configs to apply to samples before ingestion.
     ##
@@ -1017,7 +1015,6 @@ kubeEtcd:
     #   replacement: $1
     #   action: replace
 
-
 ## Component scraping kube scheduler
 ##
 kubeScheduler:
@@ -1070,7 +1067,6 @@ kubeScheduler:
     #   replacement: $1
     #   action: replace
 
-
 ## Component scraping kube proxy
 ##
 kubeProxy:
@@ -1113,7 +1109,6 @@ kubeProxy:
     #   regex: 'kube_(daemonset|deployment|pod|namespace|node|statefulset).+'
     #   sourceLabels: [__name__]
 
-
 ## Component scraping kube state metrics
 ##
 kubeStateMetrics:
@@ -1126,9 +1121,9 @@ kubeStateMetrics:
     ## 	metric relabel configs to apply to samples before ingestion.
     ##
     metricRelabelings:
-    - sourceLabels: [ __name__ ]
-      regex: ^(kube_daemonset_status_current_number_scheduled|kube_daemonset_status_desired_number_scheduled|kube_daemonset_status_number_misscheduled|kube_daemonset_status_number_ready|kube_deployment_metadata_generation|kube_deployment_spec_replicas|kube_deployment_status_observed_generation|kube_deployment_status_replicas|kube_deployment_status_replicas_available|kube_hpa_spec_max_replicas|kube_hpa_status_current_replicas|kube_hpa_status_desired_replicas|kube_job_spec_completions|kube_job_status_succeeded|kube_namespace_labels|kube_node_status_allocatable|kube_node_status_allocatable_cpu_cores|kube_node_status_allocatable_memory_bytes|kube_node_status_capacity|kube_node_status_condition|kube_persistentvolume_status_phase|kube_pod_container_info|kube_pod_container_resource_limits|kube_pod_container_resource_limits_cpu_cores|kube_pod_container_resource_limits_memory_bytes|kube_pod_container_resource_requests|kube_pod_container_resource_requests_memory_bytes|kube_pod_container_resource_requests_cpu_cores|kube_pod_container_status_restarts_total|kube_pod_container_status_running|kube_pod_container_status_waiting|kube_pod_info|kube_pod_labels|kube_pod_owner|kube_pod_status_phase|kube_replicaset_owner|kube_resourcequota|kube_service_labels|kube_statefulset_metadata_generation|kube_statefulset_replicas|kube_statefulset_status_current_revision|kube_statefulset_status_observed_generation|kube_statefulset_status_replicas|kube_statefulset_status_update_revision|kube_job_complete|kube_job_failed|kube_job_status_completion_time|kube_job_status_start_time|kube_pod_container_status_waiting_reason|kube_pod_container_status_terminated_reason)$
-      action: keep
+      - sourceLabels: [__name__]
+        regex: ^(kube_daemonset_status_current_number_scheduled|kube_daemonset_status_desired_number_scheduled|kube_daemonset_status_number_misscheduled|kube_daemonset_status_number_ready|kube_deployment_metadata_generation|kube_deployment_spec_replicas|kube_deployment_status_observed_generation|kube_deployment_status_replicas|kube_deployment_status_replicas_available|kube_hpa_spec_max_replicas|kube_hpa_status_current_replicas|kube_hpa_status_desired_replicas|kube_job_spec_completions|kube_job_status_succeeded|kube_namespace_labels|kube_node_status_allocatable|kube_node_status_allocatable_cpu_cores|kube_node_status_allocatable_memory_bytes|kube_node_status_capacity|kube_node_status_condition|kube_persistentvolume_status_phase|kube_pod_container_info|kube_pod_container_resource_limits|kube_pod_container_resource_limits_cpu_cores|kube_pod_container_resource_limits_memory_bytes|kube_pod_container_resource_requests|kube_pod_container_resource_requests_memory_bytes|kube_pod_container_resource_requests_cpu_cores|kube_pod_container_status_restarts_total|kube_pod_container_status_running|kube_pod_container_status_waiting|kube_pod_info|kube_pod_labels|kube_pod_owner|kube_pod_status_phase|kube_replicaset_owner|kube_resourcequota|kube_service_labels|kube_statefulset_metadata_generation|kube_statefulset_replicas|kube_statefulset_status_current_revision|kube_statefulset_status_observed_generation|kube_statefulset_status_replicas|kube_statefulset_status_update_revision|kube_job_complete|kube_job_failed|kube_job_status_completion_time|kube_job_status_start_time|kube_pod_container_status_waiting_reason|kube_pod_container_status_terminated_reason)$
+        action: keep
 
     # 	relabel configs to apply to samples before ingestion.
     ##
@@ -1170,9 +1165,9 @@ nodeExporter:
     ## 	metric relabel configs to apply to samples before ingestion.
     ##
     metricRelabelings:
-    - sourceLabels: [ __name__ ]
-      regex: ^(go_goroutines|go_memstats_alloc_bytes|go_memstats_heap_alloc_bytes|go_memstats_heap_inuse_bytes|go_memstats_heap_sys_bytes|go_memstats_stack_inuse_bytes|node_.*|process_cpu_seconds_total|process_max_fds|process_open_fds|process_resident_memory_bytes|process_start_time_seconds|process_virtual_memory_bytes)$
-      action: keep
+      - sourceLabels: [__name__]
+        regex: ^(go_goroutines|go_memstats_alloc_bytes|go_memstats_heap_alloc_bytes|go_memstats_heap_inuse_bytes|go_memstats_heap_sys_bytes|go_memstats_stack_inuse_bytes|node_.*|process_cpu_seconds_total|process_max_fds|process_open_fds|process_resident_memory_bytes|process_start_time_seconds|process_virtual_memory_bytes)$
+        action: keep
 
     ## 	relabel configs to apply to samples before ingestion.
     ##
@@ -1234,7 +1229,8 @@ prometheusOperator:
   ## Namespaces to scope the interaction of the Prometheus Operator and the apiserver (allow list).
   ## This is mutually exclusive with denyNamespaces. Setting this to an empty object will disable the configuration
   ##
-  namespaces: {}
+  namespaces:
+    {}
     # releaseNamespace: true
     # additional:
     # - kube-system
@@ -1263,27 +1259,27 @@ prometheusOperator:
     labels: {}
     clusterIP: ""
 
-  ## Port to expose on each node
-  ## Only used if service.type is 'NodePort'
-  ##
+    ## Port to expose on each node
+    ## Only used if service.type is 'NodePort'
+    ##
     nodePort: 30080
 
     nodePortTls: 30443
 
-  ## Additional ports to open for Prometheus service
-  ## ref: https://kubernetes.io/docs/concepts/services-networking/service/#multi-port-services
-  ##
+    ## Additional ports to open for Prometheus service
+    ## ref: https://kubernetes.io/docs/concepts/services-networking/service/#multi-port-services
+    ##
     additionalPorts: []
 
-  ## Loadbalancer IP
-  ## Only use if service.type is "loadbalancer"
-  ##
+    ## Loadbalancer IP
+    ## Only use if service.type is "loadbalancer"
+    ##
     loadBalancerIP: ""
     loadBalancerSourceRanges: []
 
-  ## Service type
-  ## NodePort, ClusterIP, loadbalancer
-  ##
+    ## Service type
+    ## NodePort, ClusterIP, loadbalancer
+    ##
     type: ClusterIP
 
     ## List of IP addresses at which the Prometheus server service is available
@@ -1330,9 +1326,9 @@ prometheusOperator:
     ## 	metric relabel configs to apply to samples before ingestion.
     ##
     metricRelabelings:
-    - sourceLabels: [ __name__ ]
-      regex: ^(go_goroutines|go_memstats_alloc_bytes|go_memstats_heap_alloc_bytes|go_memstats_heap_inuse_bytes|go_memstats_heap_sys_bytes|go_memstats_stack_inuse_bytes|process_cpu_seconds_total|process_max_fds|process_open_fds|process_resident_memory_bytes|process_start_time_seconds|process_virtual_memory_bytes|prometheus_operator_node_address_lookup_errors_total|prometheus_operator_reconcile_errors_total|prometheus_operator_spec_replicas)$
-      action: keep
+      - sourceLabels: [__name__]
+        regex: ^(go_goroutines|go_memstats_alloc_bytes|go_memstats_heap_alloc_bytes|go_memstats_heap_inuse_bytes|go_memstats_heap_sys_bytes|go_memstats_stack_inuse_bytes|process_cpu_seconds_total|process_max_fds|process_open_fds|process_resident_memory_bytes|process_start_time_seconds|process_virtual_memory_bytes|prometheus_operator_node_address_lookup_errors_total|prometheus_operator_reconcile_errors_total|prometheus_operator_spec_replicas)$
+        action: keep
 
     # 	relabel configs to apply to samples before ingestion.
     ##
@@ -1376,7 +1372,8 @@ prometheusOperator:
   ## Assign custom affinity rules to the prometheus operator
   ## ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/
   ##
-  affinity: {}
+  affinity:
+    {}
     # nodeAffinity:
     #   requiredDuringSchedulingIgnoredDuringExecution:
     #     nodeSelectorTerms:
@@ -1405,6 +1402,26 @@ prometheusOperator:
     tag: v0.43.2
     sha: ""
     pullPolicy: IfNotPresent
+
+  ## Liveness and readiness probes are missing in the upstrem chart
+  ##
+  livenessProbe:
+    enabled: true
+    path: /metrics
+    initialDelaySeconds: 120
+    periodSeconds: 10
+    timeoutSeconds: 5
+    failureThreshold: 6
+    successThreshold: 1
+
+  readinessProbe:
+    enabled: true
+    path: /metrics
+    initialDelaySeconds: 30
+    periodSeconds: 10
+    timeoutSeconds: 5
+    failureThreshold: 6
+    successThreshold: 1
 
   ## Configmap-reload image to use for reloading configmaps
   ##
@@ -1435,7 +1452,6 @@ prometheusOperator:
 ## Deploy a Prometheus instance
 ##
 prometheus:
-
   enabled: true
 
   ## Annotations for Prometheus
@@ -1518,7 +1534,7 @@ prometheus:
     minAvailable: 1
     maxUnavailable: ""
 
-# Ingress exposes thanos sidecar outside the clsuter
+  # Ingress exposes thanos sidecar outside the clsuter
   thanosIngress:
     enabled: false
 
@@ -1531,7 +1547,8 @@ prometheus:
     servicePort: 10901
     ## Hosts must be provided if Ingress is enabled.
     ##
-    hosts: []
+    hosts:
+      []
       # - thanos-gateway.domain.com
 
     ## Paths to use for ingress rules
@@ -1572,7 +1589,8 @@ prometheus:
     ## TLS configuration for Prometheus Ingress
     ## Secret must be manually created in the namespace
     ##
-    tls: []
+    tls:
+      []
       # - secretName: prometheus-general-tls
       #   hosts:
       #     - prometheus.example.com
@@ -1640,9 +1658,9 @@ prometheus:
     ## 	metric relabel configs to apply to samples before ingestion.
     ##
     metricRelabelings:
-    - sourceLabels: [ __name__ ]
-      regex: ^(go_goroutines|go_memstats_alloc_bytes|go_memstats_heap_alloc_bytes|go_memstats_heap_inuse_bytes|go_memstats_heap_sys_bytes|go_memstats_stack_inuse_bytes|process_cpu_seconds_total|process_max_fds|process_open_fds|process_resident_memory_bytes|process_start_time_seconds|process_virtual_memory_bytes|prometheus_build_info|prometheus_config_last_reload_successful|prometheus_engine_query_duration_seconds|prometheus_engine_query_duration_seconds_count|prometheus_notifications_alertmanagers_discovered|prometheus_notifications_errors_total|prometheus_notifications_queue_capacity|prometheus_notifications_queue_length|prometheus_notifications_sent_total|prometheus_remote_storage_highest_timestamp_in_seconds|prometheus_remote_storage_samples_in_total|prometheus_rule_evaluation_failures_total|prometheus_rule_group_iterations_missed_total|prometheus_sd_discovered_targets|prometheus_target_interval_length_seconds_sum|prometheus_target_interval_length_seconds_count|prometheus_target_scrapes_exceeded_sample_limit_total|prometheus_target_scrapes_sample_duplicate_timestamp_total|prometheus_target_scrapes_sample_out_of_bounds_total|prometheus_target_scrapes_sample_out_of_order_total|prometheus_target_sync_length_seconds_sum|prometheus_tsdb_compactions_failed_total|prometheus_tsdb_head_chunks|prometheus_tsdb_head_samples_appended_total|prometheus_tsdb_head_series|prometheus_tsdb_reloads_failures_total|prometheus_tsdb_wal_segment_current)$
-      action: keep
+      - sourceLabels: [__name__]
+        regex: ^(go_goroutines|go_memstats_alloc_bytes|go_memstats_heap_alloc_bytes|go_memstats_heap_inuse_bytes|go_memstats_heap_sys_bytes|go_memstats_stack_inuse_bytes|process_cpu_seconds_total|process_max_fds|process_open_fds|process_resident_memory_bytes|process_start_time_seconds|process_virtual_memory_bytes|prometheus_build_info|prometheus_config_last_reload_successful|prometheus_engine_query_duration_seconds|prometheus_engine_query_duration_seconds_count|prometheus_notifications_alertmanagers_discovered|prometheus_notifications_errors_total|prometheus_notifications_queue_capacity|prometheus_notifications_queue_length|prometheus_notifications_sent_total|prometheus_remote_storage_highest_timestamp_in_seconds|prometheus_remote_storage_samples_in_total|prometheus_rule_evaluation_failures_total|prometheus_rule_group_iterations_missed_total|prometheus_sd_discovered_targets|prometheus_target_interval_length_seconds_sum|prometheus_target_interval_length_seconds_count|prometheus_target_scrapes_exceeded_sample_limit_total|prometheus_target_scrapes_sample_duplicate_timestamp_total|prometheus_target_scrapes_sample_out_of_bounds_total|prometheus_target_scrapes_sample_out_of_order_total|prometheus_target_sync_length_seconds_sum|prometheus_tsdb_compactions_failed_total|prometheus_tsdb_head_chunks|prometheus_tsdb_head_samples_appended_total|prometheus_tsdb_head_series|prometheus_tsdb_reloads_failures_total|prometheus_tsdb_wal_segment_current)$
+        action: keep
     # - action: keep
     #   regex: 'kube_(daemonset|deployment|pod|namespace|node|statefulset).+'
     #   sourceLabels: [__name__]
@@ -1951,12 +1969,12 @@ prometheus:
     ## ref: https://github.com/prometheus-operator/prometheus-operator/blob/master/Documentation/user-guides/storage.md
     ##
     storageSpec:
-     volumeClaimTemplate:
-       spec:
-         accessModes: ["ReadWriteOnce"]
-         resources:
-           requests:
-             storage: 10Gi
+      volumeClaimTemplate:
+        spec:
+          accessModes: ["ReadWriteOnce"]
+          resources:
+            requests:
+              storage: 10Gi
     #    selector: {}
 
     # Additional volumes on the output StatefulSet definition.
@@ -2007,7 +2025,8 @@ prometheus:
     ## If additional scrape configurations are already deployed in a single secret file you can use this section.
     ## Expected values are the secret name and key
     ## Cannot be used with additionalScrapeConfigs
-    additionalScrapeConfigsSecret: {}
+    additionalScrapeConfigsSecret:
+      {}
       # enabled: false
       # name:
       # key:
@@ -2083,128 +2102,120 @@ prometheus:
   ##
   # - name: ""
 
-    ## Additional labels to set used for the ServiceMonitorSelector. Together with standard labels from
-    ## the chart
-    ##
-    # additionalLabels: {}
+  ## Additional labels to set used for the ServiceMonitorSelector. Together with standard labels from
+  ## the chart
+  ##
+  # additionalLabels: {}
 
-    ## Service label for use in assembling a job name of the form <label value>-<port>
-    ## If no label is specified, the service name is used.
-    ##
-    # jobLabel: ""
+  ## Service label for use in assembling a job name of the form <label value>-<port>
+  ## If no label is specified, the service name is used.
+  ##
+  # jobLabel: ""
 
-    ## labels to transfer from the kubernetes service to the target
-    ##
-    # targetLabels: ""
+  ## labels to transfer from the kubernetes service to the target
+  ##
+  # targetLabels: ""
 
-    ## Label selector for services to which this ServiceMonitor applies
-    ##
-    # selector: {}
+  ## Label selector for services to which this ServiceMonitor applies
+  ##
+  # selector: {}
 
-    ## Namespaces from which services are selected
-    ##
-    # namespaceSelector:
-      ## Match any namespace
-      ##
-      # any: false
+  ## Namespaces from which services are selected
+  ##
+  # namespaceSelector:
+  ## Match any namespace
+  ##
+  # any: false
 
-      ## Explicit list of namespace names to select
-      ##
-      # matchNames: []
+  ## Explicit list of namespace names to select
+  ##
+  # matchNames: []
 
-    ## Endpoints of the selected service to be monitored
-    ##
-    # endpoints: []
-      ## Name of the endpoint's service port
-      ## Mutually exclusive with targetPort
-      # - port: ""
+  ## Endpoints of the selected service to be monitored
+  ##
+  # endpoints: []
+  ## Name of the endpoint's service port
+  ## Mutually exclusive with targetPort
+  # - port: ""
 
-      ## Name or number of the endpoint's target port
-      ## Mutually exclusive with port
-      # - targetPort: ""
+  ## Name or number of the endpoint's target port
+  ## Mutually exclusive with port
+  # - targetPort: ""
 
-      ## File containing bearer token to be used when scraping targets
-      ##
-      #   bearerTokenFile: ""
+  ## File containing bearer token to be used when scraping targets
+  ##
+  #   bearerTokenFile: ""
 
-      ## Interval at which metrics should be scraped
-      ##
-      #   interval: 30s
+  ## Interval at which metrics should be scraped
+  ##
+  #   interval: 30s
 
-      ## HTTP path to scrape for metrics
-      ##
-      #   path: /metrics
+  ## HTTP path to scrape for metrics
+  ##
+  #   path: /metrics
 
-      ## HTTP scheme to use for scraping
-      ##
-      #   scheme: http
+  ## HTTP scheme to use for scraping
+  ##
+  #   scheme: http
 
-      ## TLS configuration to use when scraping the endpoint
-      ##
-      #   tlsConfig:
+  ## TLS configuration to use when scraping the endpoint
+  ##
+  #   tlsConfig:
 
-          ## Path to the CA file
-          ##
-          # caFile: ""
+  ## Path to the CA file
+  ##
+  # caFile: ""
 
-          ## Path to client certificate file
-          ##
-          # certFile: ""
+  ## Path to client certificate file
+  ##
+  # certFile: ""
 
-          ## Skip certificate verification
-          ##
-          # insecureSkipVerify: false
+  ## Skip certificate verification
+  ##
+  # insecureSkipVerify: false
 
-          ## Path to client key file
-          ##
-          # keyFile: ""
+  ## Path to client key file
+  ##
+  # keyFile: ""
 
-          ## Server name used to verify host name
-          ##
-          # serverName: ""
+  ## Server name used to verify host name
+  ##
+  # serverName: ""
 
   additionalPodMonitors: []
   ## Name of the PodMonitor to create
   ##
   # - name: ""
-
-    ## Additional labels to set used for the PodMonitorSelector. Together with standard labels from
-    ## the chart
-    ##
-    # additionalLabels: {}
-
-    ## Pod label for use in assembling a job name of the form <label value>-<port>
-    ## If no label is specified, the pod endpoint name is used.
-    ##
-    # jobLabel: ""
-
-    ## Label selector for pods to which this PodMonitor applies
-    ##
-    # selector: {}
-
-    ## PodTargetLabels transfers labels on the Kubernetes Pod onto the target.
-    ##
-    # podTargetLabels: {}
-
-    ## SampleLimit defines per-scrape limit on number of scraped samples that will be accepted.
-    ##
-    # sampleLimit: 0
-
-    ## Namespaces from which pods are selected
-    ##
-    # namespaceSelector:
-      ## Match any namespace
-      ##
-      # any: false
-
-      ## Explicit list of namespace names to select
-      ##
-      # matchNames: []
-
-    ## Endpoints of the selected pods to be monitored
-    ## https://github.com/prometheus-operator/prometheus-operator/blob/master/Documentation/api.md#podmetricsendpoint
-    ##
-    # podMetricsEndpoints: []
+  ## Additional labels to set used for the PodMonitorSelector. Together with standard labels from
+  ## the chart
+  ##
+  # additionalLabels: {}
+  ## Pod label for use in assembling a job name of the form <label value>-<port>
+  ## If no label is specified, the pod endpoint name is used.
+  ##
+  # jobLabel: ""
+  ## Label selector for pods to which this PodMonitor applies
+  ##
+  # selector: {}
+  ## PodTargetLabels transfers labels on the Kubernetes Pod onto the target.
+  ##
+  # podTargetLabels: {}
+  ## SampleLimit defines per-scrape limit on number of scraped samples that will be accepted.
+  ##
+  # sampleLimit: 0
+  ## Namespaces from which pods are selected
+  ##
+  # namespaceSelector:
+  ## Match any namespace
+  ##
+  # any: false
+  ## Explicit list of namespace names to select
+  ##
+  # matchNames: []
+  ## Endpoints of the selected pods to be monitored
+  ## https://github.com/prometheus-operator/prometheus-operator/blob/master/Documentation/api.md#podmetricsendpoint
+  ##
+  # podMetricsEndpoints: []
 
 pushgateway:
   enabled: false


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

A new way of monitoring Kyma runtime availability requires readiness probes to be configured for all workloads (deployments, stateful sets, daemon sets). Prometheus operator does not expose a health check endpoint, so as a workaround, the metrics endpoint will be used for this purpose. 

The bitnami/IBM fork of the upstream chart is doing the same: https://github.com/bitnami/charts/blame/master/bitnami/kube-prometheus/values.yaml#L225

Changes proposed in this pull request:

- Use existing metrics endpoint as a liveness/readiness probe

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
