### PR TITLE
Add  a new Condition for BEB Webhook callback status

### DIFF
--- a/components/eventing-controller/api/v1alpha1/subscription_lifecycle.go
+++ b/components/eventing-controller/api/v1alpha1/subscription_lifecycle.go
@@ -10,9 +10,9 @@ import (
 type ConditionType string
 
 const (
-	ConditionSubscribed         ConditionType = "Subscribed"
-	ConditionSubscriptionActive ConditionType = "Subscription active"
-	ConditionAPIRuleStatus      ConditionType = "APIRule status"
+	ConditionSubscribed              ConditionType = "Subscribed"
+	ConditionSubscriptionActive      ConditionType = "Subscription active"
+	ConditionAPIRuleStatus           ConditionType = "APIRule status"
 	ConditionSubscriptionWebhookCall ConditionType = "Webhook call status"
 )
 
@@ -150,7 +150,7 @@ func (s *SubscriptionStatus) IsConditionSubscribed() bool {
 func (s *SubscriptionStatus) IsConditionWebhookCall() bool {
 	for _, condition := range s.Conditions {
 		if condition.Type == ConditionSubscriptionWebhookCall &&
-				(condition.Status == corev1.ConditionTrue || condition.Status == corev1.ConditionUnknown)  {
+			(condition.Status == corev1.ConditionTrue || condition.Status == corev1.ConditionUnknown) {
 			return true
 		}
 	}

--- a/components/eventing-controller/api/v1alpha1/subscription_lifecycle.go
+++ b/components/eventing-controller/api/v1alpha1/subscription_lifecycle.go
@@ -10,10 +10,10 @@ import (
 type ConditionType string
 
 const (
-	ConditionSubscribed              ConditionType = "Subscribed"
-	ConditionSubscriptionActive      ConditionType = "Subscription active"
-	ConditionAPIRuleStatus           ConditionType = "APIRule status"
-	ConditionSubscriptionWebhookCall ConditionType = "Webhook call status"
+	ConditionSubscribed         ConditionType = "Subscribed"
+	ConditionSubscriptionActive ConditionType = "Subscription active"
+	ConditionAPIRuleStatus      ConditionType = "APIRule status"
+	ConditionWebhookCallStatus  ConditionType = "Webhook call status"
 )
 
 var allConditions = makeConditions()
@@ -37,7 +37,7 @@ const (
 	ConditionReasonAPIRuleStatusReady         ConditionReason = "APIRule status ready"
 	ConditionReasonAPIRuleStatusNotReady      ConditionReason = "APIRule status not ready"
 	ConditionReasonNATSSubscriptionActive     ConditionReason = "NATS Subscription active"
-	ConditionReasonSubscriptionWebhookCall    ConditionReason = "BEB Subscription webhook call"
+	ConditionReasonWebhookCallStatus          ConditionReason = "BEB Subscription webhook call no errors status"
 )
 
 // InitializeConditions sets unset conditions to Unknown
@@ -63,7 +63,7 @@ func (s *SubscriptionStatus) InitializeConditions() {
 }
 
 func (s SubscriptionStatus) IsReady() bool {
-	if !containSameConditionTypes(allConditions, s.Conditions) {
+	if !ContainSameConditionTypes(allConditions, s.Conditions) {
 		return false
 	}
 
@@ -95,7 +95,7 @@ func makeConditions() []Condition {
 			Status:             corev1.ConditionUnknown,
 		},
 		{
-			Type:               ConditionSubscriptionWebhookCall,
+			Type:               ConditionWebhookCallStatus,
 			LastTransitionTime: metav1.Now(),
 			Status:             corev1.ConditionUnknown,
 		},
@@ -103,7 +103,7 @@ func makeConditions() []Condition {
 	return conditions
 }
 
-func containSameConditionTypes(conditions1, conditions2 []Condition) bool {
+func ContainSameConditionTypes(conditions1, conditions2 []Condition) bool {
 	if len(conditions1) != len(conditions2) {
 		return false
 	}
@@ -149,7 +149,7 @@ func (s *SubscriptionStatus) IsConditionSubscribed() bool {
 
 func (s *SubscriptionStatus) IsConditionWebhookCall() bool {
 	for _, condition := range s.Conditions {
-		if condition.Type == ConditionSubscriptionWebhookCall &&
+		if condition.Type == ConditionWebhookCallStatus &&
 			(condition.Status == corev1.ConditionTrue || condition.Status == corev1.ConditionUnknown) {
 			return true
 		}

--- a/components/eventing-controller/api/v1alpha1/subscription_lifecycle.go
+++ b/components/eventing-controller/api/v1alpha1/subscription_lifecycle.go
@@ -13,6 +13,7 @@ const (
 	ConditionSubscribed         ConditionType = "Subscribed"
 	ConditionSubscriptionActive ConditionType = "Subscription active"
 	ConditionAPIRuleStatus      ConditionType = "APIRule status"
+	ConditionSubscriptionWebhookCall ConditionType = "Webhook call status"
 )
 
 var allConditions = makeConditions()
@@ -36,6 +37,7 @@ const (
 	ConditionReasonAPIRuleStatusReady         ConditionReason = "APIRule status ready"
 	ConditionReasonAPIRuleStatusNotReady      ConditionReason = "APIRule status not ready"
 	ConditionReasonNATSSubscriptionActive     ConditionReason = "NATS Subscription active"
+	ConditionReasonSubscriptionWebhookCall    ConditionReason = "BEB Subscription webhook call"
 )
 
 // InitializeConditions sets unset conditions to Unknown
@@ -92,6 +94,11 @@ func makeConditions() []Condition {
 			LastTransitionTime: metav1.Now(),
 			Status:             corev1.ConditionUnknown,
 		},
+		{
+			Type:               ConditionSubscriptionWebhookCall,
+			LastTransitionTime: metav1.Now(),
+			Status:             corev1.ConditionUnknown,
+		},
 	}
 	return conditions
 }
@@ -134,6 +141,16 @@ func MakeCondition(conditionType ConditionType, reason ConditionReason, status c
 func (s *SubscriptionStatus) IsConditionSubscribed() bool {
 	for _, condition := range s.Conditions {
 		if condition.Type == ConditionSubscribed && condition.Status == corev1.ConditionTrue {
+			return true
+		}
+	}
+	return false
+}
+
+func (s *SubscriptionStatus) IsConditionWebhookCall() bool {
+	for _, condition := range s.Conditions {
+		if condition.Type == ConditionSubscriptionWebhookCall &&
+				(condition.Status == corev1.ConditionTrue || condition.Status == corev1.ConditionUnknown)  {
 			return true
 		}
 	}

--- a/components/eventing-controller/api/v1alpha1/subscription_lifecycle_test.go
+++ b/components/eventing-controller/api/v1alpha1/subscription_lifecycle_test.go
@@ -40,7 +40,7 @@ func Test_InitializeConditions(t *testing.T) {
 			g := NewGomegaWithT(t)
 			s := SubscriptionStatus{}
 			s.Conditions = tt.givenConditions
-			wantConditionTypes := []ConditionType{ConditionSubscribed, ConditionSubscriptionActive, ConditionAPIRuleStatus, ConditionSubscriptionWebhookCall}
+			wantConditionTypes := []ConditionType{ConditionSubscribed, ConditionSubscriptionActive, ConditionAPIRuleStatus, ConditionWebhookCallStatus}
 
 			// then
 			s.InitializeConditions()
@@ -112,7 +112,7 @@ func Test_IsReady(t *testing.T) {
 				{Type: ConditionSubscribed, Status: corev1.ConditionTrue},
 				{Type: ConditionSubscriptionActive, Status: corev1.ConditionTrue},
 				{Type: ConditionAPIRuleStatus, Status: corev1.ConditionTrue},
-				{Type: ConditionSubscriptionWebhookCall, Status: corev1.ConditionTrue},
+				{Type: ConditionWebhookCallStatus, Status: corev1.ConditionTrue},
 			},
 			wantReadyStatus: true,
 		},

--- a/components/eventing-controller/api/v1alpha1/subscription_lifecycle_test.go
+++ b/components/eventing-controller/api/v1alpha1/subscription_lifecycle_test.go
@@ -40,7 +40,7 @@ func Test_InitializeConditions(t *testing.T) {
 			g := NewGomegaWithT(t)
 			s := SubscriptionStatus{}
 			s.Conditions = tt.givenConditions
-			wantConditionTypes := []ConditionType{ConditionSubscribed, ConditionSubscriptionActive, ConditionAPIRuleStatus}
+			wantConditionTypes := []ConditionType{ConditionSubscribed, ConditionSubscriptionActive, ConditionAPIRuleStatus, ConditionSubscriptionWebhookCall}
 
 			// then
 			s.InitializeConditions()
@@ -112,6 +112,7 @@ func Test_IsReady(t *testing.T) {
 				{Type: ConditionSubscribed, Status: corev1.ConditionTrue},
 				{Type: ConditionSubscriptionActive, Status: corev1.ConditionTrue},
 				{Type: ConditionAPIRuleStatus, Status: corev1.ConditionTrue},
+				{Type: ConditionSubscriptionWebhookCall, Status: corev1.ConditionTrue},
 			},
 			wantReadyStatus: true,
 		},

--- a/components/eventing-controller/controllers/subscription/beb/reconciler.go
+++ b/components/eventing-controller/controllers/subscription/beb/reconciler.go
@@ -688,7 +688,7 @@ func (r *Reconciler) syncInitialStatus(subscription *eventingv1alpha1.Subscripti
 			}
 		}
 	}
-	if len(currentStatus.Conditions) == 0 {
+	if len(subscription.Status.Conditions) == 0 {
 		subscription.Status = expectedStatus
 	} else {
 		subscription.Status.Conditions = currentStatus.Conditions

--- a/components/eventing-controller/controllers/subscription/beb/reconciler_test.go
+++ b/components/eventing-controller/controllers/subscription/beb/reconciler_test.go
@@ -702,10 +702,10 @@ var _ = Describe("Subscription Reconciliation Tests", func() {
 					// after the BEB subscription was created, set lastFailedDelivery
 					w.WriteHeader(http.StatusOK)
 					s := bebtypes.Subscription{
-						Name: nameMapper.MapSubscriptionName(givenSubscription),
-						SubscriptionStatus: bebtypes.SubscriptionStatusActive,
-						LastSuccessfulDelivery: time.Now().Format(time.RFC3339), //"now",
-						LastFailedDelivery: time.Now().Add(10 * time.Second).Format(time.RFC3339), // "now + 10s"
+						Name:                     nameMapper.MapSubscriptionName(givenSubscription),
+						SubscriptionStatus:       bebtypes.SubscriptionStatusActive,
+						LastSuccessfulDelivery:   time.Now().Format(time.RFC3339),                       //"now",
+						LastFailedDelivery:       time.Now().Add(10 * time.Second).Format(time.RFC3339), // "now + 10s"
 						LastFailedDeliveryReason: lastFailedDeliveryReason,
 					}
 					err := json.NewEncoder(w).Encode(s)

--- a/components/eventing-controller/controllers/subscription/beb/reconciler_test.go
+++ b/components/eventing-controller/controllers/subscription/beb/reconciler_test.go
@@ -679,6 +679,91 @@ var _ = Describe("Subscription Reconciliation Tests", func() {
 		})
 	})
 
+	When("BEB subscription is set to have `lastFailedDelivery` and `lastFailedDeliveryReason`='Webhook endpoint response code: 401' after creation", func() {
+		It("Should not mark the subscription as ready", func() {
+			subscriptionName := "test-subscription-beb-status-not-ready-3"
+			lastFailedDeliveryReason := "Webhook endpoint response code: 401"
+
+			// Ensuring subscriber subscriberSvc
+			subscriberSvc := reconcilertesting.NewSubscriberSvc("webhook", namespaceName)
+			ensureSubscriberSvcCreated(ctx, subscriberSvc)
+
+			givenSubscription := reconcilertesting.NewSubscription(subscriptionName, namespaceName, reconcilertesting.WithWebhookAuthForBEB, reconcilertesting.WithEventTypeFilter)
+			reconcilertesting.WithValidSink(subscriberSvc.Namespace, subscriberSvc.Name, givenSubscription)
+
+			isBEBSubscriptionCreated := false
+
+			By("preparing mock to simulate a non ready BEB subscription")
+			beb.GetResponse = func(w http.ResponseWriter, subscriptionName string) {
+				// until the BEB subscription creation call was performed, send successful get requests
+				if !isBEBSubscriptionCreated {
+					reconcilertesting.BEBGetSuccess(w, nameMapper.MapSubscriptionName(givenSubscription))
+				} else {
+					// after the BEB subscription was created, set lastFailedDelivery
+					w.WriteHeader(http.StatusOK)
+					s := bebtypes.Subscription{
+						Name: nameMapper.MapSubscriptionName(givenSubscription),
+						SubscriptionStatus: bebtypes.SubscriptionStatusActive,
+						LastSuccessfulDelivery: time.Now().Format(time.RFC3339), //"now",
+						LastFailedDelivery: time.Now().Add(10 * time.Second).Format(time.RFC3339), // "now + 10s"
+						LastFailedDeliveryReason: lastFailedDeliveryReason,
+					}
+					err := json.NewEncoder(w).Encode(s)
+					Expect(err).ShouldNot(HaveOccurred())
+				}
+			}
+			beb.CreateResponse = func(w http.ResponseWriter) {
+				isBEBSubscriptionCreated = true
+				reconcilertesting.BEBCreateSuccess(w)
+			}
+
+			// Create subscription
+			ensureSubscriptionCreated(ctx, givenSubscription)
+
+			By("Creating a valid APIRule")
+			getAPIRuleForASvc(ctx, subscriberSvc).Should(reconcilertesting.HaveNotEmptyAPIRule())
+
+			By("Updating the APIRule(replicating apigateway controller) status to be Ready")
+			apiRuleCreated := filterAPIRulesForASvc(getAPIRules(ctx, subscriberSvc), subscriberSvc)
+			ensureAPIRuleStatusUpdatedWithStatusReady(ctx, &apiRuleCreated).Should(BeNil())
+
+			By("Setting APIRule status to Ready")
+			subscriptionAPIReadyCondition := eventingv1alpha1.MakeCondition(eventingv1alpha1.ConditionAPIRuleStatus, eventingv1alpha1.ConditionReasonAPIRuleStatusReady, v1.ConditionTrue, "")
+			getSubscription(ctx, givenSubscription).Should(And(
+				reconcilertesting.HaveSubscriptionName(subscriptionName),
+				reconcilertesting.HaveCondition(subscriptionAPIReadyCondition),
+			))
+
+			By("Setting a subscription active condition")
+			subscriptionActiveCondition := eventingv1alpha1.MakeCondition(eventingv1alpha1.ConditionSubscriptionActive, eventingv1alpha1.ConditionReasonSubscriptionActive, v1.ConditionTrue, "")
+			getSubscription(ctx, givenSubscription).Should(And(
+				reconcilertesting.HaveSubscriptionName(subscriptionName),
+				reconcilertesting.HaveCondition(subscriptionActiveCondition),
+			))
+
+			By("Setting a subscription webhook failed condition")
+			subscriptionWebhookCallFailedCondition := eventingv1alpha1.MakeCondition(eventingv1alpha1.ConditionSubscriptionWebhookCall, eventingv1alpha1.ConditionReasonSubscriptionWebhookCall, v1.ConditionFalse, lastFailedDeliveryReason)
+			getSubscription(ctx, givenSubscription).Should(And(
+				reconcilertesting.HaveSubscriptionName(subscriptionName),
+				reconcilertesting.HaveCondition(subscriptionWebhookCallFailedCondition),
+			))
+
+			By("Marking it as not ready")
+			getSubscription(ctx, givenSubscription).Should(And(
+				reconcilertesting.HaveSubscriptionName(subscriptionName),
+				Not(reconcilertesting.HaveSubscriptionReady()),
+			))
+
+			By("Deleting the object to not provoke more reconciliation requests")
+			Expect(k8sClient.Delete(ctx, givenSubscription)).Should(BeNil())
+			getSubscription(ctx, givenSubscription).ShouldNot(reconcilertesting.HaveSubscriptionFinalizer(Finalizer))
+
+			By("Sending at least one creation request for the Subscription")
+			_, creationRequests, _ := countBEBRequests(nameMapper.MapSubscriptionName(givenSubscription))
+			Expect(creationRequests).Should(reconcilertesting.BeGreaterThanOrEqual(1))
+		})
+	})
+
 	When("Deleting a valid Subscription", func() {
 		It("Should reconcile the Subscription", func() {
 			subscriptionName := "test-delete-valid-subscription-1"

--- a/components/eventing-controller/controllers/subscription/beb/reconciler_test.go
+++ b/components/eventing-controller/controllers/subscription/beb/reconciler_test.go
@@ -742,7 +742,7 @@ var _ = Describe("Subscription Reconciliation Tests", func() {
 			))
 
 			By("Setting a subscription webhook failed condition")
-			subscriptionWebhookCallFailedCondition := eventingv1alpha1.MakeCondition(eventingv1alpha1.ConditionSubscriptionWebhookCall, eventingv1alpha1.ConditionReasonSubscriptionWebhookCall, v1.ConditionFalse, lastFailedDeliveryReason)
+			subscriptionWebhookCallFailedCondition := eventingv1alpha1.MakeCondition(eventingv1alpha1.ConditionWebhookCallStatus, eventingv1alpha1.ConditionReasonWebhookCallStatus, v1.ConditionFalse, lastFailedDeliveryReason)
 			getSubscription(ctx, givenSubscription).Should(And(
 				reconcilertesting.HaveSubscriptionName(subscriptionName),
 				reconcilertesting.HaveCondition(subscriptionWebhookCallFailedCondition),

--- a/resources/eventing/values.yaml
+++ b/resources/eventing/values.yaml
@@ -5,7 +5,7 @@ global:
   images:
     eventing_controller:
       name: eventing-controller
-      version: PR-12599
+      version: PR-12567
       pullPolicy: "IfNotPresent"
     publisher_proxy:
       name: event-publisher-proxy


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- Add  a new condition for BEB Webhook callback status
- The status "ready" of a BEB subscription checks now the status of the new condition too
- Avoid during the reconciler call to work with an outdated subscription object


**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
