### PR TITLE
Add higher level of retries for monitoring tests

### DIFF
--- a/tests/fast-integration/monitoring/helpers.js
+++ b/tests/fast-integration/monitoring/helpers.js
@@ -316,11 +316,26 @@ function removeNamePrefixes(ruleNames) {
 }
 
 async function getNotRegisteredPrometheusRuleNames() {
-    let registeredRules = await getRegisteredPrometheusRuleNames();
-    let k8sRuleNames = await getK8sPrometheusRuleNames();
-    k8sRuleNames = removeNamePrefixes(k8sRuleNames);
-    let notRegisteredRules = k8sRuleNames.filter((rule) => !registeredRules.includes(rule));
-    return notRegisteredRules;
+  let registeredRules = await getRegisteredPrometheusRuleNames();
+  let k8sRuleNames = await getK8sPrometheusRuleNames();
+  k8sRuleNames = removeNamePrefixes(k8sRuleNames);
+  let notRegisteredRules = k8sRuleNames.filter((rule) => !registeredRules.includes(rule));
+  return notRegisteredRules;
+}
+
+// Retries to execute getList() {maxRetries} times every {interval} ms until the returned list is empty
+async function retry(getList, maxRetries = 20, interval = 5*1000) {
+  let list = [];
+  let retries = 0;
+  while(retries < maxRetries) {
+    list = await getList();
+    if (list.length === 0) {
+      break;
+    }
+    await sleep(interval);
+    retries++;
+  }
+  return list;
 }
 
 module.exports = {
@@ -334,4 +349,5 @@ module.exports = {
   checkGrafanaRedirectsInKyma1,
   checkGrafanaRedirectsInKyma2,
   getNotRegisteredPrometheusRuleNames,
+  retry,
 };


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- Monitoring tests already have retries on the level of HTTP requests to prometheus API. We also need to have retries on the check performed on the response. For example, in this job (https://storage.googleapis.com/kyma-prow-logs/logs/kyma-periodic-gardener-gcp-busola-kyma/1447502387999674368/build-log.txt), `kiali-server` was initially unavailable. However, after waiting for some time it will become available.

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
