### PR TITLE
Rename Grafana ConfigMap watcher sidecar containers

### DIFF
--- a/resources/monitoring/charts/grafana/templates/_pod.tpl
+++ b/resources/monitoring/charts/grafana/templates/_pod.tpl
@@ -144,7 +144,7 @@ imagePullSecrets:
 {{- end }}
 containers:
 {{- if .Values.sidecar.datasources.enabled }}
-  - name: {{ template "grafana.name" . }}-sc-datasources
+  - name: {{ template "grafana.name" . }}-sc-datasources-watcher
     {{- if .Values.sidecar.image.sha }}
     image: "{{ .Values.sidecar.image.repository }}:{{ .Values.sidecar.image.tag }}@sha256:{{ .Values.sidecar.image.sha }}"
     {{- else }}
@@ -187,7 +187,7 @@ containers:
         mountPath: "/etc/grafana/provisioning/datasources"
 {{- end}}
 {{- if .Values.sidecar.dashboards.enabled }}
-  - name: {{ template "grafana.name" . }}-sc-dashboard
+  - name: {{ template "grafana.name" . }}-sc-dashboard-watcher
     {{- if .Values.sidecar.image.sha }}
     image: "{{ .Values.sidecar.image.repository }}:{{ .Values.sidecar.image.tag }}@sha256:{{ .Values.sidecar.image.sha }}"
     {{- else }}


### PR DESCRIPTION
Making the container a sidecar instead an init container caused failing
updates: https://github.com/kyma-project/kyma/issues/12543

This PR renames the sidecar containers to avoid naming conflicsts during
updates as a workaround until
https://github.com/kyma-incubator/reconciler/issues/330 is fixed. This
might be reverted once the issie is fixed in the reconciler for good.

<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- ...
- ...
- ...

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
Related issues: 
https://github.com/kyma-project/kyma/issues/12543
https://github.com/kyma-incubator/reconciler/issues/330