### PR TITLE
Fix of application-gateway host regression

### DIFF
--- a/components/application-gateway/internal/proxy/proxyfactory.go
+++ b/components/application-gateway/internal/proxy/proxyfactory.go
@@ -32,6 +32,7 @@ func makeProxy(targetUrl string, requestParameters *authorization.RequestParamet
 
 		req.URL.Scheme = target.Scheme
 		req.URL.Host = target.Host
+		req.Host = target.Host
 
 		combinedPath := joinPaths(target.Path, strippedPath)
 		req.URL.RawPath = combinedPath

--- a/resources/application-connector/values.yaml
+++ b/resources/application-connector/values.yaml
@@ -48,7 +48,7 @@ global:
       version: "4a206dab"
     application_gateway:
       name: "application-gateway"
-      version: "PR-11558"
+      version: "PR-12625"
     application_operator:
       name: "application-operator"
       version: "13002528"


### PR DESCRIPTION
This fix removes host header fix #12074 that caused regression described by  #12617 in application-gateway component 

We will return to the host header problem after releasing Kyma 2.0