### PR TITLE
Remove unnecessary helm values from profiles in istio-configuration component

### DIFF
--- a/resources/istio-configuration/profile-evaluation.yaml
+++ b/resources/istio-configuration/profile-evaluation.yaml
@@ -29,7 +29,6 @@ helmValues:
           memory: 10Mi
   pilot:
     autoscaleEnabled: false
-    configNamespace: istio-config
 
 components:
   ingressGateways:

--- a/resources/istio-configuration/profile-production.yaml
+++ b/resources/istio-configuration/profile-production.yaml
@@ -14,10 +14,6 @@ helmValues:
         limits:
           cpu: 500m
           memory: 1024Mi
-  pilot:
-    autoscaleMax: 5
-    autoscaleMin: 2
-    configNamespace: istio-config
 
 components:
   ingressGateways:


### PR DESCRIPTION
**Description**

The profiles for istio-configuration are partially defined using "helmValues".
These "helmValues", when rendering IstioOperator are going directly to the Helm Templates used internally by istioctl, thus overriding any values users put in IstioOperator Spec.
This is why we observed user's [can't override production profile values](https://github.com/kyma-incubator/reconciler/issues/400) - some value (like HPA settings for pilot) were ALSO defined as "helmValues", blocking any attempt to change them via user-defined overrides.

Changes proposed in this pull request:

- Remove HPA settings from "helmValues" in production profile - these are already defined in the Spec
- Remove strange, undocumented entry: "configNamespace" from both profiles.

**Related issue(s)**
https://github.com/kyma-incubator/reconciler/issues/400