### PR TITLE
Add OAuth2 secured API Rule to fast-integration tests

### DIFF
--- a/tests/fast-integration/compass-test/compass-test.js
+++ b/tests/fast-integration/compass-test/compass-test.js
@@ -12,7 +12,7 @@ const {
 const {
   ensureCommerceMockWithCompassTestFixture,
   cleanMockTestFixture,
-  checkAppGatewayResponse,
+  checkFunctionResponse,
   sendEventAndCheckResponse
 } = require("../test/fixtures/commerce-mock");
 
@@ -38,8 +38,8 @@ describe("Kyma with Compass test", async function() {
     await ensureCommerceMockWithCompassTestFixture(director, appName, scenarioName,  "mocks", testNS, withCentralAppConnectivity);
   });
 
-  it("function should reach Commerce mock API through app gateway", async function () {
-    await checkAppGatewayResponse();
+  it("function should be reachable through secured API Rule", async function () {
+    await checkFunctionResponse(testNS);
   });
     
   it("order.created.v1 event should trigger the lastorder function", async function () {

--- a/tests/fast-integration/skr-test/skr-test.js
+++ b/tests/fast-integration/skr-test/skr-test.js
@@ -18,7 +18,7 @@ const {
 } = require("../gardener");
 const {
   ensureCommerceMockWithCompassTestFixture,
-  checkAppGatewayResponse,
+  checkFunctionResponse,
   sendEventAndCheckResponse,
   deleteMockTestFixture,
 } = require("../test/fixtures/commerce-mock");
@@ -71,8 +71,8 @@ describe("SKR test", function() {
     await ensureCommerceMockWithCompassTestFixture(director, appName, scenarioName,  "mocks", testNS);
   });
 
-  it("function should reach Commerce mock API through app gateway", async function () {
-    await checkAppGatewayResponse();
+  it("function should be reachable through secured API Rule", async function () {
+    await checkFunctionResponse(testNS);
   });
     
   it("order.created.v1 event should trigger the lastorder function", async function () {

--- a/tests/fast-integration/test/1-commerce-mock.js
+++ b/tests/fast-integration/test/1-commerce-mock.js
@@ -7,7 +7,7 @@ const httpsAgent = new https.Agent({
 axios.defaults.httpsAgent = httpsAgent;
 const {
   ensureCommerceMockLocalTestFixture,
-  checkAppGatewayResponse,
+  checkFunctionResponse,
   sendEventAndCheckResponse,
   cleanMockTestFixture,
   checkInClusterEventDelivery,
@@ -53,8 +53,8 @@ describe("CommerceMock tests", function () {
     await checkInClusterEventDelivery(testNamespace);
   });
 
-  it("function should reach Commerce mock API through app gateway", async function () {
-    await checkAppGatewayResponse();
+  it("function should be reachable through secured API Rule", async function () {
+    await checkFunctionResponse(testNamespace);
   });
 
   it("order.created.v1 event should trigger the lastorder function", async function () {

--- a/tests/fast-integration/test/fixtures/commerce-mock/index.js
+++ b/tests/fast-integration/test/fixtures/commerce-mock/index.js
@@ -40,7 +40,11 @@ const {
 const {
   registerOrReturnApplication,
 } = require("../../../compass");
-const { OAuthToken, OAuthCredentials } = require("../../../lib/oauth");
+
+const {
+  OAuthToken,
+  OAuthCredentials
+} = require("../../../lib/oauth");
 
 const commerceMockYaml = fs.readFileSync(
   path.join(__dirname, "./commerce-mock.yaml"),

--- a/tests/fast-integration/test/fixtures/commerce-mock/index.js
+++ b/tests/fast-integration/test/fixtures/commerce-mock/index.js
@@ -33,12 +33,14 @@ const {
   ensureApplicationMapping,
   patchApplicationGateway,
   eventingSubscription,
-  k8sDelete
+  k8sDelete,
+  getSecretData
 } = require("../../../utils");
 
 const {
   registerOrReturnApplication,
 } = require("../../../compass");
+const { OAuthToken, OAuthCredentials } = require("../../../lib/oauth");
 
 const commerceMockYaml = fs.readFileSync(
   path.join(__dirname, "./commerce-mock.yaml"),
@@ -100,22 +102,44 @@ function serviceInstanceObj(name, serviceClassExternalName) {
   };
 }
 
-
-async function checkAppGatewayResponse() {
+async function checkFunctionResponse(functionNamespace) {
   const vs = await waitForVirtualService("mocks", "commerce-mock");
   const mockHost = vs.spec.hosts[0];
   const host = mockHost.split(".").slice(1).join(".");
 
+  // get OAuth client id and client secret from Kubernetes Secret
+  const oAuthSecretData = await getSecretData("lastorder-oauth", functionNamespace);
+
+  // get access token from OAuth server
+  const oAuthTokenGetter = new OAuthToken(
+    `https://oauth2.${host}/oauth2/token`,
+    new OAuthCredentials(oAuthSecretData["client_id"], oAuthSecretData["client_secret"])
+  );
+  const accessToken = await oAuthTokenGetter.getToken(["read", "write"]);
+
+  // expect no error when authorized
   let res = await retryPromise(
-    () => axios.post(`https://lastorder.${host}`, { orderCode: "789" }, { timeout: 5000 }),
+    () => axios.post(`https://lastorder.${host}/function`, { orderCode: "789" }, { 
+      timeout: 5000,
+      headers: { Authorization: `bearer ${accessToken}`}
+    }),
     45,
     2000
-  ).catch((err) => { throw convertAxiosError(err, "Function lastorder responded with error") });
+  ).catch((err) => {
+    throw convertAxiosError(err, "Function lastorder responded with error");
+  });
 
-  expect(res.data).to.have.nested.property(
-    "order.totalPriceWithTax.value",
-    100
-  );
+  expect(res.data).to.have.nested.property("order.totalPriceWithTax.value", 100);
+
+  // expect error when unauthorized
+  let errorOccurred = false
+  try {
+    res = await axios.post(`https://lastorder.${host}/function`, { orderCode: "789" }, { timeout: 5000 })
+  } catch (err) {
+    errorOccurred = true;
+    expect(err.response.status).to.be.equal(401);
+  }
+  expect(errorOccurred).to.be.equal(true);
 }
 
 async function sendEventAndCheckResponse() {
@@ -505,7 +529,7 @@ module.exports = {
   ensureCommerceMockLocalTestFixture,
   ensureCommerceMockWithCompassTestFixture,
   sendEventAndCheckResponse,
-  checkAppGatewayResponse,
+  checkFunctionResponse,
   checkInClusterEventDelivery,
   cleanMockTestFixture,
   deleteMockTestFixture,

--- a/tests/fast-integration/test/fixtures/commerce-mock/lastorder-function.yaml
+++ b/tests/fast-integration/test/fixtures/commerce-mock/lastorder-function.yaml
@@ -80,6 +80,16 @@ spec:
       }
     }
 ---
+apiVersion: hydra.ory.sh/v1alpha1
+kind: OAuth2Client
+metadata:
+  name: lastorder
+spec:
+  grantTypes:
+    - "client_credentials"
+  scope: "read write"
+  secretName: lastorder-oauth
+---
 apiVersion: gateway.kyma-project.io/v1alpha1
 kind: APIRule
 metadata:
@@ -87,11 +97,17 @@ metadata:
 spec:
   gateway: kyma-gateway.kyma-system.svc.cluster.local
   rules:
-    - accessStrategies:
-        - config: {}
-          handler: allow
-      methods: ["*"]
-      path: /.*
+    - path: /function
+      methods: ["GET", "POST"]
+      accessStrategies:
+        - handler: oauth2_introspection
+          config:
+            required_scope: ["read"]
+    - path: /.*
+      methods: ["GET", "POST"]
+      accessStrategies:
+        - handler: allow
+          config: {}
   service:
     host: lastorder
     name: lastorder

--- a/tests/fast-integration/upgrade-test/upgrade-test-tests.js
+++ b/tests/fast-integration/upgrade-test/upgrade-test-tests.js
@@ -1,6 +1,6 @@
 const {
   checkInClusterEventDelivery,
-  checkAppGatewayResponse,
+  checkFunctionResponse,
   sendEventAndCheckResponse,
 } = require("../test/fixtures/commerce-mock");
 const {
@@ -22,8 +22,8 @@ describe("Upgrade test tests", function () {
     await checkInClusterEventDelivery(testNamespace);
   });
 
-  it("function should reach Commerce mock API through app gateway", async function () {
-    await checkAppGatewayResponse();
+  it("function should be reachable through secured API Rule", async function () {
+    await checkFunctionResponse(testNamespace);
   });
 
   it("order.created.v1 event should trigger the lastorder function", async function () {

--- a/tests/fast-integration/utils/index.js
+++ b/tests/fast-integration/utils/index.js
@@ -674,6 +674,23 @@ async function getAllResourceTypes() {
   }
 }
 
+async function getSecretData(name, namespace) {
+  try {
+    const secret = await getSecret(name, namespace);
+    const encodedData = secret.data;
+    return Object.fromEntries(
+      Object.entries(encodedData).map(([key, value]) => {
+        const buff = Buffer.from(value, "base64");
+        const decoded = buff.toString("ascii");
+        return [key, decoded];
+      })
+    );
+  } catch (e) {
+    console.log("Error:", e);
+    throw e;
+  }
+}
+
 function ignore404(e) {
   if (e.statusCode != 404) {
     throw e;
@@ -1042,6 +1059,7 @@ module.exports = {
   getClusteraddonsconfigurations,
   getSecret,
   getSecrets,
+  getSecretData,
   listResources,
   listResourceNames,
   k8sDynamicApi,


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- Add OAuth2 secured API Rule and OAuth2Client to fast-integration tests, to cover ORY component
- Rename misleading test case
- Fix invalid `methods` property in existing API Rule

**Related issue(s)**
https://github.com/kyma-project/kyma/issues/11769
