### PR TITLE
fixed jaeger integration for kiali

### DIFF
--- a/resources/kiali/values.yaml
+++ b/resources/kiali/values.yaml
@@ -734,7 +734,7 @@ kiali:
         in_cluster_url: "http://tracing-jaeger-query.kyma-system:16686"
     #      namespace_selector: true
         url: "https://jaeger.{{ .Values.global.ingress.domainName }}"
-    #      #use_grpc:
+        use_grpc: false
     #      whitelist_istio_system: ["jaeger-query", "istio-ingressgateway"]
 
     ##########


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- kiali 1.38 uses grpc mode by default for communication to jaeger. Disabled it to have old behaviour back
- ...
- ...

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
https://github.com/kyma-project/kyma/pull/12055