### PR TITLE
bump alpine to 3.14.2 for apiserver-proxy and iam-kubeconfig-service

### DIFF
--- a/components/apiserver-proxy/Dockerfile
+++ b/components/apiserver-proxy/Dockerfile
@@ -17,7 +17,7 @@ COPY . ${BASE_APP_DIR}
 RUN CGO_ENABLED=0 GOOS=linux go build -v -o app ${BASE_APP_DIR}/cmd/proxy/main.go
 RUN mkdir /app && mv ./app /app/app && mv ${BASE_APP_DIR}/licenses /app/licenses
 
-FROM alpine:3.13.5
+FROM eu.gcr.io/kyma-project/external/alpine:3.14.2
 LABEL source = git@github.com:kyma-project/kyma.git
 WORKDIR /app
 

--- a/components/iam-kubeconfig-service/Dockerfile
+++ b/components/iam-kubeconfig-service/Dockerfile
@@ -21,7 +21,7 @@ COPY ./licenses/ ${BASE_APP_DIR}/licenses/
 RUN CGO_ENABLED=0 GOOS=linux go build -v -o app ${BASE_APP_DIR}/cmd/generator/
 RUN mkdir /app && mv ./app /app/app && mv ${BASE_APP_DIR}/licenses /app/licenses
 
-FROM eu.gcr.io/kyma-project/external/alpine:3.13.5
+FROM eu.gcr.io/kyma-project/external/alpine:3.14.2
 LABEL source = git@github.com:kyma-project/kyma.git
 WORKDIR /app
 


### PR DESCRIPTION
bump alpine to 3.14.2 for apiserver-proxy and iam-kubeconfig-service