### PR TITLE
Assure sufficient privileges to migrate 1.x users to cluster-admins

### DIFF
--- a/resources/busola-migrator/templates/rbac.yaml
+++ b/resources/busola-migrator/templates/rbac.yaml
@@ -23,5 +23,5 @@ subjects:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: kyma-admin
+  name: cluster-admin
 {{- end }}


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:
- Busola-migrator needs cluster-admin

