### PR TITLE
Update base image for gateway-legacy-test  executor to alpine 3.14.2

### DIFF
--- a/resources/application-connector/values.yaml
+++ b/resources/application-connector/values.yaml
@@ -74,7 +74,7 @@ global:
   testImages:
     application_gateway_legacy_tests:
       name: "application-gateway-legacy-tests"
-      version: "68baa911"
+      version: "PR-12547"
 
 application_connectivity_certs_setup_job:
   secrets:

--- a/tests/application-gateway-legacy-tests/test/helmtest/Dockerfile
+++ b/tests/application-gateway-legacy-tests/test/helmtest/Dockerfile
@@ -7,7 +7,7 @@ COPY . $SRC_DIR
 
 RUN CGO_ENABLED=0 go test -o proxyhelmtests.test -c ./test/helmtest/proxy/tests
 
-FROM alpine:3.10
+FROM alpine:3.11.0
 
 LABEL source=git@github.com:kyma-project/kyma.git
 

--- a/tests/application-gateway-legacy-tests/test/helmtest/Dockerfile
+++ b/tests/application-gateway-legacy-tests/test/helmtest/Dockerfile
@@ -7,7 +7,7 @@ COPY . $SRC_DIR
 
 RUN CGO_ENABLED=0 go test -o proxyhelmtests.test -c ./test/helmtest/proxy/tests
 
-FROM alpine:3.11.0
+FROM eu.gcr.io/kyma-project/external/alpine:3.14.2
 
 LABEL source=git@github.com:kyma-project/kyma.git
 


### PR DESCRIPTION
Fix for reported vulnerabilities from Protecode security scans:

https://github.tools.sap/kyma/security-scans/issues/10106
https://github.tools.sap/kyma/security-scans/issues/10107
https://github.tools.sap/kyma/security-scans/issues/10108

Solution is tu update version of base alpine image for executor of `application-gateway-legacy-tests `to latest version 3.14.2