### PR TITLE
removed trailing spaces in fluent-bit config

### DIFF
--- a/resources/logging/charts/fluent-bit/templates/configmap.yaml
+++ b/resources/logging/charts/fluent-bit/templates/configmap.yaml
@@ -31,7 +31,7 @@ data:
         Name              tail
         {{- if .Values.config.inputs.tail.alias }}
         Alias             {{ .Values.config.inputs.tail.alias }}
-        {{- end }}             
+        {{- end }}
         Tag               {{ .Values.config.inputs.tail.tag }}
         {{- if .Values.config.inputs.tail.pathKey }}
         Tag_Regex         {{ .Values.config.inputs.tail.tagRegex }}

--- a/resources/logging/charts/fluent-bit/templates/kyma-additions/_parsers.tpl
+++ b/resources/logging/charts/fluent-bit/templates/kyma-additions/_parsers.tpl
@@ -98,7 +98,7 @@
     # https://rubular.com/r/3fVxCrE5iFiZim
     Name    envoy
     Format  regex
-    Regex ^\[(?<start_time>[^\]]*)\] "(?<method>\S+)(?: +(?<path>[^\"]*?)(?: +\S*)?)? (?<protocol>\S+)" (?<code>[^ ]*) (?<response_flags>[^ ]*) (?<bytes_received>[^ ]*) (?<bytes_sent>[^ ]*) (?<duration>[^ ]*) (?<x_envoy_upstream_service_time>[^ ]*) "(?<x_forwarded_for>[^ ]*)" "(?<user_agent>[^\"]*)" "(?<request_id>[^\"]*)" "(?<authority>[^ ]*)" "(?<upstream_host>[^ ]*)"  
+    Regex ^\[(?<start_time>[^\]]*)\] "(?<method>\S+)(?: +(?<path>[^\"]*?)(?: +\S*)?)? (?<protocol>\S+)" (?<code>[^ ]*) (?<response_flags>[^ ]*) (?<bytes_received>[^ ]*) (?<bytes_sent>[^ ]*) (?<duration>[^ ]*) (?<x_envoy_upstream_service_time>[^ ]*) "(?<x_forwarded_for>[^ ]*)" "(?<user_agent>[^\"]*)" "(?<request_id>[^\"]*)" "(?<authority>[^ ]*)" "(?<upstream_host>[^ ]*)"
     Time_Format %Y-%m-%dT%H:%M:%S.%L%z
     Time_Keep   On
     Time_Key start_time


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**
trailing spaces in the fluent-bit config were letting the yaml multi-line block be stored differently in the k8s configmap (to keep the trailing spaces) leading to an unreadable config block.

Changes proposed in this pull request:

- Removed the trailing spaces, now the config is beautiful to read at runtime in the configmap
- ...
- ...

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
