### PR TITLE
kiali not working with istio 1.11 - update kiali to 1.38.1

### DIFF
--- a/resources/kiali/templates/role-viewer.yaml
+++ b/resources/kiali/templates/role-viewer.yaml
@@ -13,7 +13,6 @@ rules:
   - configmaps
   - endpoints
   - pods/log
-  - pods/proxy
   verbs:
   - get
   - list

--- a/resources/kiali/templates/role.yaml
+++ b/resources/kiali/templates/role.yaml
@@ -13,7 +13,6 @@ rules:
   - configmaps
   - endpoints
   - pods/log
-  - pods/proxy
   verbs:
   - get
   - list

--- a/resources/kiali/values.yaml
+++ b/resources/kiali/values.yaml
@@ -161,7 +161,7 @@ kiali:
     #    namespaces:
     #      exclude:
     #      - "istio-operator"
-    #      - "kube.*"
+    #      - "kube-.*"
     #      - "openshift.*"
     #      - "ibm.*"
     #      - "kiali-operator"
@@ -322,7 +322,7 @@ kiali:
     # a single, specific Kiali version, thus this setting may have no effect depending on how the
     # operator itself was configured.
     #    ---
-      image_version: "1.36.0-4c48514d"
+      image_version: "1.38.1-e0da5a68"
     #
     # Determines if the Kiali endpoint should be exposed externally.
     # If true, an Ingress will be created if on Kubernetes or a Route if on OpenShift.
@@ -354,10 +354,10 @@ kiali:
     #    message will be logged. By default, every message is logged.
     #    ---
       logger:
-        log_format: "text"
-        log_level: "info"
-        time_field_format: "2006-01-02T15:04:05Z07:00"
+        log_level: info
+        log_format: text
         sampler_rate: "1"
+        time_field_format: "2006-01-02T15:04:05Z07:00"
     #
     # The namespace into which Kiali is to be installed. If this is empty or not defined,
     # the default will be the namespace where the Kiali CR is located.
@@ -480,7 +480,6 @@ kiali:
     # Flag to indicate if iter8 extension is enabled in Kiali
     #      ---
     #      enabled: false
-    #
 
     ##########
     #  ---
@@ -556,7 +555,7 @@ kiali:
     #     workload: The name of a variable that holds the workload name, if used in that dashboard (else it must be omitted)
     # enabled: When true, Grafana support will be enabled in Kiali.
     # health_check_url: Used in the Components health feature. This is the url which kiali will ping to determine whether the component is reachable or not. It defaults to `in_cluster_url` when not provided.
-    # in_cluster_url: Set URL for in-cluster access. Example: "http://grafana.istio-system:3000". This URL can contain query parameters if needed, such as "?orgId=1".
+    # in_cluster_url: Set URL for in-cluster access. Example: "http://grafana.istio-system:3000". This URL can contain query parameters if needed, such as "?orgId=1". If not defined, it will default to "http://grafana.<istio_namespace>:3000".
     # is_core: Used in the Components health feature. When true, the unhealthy scenarios will be raised as errors. Otherwise, they will be raised as a warning.
     # url: The URL that Kiali uses when integrating with Grafana. This URL must be accessible to clients external to
     #      the cluster in order for the integration to work properly. If empty, an attempt to auto-discover it is made.
@@ -610,10 +609,13 @@ kiali:
     #                  namespace: <the namespace where your ingress is deployed>
     # config_map_name: The name of the istio control plane config map. It defaults to `istio`.
     # envoy_admin_local_port: The port which kiali will open to fetch envoy config data information.
+    # istio_canary_revision: These values are used in Canary upgrade/downgrade functionality when istio_upgrade_action is true.
+    #   current: The current installed Istio revision.
+    #   upgrade: The installed Istio Canary revision to upgrade to.
     # istio_identity_domain: The annotation used by Istio to identify domains.
-    # istio_sidecar_injector_config_map_name: The name of the istio-sidecar-injector config map.
     # istio_injection_annotation: The annotation used by Istio to automatically inject a specific workload
     # istio_sidecar_annotation: The pod annotation used by Istio to identify the sidecar.
+    # istio_sidecar_injector_config_map_name: The name of the istio-sidecar-injector config map.
     # istiod_deployment_name: The name of the istiod deployment.
     # url_service_version: The Istio service used to determine the Istio version. If empty, assumes the URL for the well-known Istio version endpoint.
     #    ---
@@ -632,10 +634,13 @@ kiali:
           enabled: true
     #      config_map_name: "istio"
     #      envoy_admin_local_port: 15000
+    #      #istio_canary_revision:
+    #        #current:
+    #        #upgrade:
     #      istio_identity_domain: "svc.cluster.local"
     #      istio_injection_annotation: "sidecar.istio.io/inject"
