### PR TITLE
Change "Tutorials" into "Developer Tutorials"

### DIFF
--- a/docs/03-tutorials/metadata.yaml
+++ b/docs/03-tutorials/metadata.yaml
@@ -1,1 +1,1 @@
-displayName: Tutorials
+displayName: Developer Tutorials


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

During the last SIG Content meeting, we agreed to change the "Tutorials" tab from the website's left-hand navigation to "Developer Tutorials" to make the tab name more descriptive and indicate to which group of target users it is devoted.

Changes proposed in this pull request:

- Change the name of the "Tutorials" tab into "Developer Tutorials"
