### PR TITLE
Move deprecated Istio proxy config

### DIFF
--- a/resources/istio-configuration/values.yaml
+++ b/resources/istio-configuration/values.yaml
@@ -3,7 +3,6 @@ helmValues:
   global:
     imagePullPolicy: IfNotPresent
     proxy:
-      holdApplicationUntilProxyStarts: true
       readinessFailureThreshold: 40
       readinessInitialDelaySeconds: 5
       readinessPeriodSeconds: 5
@@ -36,6 +35,7 @@ meshConfig:
   accessLogEncoding: JSON
   trustDomain: cluster.local
   defaultConfig:
+    holdApplicationUntilProxyStarts: true
     tracing:
       sampling: 1
       zipkin:


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**
values.global.proxy.holdApplicationUntilProxyStarts is deprecated, we should use meshConfig.defaultConfig.holdApplicationUntilProxyStarts instead

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
