### PR TITLE
Run all fast-integration tests with app-connectivity as default

### DIFF
--- a/tests/fast-integration/Makefile
+++ b/tests/fast-integration/Makefile
@@ -30,13 +30,3 @@ ci-post-upgrade:
 	npm install
 	npm run upgrade-test-tests
 	npm run upgrade-test-cleanup
-
-.PHONY: ci-application-connectivity-2
-ci-application-connectivity-2:
-	npm install
-	npm run test-application-connectivity-2
-
-.PHONY: ci-application-connectivity-2-compass
-ci-application-connectivity-2-compass:
-	npm install
-	npm run test-application-connectivity-2-compass

--- a/tests/fast-integration/compass-test/compass-test.js
+++ b/tests/fast-integration/compass-test/compass-test.js
@@ -18,7 +18,6 @@ const {
 
 describe("Kyma with Compass test", async function() {
   const director = new DirectorClient(DirectorConfig.fromEnv());
-  const withCentralAppConnectivity = (process.env.WITH_CENTRAL_APP_CONNECTIVITY === "true");
 
   const suffix = genRandom(4);
   const appName = `app-${suffix}`;
@@ -35,7 +34,7 @@ describe("Kyma with Compass test", async function() {
   });
 
   it("CommerceMock test fixture should be ready", async function () {
-    await ensureCommerceMockWithCompassTestFixture(director, appName, scenarioName,  "mocks", testNS, withCentralAppConnectivity);
+    await ensureCommerceMockWithCompassTestFixture(director, appName, scenarioName,  "mocks", testNS);
   });
 
   it("function should be reachable through secured API Rule", async function () {

--- a/tests/fast-integration/compass-test/compass-test.js
+++ b/tests/fast-integration/compass-test/compass-test.js
@@ -1,20 +1,6 @@
-const { 
-  DirectorConfig, 
-  DirectorClient,
-  registerKymaInCompass,
-  unregisterKymaFromCompass,
-} = require("../compass/");
-
-const {
-  genRandom, debug
-} = require("../utils");
-
-const {
-  ensureCommerceMockWithCompassTestFixture,
-  cleanMockTestFixture,
-  checkFunctionResponse,
-  sendEventAndCheckResponse
-} = require("../test/fixtures/commerce-mock");
+import { DirectorConfig, DirectorClient, registerKymaInCompass, unregisterKymaFromCompass } from "../compass/";
+import { genRandom } from "../utils";
+import { ensureCommerceMockWithCompassTestFixture, cleanMockTestFixture, checkFunctionResponse, sendEventAndCheckResponse } from "../test/fixtures/commerce-mock";
 
 describe("Kyma with Compass test", async function() {
   const director = new DirectorClient(DirectorConfig.fromEnv());

--- a/tests/fast-integration/compass-test/compass-test.js
+++ b/tests/fast-integration/compass-test/compass-test.js
@@ -1,6 +1,20 @@
-import { DirectorConfig, DirectorClient, registerKymaInCompass, unregisterKymaFromCompass } from "../compass/";
-import { genRandom } from "../utils";
-import { ensureCommerceMockWithCompassTestFixture, cleanMockTestFixture, checkFunctionResponse, sendEventAndCheckResponse } from "../test/fixtures/commerce-mock";
+const { 
+  DirectorConfig, 
+  DirectorClient,
+  registerKymaInCompass,
+  unregisterKymaFromCompass,
+} = require("../compass/");
+
+const {
+  genRandom, debug
+} = require("../utils");
+
+const {
+  ensureCommerceMockWithCompassTestFixture,
+  cleanMockTestFixture,
+  checkFunctionResponse,
+  sendEventAndCheckResponse
+} = require("../test/fixtures/commerce-mock");
 
 describe("Kyma with Compass test", async function() {
   const director = new DirectorClient(DirectorConfig.fromEnv());

--- a/tests/fast-integration/package.json
+++ b/tests/fast-integration/package.json
@@ -20,9 +20,7 @@
     "test-monitoring": "mocha --inline-diffs --check-leaks --reporter mocha-multi-reporters --reporter-options configFile=mocha-reporter-config.json ./monitoring-test/",
     "upgrade-test-prep": "mocha --inline-diffs --check-leaks --reporter mocha-multi-reporters --reporter-options configFile=mocha-reporter-config.json upgrade-test/upgrade-test-prep.js",
     "upgrade-test-tests": "mocha --inline-diffs --check-leaks --reporter mocha-multi-reporters --reporter-options configFile=mocha-reporter-config.json upgrade-test/upgrade-test-tests.js",
-    "upgrade-test-cleanup": "mocha --inline-diffs --check-leaks --reporter mocha-multi-reporters --reporter-options configFile=mocha-reporter-config.json upgrade-test/upgrade-test-cleanup.js",
-    "test-application-connectivity-2": "env WITH_CENTRAL_APP_CONNECTIVITY=true mocha --inline-diffs --check-leaks --reporter mocha-multi-reporters --reporter-options configFile=mocha-reporter-config.json",
-    "test-application-connectivity-2-compass": "env WITH_CENTRAL_APP_CONNECTIVITY=true mocha --inline-diffs --check-leaks --reporter mocha-multi-reporters --reporter-options configFile=mocha-reporter-config.json ./compass-test/"
+    "upgrade-test-cleanup": "mocha --inline-diffs --check-leaks --reporter mocha-multi-reporters --reporter-options configFile=mocha-reporter-config.json upgrade-test/upgrade-test-cleanup.js"
   },
   "license": "Apache-2.0",
   "devDependencies": {

--- a/tests/fast-integration/test/1-commerce-mock.js
+++ b/tests/fast-integration/test/1-commerce-mock.js
@@ -1,25 +1,13 @@
-const axios = require("axios");
-const https = require("https");
-const { expect } = require("chai");
-const httpsAgent = new https.Agent({
+import { defaults } from "axios";
+import { Agent } from "https";
+import { ensureCommerceMockLocalTestFixture, checkFunctionResponse, sendEventAndCheckResponse, cleanMockTestFixture, checkInClusterEventDelivery } from "./fixtures/commerce-mock";
+import { printRestartReport, getContainerRestartsForAllNamespaces } from "../utils";
+import { checkLokiLogs, lokiPortForward } from "../logging";
+
+const httpsAgent = new Agent({
   rejectUnauthorized: false, // curl -k
 });
-axios.defaults.httpsAgent = httpsAgent;
-const {
-  ensureCommerceMockLocalTestFixture,
-  checkFunctionResponse,
-  sendEventAndCheckResponse,
-  cleanMockTestFixture,
-  checkInClusterEventDelivery,
-} = require("./fixtures/commerce-mock");
-const {
-  printRestartReport,
-  getContainerRestartsForAllNamespaces,
-} = require("../utils");
-const {
-  checkLokiLogs,
-  lokiPortForward
-} = require("../logging");
+defaults.httpsAgent = httpsAgent;
 
 describe("CommerceMock tests", function () {
   this.timeout(10 * 60 * 1000);

--- a/tests/fast-integration/test/1-commerce-mock.js
+++ b/tests/fast-integration/test/1-commerce-mock.js
@@ -1,13 +1,25 @@
-import { defaults } from "axios";
-import { Agent } from "https";
-import { ensureCommerceMockLocalTestFixture, checkFunctionResponse, sendEventAndCheckResponse, cleanMockTestFixture, checkInClusterEventDelivery } from "./fixtures/commerce-mock";
-import { printRestartReport, getContainerRestartsForAllNamespaces } from "../utils";
-import { checkLokiLogs, lokiPortForward } from "../logging";
-
-const httpsAgent = new Agent({
+const axios = require("axios");
+const https = require("https");
+const { expect } = require("chai");
+const httpsAgent = new https.Agent({
   rejectUnauthorized: false, // curl -k
 });
-defaults.httpsAgent = httpsAgent;
+axios.defaults.httpsAgent = httpsAgent;
+const {
+  ensureCommerceMockLocalTestFixture,
+  checkFunctionResponse,
+  sendEventAndCheckResponse,
+  cleanMockTestFixture,
+  checkInClusterEventDelivery,
+} = require("./fixtures/commerce-mock");
+const {
+  printRestartReport,
+  getContainerRestartsForAllNamespaces,
+} = require("../utils");
+const {
+  checkLokiLogs,
+  lokiPortForward
+} = require("../logging");
 
 describe("CommerceMock tests", function () {
   this.timeout(10 * 60 * 1000);

--- a/tests/fast-integration/test/1-commerce-mock.js
+++ b/tests/fast-integration/test/1-commerce-mock.js
@@ -24,7 +24,6 @@ const {
 describe("CommerceMock tests", function () {
   this.timeout(10 * 60 * 1000);
   this.slow(5000);
-  const withCentralAppConnectivity = (process.env.WITH_CENTRAL_APP_CONNECTIVITY === "true");
   const testNamespace = "test";
   const testStartTimestamp = new Date().toISOString();
   let initialRestarts = null;
@@ -43,9 +42,9 @@ describe("CommerceMock tests", function () {
   });
 
   it("CommerceMock test fixture should be ready", async function () {
-    await ensureCommerceMockLocalTestFixture("mocks", testNamespace, withCentralAppConnectivity).catch((err) => {
+    await ensureCommerceMockLocalTestFixture("mocks", testNamespace).catch((err) => {
       console.dir(err); // first error is logged
-      return ensureCommerceMockLocalTestFixture("mocks", testNamespace, withCentralAppConnectivity);
+      return ensureCommerceMockLocalTestFixture("mocks", testNamespace);
     });
   });
 

--- a/tests/fast-integration/test/2-getting-started-guides.js
+++ b/tests/fast-integration/test/2-getting-started-guides.js
@@ -1,5 +1,12 @@
-import { ensureGettingStartedTestFixture, verifyOrderPersisted, cleanGettingStartedTestFixture } from "./fixtures/getting-started-guides";
-import { printRestartReport, getContainerRestartsForAllNamespaces } from "../utils";
+const {
+  ensureGettingStartedTestFixture,
+  verifyOrderPersisted,
+  cleanGettingStartedTestFixture,
+} = require("./fixtures/getting-started-guides");
+const {
+  printRestartReport,
+  getContainerRestartsForAllNamespaces,
+} = require("../utils");
 
 describe("Getting Started Guide Tests", function () {
   this.timeout(10 * 60 * 1000);

--- a/tests/fast-integration/test/2-getting-started-guides.js
+++ b/tests/fast-integration/test/2-getting-started-guides.js
@@ -12,11 +12,6 @@ describe("Getting Started Guide Tests", function () {
   this.timeout(10 * 60 * 1000);
   this.slow(5000);
 
-  if (process.env.WITH_CENTRAL_APP_CONNECTIVITY) {
-    console.log("Getting Started Guide test for Central Application Connectivity not implemented. Omitting...");
-    return;
-  }
-
   let initialRestarts = null;
 
   it("Listing all pods in cluster", async function () {

--- a/tests/fast-integration/test/2-getting-started-guides.js
+++ b/tests/fast-integration/test/2-getting-started-guides.js
@@ -1,12 +1,5 @@
-const {
-  ensureGettingStartedTestFixture,
-  verifyOrderPersisted,
-  cleanGettingStartedTestFixture,
-} = require("./fixtures/getting-started-guides");
-const {
-  printRestartReport,
-  getContainerRestartsForAllNamespaces,
-} = require("../utils");
+import { ensureGettingStartedTestFixture, verifyOrderPersisted, cleanGettingStartedTestFixture } from "./fixtures/getting-started-guides";
+import { printRestartReport, getContainerRestartsForAllNamespaces } from "../utils";
 
 describe("Getting Started Guide Tests", function () {
   this.timeout(10 * 60 * 1000);

--- a/tests/fast-integration/test/fixtures/commerce-mock/index.js
+++ b/tests/fast-integration/test/fixtures/commerce-mock/index.js
@@ -72,9 +72,9 @@ const commerceObjs = k8s.loadAllYaml(commerceMockYaml);
 const applicationObjs = k8s.loadAllYaml(applicationMockYaml);
 const lastorderObjs = k8s.loadAllYaml(lastorderFunctionYaml);
 
-function prepareLastOrderObjs(type = 'central-app-gateway', appName = 'commerce') {
+function prepareLastOrderObjs(compassEnabled = false , appName = 'commerce') {
 
-  if (type === "central-app-gateway-compass") {
+  if (compassEnabled) {
     return k8s.loadAllYaml(lastorderFunctionYaml.toString()
       .replace('%%URL%%', '"http://central-application-gateway.kyma-system:8082/%%APP_NAME%%/sap-commerce-cloud/commerce-webservices/site/orders/" + code')
       .replace('%%APP_NAME%%', appName));
@@ -291,7 +291,7 @@ async function connectCommerceMock(mockHost, tokenData) {
 }
 
 async function ensureCommerceMockWithCompassTestFixture(client, appName, scenarioName, mockNamespace, targetNamespace) {
-  const lastOrderObjs = prepareLastOrderObjs('central-app-gateway-compass', `mp-${appName}`);
+  const lastOrderObjs = prepareLastOrderObjs(true, `mp-${appName}`);
   const mockHost = await provisionCommerceMockResources(
     `mp-${appName}`,
     mockNamespace,

--- a/tests/fast-integration/test/fixtures/commerce-mock/index.js
+++ b/tests/fast-integration/test/fixtures/commerce-mock/index.js
@@ -72,19 +72,16 @@ const commerceObjs = k8s.loadAllYaml(commerceMockYaml);
 const applicationObjs = k8s.loadAllYaml(applicationMockYaml);
 const lastorderObjs = k8s.loadAllYaml(lastorderFunctionYaml);
 
-function prepareLastorderObjs(type = 'standard', appName = 'commerce') {
-  switch (type) {
-    case "central-app-gateway":
-      return k8s.loadAllYaml(lastorderFunctionYaml.toString()
-        .replace('%%URL%%', '"http://central-application-gateway.kyma-system:8080/commerce/sap-commerce-cloud-commerce-webservices/site/orders/" + code'));
-    case "central-app-gateway-compass":
-      return k8s.loadAllYaml(lastorderFunctionYaml.toString()
-        .replace('%%URL%%', '"http://central-application-gateway.kyma-system:8082/%%APP_NAME%%/sap-commerce-cloud/commerce-webservices/site/orders/" + code')
-        .replace('%%APP_NAME%%', appName));
-    default:
-      return k8s.loadAllYaml(lastorderFunctionYaml.toString()
-        .replace('%%URL%%', 'findEnv("GATEWAY_URL") + "/site/orders/" + code'));
+function prepareLastOrderObjs(type = 'central-app-gateway', appName = 'commerce') {
+
+  if (type === "central-app-gateway-compass") {
+    return k8s.loadAllYaml(lastorderFunctionYaml.toString()
+      .replace('%%URL%%', '"http://central-application-gateway.kyma-system:8082/%%APP_NAME%%/sap-commerce-cloud/commerce-webservices/site/orders/" + code')
+      .replace('%%APP_NAME%%', appName));
   }
+
+  return k8s.loadAllYaml(lastorderFunctionYaml.toString()
+    .replace('%%URL%%', '"http://central-application-gateway.kyma-system:8080/commerce/sap-commerce-cloud-commerce-webservices/site/orders/" + code'));
 }
 
 function namespaceObj(name) {
@@ -123,9 +120,9 @@ async function checkFunctionResponse(functionNamespace) {
 
   // expect no error when authorized
   let res = await retryPromise(
-    () => axios.post(`https://lastorder.${host}/function`, { orderCode: "789" }, { 
+    () => axios.post(`https://lastorder.${host}/function`, { orderCode: "789" }, {
       timeout: 5000,
-      headers: { Authorization: `bearer ${accessToken}`}
+      headers: { Authorization: `bearer ${accessToken}` }
     }),
     45,
     2000
@@ -293,12 +290,13 @@ async function connectCommerceMock(mockHost, tokenData) {
   }
 }
 
-async function ensureCommerceMockWithCompassTestFixture(client, appName, scenarioName, mockNamespace, targetNamespace, withCentralApplicationConnectivity = false) {
+async function ensureCommerceMockWithCompassTestFixture(client, appName, scenarioName, mockNamespace, targetNamespace) {
+  const lastOrderObjs = prepareLastOrderObjs('central-app-gateway-compass', `mp-${appName}`);
   const mockHost = await provisionCommerceMockResources(
     `mp-${appName}`,
     mockNamespace,
     targetNamespace,
-    withCentralApplicationConnectivity ? prepareLastorderObjs('central-app-gateway-compass', `mp-${appName}`) : prepareLastorderObjs());
+    lastOrderObjs);
   await retryPromise(() => connectMockCompass(client, appName, scenarioName, mockHost, targetNamespace), 10, 3000);
   await retryPromise(() => registerAllApis(mockHost), 10, 3000);
 
@@ -310,15 +308,9 @@ async function ensureCommerceMockWithCompassTestFixture(client, appName, scenari
     2000
   );
   await waitForServiceInstance("commerce", targetNamespace, 300 * 1000);
-
-  if (withCentralApplicationConnectivity) {
-    await waitForDeployment('central-application-gateway', 'kyma-system');
-    await waitForDeployment('central-application-connectivity-validator', 'kyma-system');
-    await patchApplicationGateway('central-application-gateway', 'kyma-system');
-  } else {
-    await waitForDeployment(`${targetNamespace}-gateway`, targetNamespace);
-    await patchApplicationGateway(`${targetNamespace}-gateway`, targetNamespace);
-  }
+  await waitForDeployment('central-application-gateway', 'kyma-system');
+  await waitForDeployment('central-application-connectivity-validator', 'kyma-system');
+  await patchApplicationGateway('central-application-gateway', 'kyma-system');
 
   const serviceBinding = {
     apiVersion: "servicecatalog.k8s.io/v1beta1",
@@ -356,21 +348,21 @@ async function ensureCommerceMockWithCompassTestFixture(client, appName, scenari
   return mockHost;
 }
 
-async function ensureCommerceMockLocalTestFixture(mockNamespace, targetNamespace, withCentralApplicationConnectivity = false) {
+async function ensureCommerceMockLocalTestFixture(mockNamespace, targetNamespace) {
   await k8sApply(applicationObjs);
+
+  const lastOrderObjs = prepareLastOrderObjs();
   const mockHost = await provisionCommerceMockResources(
     "commerce",
     mockNamespace,
     targetNamespace,
-    withCentralApplicationConnectivity ? prepareLastorderObjs('central-app-gateway') : prepareLastorderObjs());
+    lastOrderObjs);
   await retryPromise(() => connectMockLocal(mockHost, targetNamespace), 10, 3000);
   await retryPromise(() => registerAllApis(mockHost), 10, 3000);
 
-  if (withCentralApplicationConnectivity) {
-    await waitForDeployment('central-application-gateway', 'kyma-system');
-    await waitForDeployment('central-application-connectivity-validator', 'kyma-system');
-    await patchApplicationGateway('central-application-gateway', 'kyma-system');
-  }
+  await waitForDeployment('central-application-gateway', 'kyma-system');
+  await waitForDeployment('central-application-connectivity-validator', 'kyma-system');
+  await patchApplicationGateway('central-application-gateway', 'kyma-system');
 
   const webServicesSC = await waitForServiceClass(
     "webservices",


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**
The distinction between tests with or without central-app-connectivity enabled is obsolete. All tests run from jobs where it is enabled.

Changes proposed in this pull request:
- Remove make targets and test script definition that were meant for central-app-connectivity
- Remove flag usage in tests and make all tests default to "with central-app-connectivity"

**Related issue(s)**
* Builds on https://github.com/kyma-project/test-infra/pull/4065
* Part of https://github.com/kyma-project/kyma/issues/11870
