### PR TITLE
Add default global domain name

### DIFF
--- a/resources/api-gateway/values.yaml
+++ b/resources/api-gateway/values.yaml
@@ -103,6 +103,7 @@ tests:
     runAsGroup: 65534
 
 global:
+  domainName: kyma.example.com
   containerRegistry:
     path: eu.gcr.io/kyma-project
   images:

--- a/resources/application-connector/values.yaml
+++ b/resources/application-connector/values.yaml
@@ -8,6 +8,7 @@ central_application_gateway:
   enabled: true
 
 global:
+  domainName: kyma.example.com
   centralApplicationConnectivityValidatorEnabled: true
   disableLegacyConnectivity: false
   isLocalEnv: false

--- a/resources/busola-migrator/values.yaml
+++ b/resources/busola-migrator/values.yaml
@@ -1,4 +1,5 @@
 global:
+  domainName: kyma.example.com
   ingress:
     domainName: ""
   istio:

--- a/resources/compass-runtime-agent/values.yaml
+++ b/resources/compass-runtime-agent/values.yaml
@@ -1,4 +1,5 @@
 global:
+  domainName: kyma.example.com
   containerRegistry:
     path: eu.gcr.io/kyma-project
   images:

--- a/resources/eventing/values.yaml
+++ b/resources/eventing/values.yaml
@@ -29,7 +29,7 @@ global:
   secretName: ""
 
   # domainName is the global domain used in Kyma
-  domainName: "domain"
+  domainName: "kyma.example.com"
 
   istio:
     proxy:

--- a/resources/helm-broker/values.yaml
+++ b/resources/helm-broker/values.yaml
@@ -74,6 +74,7 @@ addons-ui:
   enabled: false
 
 global:
+  domainName: "kyma.example.com"
   containerRegistry:
     path: eu.gcr.io/kyma-project
   # develop mode allows use insecure (http) url for addons configuration

--- a/resources/kiali/values.yaml
+++ b/resources/kiali/values.yaml
@@ -2,6 +2,7 @@ nameOverride: "kiali"
 fullnameOverride: "kiali"
 
 global:
+  domainName: "kyma.example.com"
   istio:
     gateway:
       name: kyma-gateway

--- a/resources/monitoring/values.yaml
+++ b/resources/monitoring/values.yaml
@@ -1,4 +1,5 @@
 global:
+  domainName: "kyma.example.com"
   containerRegistry:
     path: eu.gcr.io/kyma-project
   istio:

--- a/resources/ory/values.yaml
+++ b/resources/ory/values.yaml
@@ -1,5 +1,6 @@
 # Global or kyma related overrides
 global:
+  domainName: "kyma.example.com"
   postgresql:
     postgresqlDatabase: db4hydra
     postgresqlUsername: hydra

--- a/resources/rafter/values.yaml
+++ b/resources/rafter/values.yaml
@@ -1,4 +1,5 @@
 global:
+  domainName: "kyma.example.com"
   istio:
     gateway:
       name: kyma-gateway

--- a/resources/serverless/values.yaml
+++ b/resources/serverless/values.yaml
@@ -66,6 +66,7 @@ tests:
       URLPython: "https://pkgs.dev.azure.com/kyma-wookiee/public-packages/_packaging/public-packages%40Release/pypi/simple/"
 
 global:
+  domainName: "kyma.example.com"
   commonLabels:
     app: '{{ template "name" . }}'
     version: "{{ .Values.images.manager.tag }}"

--- a/resources/service-catalog-addons/values.yaml
+++ b/resources/service-catalog-addons/values.yaml
@@ -2,6 +2,7 @@ service-catalog-ui:
   enabled: false
 
 global:
+  domainName: "kyma.example.com"
   containerRegistry:
     path: eu.gcr.io/kyma-project
   images:

--- a/resources/tracing/values.yaml
+++ b/resources/tracing/values.yaml
@@ -103,6 +103,7 @@ serviceAccount:
   name:
 
 global:
+  domainName: "kyma.example.com"
   istio:
     gateway:
       name: kyma-gateway


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- Add default `global.domainName` to all components that require this value to be set in order to simplify the CLI logic. This PR does not mean to justify the usage of `global.domainName` for components in question, it just makes Helm templating happy

**Related issue(s)**
https://github.com/kyma-project/cli/pull/1027
https://github.com/kyma-project/kyma/issues/12009
