### PR TITLE
made kubelet alert rule resilient to muliple kubelet scrapeconfigs

### DIFF
--- a/resources/monitoring/templates/prometheus/rules-1.14/kubernetes-system-kubelet.yaml
+++ b/resources/monitoring/templates/prometheus/rules-1.14/kubernetes-system-kubelet.yaml
@@ -96,7 +96,7 @@ spec:
         description: Kubelet Pod startup 99th percentile latency is {{`{{`}} $value {{`}}`}} seconds on node {{`{{`}} $labels.node {{`}}`}}.
         runbook_url: {{ .Values.defaultRules.runbookUrl }}alert-name-kubeletpodstartuplatencyhigh
         summary: Kubelet Pod startup latency is too high.
-      expr: histogram_quantile(0.99, sum(rate(kubelet_pod_worker_duration_seconds_bucket{job="kubelet", metrics_path="/metrics"}[5m])) by (instance, le)) * on(instance) group_left(node) max by (node,instance) (kubelet_node_name{job="kubelet", metrics_path="/metrics"}) > 60
+      expr: histogram_quantile(0.99, sum(rate(kubelet_pod_worker_duration_seconds_bucket{job="kubelet", metrics_path="/metrics"}[5m])) by (instance, le)) * on(instance) group_left(node) kubelet_node_name{job="kubelet", metrics_path="/metrics", service="{{ template "kube-prometheus-stack.fullname" . }}-kubelet"} > 60
       for: 15m
       labels:
         severity: warning

--- a/resources/monitoring/templates/prometheus/rules-1.14/kubernetes-system-kubelet.yaml
+++ b/resources/monitoring/templates/prometheus/rules-1.14/kubernetes-system-kubelet.yaml
@@ -96,7 +96,7 @@ spec:
         description: Kubelet Pod startup 99th percentile latency is {{`{{`}} $value {{`}}`}} seconds on node {{`{{`}} $labels.node {{`}}`}}.
         runbook_url: {{ .Values.defaultRules.runbookUrl }}alert-name-kubeletpodstartuplatencyhigh
         summary: Kubelet Pod startup latency is too high.
-      expr: histogram_quantile(0.99, sum(rate(kubelet_pod_worker_duration_seconds_bucket{job="kubelet", metrics_path="/metrics"}[5m])) by (instance, le)) * on(instance) group_left(node) kubelet_node_name{job="kubelet", metrics_path="/metrics"} > 60
+      expr: histogram_quantile(0.99, sum(rate(kubelet_pod_worker_duration_seconds_bucket{job="kubelet", metrics_path="/metrics"}[5m])) by (instance, le)) * on(instance) group_left(node) max by (node,instance) (kubelet_node_name{job="kubelet", metrics_path="/metrics"}) > 60
       for: 15m
       labels:
         severity: warning

--- a/resources/monitoring/templates/prometheus/rules-1.14/kubernetes-system-kubelet.yaml
+++ b/resources/monitoring/templates/prometheus/rules-1.14/kubernetes-system-kubelet.yaml
@@ -1,4 +1,7 @@
 {{- /*
+  Customization: KubeletPodStartUpLatencyHigh: group expression uses additional "service" label to avoid failing evaluation if the stack is deployed twice, see also https://github.com/kyma-project/kyma/pull/11771
+*/ -}}
+{{- /*
 Generated from 'kubernetes-system-kubelet' group from https://raw.githubusercontent.com/prometheus-operator/kube-prometheus/master/manifests/prometheus-rules.yaml
 Do not change in-place! In order to change this file first read following link:
 https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-prometheus-stack/hack


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**
If the user installs it's own prometheus-stack it will be default deploy a second kubelet service definition (pointing to the same endpoints). Having such situation, the KubeletPodStartUpLatencyHigh alert rule cannot evaluate with "found duplicate series for the match group"

Changes proposed in this pull request:

- improved the rule to be specific about the actual service to use
- ...
- ...

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
