### PR TITLE
enable containerd support in fluent-bit, enable new multiline feature

### DIFF
--- a/resources/logging/charts/fluent-bit/templates/configmap.yaml
+++ b/resources/logging/charts/fluent-bit/templates/configmap.yaml
@@ -60,7 +60,9 @@ data:
         Mem_Buf_Limit     {{ .Values.config.inputs.tail.memBufLimit }}
         exit_on_eof       {{ .Values.config.inputs.tail.exitOnEof }}
         {{- if eq .Values.config.inputs.tail.multiline "Off" }}
+        {{- if .Values.config.inputs.tail.parser }}
         Parser            {{ .Values.config.inputs.tail.parser }}
+        {{- end }}
         Docker_Mode       {{ .Values.config.inputs.tail.dockerMode }}
         Docker_Mode_Flush {{ .Values.config.inputs.tail.dockerModeFlush }}
         {{- end }}

--- a/resources/logging/charts/fluent-bit/values.yaml
+++ b/resources/logging/charts/fluent-bit/values.yaml
@@ -182,9 +182,9 @@ config:
       memBufLimit: 5MB
       # Exit Fluent Bit when reaching EOF of the monitored files.
       exitOnEof: "false"
-      parser: docker
+      parser: 
       # If enabled, the plugin will recombine split Docker log lines before passing them to any parser as configured above. This mode cannot be used at the same time as Multiline.
-      dockerMode: "On"
+      dockerMode: "Off"
       # Wait period time in seconds to flush queued unfinished split lines.
       dockerModeFlush: 4
       # When a message is unstructured (no parser applied), it's appended as a string under the key name log. This option allows to define an alternative name for that key.
@@ -198,7 +198,7 @@ config:
       # For new discovered files on start (without a database offset/position), read the content from the head of the file, not tail.
       readFromHead: "Off"
       # Specify one or Multiline Parser definition to apply to the content.
-      multilineParser:
+      multilineParser: docker, cri
       exclude:
         namespaces:
     additional: ""


### PR DESCRIPTION

<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- enabled new multiline feature by default
- configured docker and cri as default runtime parsers
- ...

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
solves https://github.com/kyma-project/kyma/issues/12118