### PR TITLE
Upgrade containerd lib and golang builder for application-operator

### DIFF
--- a/components/application-operator/Dockerfile
+++ b/components/application-operator/Dockerfile
@@ -1,4 +1,4 @@
-FROM eu.gcr.io/kyma-project/external/golang:1.16.4-alpine as builder
+FROM golang:1.17.3-alpine as builder
 
 ARG DOCK_PKG_DIR=/go/src/github.com/kyma-project/kyma/components/application-operator
 WORKDIR $DOCK_PKG_DIR

--- a/components/application-operator/Dockerfile
+++ b/components/application-operator/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.17.3-alpine as builder
+FROM eu.gcr.io/kyma-project/external/golang:1.17.3-alpine as builder
 
 ARG DOCK_PKG_DIR=/go/src/github.com/kyma-project/kyma/components/application-operator
 WORKDIR $DOCK_PKG_DIR

--- a/components/application-operator/go.mod
+++ b/components/application-operator/go.mod
@@ -18,7 +18,7 @@ require (
 )
 
 replace (
-	github.com/containerd/containerd => github.com/containerd/containerd v1.4.9
+	github.com/containerd/containerd => github.com/containerd/containerd v1.4.11
 	github.com/docker/distribution => github.com/docker/distribution v0.0.0-20191216044856-a8371794149d
 	github.com/docker/docker => github.com/docker/docker v20.10.8+incompatible
 	github.com/opencontainers/runc => github.com/opencontainers/runc v1.0.0-rc93

--- a/components/application-operator/go.sum
+++ b/components/application-operator/go.sum
@@ -147,8 +147,8 @@ github.com/containerd/cgroups v0.0.0-20200531161412-0dbf7f05ba59 h1:qWj4qVYZ95vL
 github.com/containerd/cgroups v0.0.0-20200531161412-0dbf7f05ba59/go.mod h1:pA0z1pT8KYB3TCXK/ocprsh7MAkoW8bZVzPdih9snmM=
 github.com/containerd/console v0.0.0-20180822173158-c12b1e7919c1/go.mod h1:Tj/on1eG8kiEhd0+fhSDzsPAFESxzBBvdyEgyryXffw=
 github.com/containerd/console v1.0.1/go.mod h1:XUsP6YE/mKtz6bxc+I8UiKKTP04qjQL4qcS3XoQ5xkw=
-github.com/containerd/containerd v1.4.9 h1:JIw9mjVw4LsGmnA/Bqg9j9e+XB7soOJufrKUpA6n2Ns=
-github.com/containerd/containerd v1.4.9/go.mod h1:bC6axHOhabU15QhwfG7w5PipXdVtMXFTttgp+kVtyUA=
+github.com/containerd/containerd v1.4.11 h1:QCGOUN+i70jEEL/A6JVIbhy4f4fanzAzSR4kNG7SlcE=
+github.com/containerd/containerd v1.4.11/go.mod h1:bC6axHOhabU15QhwfG7w5PipXdVtMXFTttgp+kVtyUA=
 github.com/containerd/continuity v0.0.0-20190426062206-aaeac12a7ffc/go.mod h1:GL3xCUCBDV3CZiTSEKksMWbLE66hEyuu9qyDOOqM47Y=
 github.com/containerd/continuity v0.0.0-20201208142359-180525291bb7 h1:6ejg6Lkk8dskcM7wQ28gONkukbQkM4qpj4RnYbpFzrI=
 github.com/containerd/continuity v0.0.0-20201208142359-180525291bb7/go.mod h1:kR3BEg7bDFaEddKm54WSmrol1fKWDU1nKYkgrcgZT7Y=

--- a/resources/application-connector/values.yaml
+++ b/resources/application-connector/values.yaml
@@ -51,7 +51,7 @@ global:
       version: "PR-11558"
     application_operator:
       name: "application-operator"
-      version: "PR-12306"
+      version: "PR-12555"
     application_registry:
       name: "application-registry"
       version: "PR-12181"


### PR DESCRIPTION
Upgrade upgrade containerd lib to v1.4.11 for to mitigate CVE-2021-41103

Upgrade golang builder image to v1.17.3 to mitigate 

CVE-2021-38297 
CVE-2021-33195 
CVE-2021-33194 
CVE-2021-34558