### PR TITLE
Fixes for Eventing K.2.0 docs

### DIFF
--- a/docs/03-tutorials/00-eventing/evnt-01-setup-in-cluster-eventing.md
+++ b/docs/03-tutorials/00-eventing/evnt-01-setup-in-cluster-eventing.md
@@ -23,8 +23,6 @@ spec:
         property: type
         type: exact
         value: sap.kyma.custom.nonexistingapp.order.created.v1
-  protocol: ""
-  protocolsettings: {}
   sink: http://myservice.mynamespace.svc.cluster.local
 ```
 

--- a/docs/05-technical-reference/00-architecture/evnt-01-architecture.md
+++ b/docs/05-technical-reference/00-architecture/evnt-01-architecture.md
@@ -2,19 +2,11 @@
 title: Eventing Architecture
 ---
 
-Eventing uses NATS to implement the Event Publisher Proxy and the Eventing Controller which work together to process and deliver events in Kyma. See how Eventing works inside a Kyma cluster:
-
-![Eventing architecture](./assets/evnt-architecture.svg)
-
-1. Kyma user creates the Application custom resource (CR).
-2. Application Operator watches for Application CRs and creates a HTTPSource CR.
-3. EventSource Controller watches for HTTPSource CRs and deploys the HTTP Source Adapter.
-4. Application Broker watches for Application CRs, exposes events, deploys NATS subscriptions, and labels secrets in the User Namespace.
-5. Kyma user creates a [Subscription CR](../../05-technical-reference/00-custom-resources/evnt-01-subscription.md) for an event.
+Eventing uses NATS to implement the Event Publisher Proxy and the Eventing Controller which work together to process and deliver events in Kyma. See also the [Event processing and delivery](../evnt-01-event-processing.md) document for more information.
 
 ## Event Publisher Proxy
 
-The Event Publisher Proxy component receives legacy and Cloud Event publishing requests from the cluster workloads (microservices or Functions) and redirects them to the NATS server. It also fetches a list of subscriptions for a connected application.
+The Event Publisher Proxy component receives legacy and Cloud Event publishing requests from the cluster workloads (microservices or Functions). It converts any legacy events to Cloud Events. Then, it redirects events to the NATS server. It also fetches a list of subscriptions for a connected application.
 
 ## Eventing Controller
 
@@ -22,15 +14,15 @@ The Eventing Controller component manages the internal infrastructure in order t
 
 ## Event types
 
-Eventing supports both Cloud Events and legacy events. Kyma converts legacy events to Cloud Events and adds the `sap.kyma.custom` prefix.
+Eventing supports both Cloud Events and legacy events. The Event Publisher Proxy  converts legacy events to Cloud Events and adds the `sap.kyma.custom` prefix.
 
-For a Subscription Custom Resource, the fully qualified event type takes the form of `sap.kyma.custom.commerce.order.created.v1`. The event type is composed of the following components:
+For a Subscription Custom Resource, the fully qualified event type takes the sample form of `sap.kyma.custom.commerce.order.created.v1`. The event type is composed of the following components:
 
 - Prefix: `sap.kyma.custom`
 - Application: `commerce`
 - Event: `order.created`
 - Version: `v1`
 ​
-For publishers, the event type takes this form:
+For publishers, the event type takes this sample form:
 - `order.created` for legacy events coming from the `commerce` application
-- `sap.kyma.custom.commerce.order.created.v1` for Cloud Events.
+- `sap.kyma.custom.commerce.order.created.v1` for Cloud Events

--- a/docs/05-technical-reference/00-architecture/evnt-01-architecture.md
+++ b/docs/05-technical-reference/00-architecture/evnt-01-architecture.md
@@ -2,7 +2,7 @@
 title: Eventing Architecture
 ---
 
-Eventing uses NATS to implement the Event Publisher Proxy and the Eventing Controller, which work together to process and deliver events in Kyma. See also the [Event processing and delivery](../evnt-01-event-processing.md) document for more information.
+The Event Publisher Proxy and the Eventing Controller are the two main components of Eventing. They work together to connect to the default NATS backend and process/deliver events in Kyma. See the [Event processing and delivery](../evnt-01-event-processing.md) document for more information.
 
 ## Event Publisher Proxy
 

--- a/docs/05-technical-reference/00-architecture/evnt-01-architecture.md
+++ b/docs/05-technical-reference/00-architecture/evnt-01-architecture.md
@@ -2,7 +2,7 @@
 title: Eventing Architecture
 ---
 
-Eventing uses NATS to implement the Event Publisher Proxy and the Eventing Controller which work together to process and deliver events in Kyma. See also the [Event processing and delivery](../evnt-01-event-processing.md) document for more information.
+Eventing uses NATS to implement the Event Publisher Proxy and the Eventing Controller, which work together to process and deliver events in Kyma. See also the [Event processing and delivery](../evnt-01-event-processing.md) document for more information.
 
 ## Event Publisher Proxy
 
@@ -14,7 +14,7 @@ The Eventing Controller component manages the internal infrastructure in order t
 
 ## Event types
 
-Eventing supports both Cloud Events and legacy events. The Event Publisher Proxy  converts legacy events to Cloud Events and adds the `sap.kyma.custom` prefix.
+Eventing supports both Cloud Events and legacy events. The Event Publisher Proxy converts legacy events to Cloud Events and adds the `sap.kyma.custom` prefix.
 
 For a Subscription Custom Resource, the fully qualified event type takes the sample form of `sap.kyma.custom.commerce.order.created.v1`. The event type is composed of the following components:
 

--- a/docs/05-technical-reference/00-architecture/evnt-01-architecture.md
+++ b/docs/05-technical-reference/00-architecture/evnt-01-architecture.md
@@ -2,7 +2,7 @@
 title: Eventing Architecture
 ---
 
-The Event Publisher Proxy and the Eventing Controller are the two main components of Eventing. They work together to connect to the default NATS backend and process/deliver events in Kyma. See the [Event processing and delivery](../evnt-01-event-processing.md) document for more information.
+Eventing uses the Event Publisher Proxy and the Eventing Controller to connect to the default NATS backend. They work together to process and deliver events in Kyma. See the [Event processing and delivery](../evnt-01-event-processing.md) document for more information.
 
 ## Event Publisher Proxy
 

--- a/docs/05-technical-reference/00-custom-resources/evnt-01-subscription.md
+++ b/docs/05-technical-reference/00-custom-resources/evnt-01-subscription.md
@@ -30,8 +30,6 @@ spec:
         property: type
         type: exact
         value: sap.kyma.custom.commerce.order.created.v1
-  protocol: ""
-  protocolsettings: {}
   sink: http://test.test.svc.cluster.local
 ```
 


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**
After a developer review, there were more areas identified where the Eventing documentation needs an update. This PR updates the Eventing documents.

Changes proposed in this pull request:

- Remove outdated architecture diagram (this also matches the state of [the current docs](https://kyma-project.io/docs/components/eventing/#architecture-architecture) )
- Clarify that Event Publisher Proxy converts legacy events to cloud events 
- Update the subscription CR in Subscription and In-cluster eventing docs: remove  `protocol:` and `protocolsettings:` fields which are not required 


**Related issue(s)**
#11200
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
