### PR TITLE
Increase maxUnavailable count for DaemonSets

### DIFF
--- a/resources/logging/charts/fluent-bit/values.yaml
+++ b/resources/logging/charts/fluent-bit/values.yaml
@@ -52,7 +52,7 @@ securityContext:
 service:
   type: ClusterIP
   port: 2020
-  labels: 
+  labels:
     {}
   annotations:
     {}
@@ -123,10 +123,9 @@ extraVolumeMounts: ""
 #     mountPath: /var/tmp
 
 updateStrategy:
-  {}
-  # type: RollingUpdate
-  # rollingUpdate:
-  #   maxUnavailable: 1
+ type: RollingUpdate
+ rollingUpdate:
+   maxUnavailable: 33%
 
 # Make use of a pre-defined configmap instead of the one templated here
 existingConfigMap: ""
@@ -182,7 +181,7 @@ config:
       memBufLimit: 5MB
       # Exit Fluent Bit when reaching EOF of the monitored files.
       exitOnEof: "false"
-      parser: 
+      parser:
       # If enabled, the plugin will recombine split Docker log lines before passing them to any parser as configured above. This mode cannot be used at the same time as Multiline.
       dockerMode: "Off"
       # Wait period time in seconds to flush queued unfinished split lines.

--- a/resources/monitoring/charts/prometheus-node-exporter/values.yaml
+++ b/resources/monitoring/charts/prometheus-node-exporter/values.yaml
@@ -33,7 +33,7 @@ prometheus:
 updateStrategy:
   type: RollingUpdate
   rollingUpdate:
-    maxUnavailable: 1
+    maxUnavailable: 33%
 
 resources:
   {}


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

DaemonSets were before changed by a rolling update with a maximum number of unavailable pods of 1. This caused timeouts in the installer on larger clusters. This PR changes the allowed unavailable pods to a percentage to be independent from the number for nodes.

Changes proposed in this pull request:

- Allow 33% maxUnavailable pods for DaemonSets

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
