### PR TITLE
bump istio-installer to 1.11.2

### DIFF
--- a/components/istio-installer/Dockerfile
+++ b/components/istio-installer/Dockerfile
@@ -2,7 +2,7 @@ FROM eu.gcr.io/kyma-project/tpi/k8s-tools:20210610-d25e85b1
 
 LABEL source=git@github.com:kyma-project/kyma.git
 
-ENV ISTIOCTL_VERSION 1.10.2
+ENV ISTIOCTL_VERSION 1.11.2
 ENV YQ_VERSION 3.1.1
 
 RUN curl -L https://github.com/istio/istio/releases/download/${ISTIOCTL_VERSION}/istioctl-${ISTIOCTL_VERSION}-linux-amd64.tar.gz -o istioctl.tar.gz &&\


### PR DESCRIPTION
updating Istio to  1.11.2 mainly to address security issues.