### PR TITLE
Fix Application Mapping CRD

### DIFF
--- a/installation/resources/crds/application-connector/applicationmappings.applicationconnector.crd.yaml
+++ b/installation/resources/crds/application-connector/applicationmappings.applicationconnector.crd.yaml
@@ -16,6 +16,14 @@ spec:
           properties:
             spec:
               type: object
+              properties:
+                services:
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      id:
+                        type: string
   scope: Namespaced
   names:
     plural: applicationmappings


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- Fix Application Mapping CRD - in the current version, there is no option to add services to the CR spec as presented [here in the documentation](https://kyma-project.io/docs/kyma/latest/05-technical-reference/00-custom-resources/ac-02-applicationmapping#sample-custom-resource). Even if we tried to create a new one CR or edit the existing one it ended up looking:
```yaml
apiVersion: applicationconnector.kyma-project.io/v1alpha1
kind: ApplicationMapping
metadata:
  creationTimestamp: "123"
  generation: 2
  name: qwe
  namespace: qwe
  resourceVersion: "123"
  uid: 123
spec: {}
```

instead of for example:
```yaml
apiVersion: applicationconnector.kyma-project.io/v1alpha1
kind: ApplicationMapping
metadata:
  creationTimestamp: "123"
  generation: 2
  name: qwe
  namespace: qwe
  resourceVersion: "123"
  uid: 123
spec:
  services:
  - id: asd
  - id: zxc
```

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
See the [issue here](https://github.com/kyma-project/kyma/issues/12323)
