### PR TITLE
Assign cluster-admin when migrating kyma namespace admins to kyma2

### DIFF
--- a/components/busola-migrator/internal/kubernetes/client.go
+++ b/components/busola-migrator/internal/kubernetes/client.go
@@ -25,7 +25,7 @@ var rbacConfig = map[model.UserPermission]struct {
 }{
 	model.UserPermissionAdmin: {
 		clusterRoleBindingName: "cluster-admin-users",
-		clusterRoleName:        "kyma-admin",
+		clusterRoleName:        "cluser-admin",
 	},
 	model.UserPermissionDeveloper: {
 		clusterRoleBindingName: "cluster-developer-users",


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- In Kyma 2 admins should be bound to cluster-admin role 

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
