### PR TITLE
Enabled non-mtls support for pushing traces

### DIFF
--- a/resources/tracing/templates/kyma-additions/peerauthentication.yaml
+++ b/resources/tracing/templates/kyma-additions/peerauthentication.yaml
@@ -1,0 +1,30 @@
+{{- if eq .Values.jaeger.spec.strategy "allInOne" }}
+---
+apiVersion: security.istio.io/v1beta1
+kind: PeerAuthentication
+metadata:
+  name: {{ template "jaeger-operator.fullname" . }}-jaeger
+  labels:
+{{ include "jaeger-operator.labels" . | indent 4 }}
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ include "jaeger-operator.fullname" . }}-jaeger
+  mtls:
+    mode: "PERMISSIVE"
+{{- end }}
+{{- if eq .Values.jaeger.spec.strategy "production" }}
+---
+apiVersion: security.istio.io/v1beta1
+kind: PeerAuthentication
+metadata:
+  name: {{ template "jaeger-operator.fullname" . }}-jaeger-collector
+  labels:
+{{ include "jaeger-operator.labels" . | indent 4 }}
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ include "jaeger-operator.fullname" . }}-jaeger-collector
+  mtls:
+    mode: "PERMISSIVE"
+{{- end }}

--- a/resources/tracing/templates/kyma-additions/peerauthentication.yaml
+++ b/resources/tracing/templates/kyma-additions/peerauthentication.yaml
@@ -12,6 +12,9 @@ spec:
       app.kubernetes.io/name: {{ include "jaeger-operator.fullname" . }}-jaeger
   mtls:
     mode: "PERMISSIVE"
+  portLevelMtls: #keep metrics port strict
+    "14269":
+      mode: STRICT
 {{- end }}
 {{- if eq .Values.jaeger.spec.strategy "production" }}
 ---
@@ -27,4 +30,7 @@ spec:
       app.kubernetes.io/name: {{ include "jaeger-operator.fullname" . }}-jaeger-collector
   mtls:
     mode: "PERMISSIVE"
+  portLevelMtls: #keep metrics port strict
+    "14269":
+      mode: STRICT
 {{- end }}

--- a/resources/tracing/values.yaml
+++ b/resources/tracing/values.yaml
@@ -72,7 +72,7 @@ jaeger:
           - label: "About Kyma"
             items:
               - label: "Documentation"
-                url: "https://kyma-project.io/docs/components/tracing/"
+                url: "https://kyma-project.io/docs/kyma/latest/01-overview/main-areas/observability"
     ingress:
       enabled: false
     annotations:


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**
With https://github.com/kyma-project/kyma/pull/11994 we removed the not required peerauthentications for the tracing components. Unfortunately, it was missed that for pushing traces still mtls communication is required as the envoys itself need to communicate without mtls. So I added peerauthentications for that scenario only.

Changes proposed in this pull request:

- added peerauthentication for jaeger collector pods
- ...
- ...

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
