### PR TITLE
Add README files for the Application Connectivity area

### DIFF
--- a/docs/01-overview/02-main-areas/application-connectivity/README.md
+++ b/docs/01-overview/02-main-areas/application-connectivity/README.md
@@ -1,0 +1,5 @@
+---
+title: Application Connectivity - overview
+---
+
+Browse the Overview files for Application Connectivity to learn about the main idea behind it.

--- a/docs/03-tutorials/application-connectivity/README.md
+++ b/docs/03-tutorials/application-connectivity/README.md
@@ -1,0 +1,5 @@
+---
+title: Application Connectivity - tutorials
+---
+
+Browse the tutorials for Application Connectivity to learn how to use it step-by-step in different scenarios.


### PR DESCRIPTION
**Description**

The new Website for Kyma 2.0 needs a README for an area (directory) for this area to be clickable also on its name (like **Main areas** in the screenshot), and not just the arrow (like **Application Connectivity** in the [preview](https://deploy-preview-11747--kyma-project-docs-preview.netlify.app/docs/kyma/preview/01-overview/02-main-areas/)). 

![image](https://user-images.githubusercontent.com/53601578/127861933-140984ca-2d3b-47c9-ae82-a62f573df257.png)


Changes proposed in this pull request:

- Add README files for the Application Connectivity area

**Related issue(s)**
#11047 
