### PR TITLE
Allow using different mock namespaces

### DIFF
--- a/tests/fast-integration/README.md
+++ b/tests/fast-integration/README.md
@@ -63,6 +63,13 @@ npm install
 npm run test-eventing
 ```
 
+**NOTE:** You can change the namespace used for the Commerce Mock objects using:
+```
+MOCK_NAMESPACE=mock2 make ci-test-eventing
+```
+Using a different namespace changes the host used for the Commerce Mock APIRule as well. 
+This allows different Commerce Mocks to co-exist in different namespaces.
+
 ## Local development
 
 Here you have sample development tasks you can execute on your local machine working with the Kyma source code.

--- a/tests/fast-integration/README.md
+++ b/tests/fast-integration/README.md
@@ -63,12 +63,12 @@ npm install
 npm run test-eventing
 ```
 
-**NOTE:** You can change the namespace used for the Commerce Mock objects using:
-```
-MOCK_NAMESPACE=mock2 make ci-test-eventing
-```
-Using a different namespace changes the host used for the Commerce Mock APIRule as well. 
-This allows different Commerce Mocks to co-exist in different namespaces.
+> **NOTE:** You can change the Namespace used for the Commerce Mock objects using:
+> ```
+> MOCK_NAMESPACE=mock2 make ci-test-eventing
+> ```
+> Using a different Namespace changes the host used for the Commerce Mock APIRule as well. 
+> This allows different Commerce Mocks to co-exist in different Namespaces.
 
 ## Local development
 

--- a/tests/fast-integration/test/fixtures/commerce-mock/commerce-mock.yaml
+++ b/tests/fast-integration/test/fixtures/commerce-mock/commerce-mock.yaml
@@ -2,7 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: commerce-mock
-  namespace: mocks
+  namespace: %%MOCK_NAMESPACE%%
   labels:
     app: commerce-mock
 spec:
@@ -49,7 +49,7 @@ apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
   name: commerce-mock
-  namespace: mocks
+  namespace: %%MOCK_NAMESPACE%%
 spec:
   accessModes:
     - ReadWriteOnce
@@ -62,7 +62,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: commerce-mock
-  namespace: mocks
+  namespace: %%MOCK_NAMESPACE%%
   labels:
     app: commerce-mock
 spec:
@@ -76,7 +76,7 @@ apiVersion: gateway.kyma-project.io/v1alpha1
 kind: APIRule
 metadata:
   name: commerce-mock
-  namespace: mocks
+  namespace: %%MOCK_NAMESPACE%%
 spec:
   gateway: kyma-gateway.kyma-system.svc.cluster.local
   rules:
@@ -86,6 +86,6 @@ spec:
       methods: ["*"]
       path: /.*
   service:
-    host: commerce
+    host: commerce-%%MOCK_NAMESPACE%%
     name: commerce-mock
     port: 10000

--- a/tests/fast-integration/test/fixtures/commerce-mock/index.js
+++ b/tests/fast-integration/test/fixtures/commerce-mock/index.js
@@ -77,7 +77,6 @@ const lastorderFunctionYaml = fs.readFileSync(
   }
 );
 
-const commerceObjs = k8s.loadAllYaml(commerceMockYaml);
 const applicationObjs = k8s.loadAllYaml(applicationMockYaml);
 const lastorderObjs = k8s.loadAllYaml(lastorderFunctionYaml);
 let eventMeshSourceNamespace = "/default/sap.kyma/tunas-prow"
@@ -103,8 +102,13 @@ function prepareLastorderObjs(type = 'standard', appName = 'commerce') {
   }
 }
 
