### PR TITLE
Move in-cluster eventing sub-test to the fixture

### DIFF
--- a/tests/fast-integration/test/1-commerce-mock.js
+++ b/tests/fast-integration/test/1-commerce-mock.js
@@ -48,12 +48,8 @@ describe("CommerceMock tests", function () {
     });
   });
 
-  it("in-cluster event should be delivered (structured mode)", async function () {
-    await checkInClusterEventDelivery(testNamespace, 'structured');
-  });
-
-  it("in-cluster event should be delivered (binary mode)", async function () {
-    await checkInClusterEventDelivery(testNamespace, 'binary');
+  it("in-cluster event should be delivered (structured and binary mode)", async function () {
+    await checkInClusterEventDelivery(testNamespace);
   });
 
   it("function should be reachable through secured API Rule", async function () {

--- a/tests/fast-integration/test/fixtures/commerce-mock/index.js
+++ b/tests/fast-integration/test/fixtures/commerce-mock/index.js
@@ -463,7 +463,6 @@ function cleanMockTestFixture(mockNamespace, targetNamespace, wait = true) {
 }
 
 async function deleteMockTestFixture(targetNamespace) {
-
   const serviceBindingUsage = {
     apiVersion: "servicecatalog.kyma-project.io/v1alpha1",
     kind: "ServiceBindingUsage",
@@ -487,7 +486,13 @@ async function deleteMockTestFixture(targetNamespace) {
   await k8sDelete(commerceObjs)
   await k8sDelete(applicationObjs)
 }
-async function checkInClusterEventDelivery(targetNamespace, encoding) {
+
+async function checkInClusterEventDelivery(targetNamespace) {
+  await checkInClusterEventDeliveryHelper(targetNamespace, 'structured');
+  await checkInClusterEventDeliveryHelper(targetNamespace, 'binary');
+}
+
+async function checkInClusterEventDeliveryHelper(targetNamespace, encoding) {
   const eventId = "event-" + genRandom(5);
   const vs = await waitForVirtualService(targetNamespace, "lastorder");
   const mockHost = vs.spec.hosts[0];


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- Move the binary mode in-cluster test to the fixture to ensure it is called in all fast-integration make targets.

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
