### PR TITLE
Increase in-cluster eventing timeout

### DIFF
--- a/tests/fast-integration/test/fixtures/commerce-mock/index.js
+++ b/tests/fast-integration/test/fixtures/commerce-mock/index.js
@@ -525,7 +525,7 @@ async function checkInClusterEventDeliveryHelper(targetNamespace, encoding) {
     let response = await axios.get(`https://${mockHost}`, { params: { inappevent: eventId } })
     expect(response).to.have.nested.property("data.id", eventId, "The same event id expected in the result");
     expect(response).to.have.nested.property("data.shipped", true, "Order should have property shipped");
-  }, 10, 1000);
+  }, 30, 2 * 1000);
 }
 
 module.exports = {


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Occasionally, event latency is larger than the timeout set on the test.

Changes proposed in this pull request:

- Use the same retry config for in-cluster eventing as for external events

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
