### PR TITLE
fix/authpolicy to use enable log-ui

### DIFF
--- a/resources/logging/charts/loki/templates/kyma-additions/authorizationpolicy.yaml
+++ b/resources/logging/charts/loki/templates/kyma-additions/authorizationpolicy.yaml
@@ -18,6 +18,8 @@ spec:
   - from:
     - source:
         requestPrincipals: ["*"]
+    - source:
+        principals: ["*"]
     to:
     - operation:
         paths: ["/api/prom/query","/api/prom/label/*","/api/prom/tail"]


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:
- With the current authPolicy, istio will prevent log-ui to fetch/display logs from Loki

The https://log-ui.ingress.domain.name url is accessible. But "log-ui" cannot fetch any labels or logs from the loki endpoint.
In the istio-proxy sidecar logs in the loki pod we can see the following messages :

`logging-loki-0 istio-proxy [2021-09-03T14:45:31.835Z] "GET /api/prom/label/app/values HTTP/1.1" 403 - rbac_access_denied_matched_policy[none] - "-" 0 19 0 - "xxx.xxx.xxx.xxx, xxx.xxx.xxx.xxx ,xxx.xxx.xxx.xxx" "Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:91.0) Gecko/20100101 Firefox/91.0" "e7010f2c-600b-49e1-85ed-8bac099772fa" "loki.ingress.domain.name" "-" inbound|3100|| - xxx.xxx.xxx.xxx:3100 xxx.xxx.xxx.xxx:0 outbound_.3100_._.logging-loki.kyma-system.svc.cluster.local -`

The field principals has a value only if a workload can identify itself via a certificate (it must have the istio proxy) during PeerAuthentication. And the field requestPrincipals is extracted from the jwt token during RequestAuthentication.


