### PR TITLE
upgrade to fluent-bit 1.8

### DIFF
--- a/resources/logging/charts/fluent-bit/templates/configmap.yaml
+++ b/resources/logging/charts/fluent-bit/templates/configmap.yaml
@@ -70,6 +70,10 @@ data:
         Multiline_Flush   {{ .Values.config.inputs.tail.multilineFlush }}
         Parser_Firstline  {{ .Values.config.inputs.tail.parserFirstline }}
         {{- end }}
+        {{- if .Values.config.inputs.tail.multilineParser }}
+        multiline.parser  {{ .Values.config.inputs.tail.multilineParser }}
+        {{- end }}
+        Read_from_Head    {{ .Values.config.inputs.tail.readFromHead }}
         
 {{- end }}
 

--- a/resources/logging/charts/fluent-bit/values.yaml
+++ b/resources/logging/charts/fluent-bit/values.yaml
@@ -9,7 +9,7 @@ replicaCount: 1
 image:
   repository: eu.gcr.io/kyma-project/tpi/fluent-bit
   pullPolicy: IfNotPresent
-  tag: 1.8.4-PR-117
+  tag: 1.8.5-ea0b3c70
 
 imagePullSecrets: []
 nameOverride: ""

--- a/resources/logging/charts/fluent-bit/values.yaml
+++ b/resources/logging/charts/fluent-bit/values.yaml
@@ -9,7 +9,7 @@ replicaCount: 1
 image:
   repository: eu.gcr.io/kyma-project/tpi/fluent-bit
   pullPolicy: IfNotPresent
-  tag: 1.5.7-a558c5c4
+  tag: 1.8.4-PR-117
 
 imagePullSecrets: []
 nameOverride: ""
@@ -197,6 +197,10 @@ config:
       multilineFlush: 4
       # Name of the parser that matchs the beginning of a multiline message.
       parserFirstline:
+      # For new discovered files on start (without a database offset/position), read the content from the head of the file, not tail.
+      readFromHead: "Off"
+      # Specify one or Multiline Parser definition to apply to the content.
+      multilineParser:
       exclude:
         namespaces:
     additional: ""
@@ -214,7 +218,7 @@ config:
       parser: "On"
       exclude: "On"
       # Set the buffer size for HTTP client when reading responses from Kubernetes API server.
-      bufferSize: "32k"
+      bufferSize: "1MB"
       kubeUrl: "https://kubernetes.default.svc:443"
       # When the source records comes from Tail input plugin, this option allows to specify what's the prefix used in Tail configuration.
       kubeTagPrefix: "kube.var.log.containers."

--- a/resources/telemetry/charts/fluent-bit/values.yaml
+++ b/resources/telemetry/charts/fluent-bit/values.yaml
@@ -7,10 +7,10 @@ kind: DaemonSet
 replicaCount: 1
 
 image:
-  repository: eu.gcr.io/kyma-project/external/fluent/fluent-bit
+  repository: eu.gcr.io/kyma-project/tpi/fluent-bit
   # Overrides the image tag whose default is {{ .Chart.AppVersion }}
-  tag: "1.8.3"
-  pullPolicy: Always
+  tag: 1.8.5-ea0b3c70
+  pullPolicy: IfNotPresent
 
 testFramework:
   image:


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- updates to latest fluent-bit image 1.8.x
- adds support for  Read_From_Head option in tail input plugin
- adds support for new Multiline Core feature in tail plugin
- Increased default buffer size for kubernetes filter

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
Fixes https://github.com/kyma-project/kyma/issues/10582
Relates to https://github.com/kyma-project/third-party-images/pull/117
Relates to https://github.com/kyma-project/third-party-images/pull/118