### PR TITLE
Delete BTP operator migrated resources in SKR test

### DIFF
--- a/tests/fast-integration/skr-svcat-migration-test/skr-svcat-migration-test.js
+++ b/tests/fast-integration/skr-svcat-migration-test/skr-svcat-migration-test.js
@@ -117,10 +117,11 @@ describe("SKR SVCAT migration test", function() {
   });
 
   it(`Should destroy sample service catalog resources`, async function() {
-    // TODO: Remove anything from BT-Operator
     await sampleResources.destroy()
+  });
 
-    // TODO: Check if no Service Instances are left over
+  it(`Should delete migrated BTP resources`, async function() {
+    await t.deleteBTPResources();
   });
 
   it(`Should deprovision SKR`, async function() {

--- a/tests/fast-integration/utils/index.js
+++ b/tests/fast-integration/utils/index.js
@@ -874,7 +874,8 @@ async function deleteAllK8sResources(
   path,
   query = {},
   retries = 2,
-  interval = 1000
+  interval = 1000,
+  keepFinalizer = false
 ) {
   try {
     let i = 0;
@@ -889,10 +890,10 @@ async function deleteAllK8sResources(
       const body = JSON.parse(response.body);
       if (body.items && body.items.length) {
         for (let o of body.items) {
-          deleteK8sResource(o);
+          deleteK8sResource(o, keepFinalizer);
         }
       } else if (!body.items) {
-        deleteK8sResource(body);
+        deleteK8sResource(body, keepFinalizer);
       }
     }
   } catch (e) {
@@ -900,8 +901,8 @@ async function deleteAllK8sResources(
   }
 }
 
-async function deleteK8sResource(o) {
-  if (o.metadata.finalizers && o.metadata.finalizers.length) {
+async function deleteK8sResource(o, keepFinalizer = false) {
+  if (o.metadata.finalizers && o.metadata.finalizers.length && !keepFinalizer) {
     const options = {
       headers: { "Content-type": "application/merge-patch+json" },
     };


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

In the SKR migration SVCAT to BTP Operator test, we would like to delete the BTP resources to prevent leaking in the Service Manager. These are the resources we create in SVCAT and migrate to BTP Operator.

sample log excerpt
```
...
Deleted resource: uaa-issuer namespace: kyma-system
Deleted resource: svcat-auditlog-management-1 namespace: default
Deleted resource: svcat-auditlog-api-1 namespace: default
Deleted resource: svcat-auditlog-api-1 namespace: default
Deleted resource: svcat-auditlog-management-1 namespace: default
Deleted resource: uaa-issuer namespace: kyma-system
Deleted resource: svcat-auditlog-api-1 namespace: default
Deleted resource: svcat-auditlog-management-1 namespace: default
Deleted resource: uaa-issuer namespace: kyma-system
Deleted resource: uaa-issuer namespace: kyma-system
Deleted resource: svcat-auditlog-api-1 namespace: default
Deleted resource: svcat-auditlog-management-1 namespace: default
Deleted resource: svcat-auditlog-api-1 namespace: default
Deleted resource: uaa-issuer namespace: kyma-system
Deleted resource: svcat-auditlog-management-1 namespace: default
Deleted resource: svcat-auditlog-management-1 namespace: default
Deleted resource: uaa-issuer namespace: kyma-system
Deleted resource: svcat-auditlog-api-1 namespace: default
Deleted resource: svcat-auditlog-api-1 namespace: default
Deleted resource: svcat-auditlog-management-1 namespace: default
Deleted resource: uaa-issuer namespace: kyma-system
Deleted resource: svcat-auditlog-management-1 namespace: default
Deleted resource: svcat-auditlog-api-1 namespace: default
Deleted resource: uaa-issuer namespace: kyma-system
Deleted resource: uaa-issuer namespace: kyma-system
Deleted resource: svcat-auditlog-management-1 namespace: default
Deleted resource: svcat-auditlog-api-1 namespace: default
Deleted resource: svcat-auditlog-management-1 namespace: default
Deleted resource: svcat-auditlog-api-1 namespace: default
Deleted resource: uaa-issuer namespace: kyma-system
Deleted resource: func-sb-svcat-auditlog-api-1 namespace: default
Deleted resource: uaa-issuer-secret namespace: kyma-system
Deleted resource: func-sb-svcat-auditlog-management-1 namespace: default
Deleted resource: uaa-issuer-secret namespace: kyma-system
Deleted resource: func-sb-svcat-auditlog-api-1 namespace: default
Deleted resource: func-sb-svcat-auditlog-management-1 namespace: default
Deleted resource: uaa-issuer-secret namespace: kyma-system
Deleted resource: func-sb-svcat-auditlog-management-1 namespace: default
Deleted resource: func-sb-svcat-auditlog-management-1 namespace: default
Deleted resource: uaa-issuer-secret namespace: kyma-system
Deleted resource: uaa-issuer-secret namespace: kyma-system
    ✓ Should delete migrated BTP resources (19068ms)
...
```

[pjtester](https://status.build.kyma-project.io/log?container=test&id=1438391801462394880&job=wozniakjan_test_of_prowjob_skr-aws-svcat-migration-dev)

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
