### PR TITLE
Fix gcloud and custom DB Ory install

### DIFF
--- a/resources/ory/files/secret-migration.sh
+++ b/resources/ory/files/secret-migration.sh
@@ -86,7 +86,9 @@ DATA=$(cat << EOF
   ${SECRET_COOKIE_KEY}: $(echo -n "${COOKIE}" | base64 -w 0)
   {{- if .Values.global.ory.hydra.persistence.enabled }}
   ${PASSWORD_KEY}: $(echo -n "${PASSWORD}" | base64 -w 0)
+    {{- if .Values.global.ory.hydra.persistence.postgresql.enabled }}
   ${PASSWORD_R_KEY}: $(echo -n "${PASSWORDR}" | base64 -w 0)
+    {{- end}}
   {{- end }}
   {{- if .Values.global.ory.hydra.persistence.gcloud.enabled }}
   ${SERVICE_ACCOUNT_KEY}: $(echo -n "${SERVICE_ACCOUNT}")


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:
Fixes a bug in installing Ory with custom DB or GCloud SQL. Such install will now fail as there are no PASSWORD_R_KEY and PASSWORD_R values passed.

- Replication password should be added only for Postgres databases.


**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
