### PR TITLE
removed resourceSelector workaround from monitoring chart

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -114,6 +114,9 @@
 # The `istio-configuration` chart
 /resources/istio-configuration/ @strekm @werdes72 @Tomasz-Smelcerz-SAP @mjakobczyk @dariusztutaj @cnvergence @veichtj @piotrkpc
 
+# The monitoring of `istio-configuration` chart
+/resources/istio-configuration/templates/monitoring @a-thaler @lilitgh @rakesh-garimella @skhalash @chrkl @shorim @lindnerby
+
 # The `tracing` chart
 /resources/tracing/ @a-thaler @lilitgh @suleymanakbas91 @clebs @rakesh-garimella @skhalash @jeremyharisch @chrkl @shorim
 

--- a/resources/istio-configuration/templates/monitoring/service-monitor.yaml
+++ b/resources/istio-configuration/templates/monitoring/service-monitor.yaml
@@ -6,7 +6,7 @@ metadata:
     meta.helm.sh/release-name: {{ $.Release.Name | quote }}	
     meta.helm.sh/release-namespace: {{ .Release.Namespace }}
   name: istio-component-monitor
-  namespace: {{ .Release.Namespace }}
+  namespace: kyma-system
   labels:
     app: {{ $.Release.Name }}	
     app.kubernetes.io/instance: {{ $.Release.Name }}	

--- a/resources/monitoring/templates/prometheus-operator/deployment.yaml
+++ b/resources/monitoring/templates/prometheus-operator/deployment.yaml
@@ -1,5 +1,5 @@
 {{- /*
-  Customization: .Values.resourceSelector.namespaces if statement is added to make comma separated namespace list work.
+  Customization: prometheusOperator.namespaces.releaseNamespace can be defined without .additional
   Liveness/readiness probes were added since they are missing in the upstream chart
 */ -}}
 {{- $namespace := printf "%s" (include "kube-prometheus-stack.namespace" .) }}
@@ -51,16 +51,12 @@ spec:
             {{- if .Values.prometheusOperator.denyNamespaces }}
             - --deny-namespaces={{ .Values.prometheusOperator.denyNamespaces | join "," }}
             {{- end }}
-            {{- if .Values.resourceSelector.namespaces }}
-            - --namespaces={{ .Values.resourceSelector.namespaces }}
-            {{ else }}
             {{- with $.Values.prometheusOperator.namespaces }}
-            {{ $ns := .additional }}
+            {{- $ns := default (list nil) .additional }} #Customization: have a default value if no additional namespace is defined
             {{- if .releaseNamespace }}
             {{- $ns = append $ns $namespace }}
             {{- end }}
             - --namespaces={{ $ns | join "," }}
-            {{- end }}
             {{- end }}
             - --logtostderr=true
             - --localhost=127.0.0.1

--- a/resources/monitoring/templates/prometheus/prometheus.yaml
+++ b/resources/monitoring/templates/prometheus/prometheus.yaml
@@ -1,6 +1,3 @@
-{{- /*
-  Customization: .Values.resourceSelector.namespaces if statement is added to make comma separated namespace list work.
-*/ -}}
 {{- if .Values.prometheus.enabled }}
 apiVersion: monitoring.coreos.com/v1
 kind: Prometheus
@@ -109,49 +106,6 @@ spec:
 {{ toYaml .Values.prometheus.prometheusSpec.configMaps | indent 4 }}
 {{- end }}
   serviceAccountName: {{ template "kube-prometheus-stack.prometheus.serviceAccountName" . }}
-
-{{- if .Values.resourceSelector.namespaces }}
-  serviceMonitorSelector: {}
-  serviceMonitorNamespaceSelector:
-    matchExpressions:
-    - key: name
-      operator: In
-      values:
-      {{- $namespaces := splitList "," .Values.resourceSelector.namespaces -}}
-      {{- range $namespaces }}
-      - {{ . }}
-      {{- end }}
-  podMonitorSelector: {}
-  podMonitorNamespaceSelector:
-    matchExpressions:
-    - key: name
-      operator: In
-      values:
-      {{- $namespaces := splitList "," .Values.resourceSelector.namespaces -}}
-      {{- range $namespaces }}
-      - {{ . }}
-      {{- end }}
-  ruleSelector: {}
-  ruleNamespaceSelector:
-    matchExpressions:
-    - key: name
-      operator: In
-      values:
-      {{- $namespaces := splitList "," .Values.resourceSelector.namespaces -}}
-      {{- range $namespaces }}
-      - {{ . }}
-      {{- end }}
-  probeSelector: {}
-  probeNamespaceSelector:
-    matchExpressions:
-    - key: name
-      operator: In
-      values:
-      {{- $namespaces := splitList "," .Values.resourceSelector.namespaces -}}
-      {{- range $namespaces }}
-      - {{ . }}
-      {{- end }}
-{{ else }}
 {{- if .Values.prometheus.prometheusSpec.serviceMonitorSelector }}
   serviceMonitorSelector:
 {{ toYaml .Values.prometheus.prometheusSpec.serviceMonitorSelector | indent 4 }}
@@ -216,7 +170,6 @@ spec:
 {{ toYaml .Values.prometheus.prometheusSpec.probeNamespaceSelector | indent 4 }}
 {{ else }}
   probeNamespaceSelector: {}
-{{- end }}
 {{- end }}
 {{- if .Values.prometheus.prometheusSpec.remoteRead }}
   remoteRead:

--- a/resources/monitoring/values.yaml
+++ b/resources/monitoring/values.yaml
@@ -106,8 +106,6 @@ global:
   imagePullSecrets: []
   # - name: "image-pull-secret"
 
-resourceSelector:
-  namespaces:
 # Default values for kube-prometheus-stack.
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.


### PR DESCRIPTION
moved istio serviceMonitor to kyma-system namespace

<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**
The resourceSelector attribute for the monitoring values.yaml was introduced to limit the scannes namespaces for the prometheus-operator with the custom installer overrides mechanism.
With the new reconciler approach, we can simply use the standard attributes in the chart.

For now all servicemonitors of kyma are located in the kyma-system namespace except of one in istio-system. To simplify the settings to limit scanning to system namespaces, I moved this one monitor to kyma-system as well.

Changes proposed in this pull request:

- remove the resourceSelctor attribute fully
- move istio servicemonitor to the kyma-system namespace
- ...

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
