### PR TITLE
bump postgres 11.12-alpine to 11.13-alpine

### DIFF
--- a/resources/ory/charts/postgresql/values.yaml
+++ b/resources/ory/charts/postgresql/values.yaml
@@ -15,7 +15,7 @@ global:
 image:
   registry: eu.gcr.io/kyma-project/external
   repository: postgres
-  tag: 11.12-alpine
+  tag: 11.13-alpine
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- bumping postgres version for ory

**Related issue(s)**
Resolves: 
CVE-2021-3711, CVE-2021-3712