### PR TITLE
Make allowlist for API-Gateway disabled as default

### DIFF
--- a/docs/api-gateway/03-02-whitelisted-domains.md
+++ b/docs/api-gateway/03-02-whitelisted-domains.md
@@ -9,7 +9,7 @@ If the domain does not match the allowlist, the API Gateway Controller sets an a
 
 >**TIP:** For more information, read about the [Api CR statuses](#custom-resource-api-rule-status-codes).
 
-By default, all domains are allowed
+By default, the feature is disabled and all domains are allowed
 
 To enable the allowlist mechanism, override the value of the **config.enableDomainAllowList** parameter in the API Gateway chart.
 

--- a/docs/api-gateway/03-02-whitelisted-domains.md
+++ b/docs/api-gateway/03-02-whitelisted-domains.md
@@ -3,15 +3,15 @@ title: Allowed domains in the API Gateway Controller
 type: Details
 ---
 
-The API Gateway Controller uses an allowlist of domains for which it allows to expose services. Every time a user creates a new APIRule custom resource (CR) for a service, the API Gateway Controller checks the domain of the service specified in the CR against the allowlist. If the domain of the service matches an allowed entry, the API Gateway Controller creates a Virtual Service and Oathkeeper Access Rules for the service according to the details specified in the CR. If the domain is not allowed, the Controller creates neither a Virtual Service nor Oathkeeper Access Rules and, as a result, does not expose the service.
+You can restrict the set of domains for which the API Gateway Controller allows to expose services. When the feature is enabled, every time a user creates a new APIRule custom resource (CR) for a service, the API Gateway Controller checks the domain of the service specified in the CR against the allowlist. If the domain of the service matches an allowed entry, the API Gateway Controller creates a Virtual Service and Oathkeeper Access Rules for the service according to the details specified in the CR. If the domain is not allowed, the Controller creates neither a Virtual Service nor Oathkeeper Access Rules and, as a result, does not expose the service.
 
 If the domain does not match the allowlist, the API Gateway Controller sets an appropriate validation status on the APIRule CR created for that service.
 
 >**TIP:** For more information, read about the [Api CR statuses](#custom-resource-api-rule-status-codes).
 
-By default, the only allowed domain is the domain of the Kyma cluster.
+By default, all domains are allowed
 
-To disable the allowlist mechanism, override the value of the **config.enableDomainAllowList** parameter in the API Gateway chart.
+To enable the allowlist mechanism, override the value of the **config.enableDomainAllowList** parameter in the API Gateway chart.
 
 >**TIP:** To learn more about how to use overrides in Kyma, see the following documents:
 >* [Helm overrides for Kyma installation](/root/kyma/#configuration-helm-overrides-for-kyma-installation)

--- a/resources/api-gateway/values.yaml
+++ b/resources/api-gateway/values.yaml
@@ -49,7 +49,7 @@ config:
       - apiserver-proxy
       - apiserver-proxy-ssl
   domainAllowList:
-  enableDomainAllowList: true
+  enableDomainAllowList: false
   defaultDomain:
   cors: # values listed below will be used to set corsPolicy in created VirtualServices (https://istio.io/docs/reference/config/networking/v1alpha3/virtual-service/#CorsPolicy)
     allowOrigins:


### PR DESCRIPTION
**Description**

With multiple domains feature introduced to Kyma 2.0, the `allowlist` in API Gateway Controller is working against preferred use-cases.

Changes proposed in this pull request:


- `allowlist` in API Gateway disabled by default
- updated documentation

**Related issue(s)**
https://github.com/kyma-project/kyma/issues/11894