### PR TITLE
Update Prometheus Alertmanager to Version 0.23.0

### DIFF
--- a/resources/monitoring/values.yaml
+++ b/resources/monitoring/values.yaml
@@ -407,7 +407,7 @@ alertmanager:
     ##
     image:
       repository: eu.gcr.io/kyma-project/external/quay.io/prometheus/alertmanager
-      tag: v0.21.0
+      tag: v0.23.0
       sha: ""
 
     ## If true then the user will be responsible to provide a secret with alertmanager configuration


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**
Regarding this [Protecode issue](https://github.tools.sap/kyma/security-scans/issues/8486) we need to update the alertmanager image.

Changes proposed in this pull request:

- Changed alertmanager image to `v0.23.0`, which is the newest stable release
- With [this PR](https://github.com/kyma-project/test-infra/pull/4102) the v0.23.0 already has been cpoied to our GCP project

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
