### PR TITLE
Add the custom domain tutorial

### DIFF
--- a/docs/03-tutorials/00-api-exposure/apix-01-expose-service-apigateway.md
+++ b/docs/03-tutorials/00-api-exposure/apix-01-expose-service-apigateway.md
@@ -22,6 +22,11 @@ Follow the instruction to deploy an unsecured instance of the HttpBin service an
   kubectl apply -f https://raw.githubusercontent.com/istio/istio/master/samples/httpbin/httpbin.yaml
   ```
 
+  > **TIP:** To deploy the service in a user Namespace, run:
+  > ``` 
+  > kubectl -n {NAMESPACE_NAME} create -f https://raw.githubusercontent.com/istio/istio/master/samples/httpbin/httpbin.yaml
+  > ```
+
 3. Expose the service by creating an APIRule CR:
 
   ```bash
@@ -54,7 +59,9 @@ Follow the instruction to deploy an unsecured instance of the HttpBin service an
 
   >**NOTE:** If you are running Kyma on Minikube, add `httpbin.kyma.local` to the entry with Minikube IP in your system's `/etc/hosts` file.
 
-  >**NOTE:** If you use a custom domain, modify the value of the **spec.gateway** parameter. Use the value of the **metadata.name** parameter from your Gateway CR. See the following example: `gateway: httpbin-gateway.default.svc.cluster.local`.
+  >**NOTE:** If you use a custom domain, modify values of the following parameters:
+  > - **spec.gateway** - use the value of the **metadata.name** parameter from your Gateway CR. See the following example: `gateway: httpbin-gateway.default.svc.cluster.local`.
+  > - **spec.service.host** - as the $DOMAIN value use the subdomain you used following the [**Use a custom domain to expose a service**](./apix-04-own-domain.md) tutorial, for example `api.mydomain.com`.
 
 ## Access the exposed resources
 

--- a/docs/03-tutorials/00-api-exposure/apix-01-expose-service-apigateway.md
+++ b/docs/03-tutorials/00-api-exposure/apix-01-expose-service-apigateway.md
@@ -59,9 +59,10 @@ Follow the instruction to deploy an unsecured instance of the HttpBin service an
 
   >**NOTE:** If you are running Kyma on Minikube, add `httpbin.kyma.local` to the entry with Minikube IP in your system's `/etc/hosts` file.
 
-  >**NOTE:** If you use a custom domain, modify values of the following parameters:
-  > - **spec.gateway** - use the value of the **metadata.name** parameter from your Gateway CR. See the following example: `gateway: httpbin-gateway.default.svc.cluster.local`.
-  > - **spec.service.host** - as the $DOMAIN value, export the subdomain you used in the [**Use a custom domain to expose a service**](./apix-04-own-domain.md) tutorial, for example `api.mydomain.com`.
+  >**NOTE:** If you use a custom domain, modify the following parameters:
+  > - **spec.gateway** - use the value of the **metadata.name** parameter from your Gateway CR. See the following example: `gateway: httpbin-gateway.namespace-name.svc.cluster.local`.
+  > - **spec.service.host** - as the ${DOMAIN} value, export the subdomain you used in the [Use a custom domain to expose a service](./apix-04-own-domain.md) tutorial, for example `api.mydomain.com`.
+  > - add the **metadata.namespace** parameter with your ${NAMESPACE}.
 
 ## Access the exposed resources
 

--- a/docs/03-tutorials/00-api-exposure/apix-01-expose-service-apigateway.md
+++ b/docs/03-tutorials/00-api-exposure/apix-01-expose-service-apigateway.md
@@ -22,7 +22,7 @@ Follow the instruction to deploy an unsecured instance of the HttpBin service an
   kubectl apply -f https://raw.githubusercontent.com/istio/istio/master/samples/httpbin/httpbin.yaml
   ```
 
-  > **TIP:** To deploy the service in a user Namespace, run:
+  > **TIP:** If you use a custom domain, deploy the service in your Namespace, run:
   > ``` 
   > kubectl -n ${NAMESPACE_NAME} create -f https://raw.githubusercontent.com/istio/istio/master/samples/httpbin/httpbin.yaml
   > ```

--- a/docs/03-tutorials/00-api-exposure/apix-01-expose-service-apigateway.md
+++ b/docs/03-tutorials/00-api-exposure/apix-01-expose-service-apigateway.md
@@ -61,7 +61,7 @@ Follow the instruction to deploy an unsecured instance of the HttpBin service an
 
   >**NOTE:** If you use a custom domain, modify values of the following parameters:
   > - **spec.gateway** - use the value of the **metadata.name** parameter from your Gateway CR. See the following example: `gateway: httpbin-gateway.default.svc.cluster.local`.
-  > - **spec.service.host** - as the $DOMAIN value use the subdomain you used following the [**Use a custom domain to expose a service**](./apix-04-own-domain.md) tutorial, for example `api.mydomain.com`.
+  > - **spec.service.host** - as the $DOMAIN value, export the subdomain you used in the [**Use a custom domain to expose a service**](./apix-04-own-domain.md) tutorial, for example `api.mydomain.com`.
 
 ## Access the exposed resources
 

--- a/docs/03-tutorials/00-api-exposure/apix-01-expose-service-apigateway.md
+++ b/docs/03-tutorials/00-api-exposure/apix-01-expose-service-apigateway.md
@@ -24,7 +24,7 @@ Follow the instruction to deploy an unsecured instance of the HttpBin service an
 
   > **TIP:** To deploy the service in a user Namespace, run:
   > ``` 
-  > kubectl -n {NAMESPACE_NAME} create -f https://raw.githubusercontent.com/istio/istio/master/samples/httpbin/httpbin.yaml
+  > kubectl -n ${NAMESPACE_NAME} create -f https://raw.githubusercontent.com/istio/istio/master/samples/httpbin/httpbin.yaml
   > ```
 
 3. Expose the service by creating an APIRule CR:

--- a/docs/03-tutorials/00-api-exposure/apix-01-expose-service-apigateway.md
+++ b/docs/03-tutorials/00-api-exposure/apix-01-expose-service-apigateway.md
@@ -54,6 +54,8 @@ Follow the instruction to deploy an unsecured instance of the HttpBin service an
 
   >**NOTE:** If you are running Kyma on Minikube, add `httpbin.kyma.local` to the entry with Minikube IP in your system's `/etc/hosts` file.
 
+  >**NOTE:** If you use a custom domain, modify the value of the **spec.gateway** parameter. Use the value of the **metadata.name** parameter from your Gateway CR. See the following example: `gateway: httpbin-gateway.default.svc.cluster.local`.
+
 ## Access the exposed resources
 
 1. Call the endpoint by sending a `GET` request to the HttpBin service:

--- a/docs/03-tutorials/00-api-exposure/apix-04-own-domain.md
+++ b/docs/03-tutorials/00-api-exposure/apix-04-own-domain.md
@@ -2,11 +2,9 @@
 title: Use a custom domain to expose a service
 ---
 
-This tutorial shows how to set up your custom domain and prepare a certifacte to be able to use the domain for exposing a service.
+This tutorial shows how to set up your custom domain and prepare a certifacte to use the domain for exposing a service.
 
-To learn how to actually expose a service, proceed to [this](..//apix-01-expose-service-apigateway.md) document.
-
-The tutorial comes with a sample HttpBin service deployment.
+To learn how to actually expose a service, go to [this](..//apix-01-expose-service-apigateway.md) tutorial.
 
 ## Prerequisites
 
@@ -15,22 +13,22 @@ Depending on your cluster provider, meet the relevant prerequisites.
 <div tabs name="cluster-provider" group="cluster-provider">
   <details>
   <summary label="Gardener">
-  Gardener clusters
+  Gardener cluster
   </summary>
 
-If you use a Gardener cluster and the source controllers, add an annotation for the DNS Provider and DNS Entry Custom Resources (CRs). The annotation allows the DNS source controllers watch resources on the default cluster and create DNS entries on the target cluster. The annotation is as follows:
+If you use a Gardener cluster, add an annotation for the `DNSProvider` and `DNSEntry` Custom Resources (CRs). The annotation allows the DNS source controllers watch resources on the default cluster and create DNS entries on the target cluster. The annotation should looks as follows:
 
 ```bash
   annotations:
     dns.gardener.cloud/class: garden
 ```
 
-For more details see the [official documentation](https://gardener.cloud/docs/concepts/networking/dns-managment/#automatic-creation-of-dns-entries-for-services-and-ingresses).
+For more details see the [official Gardener documentation](https://gardener.cloud/docs/concepts/networking/dns-managment/#automatic-creation-of-dns-entries-for-services-and-ingresses).
 
   </details>
   <details>
   <summary label="non-Gardener">
-  Non-Gardener clusters
+  Non-Gardener cluster
   </summary>
 
 If you use a cluster not managed by Gardener, install the required components manually. Follow these steps:
@@ -43,7 +41,7 @@ If you use a cluster not managed by Gardener, install the required components ma
 
 2. Download the [External DNS Management](https://github.com/gardener/external-dns-management) and [Certificate Management](https://github.com/gardener/cert-management) projects locally.
 
-3. Enable vertical Pod autoscaling on your cluster. For example, for Google Cloud Platform run:
+3. Enable vertical Pod autoscaling on your cluster. For example, for Google Cloud Platform, run:
 
    ```bash
    gcloud beta container clusters update {PROJECT_NAME} --enable-vertical-pod-autoscaling
@@ -55,7 +53,7 @@ If you use a cluster not managed by Gardener, install the required components ma
    helm install external-dns {PATH_TO_EXTERNAL_DNS_MANAGEMENT}/charts/external-dns-management --namespace={NAMESPACE_NAME} --set configuration.identifier=external-dns-identifier
    ```
 
-5. Install the `cert-management` component in your Namespace.
+5. Install the `cert-management` component in your Namespace:
 
    ```bash
    helm install cert-manager {PATH_TO_CERT_MANAGEMENT}/charts/cert-management --namespace={NAMESPACE_NAME} --set configuration.identifier=cert-manager-identifier
