### PR TITLE
Increase memory limit for eval profile

### DIFF
--- a/resources/eventing/profile-evaluation.yaml
+++ b/resources/eventing/profile-evaluation.yaml
@@ -2,7 +2,7 @@ controller:
   resources:
     limits:
       cpu: 20m
-      memory: 64Mi
+      memory: 128Mi
     requests:
       cpu: 10m
       memory: 32Mi


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- Turns out for evaluation profile, eventing-controller needs more memory limit. Clusters show, `controller` container in eventing-controller pod uses around ~115 Mi
<img width="1705" alt="Screenshot 2021-07-26 at 14 40 05" src="https://user-images.githubusercontent.com/5954057/126990469-36af132e-edd5-4ac8-ab1b-ecc6574ae3a1.png">
<img width="1716" alt="Screenshot 2021-07-26 at 14 41 16" src="https://user-images.githubusercontent.com/5954057/126990471-9262b43f-e219-4cb8-bcf4-0aee20af2787.png">


