### PR TITLE
Fix: '[spec.preserveUnknownFields: Invalid value: true: must be false

### DIFF
--- a/installation/resources/crds/application-connector/applications.applicationconnector.crd.yaml
+++ b/installation/resources/crds/application-connector/applications.applicationconnector.crd.yaml
@@ -6,6 +6,7 @@ metadata:
   name: applications.applicationconnector.kyma-project.io
 spec:
   group: applicationconnector.kyma-project.io
+  preserveUnknownFields: false
   versions:
     - name: v1alpha1
       served: true

--- a/resources/cluster-essentials/files/applications.applicationconnector.crd.yaml
+++ b/resources/cluster-essentials/files/applications.applicationconnector.crd.yaml
@@ -6,6 +6,7 @@ metadata:
   name: applications.applicationconnector.kyma-project.io
 spec:
   group: applicationconnector.kyma-project.io
+  preserveUnknownFields: false
   versions:
     - name: v1alpha1
       served: true


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

Fix:

message: '[spec.preserveUnknownFields: Invalid value: true: must be false, spec.versions[0].schema.openAPIV3Schema.properties[spec].type:
      Required value: must not be empty for specified object fields, spec.versions[0].schema.openAPIV3Schema.type:
      Required value: must not be empty at the root]'

See also https://kubernetes.io/docs/tasks/extend-kubernetes/custom-resources/custom-resource-definitions
