### PR TITLE
Add note for auth proxy configuration on Windows

### DIFF
--- a/docs/04-operation-guides/security/sec-06-access-expose-kiali-grafana.md
+++ b/docs/04-operation-guides/security/sec-06-access-expose-kiali-grafana.md
@@ -72,6 +72,8 @@ The following example shows how to use an OpenID Connect (OIDC) compliant identi
 
    - To limit access to specific user groups, configure this with the `OAUTH2_PROXY_ALLOWED_GROUPS` variable and ensure that `OAUTH2_PROXY_OIDC_GROUPS_CLAIM` points to the groups attribute name that is used by your authentication service (`groups` is the default). To get the configuration flags required for other identity provider types, see [OAuth2 Proxy docs](https://oauth2-proxy.github.io/oauth2-proxy/docs/configuration/oauth_provider/).
 
+   - The shown kubectl calls work on Linux or macOS. If you are using Windows, replace the `` \ `` character by `` ` `` (PowerShell) or `` ^ `` (CMD) for multi-line commands.
+
 <div tabs>
   <details>
   <summary>

--- a/docs/04-operation-guides/security/sec-06-access-expose-kiali-grafana.md
+++ b/docs/04-operation-guides/security/sec-06-access-expose-kiali-grafana.md
@@ -72,7 +72,7 @@ The following example shows how to use an OpenID Connect (OIDC) compliant identi
 
    - To limit access to specific user groups, configure this with the `OAUTH2_PROXY_ALLOWED_GROUPS` variable and ensure that `OAUTH2_PROXY_OIDC_GROUPS_CLAIM` points to the groups attribute name that is used by your authentication service (`groups` is the default). To get the configuration flags required for other identity provider types, see [OAuth2 Proxy docs](https://oauth2-proxy.github.io/oauth2-proxy/docs/configuration/oauth_provider/).
 
-   - The shown kubectl calls work on Linux or macOS. If you are using Windows, replace the `` \ `` character by `` ` `` (PowerShell) or `` ^ `` (CMD) for multi-line commands.
+   - The following code works on Linux and macOS. If you are using Windows, replace the `` \ `` character by `` ` `` (PowerShell) or `` ^ `` (CMD) for multi-line commands.
 
 <div tabs>
   <details>


### PR DESCRIPTION
Multi-line kubectl examples need different character to initiate new
line on Windows.

<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- Add note for auth proxy configuration on Windows

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
