### PR TITLE
Parse smctl response for fast-integration tests

### DIFF
--- a/tests/fast-integration/skr-svcat-migration-test/test-helpers.js
+++ b/tests/fast-integration/skr-svcat-migration-test/test-helpers.js
@@ -79,22 +79,31 @@ async function cleanupInstanceBinding(creds, svcatPlatform, btpOperatorInstance,
   }
 
   try {
-    args = [`unbind`, btpOperatorInstance, btpOperatorBinding, `-f`];
-    await execa(`smctl`, args);
+    args = [`unbind`, btpOperatorInstance, btpOperatorBinding, `-f`, `--mode=sync`];
+    let {stdout} = await execa(`smctl`, args);
+    if(stdout !== "Service Binding successfully deleted.") {
+      errors = errors.concat([`failed "smctl ${args.join(' ')}": ${stdout}`])
+    }
   } catch(error) {
     errors = errors.concat([`failed "smctl ${args.join(' ')}": ${error.stderr}\n${error}`]);
   }
 
   try {
     args = [`delete-platform`, svcatPlatform, `-f`];
-    await execa(`smctl`, args);
+    let {stdout} = await execa(`smctl`, args);
+    if(stdout !== "Platform(s) successfully deleted.") {
+      errors = errors.concat([`failed "smctl ${args.join(' ')}": ${stdout}`])
+    }
   } catch(error) {
     errors = errors.concat([`failed "smctl ${args.join(' ')}": ${error.stderr}\n${error}`]);
   }
 
   try {
-    args = [`deprovision`, btpOperatorInstance, `-f`];
-    await execa(`smctl`, args);
+    args = [`deprovision`, btpOperatorInstance, `-f`, `--mode=sync`];
+    let {stdout} = await execa(`smctl`, args);
+    if(stdout !== "Service Instance successfully deleted.") {
+      errors = errors.concat([`failed "smctl ${args.join(' ')}": ${stdout}`])
+    }
   } catch(error) {
     errors = errors.concat([`failed "smctl ${args.join(' ')}": ${error.stderr}\n${error}`]);
   }


### PR DESCRIPTION
smctl returns 0 on failures so we need to check stdout too

<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- smctl returns 0 even on failures, we need to parse the stdout to make sure it succeeded

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
