### PR TITLE
Add pod anti-affinity rules for istio in production profile

### DIFF
--- a/resources/istio-configuration/profile-production.yaml
+++ b/resources/istio-configuration/profile-production.yaml
@@ -17,7 +17,7 @@ helmValues:
   pilot:
     autoscaleMax: 5
     autoscaleMin: 2
-    configNamespace: istio-config     
+    configNamespace: istio-config
 
 components:
   ingressGateways:
@@ -42,6 +42,18 @@ components:
         requests:
           cpu: 100m
           memory: 128Mi
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 100
+            podAffinityTerm:
+              labelSelector:
+                matchExpressions:
+                - key: app
+                  operator: In
+                  values:
+                  - istio-ingressgateway
+              topologyKey: "kubernetes.io/hostname"
 
   pilot:
     enabled: true
@@ -49,3 +61,15 @@ components:
       hpaSpec:
         maxReplicas: 5
         minReplicas: 2
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 100
+            podAffinityTerm:
+              labelSelector:
+                matchExpressions:
+                - key: app
+                  operator: In
+                  values:
+                  - istiod
+              topologyKey: "kubernetes.io/hostname"


### PR DESCRIPTION
**Description**

To provider better availability and resilience for node / AZ failures, the istio control plane replicas should be distributed across different nodes of the cluster.

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
