### PR TITLE
Change installation timeout to 20 min

### DIFF
--- a/components/kyma-operator/pkg/kymahelm/kyma-helm-client.go
+++ b/components/kyma-operator/pkg/kymahelm/kyma-helm-client.go
@@ -226,7 +226,7 @@ func (hc *Client) InstallRelease(chartDir string, nn NamespacedName, overrideVal
 	install.Atomic = false
 	install.Wait = true
 	install.CreateNamespace = true
-	install.Timeout = 6 * time.Minute
+	install.Timeout = 20 * time.Minute
 
 	comboValues, err := GetProfileValues(*chart, profile)
 	if err != nil {


### PR DESCRIPTION

**Description**

Changes proposed in this pull request:

- kcp-kyma-prod pipeline on spinnaker is failing. The logging DaemonSet takes more than 6 minutes to deploy. This causes a timeout and fails the installation. This PR sets this timeout duration to 20min. In order to ensure that there is enough time for logging DaemonSet to deploy all of its pods.

