### PR TITLE
Cherry-pick #12085 #12115 (add binary mode to in-cluster eventing test)

### DIFF
--- a/tests/fast-integration/test/2-commerce-mock.js
+++ b/tests/fast-integration/test/2-commerce-mock.js
@@ -49,12 +49,8 @@ describe("CommerceMock tests", function () {
     });
   });
 
-  it("in-cluster event should be delivered (structured mode)", async function () {
-    await checkInClusterEventDelivery(testNamespace, 'structured');
-  });
-
-  it("in-cluster event should be delivered (binary mode)", async function () {
-    await checkInClusterEventDelivery(testNamespace, 'binary');
+  it("in-cluster event should be delivered (structured and binary mode)", async function () {
+    await checkInClusterEventDelivery(testNamespace);
   });
 
   it("function should reach Commerce mock API through app gateway", async function () {

--- a/tests/fast-integration/test/2-commerce-mock.js
+++ b/tests/fast-integration/test/2-commerce-mock.js
@@ -49,8 +49,12 @@ describe("CommerceMock tests", function () {
     });
   });
 
-  it("in-cluster event should be delivered", async function () {
-    await checkInClusterEventDelivery(testNamespace);
+  it("in-cluster event should be delivered (structured mode)", async function () {
+    await checkInClusterEventDelivery(testNamespace, 'structured');
+  });
+
+  it("in-cluster event should be delivered (binary mode)", async function () {
+    await checkInClusterEventDelivery(testNamespace, 'binary');
   });
 
   it("function should reach Commerce mock API through app gateway", async function () {

--- a/tests/fast-integration/test/fixtures/commerce-mock/index.js
+++ b/tests/fast-integration/test/fixtures/commerce-mock/index.js
@@ -480,13 +480,13 @@ async function deleteMockTestFixture(targetNamespace) {
   await k8sDelete(applicationObjs)
 }
 
-async function checkInClusterEventDelivery(targetNamespace){
-  const eventId = "event-"+genRandom(5);
+async function checkInClusterEventDelivery(targetNamespace, encoding) {
+  const eventId = "event-" + genRandom(5);
   const vs = await waitForVirtualService(targetNamespace, "lastorder");
   const mockHost = vs.spec.hosts[0];
 
   // send event using function query parameter send=true
-  await retryPromise(() => axios.post(`https://${mockHost}`, { id: eventId }, {params:{send:true}}), 10, 1000)
+  await retryPromise(() => axios.post(`https://${mockHost}`, { id: eventId }, { params: { send: true, encoding: encoding } }), 10, 1000)
   // verify if event was received using function query parameter inappevent=eventId
   await retryPromise(async () => {
     debug("Waiting for event: ",eventId);

--- a/tests/fast-integration/test/fixtures/commerce-mock/index.js
+++ b/tests/fast-integration/test/fixtures/commerce-mock/index.js
@@ -455,7 +455,6 @@ function cleanMockTestFixture(mockNamespace, targetNamespace, wait = true) {
 }
 
 async function deleteMockTestFixture(targetNamespace) {
-
   const serviceBindingUsage = {
     apiVersion: "servicecatalog.kyma-project.io/v1alpha1",
     kind: "ServiceBindingUsage",
@@ -480,7 +479,12 @@ async function deleteMockTestFixture(targetNamespace) {
   await k8sDelete(applicationObjs)
 }
 
-async function checkInClusterEventDelivery(targetNamespace, encoding) {
+async function checkInClusterEventDelivery(targetNamespace) {
+  await checkInClusterEventDeliveryHelper(targetNamespace, 'structured');
+  await checkInClusterEventDeliveryHelper(targetNamespace, 'binary');
+}
+
+async function checkInClusterEventDeliveryHelper(targetNamespace, encoding) {
   const eventId = "event-" + genRandom(5);
   const vs = await waitForVirtualService(targetNamespace, "lastorder");
   const mockHost = vs.spec.hosts[0];

--- a/tests/fast-integration/test/fixtures/commerce-mock/lastorder-function.yaml
+++ b/tests/fast-integration/test/fixtures/commerce-mock/lastorder-function.yaml
@@ -15,18 +15,41 @@ spec:
     let lastEvent = {};
     let inAppEvent = {};
     const axios = require('axios');
-    function sendEvent(type, data) {
-        const payload = {       
-          source: "kyma",
+    function sendEvent(type, data, encoding) {
+        const event = getEventPayloadAndHeaders(type, data, encoding)
+        console.log("Headers:", event.headers)
+        console.log("Payload:", event.payload)
+        return axios.post("http://eventing-event-publisher-proxy.kyma-system/publish",event.payload,{headers:event.headers})
+    }
+    function getEventPayloadAndHeaders(type, data, encoding) {
+      if(encoding==='binary') {
+        return {
+          payload: data,
+          headers: {
+            "ce-source": "/default/sap.kyma/tunas-prow",
+            "ce-specversion": "1.0",
+            "ce-eventtypeversion": "v1",
+            "ce-id": (data.id || "dummyId"),
+            "ce-type": type,
+            "Content-Type": "application/json"
+          }
+        }
+      }
+      // structured encoding
+      return {
+        payload: {
+          source: "/default/sap.kyma/tunas-prow",
           specversion: "1.0",
           eventtypeversion: "v1",
           datacontenttype: "application/json",
           id: (data.id || "dummyId"),
           type,
           data
+        },
+        headers: {
+          "Content-Type": "application/cloudevents+json"
         }
-      console.log("Payload:", payload)
-      return axios.post("http://eventing-event-publisher-proxy.kyma-system/publish",payload,{headers:{"Content-Type": "application/cloudevents+json"}})
+      }
     }
     async function getOrder(code) {
       let url = %%URL%%;
@@ -59,7 +82,8 @@ spec:
       main: async function (event, context) {
         if (event.extensions.request.query.send) {
           try {
-            const response = await sendEvent("sap.kyma.custom.inapp.order.received.v1", event.data);
+            const encoding = event.extensions.request.query.encoding
+            const response = await sendEvent("sap.kyma.custom.inapp.order.received.v1", event.data, encoding);
             console.log("In-app message sent");
           } catch (e) {
             console.dir(e)


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- Extend existing in-cluster eventing test in fast-integration to support binary-mode cloud events

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
Closes https://github.tools.sap/kyma/backlog/issues/1683