### PR TITLE
Replacing Dex with Ory Hydra login and consent app in api-gateway tests

### DIFF
--- a/resources/ory/values.yaml
+++ b/resources/ory/values.yaml
@@ -151,7 +151,7 @@ oathkeeper:
           enabled: true
           config:
             jwks_urls:
-            - http://dex-service.kyma-system.svc.cluster.local:5556/keys
+            - http://ory-hydra-public.kyma-system.svc.cluster.local:4444/.well-known/jwks.json
             scope_strategy: wildcard
       authorizers:
         allow:

--- a/resources/ory/values.yaml
+++ b/resources/ory/values.yaml
@@ -151,6 +151,7 @@ oathkeeper:
           enabled: true
           config:
             jwks_urls:
+            - http://dex-service.kyma-system.svc.cluster.local:5556/keys
             - http://ory-hydra-public.kyma-system.svc.cluster.local:4444/.well-known/jwks.json
             scope_strategy: wildcard
       authorizers:

--- a/tests/integration/api-gateway/gateway-tests/main_test.go
+++ b/tests/integration/api-gateway/gateway-tests/main_test.go
@@ -55,8 +55,8 @@ var (
 
 type Config struct {
 	HydraAddr        string        `envconfig:"TEST_HYDRA_ADDRESS"`
-	User             string        `envconfig:"TEST_USER_EMAIL"`
-	Pwd              string        `envconfig:"TEST_USER_PASSWORD"`
+	User             string        `envconfig:"TEST_USER_EMAIL,default=admin@kyma.cx"`
+	Pwd              string        `envconfig:"TEST_USER_PASSWORD,default=1234"`
 	ReqTimeout       uint          `envconfig:"TEST_REQUEST_TIMEOUT,default=180"`
 	ReqDelay         uint          `envconfig:"TEST_REQUEST_DELAY,default=5"`
 	Domain           string        `envconfig:"TEST_DOMAIN"`
@@ -108,7 +108,7 @@ func TestApiGatewayIntegration(t *testing.T) {
 		AuthStyle:    oauth2.AuthStyleInHeader,
 	}
 
-	jwtConfig, err := jwt.LoadConfig()
+	jwtConfig, err := jwt.LoadConfig(oauthClientID)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -304,7 +304,7 @@ func TestApiGatewayIntegration(t *testing.T) {
 			require.NoError(err)
 			require.NotNil(tokenOAUTH)
 
-			tokenJWT, err := jwt.Authenticate(jwtConfig.IdProviderConfig)
+			tokenJWT, err := jwt.Authenticate(oauthClientID, jwtConfig.OidcHydraConfig)
 			if err != nil {
 				t.Fatalf("failed to fetch and id_token. %s", err.Error())
 			}
@@ -354,7 +354,7 @@ func TestApiGatewayIntegration(t *testing.T) {
 			require.NoError(err)
 			require.NotNil(tokenOAUTH)
 
-			tokenJWT, err := jwt.Authenticate(jwtConfig.IdProviderConfig)
+			tokenJWT, err := jwt.Authenticate(oauthClientID, jwtConfig.OidcHydraConfig)
 			if err != nil {
 				t.Fatalf("failed to fetch and id_token. %s", err.Error())
 			}
@@ -547,7 +547,7 @@ func TestApiGatewayIntegration(t *testing.T) {
 			require.NoError(err)
 			require.NotNil(oauth)
 
-			tokenJWT, err := jwt.Authenticate(jwtConfig.IdProviderConfig)
+			tokenJWT, err := jwt.Authenticate(oauthClientID, jwtConfig.OidcHydraConfig)
 			if err != nil {
 				t.Fatalf("failed to fetch and id_token. %s", err.Error())
 			}

--- a/tests/integration/api-gateway/gateway-tests/manifests/hydra-client.yaml
+++ b/tests/integration/api-gateway/gateway-tests/manifests/hydra-client.yaml
@@ -7,6 +7,13 @@ metadata:
 spec:
   grantTypes:
   - "client_credentials"
-  scope: "read write"
+  - "implicit"
+  scope: "openid read write"
+  responseTypes:
+    - "id_token"
+    - "code"
+    - "token"  
   secretName: "{{.OauthSecretName}}"
+  redirectUris:
+    - "http://testclient3.example.com"  
 status: {}

--- a/tests/integration/api-gateway/gateway-tests/manifests/jwt-oauth-one-path-strategy.yaml
+++ b/tests/integration/api-gateway/gateway-tests/manifests/jwt-oauth-one-path-strategy.yaml
@@ -16,7 +16,7 @@ spec:
       accessStrategies:
         - handler: jwt
           config:
-            trusted_issuers: ["https://dex.{{ .Domain }}"]
+            trusted_issuers: ["https://oauth2.{{ .Domain }}/"]
         - handler: oauth2_introspection
           config:
             required_scope: ["read"]

--- a/tests/integration/api-gateway/gateway-tests/manifests/jwt-oauth-strategy.yaml
+++ b/tests/integration/api-gateway/gateway-tests/manifests/jwt-oauth-strategy.yaml
@@ -16,7 +16,7 @@ spec:
       accessStrategies:
         - handler: jwt
           config:
-            trusted_issuers: ["https://dex.{{ .Domain }}"]
+            trusted_issuers: ["https://oauth2.{{ .Domain }}/"]
     - path: /headers
       methods: ["GET"]
       accessStrategies:

--- a/tests/integration/api-gateway/gateway-tests/manifests/k8s/deployment.yaml
+++ b/tests/integration/api-gateway/gateway-tests/manifests/k8s/deployment.yaml
@@ -1,0 +1,28 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ory-hydra-login-consent
+  namespace: kyma-system
+spec:
+  selector:
+    matchLabels:
+      app: ory-hydra-login-consent
+      version: v1
+  template:
+    metadata:
+      labels:
+        app: ory-hydra-login-consent
+        version: v1
+    spec:
+      containers:
+        - name: login-consent
+          image: eu.gcr.io/kyma-project/incubator/test-hydra-login-consent
+          env:
+            - name: HYDRA_ADMIN_URL
+              value: http://ory-hydra-admin.kyma-system.svc.cluster.local:4445
+            - name: BASE_URL
+              value: ""
+            - name: PORT
+              value: "3000"
+          ports:
+          - containerPort: 3000

--- a/tests/integration/api-gateway/gateway-tests/manifests/k8s/service.yaml
+++ b/tests/integration/api-gateway/gateway-tests/manifests/k8s/service.yaml
@@ -1,0 +1,14 @@
+kind: Service
+apiVersion: v1
+metadata:
+  name: ory-hydra-login-consent
+  namespace: kyma-system
+spec:
+  selector:
+    app: ory-hydra-login-consent
+    version: v1
+  ports:
+    - name: http-login-consent
+      protocol: TCP
+      port: 80
+      targetPort: 3000

--- a/tests/integration/api-gateway/gateway-tests/manifests/k8s/virtualservice.yaml
+++ b/tests/integration/api-gateway/gateway-tests/manifests/k8s/virtualservice.yaml
@@ -1,0 +1,24 @@
+
+apiVersion: networking.istio.io/v1beta1
+kind: VirtualService
+metadata:
+  name: ory-hydra-login-consent
+  namespace: kyma-system
+  labels:
+    app: ory-hydra-login-consent
+spec:
+  gateways:
+  - kyma-system/kyma-gateway
+  hosts:
+  - ory-hydra-login-consent.kyma.example.com
+  http:
+  - match:
+    - uri:
+        exact: /login
+    - uri:
+        exact: /consent
+    route:
+    - destination:
+        host: ory-hydra-login-consent
+        port:
+          number: 80

--- a/tests/integration/api-gateway/gateway-tests/pkg/jwt/auth.go
+++ b/tests/integration/api-gateway/gateway-tests/pkg/jwt/auth.go
@@ -2,18 +2,29 @@ package jwt
 
 import (
 	"crypto/tls"
+	"log"
 	"net/http"
+	"net/http/cookiejar"
+
+	"golang.org/x/net/publicsuffix"
 )
 
-func Authenticate(config idProviderConfig) (string, error) {
+func Authenticate(oauthClientID string, config oidcHydraConfig) (string, error) {
+	jar, err := cookiejar.New(&cookiejar.Options{PublicSuffixList: publicsuffix.List})
+	if err != nil {
+		log.Fatal(err)
+	}
+
 	httpClient := &http.Client{
 		Transport: &http.Transport{
 			TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
 		},
 		Timeout: config.ClientConfig.TimeoutSeconds,
+		Jar:     jar,
 	}
 
-	idTokenProvider := newDexIdTokenProvider(httpClient, config)
+	idTokenProvider := newOidcHydraTestFlow(httpClient, config)
 	token, err := idTokenProvider.fetchIdToken()
+
 	return token, err
 }

--- a/tests/integration/api-gateway/gateway-tests/pkg/jwt/config.go
+++ b/tests/integration/api-gateway/gateway-tests/pkg/jwt/config.go
@@ -9,31 +9,22 @@ import (
 )
 
 type envConfig struct {
-	Domain           string        `envconfig:"TEST_DOMAIN,default=kyma.local"`
-	UserEmail        string        `envconfig:"TEST_USER_EMAIL"`
-	UserPassword     string        `envconfig:"TEST_USER_PASSWORD"`
-	ClientTimeout    time.Duration `envconfig:"TEST_CLIENT_TIMEOUT,default=10s"` //Don't forget the unit!
-	RetryMaxAttempts uint          `envconfig:"TEST_RETRY_MAX_ATTEMPTS,default=5"`
-	RetryDelay       uint          `envconfig:"TEST_RETRY_DELAY,default=5"`
+	Domain        string        `envconfig:"TEST_DOMAIN,default=kyma.local"`
+	UserEmail     string        `envconfig:"TEST_USER_EMAIL,default=admin@kyma.cx"`
+	UserPassword  string        `envconfig:"TEST_USER_PASSWORD,default=1234"`
+	ClientTimeout time.Duration `envconfig:"TEST_CLIENT_TIMEOUT,default=10s"` //Don't forget the unit!
 }
 
 //Config JWT configuration structure
 type Config struct {
-	IdProviderConfig idProviderConfig
-	EnvConfig        envConfig
+	OidcHydraConfig oidcHydraConfig
+	EnvConfig       envConfig
 }
 
-type idProviderConfig struct {
-	DexConfig       dexConfig
+type oidcHydraConfig struct {
+	HydraFqdn       string
 	ClientConfig    clientConfig
 	UserCredentials userCredentials
-	RetryConfig     retryConfig
-}
-
-type dexConfig struct {
-	BaseUrl           string
-	AuthorizeEndpoint string
-	TokenEndpoint     string
 }
 
 type clientConfig struct {
@@ -42,18 +33,13 @@ type clientConfig struct {
 	TimeoutSeconds time.Duration
 }
 
-type retryConfig struct {
-	MaxAttempts uint
-	Delay       time.Duration
-}
-
 type userCredentials struct {
 	Username string
 	Password string
 }
 
 //LoadConfig Generate test config from envs
-func LoadConfig() (Config, error) {
+func LoadConfig(oauthClientID string) (Config, error) {
 	env := envConfig{}
 	err := envconfig.Init(&env)
 	if err != nil {
@@ -61,27 +47,17 @@ func LoadConfig() (Config, error) {
 	}
 
 	config := Config{EnvConfig: env}
-
-	config.IdProviderConfig = idProviderConfig{
-		DexConfig: dexConfig{
-			BaseUrl:           fmt.Sprintf("https://dex.%s", env.Domain),
-			AuthorizeEndpoint: fmt.Sprintf("https://dex.%s/auth", env.Domain),
-			TokenEndpoint:     fmt.Sprintf("https://dex.%s/token", env.Domain),
-		},
+	config.OidcHydraConfig = oidcHydraConfig{
+		HydraFqdn: fmt.Sprintf("oauth2.%s", env.Domain),
 		ClientConfig: clientConfig{
-			ID:             "kyma-client",
-			RedirectUri:    "http://127.0.0.1:5555/callback",
+			ID:             oauthClientID,
+			RedirectUri:    "http://testclient3.example.com",
 			TimeoutSeconds: env.ClientTimeout,
 		},
-		RetryConfig: retryConfig{
-			MaxAttempts: env.RetryMaxAttempts,
-			Delay:       time.Duration(env.RetryDelay) * time.Second,
+		UserCredentials: userCredentials{
+			Username: env.UserEmail,
+			Password: env.UserPassword,
 		},
-	}
-
-	config.IdProviderConfig.UserCredentials = userCredentials{
-		Username: env.UserEmail,
-		Password: env.UserPassword,
 	}
 
 	return config, nil

--- a/tests/integration/api-gateway/gateway-tests/pkg/jwt/idtokenprovider.go
+++ b/tests/integration/api-gateway/gateway-tests/pkg/jwt/idtokenprovider.go
@@ -1,243 +1,95 @@
 package jwt
 
 import (
-	"bytes"
 	"fmt"
-	"io"
-	"io/ioutil"
 	"net/http"
 	"net/url"
-	"regexp"
 	"strings"
 
-	"log"
-
-	retry "github.com/avast/retry-go"
 	"github.com/pkg/errors"
-	"golang.org/x/net/html"
+)
+
+const (
+	state           = "dd3557bfb07ee1858f0ac8abc4a46aef"
+	nonce           = "dd3557bfb07ee1858f0ac8abc4a46aef"
+	authUrlTemplate = "https://%s/oauth2/auth?client_id=%s&response_type=id_token&scope=openid&redirect_uri=%s&state=%s&nonce=%s"
 )
 
 type idTokenProvider interface {
 	fetchIdToken() (string, error)
 }
 
-type dexIdTokenProvider struct {
+// OidcHydraTestFlow implements OIDC flows for deployed OryHydra with test login consent endpoints.
+type OidcHydraTestFlow struct {
 	httpClient *http.Client
-	config     idProviderConfig
+	config     oidcHydraConfig
 }
 
-func newDexIdTokenProvider(httpClient *http.Client, config idProviderConfig) idTokenProvider {
-	// turn off follow-redirects
-	httpClient.CheckRedirect = func(req *http.Request, via []*http.Request) error {
-		return http.ErrUseLastResponse
-	}
-	return &dexIdTokenProvider{httpClient, config}
+func newOidcHydraTestFlow(httpClient *http.Client, config oidcHydraConfig) idTokenProvider {
+	return &OidcHydraTestFlow{httpClient, config}
 }
 
-func (p *dexIdTokenProvider) fetchIdToken() (string, error) {
+func getToken(req *http.Request) string {
+	tokenWithTrailingState := strings.Split(req.URL.Fragment, "=")[1]
+	t := strings.Split(tokenWithTrailingState, "&")[0]
+	return t
+}
 
-	flowResult, err := p.implicitFlow()
+func (f *OidcHydraTestFlow) fetchIdToken() (string, error) {
+	return f.GetToken()
+}
+
+func (f *OidcHydraTestFlow) GetToken() (string, error) {
+	loginResp, err := f.doLogin()
 	if err != nil {
 		return "", err
 	}
-	return flowResult["id_token"], nil
+	consent := f.prepareConsent(loginResp)
+
+	return f.sentConsentToGetToken(loginResp, consent)
 }
 
-func (p *dexIdTokenProvider) implicitFlow() (map[string]string, error) {
-
-	var result map[string]string = nil
-
-	happyRun := true
-	err := retry.Do(
-		func() error {
-
-			loginEndpoint, err := p.initializeImplicitFlow()
-			if err != nil {
-				return err
-			}
-
-			approvalEndpoint, err := p.login(loginEndpoint)
-			if err != nil {
-				return err
-			}
-
-			finalRedirectURL, err := p.receiveToken(approvalEndpoint)
-			if err != nil {
-				return err
-			}
-
-			result = p.parseTokenResponse(finalRedirectURL)
-			return nil
-		},
-		retry.Attempts(p.config.RetryConfig.MaxAttempts),
-		retry.Delay(p.config.RetryConfig.Delay),
-		retry.DelayType(retry.FixedDelay),
-		retry.OnRetry(func(retryNo uint, err error) {
-			happyRun = false
-			log.Printf("Retry: [%d / %d], error: %s", retryNo, p.config.RetryConfig.MaxAttempts, err)
-		}),
-	)
-
-	if err != nil {
-		return nil, err
-	}
-
-	if happyRun {
-		log.Println("Flow finished flawlessly")
-	}
-
-	return result, nil
-}
-
-//Performs call to the <authorize> endpoint.
-func (p *dexIdTokenProvider) initializeImplicitFlow() (string, error) {
-
-	authorizeResp, err := p.httpClient.PostForm(p.config.DexConfig.AuthorizeEndpoint, url.Values{
-		"response_type": {"id_token token"},
-		"client_id":     {p.config.ClientConfig.ID},
-		"redirect_uri":  {p.config.ClientConfig.RedirectUri},
-		"scope":         {"openid profile email groups"},
-		"nonce":         {"vF7FAQlqq41CObeUFYY0ggv1qEELvfHaXQ0ER4XM"},
-	})
+func (f *OidcHydraTestFlow) sentConsentToGetToken(response *http.Response, consentForm url.Values) (string, error) {
+	redirectUrl, err := url.Parse(f.config.ClientConfig.RedirectUri)
 	if err != nil {
 		return "", err
 	}
-	defer closeRespBody(authorizeResp)
-	authorizeRespBody := readRespBody(authorizeResp)
-
-	switch authorizeResp.StatusCode {
-	case http.StatusFound:
-	case http.StatusOK:
-	default:
-		return "", fmt.Errorf("got unexpected response on authorize: %d - %s", authorizeResp.StatusCode, authorizeRespBody)
-	}
-
-	var loginEndpoint string
-	if authorizeResp.StatusCode == http.StatusOK {
-		b := bytes.NewBufferString(authorizeRespBody)
-		loginEndpoint, err = getLocalAuthEndpoint(b)
-		if err != nil {
-			return "", errors.Wrapf(err, "while fetching link to static authentication")
+	var token string
+	f.httpClient.CheckRedirect = func(req *http.Request, via []*http.Request) error {
+		if req.URL.Host == redirectUrl.Host {
+			token = getToken(req)
+			return http.ErrUseLastResponse
 		}
-	} else {
-		loginEndpoint = authorizeResp.Header.Get("location")
-		if strings.Contains(loginEndpoint, "#.*error") {
-			return "", fmt.Errorf("login - Redirected with error: '%s'", loginEndpoint)
-		}
+		return nil
 	}
-
-	return loginEndpoint, nil
+	_, _ = f.httpClient.PostForm(response.Request.URL.String(), consentForm)
+	return token, nil
 }
 
-//Handles redirect to login endpoint
-func (p *dexIdTokenProvider) login(loginEndpoint string) (string, error) {
-
-	if _, err := p.httpClient.Get(p.config.DexConfig.BaseUrl + loginEndpoint); err != nil {
-		return "", errors.Wrap(err, "while performing HTTP GET on login endpoint")
-	}
-
-	loginResp, err := p.httpClient.PostForm(p.config.DexConfig.BaseUrl+loginEndpoint, url.Values{
-		"login":    {p.config.UserCredentials.Username},
-		"password": {p.config.UserCredentials.Password},
-	})
-	if err != nil {
-		return "", errors.Wrap(err, "while performing HTTP POST on login endpoint")
-	}
-	defer closeRespBody(loginResp)
-	loginRespBody := readRespBody(loginResp)
-
-	if loginResp.StatusCode < 300 || loginResp.StatusCode > 399 {
-		return "", fmt.Errorf("login - response error: '%s' - %s", loginResp.Status, loginRespBody)
-	}
-
-	approvalEndpoint := loginResp.Header.Get("location")
-	if strings.Contains(approvalEndpoint, "#.*error") {
-		return "", fmt.Errorf("approval - Redirected with error: '%s'", approvalEndpoint)
-	}
-
-	return approvalEndpoint, nil
-}
-
-//Handles redirect to approval endpoint to get the token (end of flow)
-func (p *dexIdTokenProvider) receiveToken(approvalEndpoint string) (*url.URL, error) {
-
-	approvalResp, err := p.httpClient.Get(p.config.DexConfig.BaseUrl + approvalEndpoint)
+func (f *OidcHydraTestFlow) doLogin() (*http.Response, error) {
+	u, err := url.Parse(fmt.Sprintf(authUrlTemplate, f.config.HydraFqdn, f.config.ClientConfig.ID, f.config.ClientConfig.RedirectUri, state, nonce))
 	if err != nil {
 		return nil, err
 	}
-	defer closeRespBody(approvalResp)
-	approvalRespBody := readRespBody(approvalResp)
-
-	if approvalResp.StatusCode < 300 || approvalResp.StatusCode > 399 {
-		return nil, errors.New(fmt.Sprintf("Approval - response error: '%s' - %s", approvalResp.Status, approvalRespBody))
-	}
-
-	clientEndpoint := approvalResp.Header.Get("location")
-	if strings.Contains(clientEndpoint, "#.*error") {
-		return nil, fmt.Errorf("client - Redirected with error: '%s'", clientEndpoint)
-	}
-
-	parsedUrl, parseErr := url.Parse(clientEndpoint)
-	if parseErr != nil {
-		return nil, parseErr
-	}
-
-	return parsedUrl, nil
-}
-
-func (p *dexIdTokenProvider) parseTokenResponse(parsedUrl *url.URL) map[string]string {
-
-	result := make(map[string]string)
-	fragmentParams := strings.Split(parsedUrl.Fragment, "&")
-	for _, param := range fragmentParams {
-		keyAndValue := strings.Split(param, "=")
-		result[keyAndValue[0]] = keyAndValue[1]
-	}
-
-	return result
-}
-
-func readRespBody(resp *http.Response) string {
-
-	b, err := ioutil.ReadAll(resp.Body)
+	resp, err := f.httpClient.Get(u.String())
 	if err != nil {
-		log.Printf("WARNING: Unable to read response body (status: '%s'). Root cause: %v", resp.Status, err)
-		return "<<Error reading response body>>"
+		return nil, errors.Wrap(err, "while performing HTTP GET on auth endpoint")
 	}
-	return string(b)
-}
-
-func closeRespBody(resp *http.Response) {
-	err := resp.Body.Close()
+	loginForm := url.Values{}
+	loginForm.Set("email", f.config.UserCredentials.Username)
+	loginForm.Set("password", f.config.UserCredentials.Password)
+	loginForm.Set("challenge", resp.Request.URL.Query().Get("login_challenge"))
+	resp, err = f.httpClient.PostForm(resp.Request.URL.String(), loginForm)
 	if err != nil {
-		log.Printf("WARNING: Unable to close response body. Cause: %v", err)
+		return nil, errors.Wrap(err, "while performing HTTP POST on login endpoint")
 	}
+	return resp, nil
 }
 
-func getLocalAuthEndpoint(body io.Reader) (string, error) {
-	z := html.NewTokenizer(body)
-	for {
-		nt := z.Next()
-		if nt == html.ErrorToken {
-			return "", errors.New("got HTML error token")
-		}
-
-		token := z.Token()
-		if "a" != token.Data {
-			continue
-		}
-		for _, attr := range token.Attr {
-			if attr.Key != "href" {
-				continue
-			}
-			match, err := regexp.MatchString("/auth/local.*", attr.Val)
-			if err != nil {
-				log.Printf("WARNING: Unable to match string. Cause: %v", err)
-				return "", err
-			}
-			if match {
-				return attr.Val, nil
-			}
-		}
-	}
+func (f *OidcHydraTestFlow) prepareConsent(response *http.Response) url.Values {
+	consentForm := url.Values{}
+	consentForm.Set("challenge", response.Request.URL.Query().Get("consent_challenge"))
+	consentForm.Set("grant_scope", "openid")
+	consentForm.Set("submit", "Allow+access")
+	return consentForm
 }


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- Since Kyma 2.0 won't include Dex, we need to change our JWT tests in api-gateway.



**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
See also #11493 