### PR TITLE
Fix Eventing architecture documentation

### DIFF
--- a/docs/05-technical-reference/00-architecture/evnt-01-architecture.md
+++ b/docs/05-technical-reference/00-architecture/evnt-01-architecture.md
@@ -21,11 +21,11 @@ For a Subscription Custom Resource, the fully qualified event type takes the sam
 The event type is composed of the following components:
 - Prefix: `sap.kyma.custom`
 - Application: `commerce`
-- Event: can have two or more segments separated by `.` (for example, `order.created` or `Account.Root.Created`)
+- Event: can have two or more segments separated by `.`; for example, `order.created` or `Account.Root.Created`
 - Version: `v1`
 
 For publishers, the event type takes this sample form:
 - `order.created` or `Account.Root.Created` for legacy events coming from the `commerce` application
-- `sap.kyma.custom.commerce.order.created.v1` or `sap.kyma.custom.commerce.AccountRoot.Created.v1` for Cloud Events.
+- `sap.kyma.custom.commerce.order.created.v1` or `sap.kyma.custom.commerce.AccountRoot.Created.v1` for Cloud Events
 
->**NOTE:** In case the event contains more than two segments, Eventing combines them into two segments when creating the underlying Eventing infrastructure (for example, `Account.Root.Created` becomes `AccountRoot.Created`).
+>**NOTE:** If the event contains more than two segments, Eventing combines them into two segments when creating the underlying Eventing infrastructure. For example, `Account.Root.Created` becomes `AccountRoot.Created`.


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- Add note which was present in[ 1.24 ](https://kyma-project-old.netlify.app/docs/components/eventing#architecture-architecture-event-types)for Eventing documentation
- Fix rendering of the bulletpoint list
- Drop the definite article from component names (see https://github.com/kyma-project/community/issues/481) 

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
