### PR TITLE
kiali cannot reach jaeger - enable sidecar for kiali

### DIFF
--- a/resources/kiali/templates/kyma-additions/servicemonitor.yaml
+++ b/resources/kiali/templates/kyma-additions/servicemonitor.yaml
@@ -14,3 +14,9 @@ spec:
       - {{ .Release.Namespace | quote }}
   endpoints:
   - port: http-metrics
+    scheme: https
+    tlsConfig:
+      caFile: /etc/prometheus/secrets/istio.default/root-cert.pem
+      certFile: /etc/prometheus/secrets/istio.default/cert-chain.pem
+      keyFile: /etc/prometheus/secrets/istio.default/key.pem
+      insecureSkipVerify: true

--- a/resources/kiali/values.yaml
+++ b/resources/kiali/values.yaml
@@ -399,7 +399,7 @@ kiali:
     # Custom annotations to be created on the Kiali pod.
     #    ---
       pod_annotations:
-        "sidecar.istio.io/inject": "false"
+        "sidecar.istio.io/inject": "true"
     #
     # Custom labels to be created on the Kiali pod.
     #    ---


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**
Currently kiali cannot reach jaeger as kiali is not running with a sidecar while jaeger is doing that. By https://github.com/kyma-project/kyma/pull/11994 the peerauthentication for jaeger got removed, with that no communication is possible anymore.

With https://github.com/kyma-project/kyma/pull/11560 the sidecar for kiali got disabled to actual enable the envoy introspection feature of kiali for observed pods, which was not working when kiali is running itself with a sidecar.
By upgrading the istio version and to kiali 1.38 that is not needed anymore and the sidecar can be enabled again.


Changes proposed in this pull request:

- Enabled the sidecar for kiali
- ...
- ...

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
