### PR TITLE
Add AuthorizationPolicies for obervabilty services

### DIFF
--- a/resources/kiali/templates/kyma-additions/auth-proxy-deployment.yaml
+++ b/resources/kiali/templates/kyma-additions/auth-proxy-deployment.yaml
@@ -26,6 +26,7 @@ spec:
         - name: templates-cm
           configMap:
             name: {{ template "kiali-server.fullname" . }}-auth-proxy
+      serviceAccountName: {{ template "kiali-server.fullname" . }}-auth-proxy
       containers:
       - image: {{ include "imageurl" (dict "reg" .Values.global.containerRegistry "img" .Values.global.images.oauth2_proxy) }}
         imagePullPolicy: {{ .Values.authProxy.image.pullPolicy }}

--- a/resources/kiali/templates/kyma-additions/auth-proxy-serviceaccount.yaml
+++ b/resources/kiali/templates/kyma-additions/auth-proxy-serviceaccount.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    {{- include "kiali-server.labels" . | nindent 4 }}
+  name: {{ template "kiali-server.fullname" . }}-auth-proxy

--- a/resources/kiali/templates/kyma-additions/authorization-policy.yaml
+++ b/resources/kiali/templates/kyma-additions/authorization-policy.yaml
@@ -1,0 +1,33 @@
+apiVersion: security.istio.io/v1beta1
+kind: AuthorizationPolicy
+metadata:
+  labels:
+    {{- include "kiali-server.labels" . | nindent 4 }}
+  name: {{ include "kiali-server.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+spec:
+  action: ALLOW
+  rules:
+  - from:
+    - source:
+        principals:
+        - cluster.local/ns/{{ .Release.Namespace }}/sa/{{ template "kiali-server.fullname" . }}-auth-proxy
+    to:
+    - operation:
+        ports:
+        - "20001"
+  - from:
+    - source:
+        principals:
+          - cluster.local/ns/{{ .Release.Namespace }}/sa/monitoring-prometheus
+    to:
+    - operation:
+        ports:
+        - "9090"
+        methods:
+        - GET
+        paths:
+        - /metrics
+  selector:
+    matchLabels:
+      {{- include "kiali-server.labels" . | nindent 6 }}

--- a/resources/logging/charts/loki/templates/kyma-additions/authorizationpolicy.yaml
+++ b/resources/logging/charts/loki/templates/kyma-additions/authorizationpolicy.yaml
@@ -31,11 +31,11 @@ spec:
     - operation:
         paths: ["/loki/api/v1/push"]
         methods: ["POST"]
-  # prometheus (no istio-sidecar) having a User-Agent header can query metrics
-  - to:
+  - from:
+    - source:
+        principals:
+        - cluster.local/ns/{{ .Release.Namespace }}/sa/monitoring-prometheus
+    to:
     - operation:
         paths: ["/metrics"]
         methods: ["GET"]
-    when:
-    - key: "request.headers[User-Agent]"
-      values: ["Prometheus/*"]

--- a/resources/monitoring/charts/grafana/templates/kyma-additions/auth-proxy-deployment.yaml
+++ b/resources/monitoring/charts/grafana/templates/kyma-additions/auth-proxy-deployment.yaml
@@ -31,6 +31,7 @@ spec:
       - name: templates-cm
         configMap:
           name: {{ .Release.Name }}-auth-proxy-{{ template "grafana.name" . }}-templates
+      serviceAccountName: {{ .Release.Name }}-auth-proxy-{{ template "grafana.name" . }}
       containers:
       - image: "{{ include "imageurl" (dict "reg" .Values.global.containerRegistry "img" .Values.global.images.oauth2_proxy) }}"
         imagePullPolicy: {{ .Values.kyma.authProxy.image.pullPolicy }}

--- a/resources/monitoring/charts/grafana/templates/kyma-additions/auth-proxy-serviceaccount.yaml
+++ b/resources/monitoring/charts/grafana/templates/kyma-additions/auth-proxy-serviceaccount.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/name: auth-proxy
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    helm.sh/chart: {{ include "grafana.chart" . }}
+  name: {{ .Release.Name }}-auth-proxy-{{ template "grafana.name" . }}
+

--- a/resources/monitoring/charts/grafana/templates/kyma-additions/authorization-policy.yaml
+++ b/resources/monitoring/charts/grafana/templates/kyma-additions/authorization-policy.yaml
@@ -1,0 +1,27 @@
+apiVersion: security.istio.io/v1beta1
+kind: AuthorizationPolicy
+metadata:
+  labels:
+{{ include "grafana.labels" . | indent 4 }}
+  name: {{ template "grafana.name" . }}
+  namespace: {{ template "grafana.namespace" . }}
+spec:
+  action: ALLOW
+  rules:
+  - from:
+    - source:
+        principals:
+        - cluster.local/ns/{{ template "grafana.namespace" . }}/sa/{{ .Release.Name }}-auth-proxy-{{ template "grafana.name" . }}
+  - from:
+    - source:
+        principals:
+          - cluster.local/ns/{{ .Release.Namespace }}/sa/monitoring-prometheus
+    to:
+    - operation:
+        methods:
+        - GET
+        paths:
+        - /metrics
+  selector:
+    matchLabels:
+      app: grafana

--- a/resources/tracing/templates/kyma-additions/auth-proxy-deployment.yaml
+++ b/resources/tracing/templates/kyma-additions/auth-proxy-deployment.yaml
@@ -27,6 +27,7 @@ spec:
         - name: templates-cm
           configMap:
             name: {{ .Release.Name }}-auth-proxy-{{ template "jaeger-operator.fullname" . }}-templates
+      serviceAccountName: {{ include "jaeger-operator.fullname" . }}-auth-proxy
       containers:
       - image: "{{ include "imageurl" (dict "reg" .Values.global.containerRegistry "img" .Values.global.images.oauth2_proxy) }}"
         imagePullPolicy: {{ .Values.authProxy.image.pullPolicy }}

--- a/resources/tracing/templates/kyma-additions/auth-proxy-serviceaccount.yaml
+++ b/resources/tracing/templates/kyma-additions/auth-proxy-serviceaccount.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+{{ include "jaeger-operator.labels" . | indent 4 }}
+  name: {{ include "jaeger-operator.fullname" . }}-auth-proxy

--- a/resources/tracing/templates/kyma-additions/authorization-policy.yaml
+++ b/resources/tracing/templates/kyma-additions/authorization-policy.yaml
@@ -1,0 +1,42 @@
+apiVersion: security.istio.io/v1beta1
+kind: AuthorizationPolicy
+metadata:
+  name: {{ include "jaeger-operator.fullname" . }}-jaeger
+  namespace: {{ .Release.Namespace }}
+  labels:
+{{ include "jaeger-operator.labels" . | indent 4 }}
+spec:
+  action: ALLOW
+  rules:
+  - from:
+    - source:
+        principals:
+        - cluster.local/ns/{{ .Release.Namespace }}/sa/{{ include "jaeger-operator.fullname" . }}-auth-proxy
+        - cluster.local/ns/{{ .Release.Namespace }}/sa/kiali
+        - cluster.local/ns/{{ .Release.Namespace }}/sa/monitoring-grafana
+    to:
+      - operation:
+          ports: # Jaeger query port, limit to auth-proxy, Kiali and Grafana
+          - "16686"
+  - from:
+    - source:
+        principals:
+        - cluster.local/ns/{{ .Release.Namespace }}/sa/monitoring-prometheus
+    to:
+      - operation:
+          ports: # Jaeger metrics, limit to Prometheus. Istio does not detect this to be an HTTP connection due to the port name. No further restriction of method and path possible.
+            - "14269"
+  - to:
+    - operation:
+        ports: # Jaeger collector ports, no access restrictions
+        - "5778"
+        - "9411"
+        - "14250"
+        - "14267"
+        - "14268"
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: all-in-one
+      app.kubernetes.io/instance: tracing-jaeger
+      app.kubernetes.io/managed-by: jaeger-operator
+      app.kubernetes.io/name: tracing-jaeger

--- a/resources/tracing/templates/kyma-additions/peerauthentication.yaml
+++ b/resources/tracing/templates/kyma-additions/peerauthentication.yaml
@@ -12,8 +12,10 @@ spec:
       app.kubernetes.io/name: {{ include "jaeger-operator.fullname" . }}-jaeger
   mtls:
     mode: "PERMISSIVE"
-  portLevelMtls: #keep metrics port strict
+  portLevelMtls: #keep metrics and query port strict
     "14269":
+      mode: STRICT
+    "16686":
       mode: STRICT
 {{- end }}
 {{- if eq .Values.jaeger.spec.strategy "production" }}


### PR DESCRIPTION
Create dedicated ServiceAccounts for the auth-proxy pods that limit access to Grafana, Kiali and Jaeger and restrict access to the services to these ServiceAccounts.

<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- Create dedicated ServiceAccounts for auth-proxy pods
- Restrict access to observability services using Istio AuthorizationPolicies
- Set access to Jaeger query port to STRICT mTLS

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
