### PR TITLE
Replace the `registry` component

### DIFF
--- a/resources/serverless/charts/docker-registry/templates/deployment.yaml
+++ b/resources/serverless/charts/docker-registry/templates/deployment.yaml
@@ -47,7 +47,7 @@ spec:
 {{- end }}
       initContainers:
         - name: generate-htpasswd
-          image: "{{ include "imageurl" (dict "reg" .Values.global.containerRegistry "img" .Values.global.images.k8s_tools) }}"
+          image: "{{ include "imageurl" (dict "reg" .Values.global.containerRegistry "img" .Values.global.images.registry) }}"
 {{- if .Values.securityContext.enabled }}
           securityContext:
             privileged: {{ .Values.securityContext.privileged }}
@@ -66,7 +66,6 @@ spec:
             - sh
             - -ec
             - |
-              apk upgrade --no-cache && apk add --no-cache apache2-utils
               htpasswd -Bbn $(cat /regcred/username.txt) $(cat /regcred/password.txt) > ./data/htpasswd
               echo "Generated htpasswd file for docker-registry..."
       containers:

--- a/resources/serverless/charts/docker-registry/templates/deployment.yaml
+++ b/resources/serverless/charts/docker-registry/templates/deployment.yaml
@@ -47,7 +47,7 @@ spec:
 {{- end }}
       initContainers:
         - name: generate-htpasswd
-          image: "{{ include "imageurl" (dict "reg" .Values.global.containerRegistry "img" .Values.global.images.registry) }}"
+          image: "{{ include "imageurl" (dict "reg" .Values.global.containerRegistry "img" .Values.global.images.k8s_tools) }}"
 {{- if .Values.securityContext.enabled }}
           securityContext:
             privileged: {{ .Values.securityContext.privileged }}
@@ -63,8 +63,9 @@ spec:
           command:
           # TODO: after helm@3.5.0 is used in kyma-installer we may be able to remove that init container, as helm 3.5.0 uses sprig@3.2.0, which has `bcrypt` function
           # might want to investigate
+          # apk upgrade --no-cache && apk add --no-cache apache2-utils
             - sh
-            - -c
+            - -ec
             - |
               htpasswd -Bbn $(cat /regcred/username.txt) $(cat /regcred/password.txt) > ./data/htpasswd
               echo "Generated htpasswd file for docker-registry..."

--- a/resources/serverless/charts/docker-registry/templates/deployment.yaml
+++ b/resources/serverless/charts/docker-registry/templates/deployment.yaml
@@ -63,10 +63,10 @@ spec:
           command:
           # TODO: after helm@3.5.0 is used in kyma-installer we may be able to remove that init container, as helm 3.5.0 uses sprig@3.2.0, which has `bcrypt` function
           # might want to investigate
-          # apk upgrade --no-cache && apk add --no-cache apache2-utils
             - sh
             - -ec
             - |
+              apk upgrade --no-cache && apk add --no-cache apache2-utils
               htpasswd -Bbn $(cat /regcred/username.txt) $(cat /regcred/password.txt) > ./data/htpasswd
               echo "Generated htpasswd file for docker-registry..."
       containers:

--- a/resources/serverless/values.yaml
+++ b/resources/serverless/values.yaml
@@ -102,7 +102,7 @@ global:
       directory: "tpi"
     registry:
       name: "registry"
-      version: "2.7.1-a54d396d"
+      version: "2.7.1-PR-149"
       directory: "tpi"
     google_pause:
       name: "pause-amd64"

--- a/resources/serverless/values.yaml
+++ b/resources/serverless/values.yaml
@@ -102,7 +102,7 @@ global:
       directory: "tpi"
     registry:
       name: "registry"
-      version: "2.7.1-8c646ef0"
+      version: "2.7.1-a54d396d"
       directory: "tpi"
     google_pause:
       name: "pause-amd64"

--- a/resources/serverless/values.yaml
+++ b/resources/serverless/values.yaml
@@ -102,7 +102,7 @@ global:
       directory: "tpi"
     registry:
       name: "registry"
-      version: "2.7.1-PR-149"
+      version: "2.7.1-0646c4cd"
       directory: "tpi"
     google_pause:
       name: "pause-amd64"


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- because the `registry` that we are using in the area of serverless is no more developed ([see here](https://github.com/docker/distribution-library-image)) we decided to change the implementation of the registry to the fully compatible and not outdated [distrubution](https://github.com/distribution/distribution/tree/release/2.7).

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
https://github.com/kyma-project/third-party-images/pull/146