### PR TITLE
Remove obsolete make target ci-no-install

### DIFF
--- a/tests/fast-integration/Makefile
+++ b/tests/fast-integration/Makefile
@@ -4,9 +4,6 @@ ci:
 	npm test
 	npm run test-monitoring
 
-.PHONY: ci-no-install
-ci-no-install: ci
-
 .PHONY: ci-compass
 ci-compass:
 	npm install


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**
The make target `ci-no-install` is just shadowing the target `ci` target. It's usage also has been removed from test-infra (see https://github.com/kyma-project/test-infra/pull/4032) so it can be deleted here.

Changes proposed in this pull request:
- Delete `ci-no-install` target

**Related issue(s)**
#11668
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
