### PR TITLE
Update the commands to run Kyma Dashboard in the documentation

### DIFF
--- a/docs/02-get-started/01-quick-install.md
+++ b/docs/02-get-started/01-quick-install.md
@@ -45,18 +45,18 @@ To manage Kyma via GUI, connect it to Kyma Dashboard.
 1. To start the Dashboard, run:
 
     ```bash
-    docker run --rm -p 3001:3001 busola/local:latest
+    kyma dashboard
     ```
-
-2. Then, go to [`http://localhost:3001/`](http://localhost:3001/) to access the Dashboard.
-3. Click the button to add your cluster to the Dashboard. 
-4. [Get your `kubeconfig` file](https://kubernetes.io/docs/concepts/configuration/organize-cluster-access-kubeconfig/). Paste it into a text editor and replace the `0.0.0.0` part in the **cluster.server** value for k3d with `host.docker.internal`. <!-- //TODO: Remove the info about replacing the **cluster.server** value when this gets fixed. -->
-5. Upload it into the Dashboard as prompted.
+    This command opens the Dashboard under [`http://localhost:3001/`](http://localhost:3001/).
+    
+2. Click the button to add your cluster to the Dashboard. 
+3. [Get your `kubeconfig` file](https://kubernetes.io/docs/concepts/configuration/organize-cluster-access-kubeconfig/). Paste it into a text editor and replace the `0.0.0.0` part in the **cluster.server** value for k3d with `host.docker.internal`. <!-- //TODO: Remove the info about replacing the **cluster.server** value when this gets fixed. -->
+4. Upload it into the Dashboard as prompted.
 
 This takes you to your Kyma Dashboard.
 
 <!--
-//TODO: Finish when Busola working with Docker gets fixed. Replace the Docker command in step 1 with `kyma dashboard --local` and the address in step 2 with `https://dashboard.kyma-project/`.
+//TODO: Finish when the following get fixed: Replace the Docker command in step 1 with `kyma dashboard --local` and the address in step 2 with `https://dashboard.kyma-project/`.
 -->
 
 ## Check the list of Deployments via Dashboard

--- a/docs/04-operation-guides/operations/02-install-kyma.md
+++ b/docs/04-operation-guides/operations/02-install-kyma.md
@@ -34,7 +34,7 @@ Use the `deploy` command to install Kyma.
   kyma deploy
   ```
 
-With Kyma installed on a local k3d cluster, access Kyma Dashboard using `kyma dashboard --local`. The command opens a browser and takes you to localhost with the web-based administrative UI for Kyma. With Kyma installed on a remote cluster, access the Dashboard at [`https://dashboard.kyma-project.io`](https://dashboard.kyma-project.io).
+With Kyma installed on a local k3d cluster, access Kyma Dashboard using `kyma dashboard`. The command opens a browser and takes you to localhost with the web-based administrative UI for Kyma. With Kyma installed on a remote cluster, access the Dashboard at [`https://dashboard.kyma-project.io`](https://dashboard.kyma-project.io).
 
 <!-- `kyma dashboard --local` and the URL aren't working yet, see 02-get-started/01-quick-install.md -->
 <!-- Oct 4th: `kyma dashboard` works now, but ONLY locally -->


### PR DESCRIPTION
**Description**

The Kyma CLI command to run Kyma Dashboard now works and it's `kyma dashboard`, so the documentation must be updated. 

Changes proposed in this pull request:

- Change the command to run Kyma Dashboard to `kyma dashboard` in [Get Started - Quick Install](https://kyma-project.io/docs/kyma/latest/02-get-started/01-quick-install/) and [Installation](https://kyma-project.io/docs/kyma/latest/04-operation-guides/operations/02-install-kyma/#default-installation)

**Related issue(s)**
#11470 