### PR TITLE
Add missing liveness/readiness probes to serverless pods

### DIFF
--- a/resources/serverless/charts/webhook/templates/deployment.yaml
+++ b/resources/serverless/charts/webhook/templates/deployment.yaml
@@ -37,6 +37,20 @@ spec:
         - name: webhook
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           imagePullPolicy: "{{ .Values.image.pullPolicy }}"
+          livenessProbe:
+            httpGet:
+              port: {{ .Values.service.ports.httpMetrics.targetPort }}
+              path: "/metrics"
+            initialDelaySeconds: {{ .Values.deployment.livenessProbe.initialDelaySeconds }}
+            timeoutSeconds: {{ .Values.deployment.livenessProbe.timeoutSeconds }}
+            periodSeconds: {{.Values.deployment.livenessProbe.periodSeconds }}
+          readinessProbe:
+            httpGet:
+              port: {{ .Values.service.ports.httpMetrics.targetPort }}
+              path: "/metrics"
+            initialDelaySeconds: {{ .Values.deployment.readinessProbe.initialDelaySeconds }}
+            timeoutSeconds: {{ .Values.deployment.readinessProbe.timeoutSeconds }}
+            periodSeconds: {{.Values.deployment.readinessProbe.periodSeconds }}
           resources:
             requests:
               cpu: {{ .Values.deployment.resources.requests.cpu }}

--- a/resources/serverless/charts/webhook/values.yaml
+++ b/resources/serverless/charts/webhook/values.yaml
@@ -28,6 +28,14 @@ deployment:
     limits:
       cpu: 300m
       memory: 300Mi
+  livenessProbe:
+    initialDelaySeconds: 50
+    timeoutSeconds: 1
+    periodSeconds: 10
+  readinessProbe:
+    initialDelaySeconds: 10
+    timeoutSeconds: 1
+    periodSeconds: 2
 
 pod:
   annotations:

--- a/resources/serverless/templates/deployment.yaml
+++ b/resources/serverless/templates/deployment.yaml
@@ -77,6 +77,20 @@ spec:
               name: {{ .Values.metrics.manager.port.name }}
               protocol: {{ .Values.metrics.manager.port.protocol }}
             {{- end }}
+          livenessProbe:
+            httpGet:
+              port: {{ .Values.metrics.manager.port.port }}
+              path: "/metrics"
+            initialDelaySeconds: {{ .Values.deployment.livenessProbe.initialDelaySeconds }}
+            timeoutSeconds: {{ .Values.deployment.livenessProbe.timeoutSeconds }}
+            periodSeconds: {{.Values.deployment.livenessProbe.periodSeconds }}
+          readinessProbe:
+            httpGet:
+              port: {{ .Values.metrics.manager.port.port }}
+              path: "/metrics"
+            initialDelaySeconds: {{ .Values.deployment.readinessProbe.initialDelaySeconds }}
+            timeoutSeconds: {{ .Values.deployment.readinessProbe.timeoutSeconds }}
+            periodSeconds: {{.Values.deployment.readinessProbe.periodSeconds }}
           env:
           {{- if .Values.metrics.enabled }}
             - name: APP_METRICS_ADDRESS

--- a/resources/serverless/values.yaml
+++ b/resources/serverless/values.yaml
@@ -102,6 +102,14 @@ deployment:
   labels: {}
   annotations: {}
   extraProperties: {}
+  livenessProbe:
+    initialDelaySeconds: 50
+    timeoutSeconds: 1
+    periodSeconds: 10
+  readinessProbe:
+    initialDelaySeconds: 10
+    timeoutSeconds: 1
+    periodSeconds: 2
 
 pod:
   labels: {}


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

A new way of monitoring Kyma runtime availability requires readiness probes to be configured for all workloads (deployments, stateful sets, daemon sets). Serverless webhook service and controller manager do not expose health/readiness endpoints, so as a workaround, the metrics endpoint will be used for this purpose.

Changes proposed in this pull request:

- Use existing metrics endpoint as a liveness/readiness probe

**Related issue(s)**
Resolves #11722 
