### PR TITLE
removed unneeded label check from monitoring test

### DIFF
--- a/tests/fast-integration/monitoring-test/monitoring-test.js
+++ b/tests/fast-integration/monitoring-test/monitoring-test.js
@@ -121,9 +121,6 @@ describe("Monitoring test", function () {
       "pod",
       "namespace",
     ]);
-    await assertTimeSeriesExist("kube_namespace_labels", [
-      "label_istio_injection",
-    ]);
     await assertTimeSeriesExist("kube_service_labels", ["namespace"]);
   });
 


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

In the past the functions grafana dashboard used as expression for filling the possible namespaces on base of the istio injection label. That was changed a while a go to be much more smarter. The monitoring test assured that all expressions used in the dashboard are covered by a test, that was not adjusted.

As the way istio gets deployed changed and the istio-injection exclusion gets managed now by a webhook config and not by a label, that old check is failing.

Changes proposed in this pull request:

- removed unwanted metrics check from monitoring test
- ...
- ...

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
Fixes https://github.com/kyma-project/kyma/issues/12253