### PR TITLE
Bump apiserver-proxy and dex versions

### DIFF
--- a/resources/apiserver-proxy/values.yaml
+++ b/resources/apiserver-proxy/values.yaml
@@ -46,7 +46,7 @@ tests:
 global:
   apiserver_proxy:
     dir:
-    version: "be4c4de5"
+    version: "66fb0b9c"
   apiserver_proxy_integration_tests:
     dir:
     version: "37aa8463"

--- a/resources/dex/Chart.yaml
+++ b/resources/dex/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-appVersion: "1b1ee80f"
+appVersion: "ecda43b2"
 description: Kyma component 'dex'
 name: dex
 version: 1.0.0


### PR DESCRIPTION
**Description**
Bump Docker images versions used in Kyma
Changes proposed in this pull request:

- update apiserver-proxy Docker image version
- update dex Docker image version

**Related issue(s)**
See also: #12532, kyma-incubator/dex#31, 