### PR TITLE
Bump libgit2 to 1.1.1-r2 in function controller

### DIFF
--- a/components/function-controller/deploy/jobinit/Dockerfile
+++ b/components/function-controller/deploy/jobinit/Dockerfile
@@ -4,7 +4,7 @@ ENV BASE_APP_DIR=/workspace/go/src/github.com/kyma-project/kyma/components/funct
     CGO_ENABLED=1 \
     GOOS=linux \
     GOARCH=amd64 \
-    LIBGIT2_VERSION=1.1.1-r1
+    LIBGIT2_VERSION=1.1.1-r2
 
 RUN apk add gcc libc-dev
 RUN apk add --no-cache --repository http://dl-cdn.alpinelinux.org/alpine/edge/community libgit2-dev=${LIBGIT2_VERSION}
@@ -21,8 +21,8 @@ RUN go build -ldflags "-s -w" -a -o jobinit cmd/jobinit/main.go \
     && mv ./jobinit /app/jobinit
 
 # result container
-FROM alpine:3.13.5
-ENV LIBGIT2_VERSION=1.1.1-r1
+FROM eu.gcr.io/kyma-project/external/alpine:3.14.2
+ENV LIBGIT2_VERSION=1.1.1-r2
 
 RUN apk add --no-cache ca-certificates
 RUN apk add --no-cache --update --repository=http://dl-cdn.alpinelinux.org/alpine/edge/main openssh-client

--- a/components/function-controller/deploy/manager/Dockerfile
+++ b/components/function-controller/deploy/manager/Dockerfile
@@ -4,7 +4,7 @@ ENV BASE_APP_DIR=/workspace/go/src/github.com/kyma-project/kyma/components/funct
     CGO_ENABLED=1 \
     GOOS=linux \
     GOARCH=amd64 \
-    LIBGIT2_VERSION=1.1.1-r1
+    LIBGIT2_VERSION=1.1.1-r2
 
 RUN apk add gcc libc-dev
 RUN apk add --no-cache --repository http://dl-cdn.alpinelinux.org/alpine/edge/community libgit2-dev=${LIBGIT2_VERSION}
@@ -25,8 +25,8 @@ FROM alpine:3.13.5 as certs
 RUN apk --update add ca-certificates
 
 # result container
-FROM alpine:3.13.5
-ENV LIBGIT2_VERSION=1.1.1-r1
+FROM eu.gcr.io/kyma-project/external/alpine:3.14.2
+ENV LIBGIT2_VERSION=1.1.1-r2
 
 RUN apk add --no-cache --repository http://dl-cdn.alpinelinux.org/alpine/edge/community libgit2=${LIBGIT2_VERSION}
 

--- a/components/function-controller/deploy/webhook/Dockerfile
+++ b/components/function-controller/deploy/webhook/Dockerfile
@@ -15,7 +15,7 @@ RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -a -o webhook-server cmd/webh
 && mkdir /app \
 && mv ./webhook-server /app/webhook-server
 
-FROM alpine:3.13.5 as certs
+FROM eu.gcr.io/kyma-project/external/alpine:3.14.2 as certs
 RUN apk --update add ca-certificates
 
 FROM scratch


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Version 1.1.1-r1 is no longer available:
https://storage.googleapis.com/kyma-prow-logs/pr-logs/pull/kyma-project_kyma/12171/pre-kyma-components-function-controller/1440936449976307712/build-log.txt

Changes proposed in this pull request:

- LIBGIT2 updated from 1.1.1-r1 to 1.1.1-r2
- alpine bumped to the newest version (3.14.2) because of  -https://storage.googleapis.com/kyma-prow-logs/pr-logs/pull/kyma-project_kyma/12176/pre-main-kyma-protecode-guard/1440978171217317888/build-log.txt

**Related issue(s)**
https://github.com/kyma-project/kyma/pull/12171