### PR TITLE
Update Profile Production for ORY components

### DIFF
--- a/resources/ory/profile-production.yaml
+++ b/resources/ory/profile-production.yaml
@@ -10,6 +10,15 @@ global:
           enabled: false
 hydra:
   replicaCount: 2
+  affinity:
+    podAntiAffinity:
+      preferredDuringSchedulingIgnoredDuringExecution:
+      - weight: 100
+        podAffinityTerm:
+          labelSelector:
+            matchLabels:
+              app.kubernetes.io/name: hydra
+          topologyKey: "kubernetes.io/hostname"
 oathkeeper:
   deployment:
     resources:
@@ -17,8 +26,27 @@ oathkeeper:
         cpu: "800m"
       requests:
         cpu: "200m"
+  affinity:
+    podAntiAffinity:
+      preferredDuringSchedulingIgnoredDuringExecution:
+      - weight: 100
+        podAffinityTerm:
+          labelSelector:
+            matchLabels:
+              app: oathkeeper
+          topologyKey: "kubernetes.io/hostname"
 hpa:
   oathkeeper:
     minReplicas: 3
     maxReplicas: 10
-
+postgresql:
+  slave:
+    affinity:
+      podAntiAffinity:
+        preferredDuringSchedulingIgnoredDuringExecution:
+        - weight: 100
+          podAffinityTerm:
+            labelSelector:
+              matchLabels:
+                app: postgresql
+            topologyKey: "kubernetes.io/hostname"


### PR DESCRIPTION
Update Profile Production for ORY components to have podAntiAffinity rules for hydra, oathkeeper, and posgresql

Related to:

Multi zone, high availability topic for SKRs
 https://github.tools.sap/kyma/backlog/issues/1308 
