### PR TITLE
Enable alertmanager on kyma2

### DIFF
--- a/installation/resources/values.yaml
+++ b/installation/resources/values.yaml
@@ -19,8 +19,6 @@ logging:
     virtualservice:
       enabled: false
 monitoring:
-  alertmanager:
-    enabled: false
   grafana:
     kyma:
       console:


### PR DESCRIPTION
The alertmanager should be enabled in OSS Kyma2.

**Related issue**
https://github.com/orgs/kyma-project/projects/7#card-65407137