### PR TITLE
remove dex from oathkeeper jwks urls

### DIFF
--- a/resources/ory/values.yaml
+++ b/resources/ory/values.yaml
@@ -151,7 +151,6 @@ oathkeeper:
           enabled: true
           config:
             jwks_urls:
-            - http://dex-service.kyma-system.svc.cluster.local:5556/keys
             - http://ory-hydra-public.kyma-system.svc.cluster.local:4444/.well-known/jwks.json
             scope_strategy: wildcard
       authorizers:


### PR DESCRIPTION

**Description**

Changes proposed in this pull request:

- remove dex url from valid jwks_urls in oathkeeper configuration

**Related issue(s)**
See #12126 
