### PR TITLE
Remove Helm hook annotations from cluster essentials resources

### DIFF
--- a/resources/cluster-essentials/templates/priorityclass.yaml
+++ b/resources/cluster-essentials/templates/priorityclass.yaml
@@ -3,9 +3,6 @@ apiVersion: scheduling.k8s.io/v1
 kind: PriorityClass
 metadata:
   name: {{ .Values.global.priorityClassName }}
-  annotations:
-    "helm.sh/hook": "pre-install, pre-upgrade"
-    "helm.sh/hook-weight": "-5"
 value: {{ .Values.global.priorityClassValue }}
 globalDefault: false
 description: "Global (default) scheduling priority of Kyma components. Must not be blocked by unschedulable user workloads."

--- a/resources/cluster-essentials/templates/psp-privileged.yaml
+++ b/resources/cluster-essentials/templates/psp-privileged.yaml
@@ -3,10 +3,6 @@ apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:
   name: 002-kyma-privileged
-  annotations:
-    helm.sh/hook: "pre-upgrade, pre-install"
-    helm.sh/hook-weight: "0"
-    helm.sh/hook-delete-policy: "before-hook-creation"
 spec:
   allowPrivilegeEscalation: true
   allowedCapabilities:

--- a/resources/cluster-essentials/templates/psp-unprivileged.yaml
+++ b/resources/cluster-essentials/templates/psp-unprivileged.yaml
@@ -3,10 +3,6 @@ apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:
   name: 001-kyma-unprivileged
-  annotations:
-    helm.sh/hook: "pre-upgrade, pre-install"
-    helm.sh/hook-weight: "0"
-    helm.sh/hook-delete-policy: "before-hook-creation"
 spec:
   allowPrivilegeEscalation: false
   allowedCapabilities:

--- a/resources/cluster-essentials/templates/rbac-clusterrole.yaml
+++ b/resources/cluster-essentials/templates/rbac-clusterrole.yaml
@@ -3,10 +3,6 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: kyma:psp:privileged
-  annotations:
-    helm.sh/hook: "pre-upgrade, pre-install"
-    helm.sh/hook-weight: "0"
-    helm.sh/hook-delete-policy: "before-hook-creation"
 rules:
 - apiGroups: ["policy"] # "" indicates the core API group
   resources: ["podsecuritypolicies"]
@@ -17,10 +13,6 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: kyma:psp:unprivileged
-  annotations:
-    helm.sh/hook: "pre-upgrade, pre-install"
-    helm.sh/hook-weight: "0"
-    helm.sh/hook-delete-policy: "before-hook-creation"
 rules:
 - apiGroups: ["policy"] # "" indicates the core API group
   resources: ["podsecuritypolicies"]

--- a/resources/cluster-essentials/templates/rbac-clusterrolebinding.yaml
+++ b/resources/cluster-essentials/templates/rbac-clusterrolebinding.yaml
@@ -4,10 +4,6 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: kyma:all:psp:privileged
-  annotations:
-    helm.sh/hook: "pre-upgrade, pre-install"
-    helm.sh/hook-weight: "0"
-    helm.sh/hook-delete-policy: "before-hook-creation"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -28,10 +24,6 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: kyma:all:psp:unprivileged
-  annotations:
-    helm.sh/hook: "pre-upgrade, pre-install"
-    helm.sh/hook-weight: "0"
-    helm.sh/hook-delete-policy: "before-hook-creation"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- Since all of the resources with Helm hook annotation are ignored by the Helm templating engine, they are also ignored by the reconciler. AFAIU the only resource which is actually a pre-install/upgrade hook is the CRD installation job, which should be ignored by the reconciler. The rest does not have to be.

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