-    #      istio_sidecar_injector_config_map_name: "istio-sidecar-injector"
     #      istio_sidecar_annotation: "sidecar.istio.io/status"
+    #      istio_sidecar_injector_config_map_name: "istio-sidecar-injector"
     #      istiod_deployment_name: "istiod"
     #      url_service_version: ""
     #
@@ -696,10 +701,10 @@ kiali:
     #       and auth.token config is ignored then.
     #   username: Username to be used when making requests to Jaeger, for basic authentication. User only requires viewer permissions.
     # enabled: When true, connections to Jaeger are enabled. "in_cluster_url" and/or "url" need to be provided.
-    # health_check_url: Used in the Components health feature. This is the url which kiali will ping to determine whether the component is reachable or not. It defaults to `in_cluster_url` when not provided.
     # in_cluster_url: Set URL for in-cluster access, which enables further integration between Kiali and Jaeger.
     #      When not provided, Kiali will only show external links using the "url" config.
-    #      Example: "http://tracing.istio-system".
+    #      Note: Jaeger v1.20+ has separated ports for GRPC(16685) and HTTP(16686) requests. Make sure you use the appropriate port according to the "use_grpc" value.
+    #      Example: "http://tracing.istio-system:16685".
     # is_core: Used in the Components health feature. When true, the unhealthy scenarios will be raised as errors. Otherwise, they will be raised as a warning.
     # namespace_selector: Kiali use this boolean to look traces with namespace selector : service.namespace. Default: true
     # url: External URL that will be used to generate links to Jaeger. It must be accessible to clients external to
@@ -779,6 +784,7 @@ kiali:
     #    ---
     #    app_label_name: "app"
     #    injection_label_name: "istio-injection"
+    #    injection_label_rev:  "istio.io/rev"
     #    version_label_name: "version"
 
     ##########
@@ -790,13 +796,21 @@ kiali:
     #    ---
     #    istio_injection_action: true
     #
-   # Default settings for the UI. These defaults apply to all users.
+    # Flag to activate the Kiali functionality of upgrading namespaces to point to installed Istio Canary revision.
+    # Related Canary upgrade and current revisions of Istio should be defined in istio_canary_revision section.
+    #    ---
+    #    istio_upgrade_action: false
+    #
+    # Default settings for the UI. These defaults apply to all users.
     #    ---
     #    ui_defaults:
     #
-    # Default presets for Graph Find/Hide
+    # Default settings for UI Graph
     #      ---
     #      graph:
+    #
+    # Each Find/Hide option consists of a human readable description and a valid Find/Hide expression
+    #      ---
     #        find_options:
     #        - description: "Find: slow edges (> 1s)"
     #          expression: "rt > 1000"
@@ -809,6 +823,19 @@ kiali:
     #          expression: "healthy"
     #        - description: "Hide: unknown nodes"
     #          expression:  "name = unknown"
+    #
+    # Traffic settings determine which rates are used to determine graph traffic. gRPC traffic is
+    # measured in requests or sent/received/total messages.  HTTP traffic is measure in requests.
+    # TCP traffic is measured in sent/received/total bytes.  Only request traffic supplies response
+    # codes.  Valid values:
+    # grpc: none | requests | sent | received | total
+    # http: none | requests
+    # tcp:  none | sent | received | total
+    #        ---
+    #        traffic:
+    #          grpc: "requests"
+    #          http: "requests"
+    #          tcp:  "sent"
     #
     # Duration of metrics to fetch on each refresh. Omit for default.
     # Valid values: 1m, 5m, 10m, 30m, 1h, 3h, 6h, 12h, 1d, 7d, 30d
@@ -826,6 +853,14 @@ kiali:
     # Valid values: pause, 10s, 15s, 30s, 1m, 5m, 15m
     #      ---
     #      refresh_interval: "15s"
+    #
+    #   Features specific to the validations subsystem.
+    #    ---
+    #    validations:
+    #
+    #      If you wish to ignore one or more validation errors, put their validation codes (e.g. KIA0101) in this list.
+    #      ---
+    #      ignore: []
 
     ##########
     #  ---
@@ -859,6 +894,7 @@ kiali:
     #    - "VirtualService"
     #    - "WorkloadEntry"
     #    - "WorkloadGroup"
+
     #
     # List of namespaces or regex defining namespaces to include in a cache.
     #    ---
@@ -885,7 +921,6 @@ kiali:
     # The QPS value of the Kubernetes client.
     #    ---
       qps: 50
-    #
 
     ##########
     #  ---


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

With the upgrade to istio 1.11 kiali stopped working in major parts mainly caused by https://github.com/kiali/kiali/issues/4054. This PR updates kiali to 1.38.1 which is the official version supporting istio 1.11

Changes proposed in this pull request:

- update kiali image to 1.38.1
- update kiali helm charts to the changes from upstream
- ...

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
https://github.com/kyma-project/third-party-images/pull/122