### PR TITLE
Add liveness/readiness probes to ory-hydra-maester

### DIFF
--- a/resources/ory/charts/hydra/charts/hydra-maester/templates/deployment.yaml
+++ b/resources/ory/charts/hydra/charts/hydra-maester/templates/deployment.yaml
@@ -59,6 +59,20 @@ spec:
           ports:
             - containerPort: {{ .Values.port.metrics }}
               name: metrics
+          livenessProbe:
+            httpGet:
+              port: {{ .Values.port.metrics }}
+              path: "/metrics"
+            initialDelaySeconds: {{ .Values.deployment.livenessProbe.initialDelaySeconds }}
+            timeoutSeconds: {{ .Values.deployment.livenessProbe.timeoutSeconds }}
+            periodSeconds: {{.Values.deployment.livenessProbe.periodSeconds }}
+          readinessProbe:
+            httpGet:
+              port: {{ .Values.port.metrics }}
+              path: "/metrics"
+            initialDelaySeconds: {{ .Values.deployment.readinessProbe.initialDelaySeconds }}
+            timeoutSeconds: {{ .Values.deployment.readinessProbe.timeoutSeconds }}
+            periodSeconds: {{.Values.deployment.readinessProbe.periodSeconds }}
         - name: watcher
           image: "{{ .Values.jobs.image.repository }}:{{ .Values.jobs.image.tag }}"
           securityContext:

--- a/resources/ory/charts/hydra/charts/hydra-maester/values.yaml
+++ b/resources/ory/charts/hydra/charts/hydra-maester/values.yaml
@@ -36,7 +36,8 @@ port:
 deployment:
   strategy: {} # Read more: https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#strategy
 
-  resources: {}
+  resources:
+    {}
     #  We usually recommend not to specify default resources and to leave this as a conscious
     #  choice for the user. This also increases chances charts run on environments with little
     #  resources, such as Minikube. If you do want to specify resources, uncomment the following
@@ -58,6 +59,16 @@ deployment:
   tolerations: []
   annotations: {}
   podLabels: {}
+
+  livenessProbe:
+    initialDelaySeconds: 50
+    timeoutSeconds: 1
+    periodSeconds: 10
+
+  readinessProbe:
+    initialDelaySeconds: 10
+    timeoutSeconds: 1
+    periodSeconds: 2
 
 # Configure node affinity
 affinity: {}


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

A new way of monitoring Kyma runtime availability requires readiness probes to be configured for all workloads (deployments, stateful sets, daemon sets). ory-hydra-maester does not expose a health check endpoint, so as a workaround, the metrics endpoint will be used for this purpose.

Changes proposed in this pull request:

- Use existing metrics endpoint as a liveness/readiness probe

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
