### PR TITLE
[istio-conf] adjust helm settings to match Kyma 1 convention for tracing

### DIFF
--- a/resources/istio-configuration/templates/istio-operator.yaml
+++ b/resources/istio-configuration/templates/istio-operator.yaml
@@ -25,6 +25,8 @@ spec:
 {{- toYaml .Values.components.pilot.config | nindent 10}}
   meshConfig:
 {{- toYaml .Values.meshConfig | nindent 4 }}
+    enableTracing: {{ .Values.global.tracing.enabled }}
+
   values:
     global:
 {{- toYaml .Values.helmValues.global | nindent 8 }}

--- a/resources/istio-configuration/templates/istio-operator.yaml
+++ b/resources/istio-configuration/templates/istio-operator.yaml
@@ -24,8 +24,7 @@ spec:
       k8s:
 {{- toYaml .Values.components.pilot.config | nindent 10}}
   meshConfig:
-{{- toYaml .Values.meshConfig | nindent 4 }}
-    enableTracing: {{ .Values.global.tracing.enabled }}
+{{- tpl (toYaml .Values.meshConfig | nindent 4) . | replace "'true'" "true" | replace "'false'" "false" }}
 
   values:
     global:

--- a/resources/istio-configuration/values.yaml
+++ b/resources/istio-configuration/values.yaml
@@ -41,7 +41,6 @@ meshConfig:
       zipkin:
         address: "zipkin.kyma-system:9411"
   enablePrometheusMerge: false
-  enableTracing: true
 
 components:
   egressGateways:
@@ -121,3 +120,5 @@ global:
       name: "istio"
       version: "1.11.4-distroless"
       directory: "external"
+  tracing:
+    enabled: true

--- a/resources/istio-configuration/values.yaml
+++ b/resources/istio-configuration/values.yaml
@@ -41,6 +41,7 @@ meshConfig:
       zipkin:
         address: "zipkin.kyma-system:9411"
   enablePrometheusMerge: false
+  enableTracing: "{{ .Values.global.tracing.enabled }}"
 
 components:
   egressGateways:


### PR DESCRIPTION
In Kyma2 tracing was controlled by setting meshConfig.enableTracing while
in Kyma 1.x it's global.tracing.enabled. This changes the config, so both options are supported