-async function checkFunctionResponse(functionNamespace) {
-  const vs = await waitForVirtualService("mocks", "commerce-mock");
+// Allows creating Commerce Mock objects in a specific namespace
+function prepareCommerceObjs(mockNamespace) {
+  return k8s.loadAllYaml(commerceMockYaml.toString().replace(/%%MOCK_NAMESPACE%%/g, mockNamespace))
+}
+
+async function checkFunctionResponse(functionNamespace, mockNamespace = 'mocks') {
+  const vs = await waitForVirtualService(mockNamespace, "commerce-mock");
   const mockHost = vs.spec.hosts[0];
   const host = mockHost.split(".").slice(1).join(".");
 
@@ -143,8 +147,8 @@ async function checkFunctionResponse(functionNamespace) {
   expect(errorOccurred).to.be.equal(true);
 }
 
-async function sendEventAndCheckResponse() {
-  const vs = await waitForVirtualService("mocks", "commerce-mock");
+async function sendEventAndCheckResponse(mockNamespace = 'mocks') {
+  const vs = await waitForVirtualService(mockNamespace, "commerce-mock");
   const mockHost = vs.spec.hosts[0];
   const host = mockHost.split(".").slice(1).join(".");
 
@@ -196,9 +200,9 @@ async function sendEventAndCheckResponse() {
   );
 }
 
-async function sendLegacyEventAndCheckTracing() {
+async function sendLegacyEventAndCheckTracing(mockNamespace = 'mocks') {
   // Send an event and get it back from the lastorder function
-  const res = await sendEventAndCheckResponse();
+  const res = await sendEventAndCheckResponse(mockNamespace);
   expect(res.data).to.have.nested.property("event.headers.x-b3-traceid");
   expect(res.data).to.have.nested.property("podName");
 
@@ -515,7 +519,7 @@ async function ensureCommerceMockLocalTestFixture(mockNamespace, targetNamespace
 
 async function provisionCommerceMockResources(appName, mockNamespace, targetNamespace, functionObjs = lastorderObjs) {
   await k8sApply([namespaceObj(mockNamespace), namespaceObj(targetNamespace)]);
-  await k8sApply(commerceObjs);
+  await k8sApply(prepareCommerceObjs(mockNamespace));
   await k8sApply(functionObjs, targetNamespace, true);
   await k8sApply([
     eventingSubscription(
@@ -524,8 +528,8 @@ async function provisionCommerceMockResources(appName, mockNamespace, targetName
       "order-created",
       targetNamespace)
   ]);
-  await waitForDeployment("commerce-mock", "mocks", 120 * 1000);
-  const vs = await waitForVirtualService("mocks", "commerce-mock");
+  await waitForDeployment("commerce-mock", mockNamespace, 120 * 1000);
+  const vs = await waitForVirtualService(mockNamespace, "commerce-mock");
   const mockHost = vs.spec.hosts[0];
   await retryPromise(
     () =>
@@ -569,7 +573,7 @@ function cleanMockTestFixture(mockNamespace, targetNamespace, wait = true) {
   return deleteNamespaces([mockNamespace, targetNamespace], wait);
 }
 
-async function deleteMockTestFixture(targetNamespace) {
+async function deleteMockTestFixture(mockNamespace) {
   const serviceBindingUsage = {
     apiVersion: "servicecatalog.kyma-project.io/v1alpha1",
     kind: "ServiceBindingUsage",
@@ -579,7 +583,7 @@ async function deleteMockTestFixture(targetNamespace) {
       usedBy: { kind: "serverless-function", name: "lastorder" },
     },
   };
-  await k8sDelete([serviceBindingUsage], targetNamespace);
+  await k8sDelete([serviceBindingUsage], mockNamespace);
   const serviceBinding = {
     apiVersion: "servicecatalog.k8s.io/v1beta1",
     kind: "ServiceBinding",
@@ -588,9 +592,9 @@ async function deleteMockTestFixture(targetNamespace) {
       instanceRef: { name: "commerce" },
     },
   };
-  await k8sDelete([serviceBinding], targetNamespace, false);
+  await k8sDelete([serviceBinding], mockNamespace, false);
   await k8sDelete(lastorderObjs)
-  await k8sDelete(commerceObjs)
+  await k8sDelete(prepareCommerceObjs(mockNamespace))
   await k8sDelete(applicationObjs)
 }
 


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

The existing Commerce Mock fixture uses a fixed host value for the APIRule. 

Changes proposed in this pull request:

- Parametrize the Commerce Mock objects used in the test, to allow co-existing mocks in different namespaces.
- Make sure the mock namespace is passed around every where in the test. Currently in many places the value "mocks" is hardcoded!

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
Closes #12605 