### PR TITLE
[istio-conf] adjust helm settings to match Kyma 1 convention for tracing

### DIFF
--- a/resources/istio-configuration/templates/istio-operator.yaml
+++ b/resources/istio-configuration/templates/istio-operator.yaml
@@ -25,6 +25,8 @@ spec:
 {{- toYaml .Values.components.pilot.config | nindent 10}}
   meshConfig:
 {{- toYaml .Values.meshConfig | nindent 4 }}
+    enableTracing: {{ .Values.global.tracing.enabled }}
+
   values:
     global:
 {{- toYaml .Values.helmValues.global | nindent 8 }}

--- a/resources/istio-configuration/values.yaml
+++ b/resources/istio-configuration/values.yaml
@@ -41,7 +41,6 @@ meshConfig:
       zipkin:
         address: "zipkin.kyma-system:9411"
   enablePrometheusMerge: false
-  enableTracing: true
 
 components:
   egressGateways:
@@ -121,3 +120,5 @@ global:
       name: "istio"
       version: "1.11.4-distroless"
       directory: "external"
+  tracing:
+    enabled: true


### PR DESCRIPTION
In Kyma2 tracing was controlled by setting `meshConfig.enableTracing` while
in Kyma 1.x it's `global.tracing.enabled`. This changes the config, so it matches
Kyma 1.x convention


