### PR TITLE
Revert "Use latest minio image (#11568)"

### DIFF
--- a/resources/rafter/values.yaml
+++ b/resources/rafter/values.yaml
@@ -210,7 +210,7 @@ controller-manager:
         pullPolicy: IfNotPresent
 
     image:
-      tag: RELEASE.2020-09-21T22-31-59Z-deb4ee80
+      tag: RELEASE.2020-09-21T22-31-59Z-f5446c93
       repository: eu.gcr.io/kyma-project/tpi/minio/minio
 
     pod:

--- a/resources/rafter/values.yaml
+++ b/resources/rafter/values.yaml
@@ -210,7 +210,7 @@ controller-manager:
         pullPolicy: IfNotPresent
 
     image:
-      tag: RELEASE.2021-06-17T00-10-46Z-355e9c77
+      tag: RELEASE.2020-09-21T22-31-59Z-deb4ee80
       repository: eu.gcr.io/kyma-project/tpi/minio/minio
 
     pod:


### PR DESCRIPTION
This reverts commit 7f9165cbe59ce0fb75b9bfe4079d8948d45d2a51.

Due to wrong minio licence

**Description**

Changes proposed in this pull request:

- Reverting to previously used minio version ( license reasons )
