### PR TITLE
Remove axios-retry

### DIFF
--- a/tests/fast-integration/test/1-commerce-mock.js
+++ b/tests/fast-integration/test/1-commerce-mock.js
@@ -1,6 +1,5 @@
 const axios = require("axios");
 const https = require("https");
-const { expect } = require("chai");
 const httpsAgent = new https.Agent({
   rejectUnauthorized: false, // curl -k
 });


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- `axios-retry` was not configured properly, since the `shouldResetTimeout` property should have been set to `true` to ensure that the timeout provided is used for each retry separately. Nevertheless, we decided to remove the `axios-retry` dependency and use instead the `retryPromise` from `utils` to be more consistent with the other tests. Also, `retryPromise` is more generic and can be used for any promise and not only with `axios`.

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
#12183