### PR TITLE
Bump alpine for kyma-operator for release-1.24

### DIFF
--- a/components/kyma-operator/Dockerfile
+++ b/components/kyma-operator/Dockerfile
@@ -19,7 +19,7 @@ COPY ./licenses/ ${BASE_APP_DIR}/licenses/
 RUN CGO_ENABLED=0 GOOS=linux go build -v -o kyma-operator ${BASE_APP_DIR}/cmd/operator/main.go
 RUN mkdir /app && mv ./kyma-operator /app/kyma-operator && mv ${BASE_APP_DIR}/licenses /app/licenses
 
-FROM alpine:3.13.5
+FROM eu.gcr.io/kyma-project/external/alpine:3.14.2
 LABEL source = git@github.com:kyma-project/kyma.git
 WORKDIR /app
 


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- bump alpine image for Kyma-operator to eu.gcr.io/kyma-project/external/alpine:3.14.2

**Related issue(s)**
Resolves: CVE-2021-3711, CVE-2021-3712