### PR TITLE
SKR migration test check env variables in function pods

### DIFF
--- a/tests/fast-integration/skr-svcat-migration-test/skr-svcat-migration-test.js
+++ b/tests/fast-integration/skr-svcat-migration-test/skr-svcat-migration-test.js
@@ -85,6 +85,10 @@ describe("SKR SVCAT migration test", function() {
     secretsAndPresets = await sampleResources.storeSecretsAndPresets()
   });
 
+  it(`Should check if pod presets injected secrets to functions containers`, async function() {
+    await t.checkPodPresetEnvInjected();
+  });
+
   it(`Should install BTP service operator migration helm chart`, async function() {
     await t.installBTPServiceOperatorMigrationHelmChart();
   });
@@ -102,6 +106,14 @@ describe("SKR SVCAT migration test", function() {
     // Check if Secrets and PodPresets are still available
     await sampleResources.checkSecrets(existing.secrets)
     await sampleResources.checkPodPresets(secretsAndPresets.podPresets, existing.podPresets)
+  });
+
+  it(`Should restart functions pods`, async function() {
+    await t.restartFunctionsPods();
+  });
+
+  it(`Should check if pod presets injected secrets in functions containers are present after migration`, async function() {
+    await t.checkPodPresetEnvInjected();
   });
 
   it(`Should destroy sample service catalog resources`, async function() {


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**
This enhances the SKR BTP migration fast integration test with explicit checks whether pods from `Functions` get correctly injected env variables from `PodPresets` even after the SVCAT has been removed and BTP related resources migrated.

<details><summary>Sample error output when the timeout of 100 seconds expires checking the pods to be new and ready (mocked by shortening the timeout to 1 second).</summary>
<p>

```
Error: Failed to restart function pods in 100 seconds. Expecting exactly one pod for each function with new unique names and in ready status but found:
[
  {
    "function name": "svcat-auditlog-api-1",
    "pods": [
      {
        "pod name": "svcat-auditlog-api-1-hn622-6f8d9d7f5-bpht5",
        "phase": "Running"
      },
      {
        "pod name": "svcat-auditlog-api-1-hn622-6f8d9d7f5-z4bqv",
        "phase": "Pending"
      }
    ]
  },
  {
    "function name": "svcat-auditlog-management-1",
    "pods": [
      {
        "pod name": "svcat-auditlog-management-1-x26qg-b64fcfdd8-bxb6n",
        "phase": "Running"
      },
      {
        "pod name": "svcat-auditlog-management-1-x26qg-b64fcfdd8-hhx2w",
        "phase": "Pending"
      }
    ]
  },
  {
    "function name": "svcat-html5-apps-repo-1",
    "pods": [
      {
        "pod name": "svcat-html5-apps-repo-1-8mrzl-6d65b6f86d-4lvmk",
        "phase": "Pending"
      },
      {
        "pod name": "svcat-html5-apps-repo-1-8mrzl-6d65b6f86d-5xll6",
        "phase": "Running"
      }
    ]
  }
]

Pod names before restart:
{
  "svcat-auditlog-api-1": "svcat-auditlog-api-1-hn622-6f8d9d7f5-bpht5",
  "svcat-auditlog-management-1": "svcat-auditlog-management-1-x26qg-b64fcfdd8-bxb6n",
  "svcat-html5-apps-repo-1": "svcat-html5-apps-repo-1-8mrzl-6d65b6f86d-5xll6"
}
    at Object.restartFunctionsPods (/home/wozy/projects/go/src/github.com/kyma-project/kyma/tests/fast-integration/skr-svcat-migration-test/test-helpers.js:141:15)
```

</p>
</details>

<details><summary>sample output when expected env is missing in the pod</summary>
<p>

```
Error: failed to execute kubectl exec svcat-html5-apps-repo-1-8mrzl-6d65b6f86d-4lvmk -c function -n default -- sh -c for v in grant_type saasregistryenabled sap.cloud.service uaa uri vendor vendorx; do x="$(eval echo \$$v)"; if [[ -z "$x" ]]; then echo missing $v env variable; exit 1; else echo found $v env variable; fi; done:
found grant_type env variable
found saasregistryenabled env variable
found sap.cloud.service env variable
found uaa env variable
found uri env variable
missing vendor env variable,
command terminated with exit code 1
    at kubectlExecInPod (/home/wozy/projects/go/src/github.com/kyma-project/kyma/tests/fast-integration/utils/index.js:614:11)
    at processTicksAndRejections (node:internal/process/task_queues:96:5)
    at async Object.checkPodPresetEnvInjected (/home/wozy/projects/go/src/github.com/kyma-project/kyma/tests/fast-integration/skr-svcat-migration-test/test-helpers.js:86:9)
```

</p>
</details>

[pjtester](https://status.build.kyma-project.io/view/gs/kyma-prow-logs/logs/wozniakjan_test_of_prowjob_skr-aws-svcat-migration-dev/1435895519334371328)

**Related issue(s)**
depends on https://github.com/kyma-project/kyma/pull/12016 and https://github.com/kyma-project/kyma/pull/12023