@@ -65,6 +63,8 @@ If you use a cluster not managed by Gardener, install the required components ma
 </div>
 
 ## Steps
+
+Follow these steps to set up your custom domain and 
 
 1. Install Kyma 2.0 or higher.
 
@@ -77,12 +77,12 @@ If you use a cluster not managed by Gardener, install the required components ma
 3. Create a Secret. See the [official External DNS Management docuemntation](https://github.com/gardener/external-dns-management) and choose your DNS cloud service provider for the exact guidelines. Once the `Secret` CR is ready, run the following command:
 
    ```bash
-   kubectl apply -n {NAMESPACE_NAME} -f {SECRET_NAME}.yaml
+   kubectl apply -n {NAMESPACE_NAME} -f {SECRET}.yaml
    ```
 
 4. Set up the `external-dns-management` component.
 
-- Create a `DNSProvider` Custom Resource Definition (CRD). See the following example and modify values for the **namespace**, [**spec.type**](https://github.com/gardener/external-dns-management#external-dns-management), **spec.secretRef.name** and **spec.domains.include** parameters. Use the **spec.secretRef.name** from the `{SECRET_NAME}.yaml`.
+- Create a `DNSProvider` Custom Resource Definition (CRD). See the following example and modify values for the **namespace**, [**spec.type**](https://github.com/gardener/external-dns-management#external-dns-management), **spec.secretRef.name** and **spec.domains.include** parameters. Use the **spec.secretRef.name** from the `{SECRET}.yaml`.
 
    ```bash
    apiVersion: dns.gardener.cloud/v1alpha1
@@ -90,7 +90,7 @@ If you use a cluster not managed by Gardener, install the required components ma
    metadata:
      name: dns-provider
      namespace: NAMESPACE_NAME
-     # Uncomment when using on Gardener cluster
+     # Uncomment when using on a Gardener cluster
    #  annotations:
    #    dns.gardener.cloud/class: garden
    spec:
@@ -99,7 +99,7 @@ If you use a cluster not managed by Gardener, install the required components ma
        name: secret-name
      domains:
        include:
-         # this must be replaced with a (sub)domain of the hosted zone
+         # replace with a domain of the hosted zone
          - domain-name
    ```
 

--- a/docs/03-tutorials/00-api-exposure/apix-04-own-domain.md
+++ b/docs/03-tutorials/00-api-exposure/apix-04-own-domain.md
@@ -38,7 +38,7 @@ If you use a cluster not managed by Gardener, install the required components ma
 
 ## Steps
 
-Follow these steps to set up your custom domain and prepare a certificate required to expose a service using your custom domain.
+Follow these steps to set up your custom domain and prepare a certificate required to expose a service.
 
 1. Install Kyma 2.0 or higher.
 

--- a/docs/03-tutorials/00-api-exposure/apix-04-own-domain.md
+++ b/docs/03-tutorials/00-api-exposure/apix-04-own-domain.md
@@ -65,14 +65,14 @@ Follow these steps to set up your custom domain and prepare a certificate requir
 
 4. Set up the `external-dns-management` component.
 
-- Create a DNSProvider CR. Export values of the **metadata.namespace**, [**spec.type**](https://github.com/gardener/external-dns-management#using-the-dns-controller-manager), **metadata.spec.secretRef.name** and **metadata.spec.domains.include** parameters as environment variables. As the value of **spec.type**, use the relevant provider type. See the [official Gardener examples](https://github.com/gardener/external-dns-management/tree/master/examples) of the DNSProvider CR. For the **spec.secretRef.name** parameter, use the **metadata.name** value from your `{SECRET}.yaml`. Run:
+- Create a DNSProvider CR. Export values of the **metadata.namespace**, [**spec.type**](https://github.com/gardener/external-dns-management#using-the-dns-controller-manager), **metadata.spec.secretRef.name** and **metadata.spec.domains.include** parameters as environment variables. As the value of **spec.type**, use the relevant provider type. See the [official Gardener examples](https://github.com/gardener/external-dns-management/tree/master/examples) of the DNSProvider CR. For the **spec.secretRef.name** parameter, use the **metadata.name** value from your `{SECRET}.yaml`. The domain you provide is the one that you own, for example `mydomain.com`. In the next steps you provide a subdomain of this domain, for example `api.mydomain.com`. Run:
 
-   ```bash
-   export NAMESPACE={NAMESPACE_NAME}
-   export SPEC_TYPE={PROVIDER_TYPE}
-   export SECRET={SECRET_NAME}
-   export DOMAIN={CLUSTER_DOMAIN}
-   ```
+  ```bash
+  export NAMESPACE={NAMESPACE_NAME}
+  export SPEC_TYPE={PROVIDER_TYPE}
+  export SECRET={SECRET_NAME}
+  export DOMAIN={CLUSTER_DOMAIN} #eg. mydomain.com
+  ```
   
   Create a DNSProvider CR. Run:
 
@@ -83,23 +83,23 @@ Follow these steps to set up your custom domain and prepare a certificate requir
   </summary>
 
   ```bash
-   cat <<EOF | kubectl apply -f -
-   apiVersion: dns.gardener.cloud/v1alpha1
-   kind: DNSProvider
-   metadata:
-     name: dns-provider
-     namespace: $NAMESPACE
-     annotations:
-       dns.gardener.cloud/class: garden
-   spec:
-     type: $SPEC_TYPE
-     secretRef:
-       name: $SECRET
-     domains:
-       include:
-         - $DOMAIN
-   EOF  
-   ```
+  cat <<EOF | kubectl apply -f -
+  apiVersion: dns.gardener.cloud/v1alpha1
+  kind: DNSProvider
+  metadata:
+    name: dns-provider
+    namespace: $NAMESPACE
+    annotations:
+      dns.gardener.cloud/class: garden
+  spec:
+    type: $SPEC_TYPE
+    secretRef:
+      name: $SECRET
+    domains:
+      include:
+        - $DOMAIN
+  EOF
+  ```
 
   </details>
   <details>
@@ -108,34 +108,34 @@ Follow these steps to set up your custom domain and prepare a certificate requir
   </summary>
 
   ```bash
-   cat <<EOF | kubectl apply -f -
-   apiVersion: dns.gardener.cloud/v1alpha1
-   kind: DNSProvider
-   metadata:
-     name: dns-provider
-     namespace: $NAMESPACE
-   spec:
-     type: $SPEC_TYPE
-     secretRef:
-       name: $SECRET
-     domains:
-       include:
-         - $DOMAIN
-   EOF  
-   ```
+  cat <<EOF | kubectl apply -f -
+  apiVersion: dns.gardener.cloud/v1alpha1
+  kind: DNSProvider
+  metadata:
+    name: dns-provider
+    namespace: $NAMESPACE
+  spec:
+    type: $SPEC_TYPE
+    secretRef:
+      name: $SECRET
+    domains:
+      include:
+        - $DOMAIN
+  EOF
+  ```
 
-   </details>
-   </div>
+  </details>
+  </div>
 
 - Create a DNSEntry CR. Export values of the **metadata.namespace**, **metadata.spec.dnsName**, and **metadata.spec.targets.IP** parameters as environment variables. Optionally, you can also change the value of **metadata.spec.ttl**. Run:
 
-   ```bash
-   export NAMESPACE={NAMESPACE_NAME}
-   export SUBDOMAIN={YOUR_SUBDOMAIN}
-   export IP={SECRET_NAME}
-   ```
+  ```bash
+  export NAMESPACE={NAMESPACE_NAME}
+  export SUBDOMAIN={YOUR_SUBDOMAIN} #e.g: *.api.mydomain.com
+  export IP={INGRESS_GATEWAY_IP}
+  ```
 
-   Create a DNSEntry CR. Run:
+ Create a DNSEntry CR. Run:
 
   <div tabs>
   <details>
@@ -144,20 +144,21 @@ Follow these steps to set up your custom domain and prepare a certificate requir
   </summary>
 
   ```bash
-   cat <<EOF | kubectl apply -f -
-   apiVersion: dns.gardener.cloud/v1alpha1
-   kind: DNSEntry
-   metadata:
-     name: dns-entry
-     namespace: $NAMESPACE
-     annotations:
-       dns.gardener.cloud/class: garden
-   spec:
-     dnsName: "$SUBDOMAIN"
-     ttl: 600
-     targets:
-       - $IP
-   ```
+  cat <<EOF | kubectl apply -f -
+  apiVersion: dns.gardener.cloud/v1alpha1
+  kind: DNSEntry
+  metadata:
+    name: dns-entry
+    namespace: $NAMESPACE
+    annotations:
+      dns.gardener.cloud/class: garden
+  spec:
+    dnsName: "$SUBDOMAIN"
+    ttl: 600
+    targets:
+      - $IP
+  EOF
+  ```
 
   </details>
   <details>
@@ -166,28 +167,29 @@ Follow these steps to set up your custom domain and prepare a certificate requir
   </summary>
 
   ```bash
-   cat <<EOF | kubectl apply -f -
-   apiVersion: dns.gardener.cloud/v1alpha1
-   kind: DNSEntry
-   metadata:
-     name: dns-entry
-     namespace: $NAMESPACE
-   spec:
-     dnsName: "$SUBDOMAIN"
-     ttl: 600
-     targets:
-       - $IP
-   ```
+  cat <<EOF | kubectl apply -f -
+  apiVersion: dns.gardener.cloud/v1alpha1
+  kind: DNSEntry
+  metadata:
+    name: dns-entry
+    namespace: $NAMESPACE
+  spec:
+    dnsName: "$SUBDOMAIN"
+    ttl: 600
+    targets:
+      - $IP
+  EOF
+  ```
 
-   </details>
-   </div>
+  </details>
+  </div>
 
-    >**NOTE:** To check the Ingress Gateway IP, run:
-    >```bash
-    >kubectl -n istio-system get service istio-ingressgateway -o jsonpath='{.status.loadBalancer.ingress[0].ip}'
-    >```
+  >**NOTE:** To check the Ingress Gateway IP, run:
+  >```bash
+  >kubectl -n istio-system get service istio-ingressgateway -o jsonpath='{.status.loadBalancer.ingress[0].ip}'
+  >```
 
-   >**NOTE:** You can create many DNSEntry CRs for one DNSProvider, depending on the number of subdomains you want to use.
+  >**NOTE:** You can create many DNSEntry CRs for one DNSProvider, depending on the number of subdomains you want to use. To simplify your setup, consider using a wildcard subdomain if all your DNSEntry objects share the same subdomain and resolve to the same IP, for example: *.api.mydomain.com.
 
 5. Create an Issuer CR. Export values of the **metadata.spec.acme.email**, **metadata.spec.domains.include**, and **metadata.spec.domains.exclude** parameters as environment variables. As the values for the **metadata.spec.domains.include** parameter, use the main domain, the subdomain from the **spec.dnsName** parameter of the DNSEntry CR, and a wildcard DNS record. Run:
 
@@ -195,7 +197,7 @@ Follow these steps to set up your custom domain and prepare a certificate requir
    export EMAIL={YOUR_EMAIL_ADDRESS}
    export DOMAIN={CLUSTER_DOMAIN}
    export SUBDOMAIN={YOUR_SUBDOMAIN}
-   export WILDCARD={YOUR_WILDCARD_DNS_RECORD, e.g. *.mydomain.com}
+   export WILDCARD={YOUR_WILDCARD_SUBDOMAIN} #e.g. *api.mydomain.com
    ```
 
    Create an Issuer CR. Run:
@@ -231,10 +233,10 @@ Follow these steps to set up your custom domain and prepare a certificate requir
 6. Create a Certificate CR. Export values of the **metadata.namespace**, **spec.secretName**, **spec.commonName**, and **spec.issuerRef.name**, and **spec.dnsNames** parameters as environment variables. As the value for the **spec.issuerRef.name** parameter, use the value from te **metadata.name** parameter of the Issuer CR. Run:
 
    ```bash
-   export SECRET_2={SECRET_NAME}
+   export SECRET_2={SECRET_NAME} #e.g: httpbin-tls-credentials
    export DOMAIN={CLUSTER_DOMAIN}
    export ISSUER={ISSUER_NAME}
-   export SUBDOMAIN={YOUR_SUBDOMAIN}
+   export SUBDOMAIN={YOUR_SUBDOMAIN} #e.g: *.api.mydomain.com
    ```
 
    Create a Certificate CR. Run:

--- a/docs/03-tutorials/00-api-exposure/apix-04-own-domain.md
+++ b/docs/03-tutorials/00-api-exposure/apix-04-own-domain.md
@@ -273,7 +273,7 @@ Follow these steps to set up your custom domain and prepare a certificate requir
      name: httpbin-gateway
    spec:
      selector:
-       istio: ingressgateway # Use Istio Ingress Gateway as deafult
+       istio: ingressgateway # Use Istio Ingress Gateway as default
      servers:
        - port:
            number: 443
@@ -299,4 +299,4 @@ Follow these steps to set up your custom domain and prepare a certificate requir
 
 When you finish the setup, go to [this](./apix-01-expose-service-apigateway.md) tutorial to learn how to expose a service.
 
-If you want to expose a different workload using a different domain,  repeat steps from 2 to 8.
+If you want to expose a different workload using a different domain, repeat steps from 2 to 8 with the new details.

--- a/docs/03-tutorials/00-api-exposure/apix-04-own-domain.md
+++ b/docs/03-tutorials/00-api-exposure/apix-04-own-domain.md
@@ -187,8 +187,8 @@ Follow these steps to set up your custom domain and prepare a certificate requir
 
    Press `i` to enter and `esc` to exit the interactive mode. Save the changes and exit the editor by pressing `:wq`.
 
-9. Restart API Gateway. Run:
-   
+9. Restart the relevant deployment using this command:
+
    ```bash
    kubectl rollout restart deployment {DEPLOYMENT_NAME}
    ```

--- a/docs/03-tutorials/00-api-exposure/apix-04-own-domain.md
+++ b/docs/03-tutorials/00-api-exposure/apix-04-own-domain.md
@@ -1,0 +1,168 @@
+---
+title: Use a custom domain to expose a service
+---
+
+This tutorial shows how to set up your custom domain and prepare a certifacte to be able to use the domain for exposing a service.
+
+To learn how to actually expose a service, proceed to [this](..//apix-01-expose-service-apigateway.md) document.
+
+The tutorial comes with a sample HttpBin service deployment.
+
+## Prerequisites
+
+Depending on your cluster provider, meet the relevant prerequisites.
+
+<div tabs name="cluster-provider" group="cluster-provider">
+  <details>
+  <summary label="Gardener">
+  Gardener clusters
+  </summary>
+
+If you use a Gardener cluster and the source controllers, add an annotation for the DNS Provider and DNS Entry Custom Resources (CRs). The annotation allows the DNS source controllers watch resources on the default cluster and create DNS entries on the target cluster. The annotation is as follows:
+
+```bash
+  annotations:
+    dns.gardener.cloud/class: garden
+```
+
+For more details see the [official documentation](https://gardener.cloud/docs/concepts/networking/dns-managment/#automatic-creation-of-dns-entries-for-services-and-ingresses).
+
+  </details>
+  <details>
+  <summary label="non-Gardener">
+  Non-Gardener clusters
+  </summary>
+
+If you use a cluster not managed by Gardener, install the required components manually. Follow these steps:
+
+1. Create a Namespace. Run:
+
+   ```bash
+   kubectl create ns {NAMESPACE_NAME}
+   ```
+
+2. Download the [External DNS Management](https://github.com/gardener/external-dns-management) and [Certificate Management](https://github.com/gardener/cert-management) projects locally.
+
+3. Enable vertical Pod autoscaling on your cluster. For example, for Google Cloud Platform run:
+
+   ```bash
+   gcloud beta container clusters update {PROJECT_NAME} --enable-vertical-pod-autoscaling
+   ```
+
+4. Install the `external-dns-management` component in your Namespace:
+
+   ```bash
+   helm install external-dns {PATH_TO_EXTERNAL_DNS_MANAGEMENT}/charts/external-dns-management --namespace={NAMESPACE_NAME} --set configuration.identifier=external-dns-identifier
+   ```
+
+5. Install the `cert-management` component in your Namespace.
+
+   ```bash
+   helm install cert-manager {PATH_TO_CERT_MANAGEMENT}/charts/cert-management --namespace={NAMESPACE_NAME} --set configuration.identifier=cert-manager-identifier
+   ```
+
+</details>
+</div>
+
+## Steps
+
+1. Install Kyma 2.0 or higher.
+
+2. Create a Namespace. Run:
+
+   ```bash
+   kubectl create ns {NAMESPACE_NAME}
+   ```
+
+3. Create a Secret. See the [official External DNS Management docuemntation](https://github.com/gardener/external-dns-management) and choose your DNS cloud service provider for the exact guidelines. Once the `Secret` CR is ready, run the following command:
+
+   ```bash
+   kubectl apply -n {NAMESPACE_NAME} -f {SECRET_NAME}.yaml
+   ```
+
+4. Set up the `external-dns-management` component.
+
+- Create a `DNSProvider` Custom Resource Definition (CRD). See the following example and modify values for the **namespace**, [**spec.type**](https://github.com/gardener/external-dns-management#external-dns-management), **spec.secretRef.name** and **spec.domains.include** parameters. Use the **spec.secretRef.name** from the `{SECRET_NAME}.yaml`.
+
+   ```bash
+   apiVersion: dns.gardener.cloud/v1alpha1
+   kind: DNSProvider
+   metadata:
+     name: dns-provider
+     namespace: NAMESPACE_NAME
+     # Uncomment when using on Gardener cluster
+   #  annotations:
+   #    dns.gardener.cloud/class: garden
+   spec:
+     type: your-provider-dns
+     secretRef:
+       name: secret-name
+     domains:
+       include:
+         # this must be replaced with a (sub)domain of the hosted zone
+         - domain-name
+   ```
+
+   Once the `DNSProvider` CRD is ready, create the `DNSProvider` CR. Run:
+
+   ```bash
+   kubectl apply -n {NAMESPACE_NAME} -f {DNS-PROVIDER}.yaml
+   ```
+
+- Create a `DNSEntry` CRD. See the following example and modify values for the **namespace**, **spec.dnsName**, **spec.ttl**, and **spec.targets.IP** parameters:
+
+   ```bash
+   apiVersion: dns.gardener.cloud/v1alpha1
+   kind: DNSEntry
+   metadata:
+     name: dns-entry
+     namespace: NAMESPACE_NAME
+     # Uncomment when using on Gardener cluster
+   #  annotations:
+   #    dns.gardener.cloud/class: garden
+   spec:
+     dnsName: "sub.domain-name"
+     ttl: 600
+     targets:
+       - IP # edit this value
+   ```
+
+   Once the `DNSEntry` CRD is ready, create the `DNSEntry` CR. Run:
+
+   ```bash
+   kubectl apply -n {NAMESPACE_NAME} -f {DNS-ENTRY}.yaml
+   ```
+
+   >**NOTE:** You can create many `DNSEntry` CRs for one `DNSProvider` depending on the number of subdomains you want to use.
+
+5. Create an `Issuer` CRD. See the following example and modify values of the **spec.acme.email**, **spec.domains.include**, and **spec.domains.exclude** parameters.
+
+```bash
+   apiVersion: cert.gardener.cloud/v1alpha1
+   kind: Issuer
+   metadata:
+     name: letsencrypt-staging
+     namespace: default
+   spec:
+     acme:
+       server: https://acme-staging-v02.api.letsencrypt.org/directory
+       email: YOUR-EMAIL-ADDRESS
+       autoRegistration: true
+
+       # Name of a secret used to store the ACME account private key
+       # If does not exist a new one is created
+       privateKeySecretRef:
+         name: letsencrypt-staging-secret
+         namespace: default
+
+       # optionally restrict domain ranges for which certificates can be requested
+       domains:
+         include:
+           - progamer.kyma-goat.ga
+           - helloworld.progamer.kyma-goat.ga
+           - httpbin.progamer.kyma-goat.ga
+           - "*.progamer.kyma-goat.ga""
+   #     exclude:
+   #     - private.sub1.mydomain.com
+   ```
+

--- a/docs/03-tutorials/00-api-exposure/apix-04-own-domain.md
+++ b/docs/03-tutorials/00-api-exposure/apix-04-own-domain.md
@@ -4,9 +4,9 @@ title: Use a custom domain to expose a service
 
 This tutorial shows how to set up your custom domain and prepare a certificate to use the domain for exposing a service. The components used are Gardener [External DNS Management](https://gardener.cloud/docs/concepts/networking/dns-managment/#external-dns-management) and [Certificate Management](https://gardener.cloud/docs/concepts/networking/cert-managment/).
 
-To learn how to expose a service, go to [this](./apix-01-expose-service-apigateway.md) tutorial.
+To learn how to expose a service, go to the [**Expose a service**](./apix-01-expose-service-apigateway.md) tutorial.
 
-For this tutorial, use Kyma 2.0 or higher.
+TO follow this tutorial, use Kyma 2.0 or higher.
 
 ## Prerequisites
 
@@ -45,7 +45,11 @@ If you use a cluster not managed by Gardener, install the required components ma
    helm install cert-manager {PATH_TO_CERT_MANAGEMENT}/charts/cert-management --namespace=gardener-components --set configuration.identifier=cert-manager-identifier
    ```
 
-6. Add the following RBAC rules to allow the Certificate Management component to configure objects. Run:
+6. Add the following RBAC rules to allow the Certificate Management component to configure objects. Create an `istio-systen` Namespace, a ClutserRole and a RoleBinding:
+
+    ```bash
+    kubectl create ns istio-system
+    ```
 
     ```bash
     cat <<EOF | kubectl apply -f -
@@ -92,7 +96,7 @@ Follow these steps to set up your custom domain and prepare a certificate requir
 
 1. [Install Kyma](../../04-operation-guides/operations/01-install-kyma.md) 2.0 or higher.
 
-2. Create a Namespace, if it doesn't exist yet. Run:
+2. Create a Namespace. Run:
 
    ```bash
    kubectl create ns {NAMESPACE_NAME}
@@ -173,7 +177,7 @@ Follow these steps to set up your custom domain and prepare a certificate requir
   ```bash
   export NAMESPACE={NAMESPACE_NAME}
   export WILDCARD={WILDCRAD_SUBDOMAIN} #e.g. *.api.mydomain.com
-  export IP=$(kubectl -n istio-system get service istio-ingressgateway -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
+  export IP=$(kubectl -n istio-system get service istio-ingressgateway -o jsonpath='{.status.loadBalancer.ingress[0].ip}') # assuming only one LoadBalancer with external IP
   ```
 
  Create a DNSEntry CR. Run:
@@ -224,11 +228,6 @@ Follow these steps to set up your custom domain and prepare a certificate requir
 
   </details>
   </div>
-
-  >**NOTE:** To check the Ingress Gateway IP, run:
-  >```bash
-  >kubectl -n istio-system get service istio-ingressgateway -o jsonpath='{.status.loadBalancer.ingress[0].ip}'
-  >```
 
   >**NOTE:** You can create many DNSEntry CRs for one DNSProvider, depending on the number of subdomains you want to use. To simplify your setup, consider using a wildcard subdomain if all your DNSEntry objects share the same subdomain and resolve to the same IP, for example: `*.api.mydomain.com`. Remember that such a wildcard entry results in DNS configuration that doesn't support the following hosts: `api.mydomain.com` and `mydomain.com`. We don't use these hosts in this tutorial, but you can add DNS Entries for them if you need.
 
@@ -303,7 +302,6 @@ Follow these steps to set up your custom domain and prepare a certificate requir
    ```
 
    > **NOTE:** The Certificte CR and the Secret with the TLS certificate are created in the same Namespace. Additionally, Istio requires the Secret to be stored in the `istio-system` Namespace so that the Secret could be used for HTTPS traffic. As a result the Certificate must be also created in the `istio-system` Namespace.
-
 
 7. Create a Gateway CR. Export values of the **spec.servers.tls.credentialName** and **spec.servers.hosts** parameters as anvironment variables. For the **spec.servers.tls.credentialName** parameter, use the **spec.secretName** value of the Certificate CR. As the value of **spec.servers.hosts**, use the wildcard DNS record. Run:
 

--- a/docs/03-tutorials/00-api-exposure/apix-04-own-domain.md
+++ b/docs/03-tutorials/00-api-exposure/apix-04-own-domain.md
@@ -64,7 +64,7 @@ If you use a cluster not managed by Gardener, install the required components ma
 
 ## Steps
 
-Follow these steps to set up your custom domain and 
+Follow these steps to set up your custom domain and prepare a certificate required to expose a service.
 
 1. Install Kyma 2.0 or higher.
 

--- a/docs/03-tutorials/00-api-exposure/apix-04-own-domain.md
+++ b/docs/03-tutorials/00-api-exposure/apix-04-own-domain.md
@@ -248,6 +248,7 @@ Follow these steps to set up your custom domain and prepare a certificate requir
    metadata:
      name: httpbin-cert
      namespace: istio-system
+   spec:  
      secretName: $SECRET_2
      commonName: $DOMAIN
      issuerRef:

--- a/docs/03-tutorials/00-api-exposure/apix-04-own-domain.md
+++ b/docs/03-tutorials/00-api-exposure/apix-04-own-domain.md
@@ -6,7 +6,7 @@ This tutorial shows how to set up your custom domain and prepare a certificate t
 
 To learn how to expose a service, go to [this](./apix-01-expose-service-apigateway.md) tutorial.
 
-For the purposes of this tutorial, use Kyma 2.0 or higher.
+For this tutorial, use Kyma 2.0 or higher.
 
 ## Prerequisites
 
@@ -57,7 +57,7 @@ Follow these steps to set up your custom domain and prepare a certificate requir
    kubectl create ns {NAMESPACE_NAME}
    ```
 
-3. Create a Secret containing credentails for your DNS cloud service provider account. See the [official External DNS Management docuemntation](https://github.com/gardener/external-dns-management/blob/master/README.md#external-dns-management), choose your DNS cloud service provider, and follow the relevant guidelines. Remember to edit the **metadata.namespace** parameter and provide your {NAMESPACE_NAME} as the required value.  Once the YAML file with the relevant parameters is ready, create a Secret Custom Resource (CR). Run the following command:
+3. Create a Secret containing credentials for your DNS cloud service provider account. See the [official External DNS Management docuemntation](https://github.com/gardener/external-dns-management/blob/master/README.md#external-dns-management), choose your DNS cloud service provider, and follow the relevant guidelines. Remember to edit the **metadata.namespace** parameter and provide your {NAMESPACE_NAME} as the required value.  Once the YAML file with the relevant parameters is ready, create a Secret Custom Resource (CR). Run the following command:
 
    ```bash
    kubectl apply -n {NAMESPACE_NAME} -f {SECRET}.yaml

--- a/docs/03-tutorials/00-api-exposure/apix-04-own-domain.md
+++ b/docs/03-tutorials/00-api-exposure/apix-04-own-domain.md
@@ -6,7 +6,7 @@ This tutorial shows how to set up your custom domain and prepare a certificate t
 
 To learn how to expose a service, go to the [**Expose a service**](./apix-01-expose-service-apigateway.md) tutorial.
 
-TO follow this tutorial, use Kyma 2.0 or higher.
+To follow this tutorial, use Kyma 2.0 or higher.
 
 ## Prerequisites
 

--- a/docs/03-tutorials/00-api-exposure/apix-04-own-domain.md
+++ b/docs/03-tutorials/00-api-exposure/apix-04-own-domain.md
@@ -337,7 +337,7 @@ Follow these steps to set up your custom domain and prepare a certificate requir
    EOF
    ```
 
-8. Add your subdomain(s) at the end of the API Gateway **domain.allowlist** parameter. See the following example: `--domain-allowlist=my.sub1.mydomain.com`. Use a comma as a separator. Run the following command, to edit the deployment:
+8. Add your subdomain(s) at the end of the API Gateway **domain.allowlist** parameter. See the following example: `--domain-allowlist=api.mydomain.com`. Use a comma as a separator. Run the following command, to edit the deployment:
 
   ```bash
   kubectl edit deployment -n kyma-system api-gateway

--- a/docs/03-tutorials/00-api-exposure/apix-04-own-domain.md
+++ b/docs/03-tutorials/00-api-exposure/apix-04-own-domain.md
@@ -57,7 +57,7 @@ Follow these steps to set up your custom domain and prepare a certificate requir
    kubectl create ns {NAMESPACE_NAME}
    ```
 
-3. Create a Secret containing credentails for your DNS cloud service provider account. See the [official External DNS Management docuemntation](https://github.com/gardener/external-dns-management/blob/master/README.md#external-dns-management), choose your DNS cloud service provider, and follow the relevant guidelines. Remember to edit the **metadata.namespace** parameter and provide you {NAMESPACE_NAME} as the required value.  Once the YAML file with the relevant parameters is ready, create a Secret Custom Resource (CR). Run the following command:
+3. Create a Secret containing credentails for your DNS cloud service provider account. See the [official External DNS Management docuemntation](https://github.com/gardener/external-dns-management/blob/master/README.md#external-dns-management), choose your DNS cloud service provider, and follow the relevant guidelines. Remember to edit the **metadata.namespace** parameter and provide your {NAMESPACE_NAME} as the required value.  Once the YAML file with the relevant parameters is ready, create a Secret Custom Resource (CR). Run the following command:
 
    ```bash
    kubectl apply -n {NAMESPACE_NAME} -f {SECRET}.yaml
@@ -238,6 +238,7 @@ Follow these steps to set up your custom domain and prepare a certificate requir
    export DOMAIN={CLUSTER_DOMAIN}
    export ISSUER={ISSUER_NAME}
    export SUBDOMAIN={YOUR_SUBDOMAIN}
+   ```
 
    Create a Certificate CR. Run:
 
@@ -300,3 +301,5 @@ Follow these steps to set up your custom domain and prepare a certificate requir
    >**TIP:** To avoid adding every subdomain to the API Gateway **domain.allowlist** parameter, disable the allowlist mechanism. Override the value of the **config.enableDomainAllowList** parameter in the API Gateway chart by changing its value to `false`. For more details on overrides, see how to [change Kyma settings](../../04-operation-guides/operations/03-change-kyma-config-values.md).
 
 When you finish the setup, go to [this](./apix-01-expose-service-apigateway.md) tutorial to learn how to expose a service.
+
+If you want to expose a different workload using a different domain,  repeat steps from 2 to 8.

--- a/docs/03-tutorials/00-api-exposure/apix-04-own-domain.md
+++ b/docs/03-tutorials/00-api-exposure/apix-04-own-domain.md
@@ -2,7 +2,7 @@
 title: Use a custom domain to expose a service
 ---
 
-This tutorial shows how to set up your custom domain and prepare a certificate to use the domain for exposing a service.
+This tutorial shows how to set up your custom domain and prepare a certificate to use the domain for exposing a service. The components used are Gardener [External DNS Management](https://gardener.cloud/docs/concepts/networking/dns-managment/#external-dns-management) and [Certificate Management](https://gardener.cloud/docs/concepts/networking/cert-managment/).
 
 To learn how to expose a service, go to [this](./apix-01-expose-service-apigateway.md) tutorial.
 

--- a/docs/03-tutorials/00-api-exposure/apix-04-own-domain.md
+++ b/docs/03-tutorials/00-api-exposure/apix-04-own-domain.md
@@ -38,7 +38,7 @@ If you use a cluster not managed by Gardener, install the required components ma
 
 ## Steps
 
-Follow these steps to set up your custom domain and prepare a certificate required to expose a service.
+Follow these steps to set up your custom domain and prepare a certificate required to expose a service using your custom domain.
 
 1. Install Kyma 2.0 or higher.
 
@@ -48,7 +48,7 @@ Follow these steps to set up your custom domain and prepare a certificate requir
    kubectl create ns {NAMESPACE_NAME}
    ```
 
-3. Create a Secret containing the credentails for your DNS cloud service provider account. See the [official External DNS Management docuemntation](https://github.com/gardener/external-dns-management/blob/master/README.md#external-dns-management), choose your DNS cloud service provider, and follow the relevant guidelines. Once the YAML file with the required parameters is ready, create a Secret Custom Resource (CR). Run the following command:
+3. Create a Secret containing credentails for your DNS cloud service provider account. See the [official External DNS Management docuemntation](https://github.com/gardener/external-dns-management/blob/master/README.md#external-dns-management), choose your DNS cloud service provider, and follow the relevant guidelines. Once the YAML file with the required parameters is ready, create a Secret Custom Resource (CR). Run the following command:
 
    ```bash
    kubectl apply -n {NAMESPACE_NAME} -f {SECRET}.yaml
@@ -68,14 +68,14 @@ Follow these steps to set up your custom domain and prepare a certificate requir
      annotations:
        dns.gardener.cloud/class: garden
    spec:
-     type: your-provider-dns # Edit this value
+     type: your-provider-dns-type # Edit this value
      secretRef:
        name: secret-name # Edit this value
      domains:
        include:
          # Replace with a domain of the hosted zone
          - mydomain.com # Edit this value
-    EOF     
+   EOF  
    ```
 
 - Create a DNSEntry CR. See the following example and modify values for the **namespace**, **spec.dnsName**, **spec.ttl**, and **spec.targets.IP** parameters. Run:
@@ -94,7 +94,7 @@ Follow these steps to set up your custom domain and prepare a certificate requir
      ttl: 600
      targets:
        - 1.2.3.4 # Edit this value
-    EOF   
+   EOF
    ```
 
    >**NOTE:** You can create many DNSEntry CRs for one DNSProvider depending on the number of subdomains you want to use.
@@ -121,13 +121,13 @@ Follow these steps to set up your custom domain and prepare a certificate requir
        # Optionally, restrict domain ranges for which certificates can be requested
        domains:
          include:
-           - private.sub1.mydomain.com # Edit this value
+           - private.sub1.mydomain.com # The subdomain provided in the DNS Entry created in the previous step. Edit this value
    #     exclude:
    #       - private.sub2.mydomain.com # Edit this value
    EOF
    ```
 
-6. Create a Certificate CR. See the following example and modify values of the **spec.secretName**, **spec.commonName**, , and **spec.issuerRef.name** parameters. As the value for the **spec.issuerRef.name** parameter, use the Issuer name from the Issuer CR. Run:
+6. Create a Certificate CR. See the following example and modify values of the **spec.secretName**, **spec.commonName**, , and **spec.issuerRef.name** parameters. As the value for the **spec.issuerRef.name** parameter, use the value from te **metadata.name** parameter of the Issuer CR. Run:
 
    ```bash
    cat <<EOF | kubectl apply -f -
@@ -140,7 +140,7 @@ Follow these steps to set up your custom domain and prepare a certificate requir
      secretName: httpbin-tls-credentials # Name of the created Secret. Edit this value
      commonName: mydomain.com # Edit this value
      issuerRef:
-       # Name of the Issuer created previously
+       # Name of the Issuer created in the previous step
        name: letsencrypt-staging
        namespace: default
      dnsNames:

--- a/docs/03-tutorials/00-api-exposure/apix-04-own-domain.md
+++ b/docs/03-tutorials/00-api-exposure/apix-04-own-domain.md
@@ -195,4 +195,6 @@ Follow these steps to set up your custom domain and prepare a certificate requir
 
    >**TIP:** To check the deployment name, run: `kubectl get deployments -A`
 
+   >**TIP:** To avoid adding every subdomain to the API Gateway **domain.allowlist** parameter, disable the allowlist mechanism. Override the value of the **config.enableDomainAllowList** parameter in the API Gateway chart by changing its value to `false`. For more details on overrides, see how to [change Kyma settings](../../04-operation-guides/operations/03-change-kyma-config-values.md).
+
 When you finish the setup, go to [this](./apix-01-expose-service-apigateway.md) tutorial to learn how to expose a service.

--- a/docs/03-tutorials/00-api-exposure/apix-04-own-domain.md
+++ b/docs/03-tutorials/00-api-exposure/apix-04-own-domain.md
@@ -189,7 +189,7 @@ Follow these steps to set up your custom domain and prepare a certificate requir
   >kubectl -n istio-system get service istio-ingressgateway -o jsonpath='{.status.loadBalancer.ingress[0].ip}'
   >```
 
-  >**NOTE:** You can create many DNSEntry CRs for one DNSProvider, depending on the number of subdomains you want to use. To simplify your setup, consider using a wildcard subdomain if all your DNSEntry objects share the same subdomain and resolve to the same IP, for example: *.api.mydomain.com.
+  >**NOTE:** You can create many DNSEntry CRs for one DNSProvider, depending on the number of subdomains you want to use. To simplify your setup, consider using a wildcard subdomain if all your DNSEntry objects share the same subdomain and resolve to the same IP, for example: `*.api.mydomain.com`.
 
 5. Create an Issuer CR. Export values of the **metadata.spec.acme.email**, **metadata.spec.domains.include**, and **metadata.spec.domains.exclude** parameters as environment variables. As the values for the **metadata.spec.domains.include** parameter, use the main domain, the subdomain from the **spec.dnsName** parameter of the DNSEntry CR, and a wildcard DNS record. Run:
 
@@ -233,10 +233,10 @@ Follow these steps to set up your custom domain and prepare a certificate requir
 6. Create a Certificate CR. Export values of the **metadata.namespace**, **spec.secretName**, **spec.commonName**, and **spec.issuerRef.name**, and **spec.dnsNames** parameters as environment variables. As the value for the **spec.issuerRef.name** parameter, use the value from te **metadata.name** parameter of the Issuer CR. Run:
 
    ```bash
-   export SECRET_2={SECRET_NAME} #e.g: httpbin-tls-credentials
+   export TLS_SECRET={SECRET_NAME} #e.g: httpbin-tls-credentials
    export DOMAIN={CLUSTER_DOMAIN}
    export ISSUER={ISSUER_NAME}
-   export SUBDOMAIN={YOUR_SUBDOMAIN} #e.g: *.api.mydomain.com
+   export WILDCARD={YOUR_WILDCARD_SUBDOMAIN} #e.g: *.api.mydomain.com
    ```
 
    Create a Certificate CR. Run:
@@ -249,21 +249,21 @@ Follow these steps to set up your custom domain and prepare a certificate requir
      name: httpbin-cert
      namespace: istio-system
    spec:  
-     secretName: $SECRET_2
+     secretName: $TLS_SECRET
      commonName: $DOMAIN
      issuerRef:
        name: $ISSUER
        namespace: default
      dnsNames:
-       - $SUBDOMAIN
+       - "$WILDCARD"
    EOF
    ```
 
 7. Create a Gateway CR. Export values of the **spec.servers.tls.credentialName** and **spec.servers.hosts** parameters as anvironment variables. For the **spec.servers.tls.credentialName** parameter, use the **spec.secretName** value of the Certificate CR. As the value of **spec.servers.hosts**, use the wildcard DNS record. Run:
 
    ```bash
-   export SECRET_2={SECRET_NAME}
-   export WILDCARD={YOUR_WILDCARD_DNS_RECORD, e.g. *.mydomain.com}
+   export TLS_SECRET={SECRET_NAME}
+   export WILDCARD={YOUR_WILDCARD_SUBDOMAIN} # e.g. *api.mydomain.com
    ```
 
    Create a Gateway CR. Run:
@@ -284,7 +284,7 @@ Follow these steps to set up your custom domain and prepare a certificate requir
            protocol: HTTPS
          tls:
            mode: SIMPLE
-           credentialName: $SECRET_2
+           credentialName: $TLS_SECRET
          hosts:
            - "$WILDCARD"
    EOF

--- a/docs/03-tutorials/00-api-exposure/apix-04-own-domain.md
+++ b/docs/03-tutorials/00-api-exposure/apix-04-own-domain.md
@@ -49,7 +49,7 @@ If you use a cluster not managed by Gardener, install the required components ma
 
 Follow these steps to set up your custom domain and prepare a certificate required to expose a service.
 
-1. Install Kyma 2.0 or higher.
+1. [Install Kyma](../../04-operation-guides/operations/01-install-kyma.md) 2.0 or higher.
 
 2. Create a Namespace. Run:
 

--- a/docs/03-tutorials/00-api-exposure/apix-04-own-domain.md
+++ b/docs/03-tutorials/00-api-exposure/apix-04-own-domain.md
@@ -6,6 +6,8 @@ This tutorial shows how to set up your custom domain and prepare a certificate t
 
 To learn how to expose a service, go to [this](./apix-01-expose-service-apigateway.md) tutorial.
 
+For the purposes of this tutorial, use Kyma 2.0 or higher.
+
 ## Prerequisites
 
 If you use a cluster not managed by Gardener, install the required components manually. Follow these steps:
@@ -13,30 +15,35 @@ If you use a cluster not managed by Gardener, install the required components ma
 1. Create a Namespace. Run:
 
    ```bash
-   kubectl create ns {NAMESPACE_NAME}
+   kubectl create ns gardener-components
    ```
 
-2. Download the [External DNS Management](https://github.com/gardener/external-dns-management) and [Certificate Management](https://github.com/gardener/cert-management) projects locally.
+2. Download the [External DNS Management](https://github.com/gardener/external-dns-management) and [Certificate Management](https://github.com/gardener/cert-management) projects locally. Run:
+
+   ```bash
+   git clone --branch v0.10.4 https://github.com/gardener/external-dns-management.git
+   git clone --branch v0.8.3 https://github.com/gardener/cert-management.git
+   ```
+
+   > **NOTE:** This tutorial uses the External DNS Management v.0.10.4 and the Certificate Management v0.8.3.
 
 3. Enable vertical Pod autoscaling on your cluster. For example, for Google Cloud Platform, run:
 
    ```bash
-   gcloud beta container clusters update {PROJECT_NAME} --enable-vertical-pod-autoscaling
+   gcloud container clusters update {CLUSTER_NAME} --enable-vertical-pod-autoscaling --zone="{CLUSTER_ZONE}" --project="{PROJECT_NAME}"
    ```
 
-4. Install the `external-dns-management` component in your Namespace:
+4. Install the `external-dns-management` component in the `gardener-components` Namespace:
 
    ```bash
-   helm install external-dns {PATH_TO_EXTERNAL_DNS_MANAGEMENT}/charts/external-dns-management --namespace={NAMESPACE_NAME} --set configuration.identifier=external-dns-identifier
+   helm install external-dns {PATH_TO_EXTERNAL_DNS_MANAGEMENT}/charts/external-dns-management --namespace=gardener-components --set configuration.identifier=external-dns-identifier
    ```
 
-5. Install the `cert-management` component in your Namespace:
+5. Install the `cert-management` component in the `gardener-components` Namespace:
 
    ```bash
-   helm install cert-manager {PATH_TO_CERT_MANAGEMENT}/charts/cert-management --namespace={NAMESPACE_NAME} --set configuration.identifier=cert-manager-identifier
+   helm install cert-manager {PATH_TO_CERT_MANAGEMENT}/charts/cert-management --namespace=gardener-components --set configuration.identifier=cert-manager-identifier
    ```
-
-When you meet the prerequisites, go directly to step 2.
 
 ## Steps
 
@@ -50,7 +57,7 @@ Follow these steps to set up your custom domain and prepare a certificate requir
    kubectl create ns {NAMESPACE_NAME}
    ```
 
-3. Create a Secret containing credentails for your DNS cloud service provider account. See the [official External DNS Management docuemntation](https://github.com/gardener/external-dns-management/blob/master/README.md#external-dns-management), choose your DNS cloud service provider, and follow the relevant guidelines. Once the YAML file with the required parameters is ready, create a Secret Custom Resource (CR). Run the following command:
+3. Create a Secret containing credentails for your DNS cloud service provider account. See the [official External DNS Management docuemntation](https://github.com/gardener/external-dns-management/blob/master/README.md#external-dns-management), choose your DNS cloud service provider, and follow the relevant guidelines. Remember to edit the **metadata.namespace** parameter and provide you {NAMESPACE_NAME} as the required value.  Once the YAML file with the relevant parameters is ready, create a Secret Custom Resource (CR). Run the following command:
 
    ```bash
    kubectl apply -n {NAMESPACE_NAME} -f {SECRET}.yaml
@@ -58,54 +65,142 @@ Follow these steps to set up your custom domain and prepare a certificate requir
 
 4. Set up the `external-dns-management` component.
 
-- Create a DNSProvider CR. See the following example and modify values for the **metadata.namespace**, [**spec.type**](https://github.com/gardener/external-dns-management#using-the-dns-controller-manager), **metadata.spec.secretRef.name** and **metadata.spec.domains.include** parameters. As the value of **spec.type**, use the relevant provider type. See the [official Gardener examples](https://github.com/gardener/external-dns-management/tree/master/examples) of the DNSProvider CR. For the **spec.secretRef.name** parameter, use the **metadata.name** value from your `{SECRET}.yaml`. Run:
+- Create a DNSProvider CR. Export values of the **metadata.namespace**, [**spec.type**](https://github.com/gardener/external-dns-management#using-the-dns-controller-manager), **metadata.spec.secretRef.name** and **metadata.spec.domains.include** parameters as environment variables. As the value of **spec.type**, use the relevant provider type. See the [official Gardener examples](https://github.com/gardener/external-dns-management/tree/master/examples) of the DNSProvider CR. For the **spec.secretRef.name** parameter, use the **metadata.name** value from your `{SECRET}.yaml`. Run:
 
    ```bash
+   export NAMESPACE={NAMESPACE_NAME}
+   export SPEC_TYPE={PROVIDER_TYPE}
+   export SECRET={SECRET_NAME}
+   export DOMAIN={CLUSTER_DOMAIN}
+   ```
+  
+  Create a DNSProvider CR. Run:
+
+  <div tabs>
+  <details>
+  <summary>
+  Gardener cluster
+  </summary>
+
+  ```bash
    cat <<EOF | kubectl apply -f -
    apiVersion: dns.gardener.cloud/v1alpha1
    kind: DNSProvider
    metadata:
      name: dns-provider
-     namespace: NAMESPACE_NAME # Edit this value
+     namespace: $NAMESPACE
      annotations:
        dns.gardener.cloud/class: garden
    spec:
-     type: your-provider-dns-type # Edit this value
+     type: $SPEC_TYPE
      secretRef:
-       name: secret-name # Edit this value
+       name: $SECRET
      domains:
        include:
-         - mydomain.com # The main domain. Edit this value
+         - $DOMAIN
    EOF  
    ```
 
-- Create a DNSEntry CR. See the following example and modify values for the **metadata.namespace**, **metadata.spec.dnsName**, and **metadata.spec.targets.IP** parameters. Optionally, you can also change the value of **metadata.spec.ttl**. Run:
+  </details>
+  <details>
+  <summary>
+  Non-Gardener cluster
+  </summary>
+
+  ```bash
+   cat <<EOF | kubectl apply -f -
+   apiVersion: dns.gardener.cloud/v1alpha1
+   kind: DNSProvider
+   metadata:
+     name: dns-provider
+     namespace: $NAMESPACE
+   spec:
+     type: $SPEC_TYPE
+     secretRef:
+       name: $SECRET
+     domains:
+       include:
+         - $DOMAIN
+   EOF  
+   ```
+
+   </details>
+   </div>
+
+- Create a DNSEntry CR. Export values of the **metadata.namespace**, **metadata.spec.dnsName**, and **metadata.spec.targets.IP** parameters as environment variables. Optionally, you can also change the value of **metadata.spec.ttl**. Run:
 
    ```bash
+   export NAMESPACE={NAMESPACE_NAME}
+   export SUBDOMAIN={YOUR_SUBDOMAIN}
+   export IP={SECRET_NAME}
+   ```
+
+   Create a DNSEntry CR. Run:
+
+  <div tabs>
+  <details>
+  <summary>
+  Gardener cluster
+  </summary>
+
+  ```bash
    cat <<EOF | kubectl apply -f -
    apiVersion: dns.gardener.cloud/v1alpha1
    kind: DNSEntry
    metadata:
      name: dns-entry
-     namespace: NAMESPACE_NAME # Edit this value
+     namespace: $NAMESPACE
      annotations:
        dns.gardener.cloud/class: garden
    spec:
-     dnsName: "my.sub1.mydomain.com" # Your subdomain. Edit this value
+     dnsName: "$SUBDOMAIN"
      ttl: 600
      targets:
-       - 1.2.3.4 # IP address. Edit this value
-   EOF
+       - $IP
    ```
 
+  </details>
+  <details>
+  <summary>
+  Non-Gardener cluster
+  </summary>
+
+  ```bash
+   cat <<EOF | kubectl apply -f -
+   apiVersion: dns.gardener.cloud/v1alpha1
+   kind: DNSEntry
+   metadata:
+     name: dns-entry
+     namespace: $NAMESPACE
+     annotations:
+       dns.gardener.cloud/class: garden
+   spec:
+     dnsName: "$SUBDOMAIN"
+     ttl: 600
+     targets:
+       - $IP
+   ```
+
+   </details>
+   </div>
+
     >**NOTE:** To check the Ingress Gateway IP, run:
-    >```
+    >```bash
     >kubectl -n istio-system get service istio-ingressgateway -o jsonpath='{.status.loadBalancer.ingress[0].ip}'
     >```
 
    >**NOTE:** You can create many DNSEntry CRs for one DNSProvider, depending on the number of subdomains you want to use.
 
-5. Create an Issuer CR. See the following example and modify values of the **metadata.spec.acme.email**, **metadata.spec.domains.include**, and **metadata.spec.domains.exclude** parameters. As the values for the **metadata.spec.domains.include** parameter, use the main domain, the subdomain from the **spec.dnsName** parameter of the DNSEntry CR, and a wildcard DNS record. Run:
+5. Create an Issuer CR. Export values of the **metadata.spec.acme.email**, **metadata.spec.domains.include**, and **metadata.spec.domains.exclude** parameters as environment variables. As the values for the **metadata.spec.domains.include** parameter, use the main domain, the subdomain from the **spec.dnsName** parameter of the DNSEntry CR, and a wildcard DNS record. Run:
+
+   ```bash
+   export EMAIL={YOUR_EMAIL_ADDRESS}
+   export DOMAIN={CLUSTER_DOMAIN}
+   export SUBDOMAIN={YOUR_SUBDOMAIN}
+   export WILDCARD={YOUR_WILDCARD_DNS_RECORD, e.g. *.mydomain.com}
+   ```
+
+   Create an Issuer CR. Run:
 
    ```bash
    cat <<EOF | kubectl apply -f -
@@ -117,7 +212,7 @@ Follow these steps to set up your custom domain and prepare a certificate requir
    spec:
      acme:
        server: https://acme-staging-v02.api.letsencrypt.org/directory
-       email: YOUR_EMAIL_ADDRESS # Edit this value
+       email: $EMAIL
        autoRegistration: true
        # Name of the Secret used to store the ACME account private key
        # If doesn't exist, a new one is created
@@ -126,16 +221,25 @@ Follow these steps to set up your custom domain and prepare a certificate requir
          namespace: default
        domains:
          include:
-           - mydomain.com # The main domain. Edit this value
-           - my.sub1.mydomain.com # The subdomain provided in the DNS Entry created in the previous step. Edit this value
-           - "*.mydomain.com" # A wildcard DNS record. Edit this value
+           - $DOMAIN
+           - $SUBDOMAIN
+           - "$WILDCARD"
          # Optionally, restrict domain ranges for which certificates can be requested
    #     exclude:
    #       - my.sub2.mydomain.com # Edit this value
    EOF
    ```
 
-6. Create a Certificate CR. See the following example and modify values of the **spec.secretName**, **spec.commonName**, and **spec.issuerRef.name**, and **spec.dnsNames** parameters. As the value for the **spec.issuerRef.name** parameter, use the value from te **metadata.name** parameter of the Issuer CR. Run:
+6. Create a Certificate CR. Export values of the **metadata.namespace**, **spec.secretName**, **spec.commonName**, and **spec.issuerRef.name**, and **spec.dnsNames** parameters as environment variables. As the value for the **spec.issuerRef.name** parameter, use the value from te **metadata.name** parameter of the Issuer CR. Run:
+
+   ```bash
+   export NAMESPACE={NAMESPACE_NAME}
+   export SECRET_2={SECRET_NAME}
+   export DOMAIN={CLUSTER_DOMAIN}
+   export ISSUER={ISSUER_NAME}
+   export SUBDOMAIN={YOUR_SUBDOMAIN}
+
+   Create a Certificate CR. Run:
 
    ```bash
    cat <<EOF | kubectl apply -f -
@@ -143,19 +247,25 @@ Follow these steps to set up your custom domain and prepare a certificate requir
    kind: Certificate
    metadata:
      name: httpbin-cert
-     namespace: istio-system
-   spec:
-     secretName: httpbin-tls-credentials # Name of the Secret created using this CR. Edit this value
-     commonName: mydomain.com # The main domain. Edit this value
+     namespace: $NAMESPACE
+     secretName: $SECRET_2
+     commonName: $DOMAIN
      issuerRef:
-       name: letsencrypt-staging # Name of the Issuer created in the previous step. Edit this value
+       name: $ISSUER
        namespace: default
      dnsNames:
        - my.sub1.mydomain.com # Edit this value
    EOF
    ```
 
-7. Create a Gateway CR. See the following example and modify values of the **spec.servers.tls.credentialName** and **spec.servers.hosts** parameters. For the **spec.servers.tls.credentialName** parameter, use the **spec.secretName** value of the Certificate CR. As the value of **spec.servers.hosts**, use the subdomain from the **spec.dnsName** parameter of the DNSEntry CR. Run:
+7. Create a Gateway CR. Export values of the **spec.servers.tls.credentialName** and **spec.servers.hosts** parameters as anvironment variables. For the **spec.servers.tls.credentialName** parameter, use the **spec.secretName** value of the Certificate CR. As the value of **spec.servers.hosts**, use the wildcard DNS record. Run:
+
+   ```bash
+   export SECRET_2={SECRET_NAME}
+   export WILDCARD={YOUR_WILDCARD_DNS_RECORD, e.g. *.mydomain.com}
+   ```
+
+   Create a Gateway CR. Run:
 
    ```bash
    cat <<EOF | kubectl apply -f -
@@ -169,31 +279,23 @@ Follow these steps to set up your custom domain and prepare a certificate requir
      servers:
        - port:
            number: 443
-           name: https-httpbin
+           name: https
            protocol: HTTPS
          tls:
            mode: SIMPLE
-           credentialName: secret-name # Name of the Secret created in the Certificate CR in the previous step. Edit this value
+           credentialName: $SECRET_2
          hosts:
-           - "my.sub1.mydomain.com" # Edit this value
+           - "$WILDCARD"
    EOF
    ```
 
 8. Add your subdomain(s) at the end of the API Gateway **domain.allowlist** parameter. See the following example: `--domain-allowlist=my.sub1.mydomain.com`. Use a comma as a separator. Run the following command, to edit the deployment:
 
-   ```bash
+  ```bash
   kubectl edit deployment -n kyma-system api-gateway
   ```
 
    Press `i` to enter and `esc` to exit the interactive mode. Save the changes and exit the editor by pressing `:wq`.
-
-9. Restart the relevant deployment using this command:
-
-   ```bash
-   kubectl rollout restart deployment {DEPLOYMENT_NAME}
-   ```
-
-   >**TIP:** To check the deployment name, run: `kubectl get deployments -A`
 
    >**TIP:** To avoid adding every subdomain to the API Gateway **domain.allowlist** parameter, disable the allowlist mechanism. Override the value of the **config.enableDomainAllowList** parameter in the API Gateway chart by changing its value to `false`. For more details on overrides, see how to [change Kyma settings](../../04-operation-guides/operations/03-change-kyma-config-values.md).
 

--- a/docs/03-tutorials/00-api-exposure/apix-04-own-domain.md
+++ b/docs/03-tutorials/00-api-exposure/apix-04-own-domain.md
@@ -45,15 +45,7 @@ If you use a cluster not managed by Gardener, install the required components ma
    helm install cert-manager {PATH_TO_CERT_MANAGEMENT}/charts/cert-management --namespace=gardener-components --set configuration.identifier=cert-manager-identifier
    ```
 
-6. Add the following RBAC rules to allow the Certificate Management component to configure objects in a user's Namespace. Create a Namspacer and add two RBAC rules. Run:
-
-   ```bash
-   export NAMESPACE_NAME={YOUR_NAMESPACE}  #Namespace for your workload
-   ```
-
-   ```bash
-   kubectl create ns ${NAMESPACE_NAME}
-   ```
+6. Add the following RBAC rules to allow the Certificate Management component to configure objects. Run:
 
     ```bash
     cat <<EOF | kubectl apply -f -
@@ -279,6 +271,8 @@ Follow these steps to set up your custom domain and prepare a certificate requir
    EOF
    ```
 
+   > **NOTE:** The Issuer CR  must be created in the `default` Namespace.
+
 6. Create a Certificate CR. Export values of the **metadata.namespace**, **spec.secretName**, **spec.commonName**, and **spec.issuerRef.name**, and **spec.dnsNames** parameters as environment variables. As the value for the **spec.issuerRef.name** parameter, use the value from te **metadata.name** parameter of the Issuer CR. Run:
 
    ```bash
@@ -346,9 +340,9 @@ Follow these steps to set up your custom domain and prepare a certificate requir
 
 8. Add your subdomain(s) at the end of the API Gateway **domain.allowlist** parameter. See the following example: `--domain-allowlist=api.mydomain.com`. Use a comma as a separator. Run the following command, to edit the deployment:
 
-  ```bash
-  kubectl edit deployment -n kyma-system api-gateway
-  ```
+   ```bash
+   kubectl edit deployment -n kyma-system api-gateway
+   ```
 
    >**TIP:** To avoid adding every subdomain to the API Gateway **domain.allowlist** parameter, disable the allowlist mechanism. Override the value of the **config.enableDomainAllowList** parameter in the API Gateway chart by changing its value to `false`. For more details on overrides, see how to [change Kyma settings](../../04-operation-guides/operations/03-change-kyma-config-values.md).
 

--- a/docs/03-tutorials/00-api-exposure/apix-04-own-domain.md
+++ b/docs/03-tutorials/00-api-exposure/apix-04-own-domain.md
@@ -233,7 +233,6 @@ Follow these steps to set up your custom domain and prepare a certificate requir
 6. Create a Certificate CR. Export values of the **metadata.namespace**, **spec.secretName**, **spec.commonName**, and **spec.issuerRef.name**, and **spec.dnsNames** parameters as environment variables. As the value for the **spec.issuerRef.name** parameter, use the value from te **metadata.name** parameter of the Issuer CR. Run:
 
    ```bash
-   export NAMESPACE={NAMESPACE_NAME}
    export SECRET_2={SECRET_NAME}
    export DOMAIN={CLUSTER_DOMAIN}
    export ISSUER={ISSUER_NAME}
@@ -248,14 +247,14 @@ Follow these steps to set up your custom domain and prepare a certificate requir
    kind: Certificate
    metadata:
      name: httpbin-cert
-     namespace: $NAMESPACE
+     namespace: istio-system
      secretName: $SECRET_2
      commonName: $DOMAIN
      issuerRef:
        name: $ISSUER
        namespace: default
      dnsNames:
-       - my.sub1.mydomain.com # Edit this value
+       - $SUBDOMAIN
    EOF
    ```
 

--- a/docs/03-tutorials/00-api-exposure/apix-04-own-domain.md
+++ b/docs/03-tutorials/00-api-exposure/apix-04-own-domain.md
@@ -172,8 +172,6 @@ Follow these steps to set up your custom domain and prepare a certificate requir
    metadata:
      name: dns-entry
      namespace: $NAMESPACE
-     annotations:
-       dns.gardener.cloud/class: garden
    spec:
      dnsName: "$SUBDOMAIN"
      ttl: 600

--- a/docs/03-tutorials/00-api-exposure/apix-04-own-domain.md
+++ b/docs/03-tutorials/00-api-exposure/apix-04-own-domain.md
@@ -16,7 +16,7 @@ Depending on your cluster provider, meet the relevant prerequisites.
   Gardener cluster
   </summary>
 
-If you use a Gardener cluster, add an annotation for the `DNSProvider` and `DNSEntry` Custom Resources (CRs). The annotation allows the DNS source controllers to watch resources on the default cluster and create DNS entries on the target cluster. The annotation should look as follows:
+If you use a Gardener cluster, add an annotation for the DNSProvider and DNSEntry Custom Resources (CRs). The annotation allows the DNS source controllers to watch resources on the default cluster and create DNS entries on the target cluster. The annotation should look as follows:
 
 ```bash
   annotations:
@@ -137,7 +137,7 @@ Follow these steps to set up your custom domain and prepare a certificate requir
 
 5. Create an Issuer CRD. See the following example and modify values of the **spec.acme.email**, **spec.domains.include**, and **spec.domains.exclude** parameters. As the value for the **spec.domains.include** parameter, use the subdomain from `{DNS-ENTRY}.yaml`.
 
-```bash
+   ```bash
    apiVersion: cert.gardener.cloud/v1alpha1
    kind: Issuer
    metadata:

--- a/docs/03-tutorials/00-api-exposure/apix-04-own-domain.md
+++ b/docs/03-tutorials/00-api-exposure/apix-04-own-domain.md
@@ -58,7 +58,7 @@ Follow these steps to set up your custom domain and prepare a certificate requir
 
 4. Set up the `external-dns-management` component.
 
-- Create a DNSProvider CR. See the following example and modify values for the **metadata.namespace**, [**spec.type**](https://github.com/gardener/external-dns-management#using-the-dns-controller-manager), **metadata.spec.secretRef.name** and **metadata.spec.domains.include** parameters. As the value of **spec.type**, use the relevant provider type. See the [official Gardener examples](https://github.com/gardener/external-dns-management/tree/master/examples) of the DNSProvider CR. For the **spec.secretRef.name** parameter, use the **metadata.name** value from `{SECRET}.yaml`. Run:
+- Create a DNSProvider CR. See the following example and modify values for the **metadata.namespace**, [**spec.type**](https://github.com/gardener/external-dns-management#using-the-dns-controller-manager), **metadata.spec.secretRef.name** and **metadata.spec.domains.include** parameters. As the value of **spec.type**, use the relevant provider type. See the [official Gardener examples](https://github.com/gardener/external-dns-management/tree/master/examples) of the DNSProvider CR. For the **spec.secretRef.name** parameter, use the **metadata.name** value from your `{SECRET}.yaml`. Run:
 
    ```bash
    cat <<EOF | kubectl apply -f -
@@ -75,8 +75,7 @@ Follow these steps to set up your custom domain and prepare a certificate requir
        name: secret-name # Edit this value
      domains:
        include:
-         # Replace with the domain of the hosted zone
-         - mydomain.com # Edit this value
+         - mydomain.com # The main domain. Edit this value
    EOF  
    ```
 
@@ -92,11 +91,10 @@ Follow these steps to set up your custom domain and prepare a certificate requir
      annotations:
        dns.gardener.cloud/class: garden
    spec:
-     # Replace with your subdomain
-     dnsName: "my.sub1.mydomain.com" # Edit this value
+     dnsName: "my.sub1.mydomain.com" # Your subdomain. Edit this value
      ttl: 600
      targets:
-       - 1.2.3.4 # Edit this value
+       - 1.2.3.4 # IP address. Edit this value
    EOF
    ```
 
@@ -105,9 +103,9 @@ Follow these steps to set up your custom domain and prepare a certificate requir
     >kubectl -n istio-system get service istio-ingressgateway -o jsonpath='{.status.loadBalancer.ingress[0].ip}'
     >```
 
-   >**NOTE:** You can create many DNSEntry CRs for one DNSProvider depending on the number of subdomains you want to use.
+   >**NOTE:** You can create many DNSEntry CRs for one DNSProvider, depending on the number of subdomains you want to use.
 
-5. Create an Issuer CR. See the following example and modify values of the **metadata.spec.acme.email**, **metadata.spec.domains.include**, and **metadata.spec.domains.exclude** parameters. As the value for the **metadata.spec.domains.include** parameter, use the main domainm subdomain from the **spec.dnsName** parameter of the DNSEntry CR, and a wildcard DNS record. Run:
+5. Create an Issuer CR. See the following example and modify values of the **metadata.spec.acme.email**, **metadata.spec.domains.include**, and **metadata.spec.domains.exclude** parameters. As the values for the **metadata.spec.domains.include** parameter, use the main domain, the subdomain from the **spec.dnsName** parameter of the DNSEntry CR, and a wildcard DNS record. Run:
 
    ```bash
    cat <<EOF | kubectl apply -f -
@@ -122,15 +120,15 @@ Follow these steps to set up your custom domain and prepare a certificate requir
        email: YOUR_EMAIL_ADDRESS # Edit this value
        autoRegistration: true
        # Name of the Secret used to store the ACME account private key
-       # If does not exist, a new one is created
+       # If doesn't exist, a new one is created
        privateKeySecretRef:
          name: letsencrypt-staging-secret
          namespace: default
        domains:
          include:
            - mydomain.com # The main domain. Edit this value
-           - "*.mydomain.com" # A wildcard DNS record. Edit this value
            - my.sub1.mydomain.com # The subdomain provided in the DNS Entry created in the previous step. Edit this value
+           - "*.mydomain.com" # A wildcard DNS record. Edit this value
          # Optionally, restrict domain ranges for which certificates can be requested
    #     exclude:
    #       - my.sub2.mydomain.com # Edit this value
@@ -148,10 +146,9 @@ Follow these steps to set up your custom domain and prepare a certificate requir
      namespace: istio-system
    spec:
      secretName: httpbin-tls-credentials # Name of the Secret created using this CR. Edit this value
-     commonName: mydomain.com # Edit this value
+     commonName: mydomain.com # The main domain. Edit this value
      issuerRef:
-       # Name of the Issuer created in the previous step
-       name: letsencrypt-staging # Edit this value
+       name: letsencrypt-staging # Name of the Issuer created in the previous step. Edit this value
        namespace: default
      dnsNames:
        - my.sub1.mydomain.com # Edit this value
@@ -176,7 +173,7 @@ Follow these steps to set up your custom domain and prepare a certificate requir
            protocol: HTTPS
          tls:
            mode: SIMPLE
-           credentialName: secret-name # Edit this value
+           credentialName: secret-name # Name of the Secret created in the Certificate CR in the previous step. Edit this value
          hosts:
            - "my.sub1.mydomain.com" # Edit this value
    EOF


### PR DESCRIPTION
**Description**

Describe  how to solve the original issue: https://github.com/kyma-project/kyma/issues/5578
Users want to expose workloads on different domains, like: workload.a => `foo.com`, workload.b => `bar.com`, with properly working TLS certificates.

Changes proposed in this pull request:

- Added a tutorial for using custom domains

**Related issue(s)**
Resolves #11828
