### PR TITLE
authproxy must not forward host header for istio routing

### DIFF
--- a/resources/kiali/templates/kyma-additions/auth-proxy-deployment.yaml
+++ b/resources/kiali/templates/kyma-additions/auth-proxy-deployment.yaml
@@ -47,6 +47,7 @@ spec:
         - --reverse-proxy=true
         - --auth-logging={{ .Values.authProxy.config.authLogging }}
         - --request-logging={{ .Values.authProxy.config.requestLogging }}
+        - --pass-host-header={{ .Values.authProxy.config.passHostHeader }}
         envFrom:
         - secretRef:
             name: {{ template "kiali-server.fullname" . }}-auth-proxy

--- a/resources/kiali/values.yaml
+++ b/resources/kiali/values.yaml
@@ -43,6 +43,7 @@ authProxy:
     scopes: "groups"
     authLogging: true
     requestLogging: false
+    passHostHeader: false
   env: {}
   nodeSelector: {}
   securityContext:

--- a/resources/monitoring/charts/grafana/templates/kyma-additions/auth-proxy-deployment.yaml
+++ b/resources/monitoring/charts/grafana/templates/kyma-additions/auth-proxy-deployment.yaml
@@ -52,6 +52,7 @@ spec:
         - --reverse-proxy=true
         - --auth-logging={{ .Values.kyma.authProxy.config.authLogging }}
         - --request-logging={{ .Values.kyma.authProxy.config.requestLogging }}
+        - --pass-host-header={{ .Values.kyma.authProxy.config.passHostHeader }}
         envFrom:
         - secretRef:
             name: {{ .Release.Name }}-auth-proxy-{{ template "grafana.name" . }}

--- a/resources/monitoring/charts/grafana/values.yaml
+++ b/resources/monitoring/charts/grafana/values.yaml
@@ -789,6 +789,7 @@ kyma:
       scopes: "groups"
       authLogging: true
       requestLogging: false
+      passHostHeader: false
     env: {}
     nodeSelector: {}
     securityContext:

--- a/resources/tracing/templates/kyma-additions/auth-proxy-deployment.yaml
+++ b/resources/tracing/templates/kyma-additions/auth-proxy-deployment.yaml
@@ -48,6 +48,7 @@ spec:
         - --reverse-proxy=true
         - --auth-logging={{ .Values.authProxy.config.authLogging }}
         - --request-logging={{ .Values.authProxy.config.requestLogging }}
+        - --pass-host-header={{ .Values.authProxy.config.passHostHeader }}
         envFrom:
         - secretRef:
             name: {{ include "jaeger-operator.fullname" . }}-auth-proxy

--- a/resources/tracing/values.yaml
+++ b/resources/tracing/values.yaml
@@ -136,6 +136,7 @@ authProxy:
     scopes: "groups"
     authLogging: true
     requestLogging: false
+    passHostHeader: false
   env: {}
   nodeSelector: {}
   podSecurityContext: {}


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**
When enabling strict mTLS mode for the components running behind an oauth2-proxy (grafana,kiali, jaeger), traffic will not be routed anymore properly to the upstream components. 

For example, if enabling STRICT mTLS mode for the peerauthentication resource with name `tracing-jaeger-metrics`, then the `jaeger.<domain>` is not working anymore and reports an `upstream connect error or disconnect/reset before headers. reset reason: connection termination`
When calling the pod tracing-jaeger-... with port-forward 16686, then the application responds correctly.
When calling the service tracing-jaeger-query with port-forward 16686,  then the application responds correctly.
The service tracing-jaeger-query-secured does the authentication and seems to forward the request.
In the istio-proxy log from tracing-jaeger-... pod these suspicious logs are written:
```
[2021-09-11T10:53:13.360Z] "- - -" 0 NR filter_chain_not_found - "-" 0 0 0 - "-" "-" "-" "-" "-" - - 10.244.1.24:16686 10.244.3.150:42294 - -
[2021-09-11T10:53:13.381Z] "- - -" 0 NR filter_chain_not_found - "-" 0 0 0 - "-" "-" "-" "-" "-" - - 10.244.1.24:16686 10.244.3.150:42296 - -
[2021-09-11T10:53:13.393Z] "- - -" 0 NR filter_chain_not_found - "-" 0 0 0 - "-" "-" "-" "-" "-" - - 10.244.1.24:16686 10.244.3.150:42298 - -
[2021-09-11T10:53:13.492Z] "- - -" 0 NR filter_chain_not_found - "-" 0 0 0 - "-" "-" "-" "-" "-" - - 10.244.1.24:16686 10.244.3.150:42300 - -
[2021-09-11T10:53:13.510Z] "- - -" 0 NR filter_chain_not_found - "-" 0 0 0 - "-" "-" "-" "-" "-" - - 10.244.1.24:16686 10.244.3.150:42304 - -
[2021-09-11T10:53:13.524Z] "- - -" 0 NR filter_chain_not_found - "-" 0 0 0 - "-" "-" "-" "-" "-" - - 10.244.1.24:16686 10.244.3.150:42306 - -
```
In the tracing-auth-proxy-... pod in the auth-proxy container the response code is 503 for the request:
`127.0.0.6 - 93ee8c60-da2c-487d-8b38-9b975a13e489 - <my@email.com> [2021/09/11 10:53:13] jaeger.<custom-domain> GET / "/search" HTTP/1.1 "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/93.0.4577.63 Safari/537.36" 503 95 0.003`

**Solution**
Istio is routing based on the port and Host header, rather than port and IP. As the auth-proxy by default is forwarding the host header, a route cannot be determined. The solution is to disable the host header forwarding on the proxy.


Changes proposed in this pull request:

- Introduced flag for disabling host header forwarding
- Configured the flag false by default
- ...

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
See also https://www.fpcomplete.com/blog/istio-mtls-debugging-story/