### PR TITLE
Fix a typo in the central_application_connectivity_validator parameter name

### DIFF
--- a/docs/application-connector/05-00-application-connector.md
+++ b/docs/application-connector/05-00-application-connector.md
@@ -15,7 +15,7 @@ This table lists the configurable parameters, their descriptions, and default va
 
 | Parameter | Description | Default value |
 |-----------|-------------|---------------|
-| **central_connectivity_validator.enabled** | Specifies whether to use Central Connectivity Validator for Application Operator. If enabled, it removes the existing per-Application Gateways and installs the Central Connectivity Validator chart. | `false` |
+| **central_application_connectivity_validator.enabled** | Specifies whether to use Central Connectivity Validator for Application Operator. If enabled, it removes the existing per-Application Gateways and installs the Central Connectivity Validator chart. | `false` |
 | **global.disableLegacyConnectivity** | Disables the default standalone (legacy) connectivity components and enables the Compass mode. | `false` |
 | **global.isLocalEnv** | Specifies whether the component is run locally or on a cluster. Used in Connector Service and Application Registry. | `false` |
 | **global.log.format** | Specifies the logging format. Used in Application Operator. | `json` |


### PR DESCRIPTION
**Description**

Cherry-picks #11778 
