### PR TITLE
Improve KEB error response logging for fast-integration tests

### DIFF
--- a/tests/fast-integration/kyma-environment-broker/helpers.js
+++ b/tests/fast-integration/kyma-environment-broker/helpers.js
@@ -84,8 +84,9 @@ async function ensureOperationSucceeded(keb, instanceID, operationID) {
   );
 
   debug("KEB operation:", res);
-  expect(res).to.have.property("state", "succeeded");
-
+  if(res.state !== "succeeded") {
+    throw(`operation didn't succeed in 2h: ${JSON.stringify(res)}`);
+  }
   return res;
 }
 


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Currently, KEB client for fast-integration tests returns rather cryptic response
```
  1) SKR test
       Provision SKR with ID 14c2e726-c8eb-4e64-86bc-19b9a0f8a8f7:

      AssertionError: expected { Object (state, description) } to have property 'state' of 'succeeded', but got 'failed'      
      actual expected
      
      failedsucceeded
      
      at ensureOperationSucceeded (kyma-environment-broker/helpers.js:87:23)
      at processTicksAndRejections (internal/process/task_queues.js:95:5)
      at async provisionSKR (kyma-environment-broker/helpers.js:26:3)
      at async Context.<anonymous> (skr-test/skr-test.js:92:11)
```

this should improve the descriptiveness of the error message to provide all details in the response object `state` as well as `description` instead of not very clear `failedsucceeded`.

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
