### PR TITLE
Rename component istio to istio-configuration for Kyma installation

### DIFF
--- a/installation/resources/components.yaml
+++ b/installation/resources/components.yaml
@@ -2,7 +2,7 @@
 defaultNamespace: kyma-system
 prerequisites:
   - name: "cluster-essentials"
-  - name: "istio"
+  - name: "istio-configuration"
     namespace: "istio-system"
   - name: "certificates"
     namespace: "istio-system"


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

By default Kyma is now installed by Kyma CLI using Reconciler so the installation with `istio` component will not work. `Istio-configuration` is the only chart that is Reconciler-ready and has to be used instead of `istio` (which will be removed eventually).

Changes proposed in this pull request:

- rename component `istio` to `istio-configuration`

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
PR changing reconcile action name for Istio: https://github.com/kyma-incubator/reconciler/pull/171
