### PR TITLE
refactoring according to golangci-lint checks

### DIFF
--- a/components/eventing-controller/Makefile
+++ b/components/eventing-controller/Makefile
@@ -4,6 +4,7 @@ BUILDPACK = eu.gcr.io/kyma-project/test-infra/buildpack-golang-kubebuilder2:v202
 SCRIPTS_DIR = $(realpath $(shell pwd)/../..)/common/makefiles
 
 override ENTRYPOINT = cmd/eventing-controller/main.go
+override IGNORE_LINTING_ISSUES =
 
 include $(SCRIPTS_DIR)/generic-make-go.mk
 

--- a/components/eventing-controller/controllers/subscription/nats/reconciler.go
+++ b/components/eventing-controller/controllers/subscription/nats/reconciler.go
@@ -45,13 +45,10 @@ var (
 )
 
 const (
-	NATSProtocol = "NATS"
-	// NATSFirstInstanceName the name of first instance of NATS cluster
-	NATSFirstInstanceName = "eventing-nats-1"
-	// NATSNamespace namespace of NATS cluster
-	NATSNamespace = "kyma-system"
-
-	reconcilerName = "nats-subscription-reconciler"
+	NATSProtocol          = "NATS"
+	NATSFirstInstanceName = "eventing-nats-1" // NATSFirstInstanceName the name of first instance of NATS cluster
+	NATSNamespace         = "kyma-system"     // NATSNamespace namespace of NATS cluster
+	reconcilerName        = "nats-subscription-reconciler"
 )
 
 func NewReconciler(ctx context.Context, client client.Client, applicationLister *application.Lister, cache cache.Cache, logger *logger.Logger, recorder record.EventRecorder, cfg env.NatsConfig, subsCfg env.DefaultSubscriptionConfig) *Reconciler {

--- a/resources/eventing/values.yaml
+++ b/resources/eventing/values.yaml
@@ -8,7 +8,7 @@ global:
       version: PR-11920
     eventing_controller:
       name: eventing-controller
-      version: 571bf38e
+      version: PR-12553
       pullPolicy: "IfNotPresent"
     publisher_proxy:
       name: event-publisher-proxy
@@ -24,7 +24,7 @@ global:
       name: prometheus-nats-exporter
       version: 0.9.0
       directory: external/natsio
-    
+
 
   # secretName defines optionally another name than the default secret name
   secretName: ""

--- a/resources/eventing/values.yaml
+++ b/resources/eventing/values.yaml
@@ -8,7 +8,7 @@ global:
       version: PR-11920
     eventing_controller:
       name: eventing-controller
-      version: PR-12553
+      version: PR-12599
       pullPolicy: "IfNotPresent"
     publisher_proxy:
       name: event-publisher-proxy


### PR DESCRIPTION
@k15r noticed that `golangci-lint checks` shows following minor issues with the eventing `eventing-controllers` code base.

```console
#################################################################################################
# Thu Nov 11 17:08:50 CET 2021
# Run golangci-lint checks
#################################################################################################

Checks: deadcode errcheck gosimple govet ineffassign staticcheck structcheck typecheck unused varcheck golint gofmt misspell gochecknoinits unparam scopelint gosec
WARN [runner] The linter 'scopelint' is deprecated (since v1.39.0) due to: The repository of the linter has been deprecated by the owner.  Replaced by exportloopref.
testing/matchers.go:169: File is not `gofmt`-ed with `-s` (gofmt)
			return s.Status.CleanEventTypes },
testing/test_helpers.go:464:6: func ToUnstructuredApiRule should be ToUnstructuredAPIRule (golint)
func ToUnstructuredApiRule(obj interface{}) (*unstructured.Unstructured, error) {
     ^
reconciler/subscription/nats/reconciler_test.go:415:1: context.Context should be the first parameter of a function (golint)
func ensureSubscriptionCreated(subscription *eventingv1alpha1.Subscription, ctx context.Context) {
^
reconciler/subscription/nats/reconciler_test.go:435:1: context.Context should be the first parameter of a function (golint)
func ensureSubscriptionUpdated(subscription *eventingv1alpha1.Subscription, ctx context.Context) {
^
reconciler/subscription/nats/reconciler_test.go:470:1: context.Context should be the first parameter of a function (golint)
func getSubscription(subscription *eventingv1alpha1.Subscription, ctx context.Context) AsyncAssertion {
^
reconciler/subscription/nats/reconciler_test.go:511:2: var `testId` should be `testID` (golint)
	testId            int
	^
reconciler/subscription/nats/reconciler_test.go:512:2: var `natsUrl` should be `natsURL` (golint)
	natsUrl           string
	^
reconciler/subscription/nats/reconciler_test.go:556:2: var `natsUrl` should be `natsURL` (golint)
	natsUrl := natsServer.ClientURL()
	^
reconciler/subscription/nats/reconciler_test.go:614:20: func parameter `natsUrl` should be `natsURL` (golint)
func connectToNats(natsUrl string) (*nats.Conn, error) {
                   ^
make: [lint] Error 1 (ignored)
```

This PR tries to fix these issues.