### PR TITLE
Fix for storing  timestamp of lastAttempt of synchronisation in Connection CR and processing it in reconciliation loop

### DIFF
--- a/components/compass-runtime-agent/internal/compassconnection/controller.go
+++ b/components/compass-runtime-agent/internal/compassconnection/controller.go
@@ -93,15 +93,16 @@ func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 
 	log.Infof("Processing Compass Connection, current status: %s", instance.Status)
 
-	//If minimalConfigSyncTime did not pass from connection.Status.ConnectionStatus.LastSync, skip connection
-	if !shouldReconnect(instance, r.minimalConfigSyncTime) {
-		log.Infof("Skipping connection initialization. Minimal resync time not passed not passed. Last attempt: %v", instance.Status.ConnectionStatus.LastSync)
-		return reconcile.Result{}, nil
-	}
-
-	// If connection is not established read Config Map and try to fetch Certifice
-	if instance.ShouldAttemptReconnect() { //
+	// If connection is not established read Config Map and try to fetch Certificate
+	if instance.ShouldAttemptReconnect() {
 		log.Infof("Attempting to initialize connection with Compass...")
+
+		//If minimalConfigSyncTime did not pass from connection.Status.ConnectionStatus.LastSync, skip connection
+		if !shouldReconnect(instance, r.minimalConfigSyncTime) {
+			log.Infof("Skipping connection initialization. Minimal resync time not passed. Last attempt: %v", instance.Status.ConnectionStatus.LastSync)
+			return reconcile.Result{}, nil
+		}
+
 		instance, err := r.supervisor.InitializeCompassConnection()
 		if err != nil {
 			log.Errorf("Failed to initialize Compass Connection: %s", err.Error())

--- a/components/compass-runtime-agent/internal/compassconnection/controller.go
+++ b/components/compass-runtime-agent/internal/compassconnection/controller.go
@@ -153,7 +153,7 @@ func shouldReconnect(connection *v1alpha1.CompassConnection, minimalConfigSyncTi
 		return true
 	}
 
-	if connection.Status.ConnectionStatus == nil  {
+	if connection.Status.ConnectionStatus == nil {
 		return true
 	}
 

--- a/components/compass-runtime-agent/internal/compassconnection/controller.go
+++ b/components/compass-runtime-agent/internal/compassconnection/controller.go
@@ -93,14 +93,14 @@ func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 
 	log.Infof("Processing Compass Connection, current status: %s", instance.Status)
 
-	// If minimalConfigSyncTime did not pass, skip synchronization
-	if !shouldResyncConfig(instance, r.minimalConfigSyncTime) {
-		log.Infof("Skipping config initialization/synchronization. Minimal resync time not passed. Last attempt: %v", instance.Status.SynchronizationStatus.LastAttempt)
+	//If minimalConfigSyncTime did not pass from connection.Status.ConnectionStatus.LastSync, skip connection
+	if !shouldReconnect(instance, r.minimalConfigSyncTime) {
+		log.Infof("Skipping connection initialization. Minimal resync time not passed not passed. Last attempt: %v", instance.Status.ConnectionStatus.LastSync)
 		return reconcile.Result{}, nil
 	}
 
-	// If connection is not established read Config Map and try to fetch Certificate
-	if instance.ShouldAttemptReconnect() {
+	// If connection is not established read Config Map and try to fetch Certifice
+	if instance.ShouldAttemptReconnect() { //
 		log.Infof("Attempting to initialize connection with Compass...")
 		instance, err := r.supervisor.InitializeCompassConnection()
 		if err != nil {
@@ -109,6 +109,12 @@ func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 		}
 
 		log.Infof("Attempt to initialize Compass Connection ended with status: %s", instance.Status)
+		return reconcile.Result{}, nil
+	}
+
+	// If minimalConfigSyncTime did not pass from SynchronizationStatus.LastAttempt, skip synchronization
+	if !shouldResyncConfig(instance, r.minimalConfigSyncTime) {
+		log.Infof("Skipping config synchronization. Minimal resync time not passed. Last attempt: %v", instance.Status.SynchronizationStatus.LastAttempt)
 		return reconcile.Result{}, nil
 	}
 
@@ -126,7 +132,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 	return reconcile.Result{}, nil
 }
 
-// Initialization and Configuration resync is performed not more frequent that minimalConfigSyncTime,
+// Configuration resync is performed not more frequent that minimalConfigSyncTime,
 // unless deliberately requested by spec.ResyncNow set to true
 func shouldResyncConfig(connection *v1alpha1.CompassConnection, minimalConfigSyncTime time.Duration) bool {
 	if connection.Spec.ResyncNow {
@@ -140,4 +146,18 @@ func shouldResyncConfig(connection *v1alpha1.CompassConnection, minimalConfigSyn
 	timeSinceLastSyncAttempt := time.Now().Unix() - connection.Status.SynchronizationStatus.LastAttempt.Unix()
 
 	return timeSinceLastSyncAttempt >= int64(minimalConfigSyncTime.Seconds())
+}
+
+func shouldReconnect(connection *v1alpha1.CompassConnection, minimalConfigSyncTime time.Duration) bool {
+	if connection.Spec.ResyncNow {
+		return true
+	}
+
+	if connection.Status.ConnectionStatus == nil  {
+		return true
+	}
+
+	timeSinceLastConnAttempt := time.Now().Unix() - connection.Status.ConnectionStatus.LastSync.Unix()
+
+	return timeSinceLastConnAttempt >= int64(minimalConfigSyncTime.Seconds())
 }

--- a/components/compass-runtime-agent/internal/compassconnection/package_test.go
+++ b/components/compass-runtime-agent/internal/compassconnection/package_test.go
@@ -318,7 +318,7 @@ func TestCompassConnectionController(t *testing.T) {
 		// given
 		configurationClientMock.ExpectedCalls = nil
 		configurationClientMock.Calls = nil
-		configurationClientMock.On("FetchConfiguration").After(1*time.Second).Return(nil, errors.New("error"))
+		configurationClientMock.On("FetchConfiguration").After(1*time.Second).Return(nil, nil, errors.New("error"))
 
 		// when
 		// 2 seconds wait for call + 1 second for timeout
@@ -341,7 +341,7 @@ func TestCompassConnectionController(t *testing.T) {
 		// given
 		configurationClientMock.ExpectedCalls = nil
 		configurationClientMock.Calls = nil
-		configurationClientMock.On("FetchConfiguration").After(1*time.Second).Return(nil, errors.New("error"))
+		configurationClientMock.On("FetchConfiguration").After(1*time.Second).Return(nil, nil, errors.New("error"))
 
 		// when
 		// 2 seconds wait for call + 1 second for timeout

--- a/components/compass-runtime-agent/internal/compassconnection/package_test.go
+++ b/components/compass-runtime-agent/internal/compassconnection/package_test.go
@@ -379,7 +379,7 @@ func TestCompassConnectionController(t *testing.T) {
 		// when
 		// 2 seconds wait for call + 1 second for timeout
 		err = waitFor(checkInterval, testTimeout, func() bool {
-			return mockFunctionCalled(&badConnectorMock.Mock, "Configuration", connectorTokenHeaders)
+			return mockFunctionCalled(&badConnectorMock.Mock, "Configuration", connectorTokenHeadersFunc)
 		})
 
 		require.NoError(t, err)
@@ -413,7 +413,7 @@ func TestCompassConnectionController(t *testing.T) {
 		// when
 		// 2 seconds wait for call + 1 second for timeout
 		err = waitFor(checkInterval, testTimeout, func() bool {
-			return mockFunctionCalled(&badConnectorMock.Mock, "Configuration", connectorTokenHeaders)
+			return mockFunctionCalled(&badConnectorMock.Mock, "Configuration", connectorTokenHeadersFunc)
 		})
 
 		require.NoError(t, err)

--- a/components/compass-runtime-agent/internal/compassconnection/package_test.go
+++ b/components/compass-runtime-agent/internal/compassconnection/package_test.go
@@ -362,7 +362,7 @@ func TestCompassConnectionController(t *testing.T) {
 	t.Run("Compass Connection Controller should skip all attempts of Connection Initialisation if failed to fetch configuration from Connector AND minimalConfigSyncTime HAS NOT passed", func(t *testing.T) {
 		// given
 		badConnectorMock := &connectorMocks.Client{}
-		badConnectorMock.On("Configuration", connectorTokenHeaders).After(1*time.Second).Return(gqlschema.Configuration{}, errors.New("Failed to get configuration. Timeout!!!"))
+		badConnectorMock.On("Configuration", connectorTokenHeadersFunc).After(1*time.Second).Return(gqlschema.Configuration{}, errors.New("Failed to get configuration. Timeout!!!"))
 
 		clientsProviderMock.ExpectedCalls = nil
 		clientsProviderMock.Calls = nil
@@ -396,7 +396,7 @@ func TestCompassConnectionController(t *testing.T) {
 	t.Run("Compass Connection Controller should resume attempts of Connection Initialisation if failed to fetch configuration from Connector AND minimalConfigSyncTime HAS passed", func(t *testing.T) {
 		// given
 		badConnectorMock := &connectorMocks.Client{}
-		badConnectorMock.On("Configuration", connectorTokenHeaders).After(1*time.Second).Return(gqlschema.Configuration{}, errors.New("Failed to get configuration. Timeout!!!"))
+		badConnectorMock.On("Configuration", connectorTokenHeadersFunc).After(1*time.Second).Return(gqlschema.Configuration{}, errors.New("Failed to get configuration. Timeout!!!"))
 
 		clientsProviderMock.ExpectedCalls = nil
 		clientsProviderMock.Calls = nil

--- a/components/compass-runtime-agent/internal/compassconnection/supervisor.go
+++ b/components/compass-runtime-agent/internal/compassconnection/supervisor.go
@@ -328,24 +328,6 @@ func (s *crSupervisor) setConnectionMaintenanceFailedStatus(connectionCR *v1alph
 	connectionCR.Status.ConnectionStatus.Error = errorMsg
 }
 
-
-/*
-2021-11-22 06:58:43
-{"log":"time=\"2021-11-22T05:58:43Z\" level=error msg=\"Error while trying to maintain connection: Failed to connect to Compass Connector: Management info is empty\" CompassConnection=compass-connection Supervisor=CompassConnection
-","time":"2021-11-22T05:58:43.744997887Z"}
-2021-11-22 06:58:50
-{"log":"time=\"2021-11-22T05:58:50Z\" level=error msg=\"Error while trying to maintain connection: Failed to connect to Compass Connector: Management info is empty\" CompassConnection=compass-connection Supervisor=CompassConnection
-","time":"2021-11-22T05:58:50.984370156Z"}
-2021-11-22 06:58:59
-{"log":"time=\"2021-11-22T05:58:59Z\" level=error msg=\"Error while trying to maintain connection: Failed to connect to Compass Connector: Management info is empty\" CompassConnection=compass-connection Supervisor=CompassConnection
-","time":"2021-11-22T05:58:59.159868934Z"}
-2021-11-22 06:59:07
-{"log":"time=\"2021-11-22T05:59:07Z\" level=error msg=\"Error while trying to maintain connection: Failed to connect to Compass Connector: Management info is empty\" CompassConnection=compass-connection Supervisor=CompassConnection
-","time":"2021-11-22T05:59:07.17789839Z"}
-
-
-*/
-
 func (s *crSupervisor) updateCompassConnection(connectionCR *v1alpha1.CompassConnection) (*v1alpha1.CompassConnection, error) {
 	// TODO: with retries
 

--- a/components/compass-runtime-agent/internal/compassconnection/supervisor.go
+++ b/components/compass-runtime-agent/internal/compassconnection/supervisor.go
@@ -121,13 +121,12 @@ func (s *crSupervisor) InitializeCompassConnection() (*v1alpha1.CompassConnectio
 // SynchronizeWithCompass synchronizes with Compass
 func (s *crSupervisor) SynchronizeWithCompass(connection *v1alpha1.CompassConnection) (*v1alpha1.CompassConnection, error) {
 	s.log = s.log.WithField("CompassConnection", connection.Name)
-	syncAttemptTime := metav1.Now()
 
 	s.log.Infof("Trying to maintain connection to Connector with %s url...", connection.Spec.ManagementInfo.ConnectorURL)
 	err := s.maintainCompassConnection(connection)
 	if err != nil {
 		errorMsg := fmt.Sprintf("Error while trying to maintain connection: %s", err.Error())
-		s.setConnectionMaintenanceFailedStatus(connection, syncAttemptTime, errorMsg)
+		s.setConnectionMaintenanceFailedStatus(connection, metav1.Now(), errorMsg)
 		return s.updateCompassConnection(connection)
 	}
 
@@ -135,7 +134,7 @@ func (s *crSupervisor) SynchronizeWithCompass(connection *v1alpha1.CompassConnec
 	runtimeConfig, err := s.configProvider.GetRuntimeConfig()
 	if err != nil {
 		errorMsg := fmt.Sprintf("Failed to read Runtime config: %s", err.Error())
-		s.setSyncFailedStatus(connection, syncAttemptTime, errorMsg)
+		s.setSyncFailedStatus(connection, metav1.Now(), errorMsg)
 		return s.updateCompassConnection(connection)
 	}
 
@@ -143,20 +142,21 @@ func (s *crSupervisor) SynchronizeWithCompass(connection *v1alpha1.CompassConnec
 	directorClient, err := s.clientsProvider.GetDirectorClient(runtimeConfig)
 	if err != nil {
 		errorMsg := fmt.Sprintf("Failed to prepare configuration client: %s", err.Error())
-		s.setSyncFailedStatus(connection, syncAttemptTime, errorMsg)
+		s.setSyncFailedStatus(connection, metav1.Now(), errorMsg)
 		return s.updateCompassConnection(connection)
 	}
 
 	applicationsConfig, runtimeLabels, err := directorClient.FetchConfiguration()
 	if err != nil {
 		errorMsg := fmt.Sprintf("Failed to fetch configuration: %s", err.Error())
-		s.setSyncFailedStatus(connection, syncAttemptTime, errorMsg)
+		s.setSyncFailedStatus(connection, metav1.Now(), errorMsg)
 		return s.updateCompassConnection(connection)
 	}
 
 	s.log.Infof("Applying configuration to the cluster...")
 	results, err := s.syncService.Apply(applicationsConfig)
 	if err != nil {
+		syncAttemptTime := metav1.Now()
 		connection.Status.State = v1alpha1.ResourceApplicationFailed
 		connection.Status.SynchronizationStatus = &v1alpha1.SynchronizationStatus{
 			LastAttempt:         syncAttemptTime,
@@ -175,6 +175,7 @@ func (s *crSupervisor) SynchronizeWithCompass(connection *v1alpha1.CompassConnec
 	s.log.Infof("Labeling Runtime with URLs...")
 	_, err = directorClient.SetURLsLabels(s.runtimeURLsConfig, runtimeLabels)
 	if err != nil {
+		syncAttemptTime := metav1.Now()
 		connection.Status.State = v1alpha1.MetadataUpdateFailed
 		connection.Status.SynchronizationStatus = &v1alpha1.SynchronizationStatus{
 			LastAttempt:         syncAttemptTime,
@@ -185,7 +186,7 @@ func (s *crSupervisor) SynchronizeWithCompass(connection *v1alpha1.CompassConnec
 	}
 
 	// TODO: decide the approach of setting this status. Should it be success even if one App failed?
-	s.setConnectionSynchronizedStatus(connection, syncAttemptTime)
+	s.setConnectionSynchronizedStatus(connection, metav1.Now())
 	connection.Spec.ResyncNow = false
 
 	return s.updateCompassConnection(connection)
@@ -326,6 +327,24 @@ func (s *crSupervisor) setConnectionMaintenanceFailedStatus(connectionCR *v1alph
 	connectionCR.Status.ConnectionStatus.LastSync = attemptTime
 	connectionCR.Status.ConnectionStatus.Error = errorMsg
 }
+
+
+/*
+2021-11-22 06:58:43
+{"log":"time=\"2021-11-22T05:58:43Z\" level=error msg=\"Error while trying to maintain connection: Failed to connect to Compass Connector: Management info is empty\" CompassConnection=compass-connection Supervisor=CompassConnection
+","time":"2021-11-22T05:58:43.744997887Z"}
+2021-11-22 06:58:50
+{"log":"time=\"2021-11-22T05:58:50Z\" level=error msg=\"Error while trying to maintain connection: Failed to connect to Compass Connector: Management info is empty\" CompassConnection=compass-connection Supervisor=CompassConnection
+","time":"2021-11-22T05:58:50.984370156Z"}
+2021-11-22 06:58:59
+{"log":"time=\"2021-11-22T05:58:59Z\" level=error msg=\"Error while trying to maintain connection: Failed to connect to Compass Connector: Management info is empty\" CompassConnection=compass-connection Supervisor=CompassConnection
+","time":"2021-11-22T05:58:59.159868934Z"}
+2021-11-22 06:59:07
+{"log":"time=\"2021-11-22T05:59:07Z\" level=error msg=\"Error while trying to maintain connection: Failed to connect to Compass Connector: Management info is empty\" CompassConnection=compass-connection Supervisor=CompassConnection
+","time":"2021-11-22T05:59:07.17789839Z"}
+
+
+*/
 
 func (s *crSupervisor) updateCompassConnection(connectionCR *v1alpha1.CompassConnection) (*v1alpha1.CompassConnection, error) {
 	// TODO: with retries

--- a/components/compass-runtime-agent/internal/compassconnection/supervisor.go
+++ b/components/compass-runtime-agent/internal/compassconnection/supervisor.go
@@ -126,7 +126,7 @@ func (s *crSupervisor) SynchronizeWithCompass(connection *v1alpha1.CompassConnec
 	err := s.maintainCompassConnection(connection)
 	if err != nil {
 		errorMsg := fmt.Sprintf("Error while trying to maintain connection: %s", err.Error())
-		s.setConnectionMaintenanceFailedStatus(connection, metav1.Now(), errorMsg)
+		s.setConnectionMaintenanceFailedStatus(connection, metav1.Now(), errorMsg) // save in ConnectionStatus.LastSync
 		return s.updateCompassConnection(connection)
 	}
 
@@ -134,7 +134,7 @@ func (s *crSupervisor) SynchronizeWithCompass(connection *v1alpha1.CompassConnec
 	runtimeConfig, err := s.configProvider.GetRuntimeConfig()
 	if err != nil {
 		errorMsg := fmt.Sprintf("Failed to read Runtime config: %s", err.Error())
-		s.setSyncFailedStatus(connection, metav1.Now(), errorMsg)
+		s.setSyncFailedStatus(connection, metav1.Now(), errorMsg)   // save in SynchronizationStatus.LastAttempt
 		return s.updateCompassConnection(connection)
 	}
 
@@ -142,14 +142,14 @@ func (s *crSupervisor) SynchronizeWithCompass(connection *v1alpha1.CompassConnec
 	directorClient, err := s.clientsProvider.GetDirectorClient(runtimeConfig)
 	if err != nil {
 		errorMsg := fmt.Sprintf("Failed to prepare configuration client: %s", err.Error())
-		s.setSyncFailedStatus(connection, metav1.Now(), errorMsg)
+		s.setSyncFailedStatus(connection, metav1.Now(), errorMsg)  // save in SynchronizationStatus.LastAttempt
 		return s.updateCompassConnection(connection)
 	}
 
 	applicationsConfig, runtimeLabels, err := directorClient.FetchConfiguration()
 	if err != nil {
 		errorMsg := fmt.Sprintf("Failed to fetch configuration: %s", err.Error())
-		s.setSyncFailedStatus(connection, metav1.Now(), errorMsg)
+		s.setSyncFailedStatus(connection, metav1.Now(), errorMsg)  // save in SynchronizationStatus.LastAttempt
 		return s.updateCompassConnection(connection)
 	}
 

--- a/components/compass-runtime-agent/internal/compassconnection/supervisor.go
+++ b/components/compass-runtime-agent/internal/compassconnection/supervisor.go
@@ -134,7 +134,7 @@ func (s *crSupervisor) SynchronizeWithCompass(connection *v1alpha1.CompassConnec
 	runtimeConfig, err := s.configProvider.GetRuntimeConfig()
 	if err != nil {
 		errorMsg := fmt.Sprintf("Failed to read Runtime config: %s", err.Error())
-		s.setSyncFailedStatus(connection, metav1.Now(), errorMsg)   // save in SynchronizationStatus.LastAttempt
+		s.setSyncFailedStatus(connection, metav1.Now(), errorMsg) // save in SynchronizationStatus.LastAttempt
 		return s.updateCompassConnection(connection)
 	}
 
@@ -142,14 +142,14 @@ func (s *crSupervisor) SynchronizeWithCompass(connection *v1alpha1.CompassConnec
 	directorClient, err := s.clientsProvider.GetDirectorClient(runtimeConfig)
 	if err != nil {
 		errorMsg := fmt.Sprintf("Failed to prepare configuration client: %s", err.Error())
-		s.setSyncFailedStatus(connection, metav1.Now(), errorMsg)  // save in SynchronizationStatus.LastAttempt
+		s.setSyncFailedStatus(connection, metav1.Now(), errorMsg) // save in SynchronizationStatus.LastAttempt
 		return s.updateCompassConnection(connection)
 	}
 
 	applicationsConfig, runtimeLabels, err := directorClient.FetchConfiguration()
 	if err != nil {
 		errorMsg := fmt.Sprintf("Failed to fetch configuration: %s", err.Error())
-		s.setSyncFailedStatus(connection, metav1.Now(), errorMsg)  // save in SynchronizationStatus.LastAttempt
+		s.setSyncFailedStatus(connection, metav1.Now(), errorMsg) // save in SynchronizationStatus.LastAttempt
 		return s.updateCompassConnection(connection)
 	}
 

--- a/resources/compass-runtime-agent/values.yaml
+++ b/resources/compass-runtime-agent/values.yaml
@@ -5,7 +5,7 @@ global:
   images:
     compass_runtime_agent:
       name: "compass-runtime-agent"
-      version: "4a206dab"
+      version: "PR-12672"
   istio:
     gateway:
       name: kyma-gateway


### PR DESCRIPTION
**Description**
We have a code in Compass Runtime Agent reconciliation loop to wait with next attempt of SKR synchronisation with Compass with the value of `minimalConfigSyncTime` which normally is `30s`. The waiting time window is calculated with using value of previous attempt timestamp stored as  'SynchronizationStatus.LastAttempt' in Compass Connection CR.  (`Current time - timestamp of last attempt`).

The problem was that when saving this timestamp - its value was taken before any communication with Compass API is happened. As a result in a situation when communication with Compass API resulted with timeout after `TimeoutTime` we did not wait enough long before trying to do it again. The fix is to store in Connection CR the value of lastAttempt time read AFTER any API call to Compass fails.

Additionally same safety check to wait before next call to Compass API has been added to the code of Initialisation of  Compass Connection for newly created runtime. As a result in reconciliation loop all attempts subsequent to call CompassAPI will be executed no more oftern than `minimalConfigSyncTime`

**Before:**

```
time := readTimestamp()
executeCompassAPICallWhichFailsAfterTimeoutTime()
saveLastAttemptTimeToCompassCR(time)
```

For the next attempt we wait  `minimalConfigSyncTime` -  `TimeoutTime`

**After:**

```
executeCompassAPICallWhichFailsAfterTimeoutTime()
saveLastAttemptTimeToCompassCR(readTimestamp())
```

For the next attempt we wait  `minimalConfigSyncTime` no matter how long the `TimeoutTime` was


**Example logs from one runtime where you can observe the problem.**
Calls are waiting 6-7 secs not 30 sec.

```
2021-11-22 06:58:43	
{"log":"time=\"2021-11-22T05:58:43Z\" level=error msg=\"Error while trying to maintain connection: Failed to connect to Compass Connector: Management info is empty\" CompassConnection=compass-connection Supervisor=CompassConnection
","time":"2021-11-22T05:58:43.744997887Z"}
2021-11-22 06:58:50	
{"log":"time=\"2021-11-22T05:58:50Z\" level=error msg=\"Error while trying to maintain connection: Failed to connect to Compass Connector: Management info is empty\" CompassConnection=compass-connection Supervisor=CompassConnection
","time":"2021-11-22T05:58:50.984370156Z"}
2021-11-22 06:58:59	
{"log":"time=\"2021-11-22T05:58:59Z\" level=error msg=\"Error while trying to maintain connection: Failed to connect to Compass Connector: Management info is empty\" CompassConnection=compass-connection Supervisor=CompassConnection
","time":"2021-11-22T05:58:59.159868934Z"}
2021-11-22 06:59:07	
{"log":"time=\"2021-11-22T05:59:07Z\" level=error msg=\"Error while trying to maintain connection: Failed to connect to Compass Connector: Management info is empty\" CompassConnection=compass-connection Supervisor=CompassConnection
","time":"2021-11-22T05:59:07.17789839Z"}
```