### PR TITLE
Explicit delete pods for fast integration tests

### DIFF
--- a/tests/fast-integration/skr-svcat-migration-test/test-helpers.js
+++ b/tests/fast-integration/skr-svcat-migration-test/test-helpers.js
@@ -3,7 +3,7 @@ const execa = require("execa");
 const fs = require('fs');
 const os = require('os');
 const {
-    getEnvOrThrow, getConfigMap, kubectlExecInPod, listPods, deleteK8sResource, sleep, deleteAllK8sResources, listResources
+    getEnvOrThrow, getConfigMap, kubectlExecInPod, listPods, deleteK8sPod, sleep, deleteAllK8sResources, listResources
 } = require("../utils");
 
 class SMCreds {
@@ -103,7 +103,11 @@ async function restartFunctionsPods() {
     for (let f of functions) {
         let pod = await getFunctionPod(f.name);
         console.log("delete pod", pod.metadata.name);
-        await deleteK8sResource(pod);
+        try {
+          await deleteK8sPod(pod);
+        } catch(err) {
+          throw new Error(`failed to delete pod ${pod.metadata.name}: ${err}`);
+        }
         podNames[f.name] = pod.metadata.name;
     }
 
@@ -114,7 +118,12 @@ async function restartFunctionsPods() {
         for (let f of functions) {
             let labelSelector = `serverless.kyma-project.io/function-name=${f.name},serverless.kyma-project.io/resource=deployment`;
             console.log(`polling pods with labelSelector ${labelSelector}`);
-            const res = await listPods(labelSelector);
+            let res = {};
+            try {
+                res = await listPods(labelSelector);
+            } catch(err) {
+                throw new Error(`failed to list pods with labelSelector ${labelSelector}: ${err}`);
+            }
             if (res.body.items.length != 1) {
                 // there are either multiple or 0 pods for the function, we need to wait
                 let pn = res.body.items.map(p=> {return {"pod name": p.metadata.name, phase: p.status.phase}});
@@ -146,6 +155,7 @@ async function restartFunctionsPods() {
         let originalNames = JSON.stringify(podNames, null, 2);
         throw new Error(`Failed to restart function pods in 100 seconds. Expecting exactly one pod for each function with new unique names and in ready status but found:\n${info}\n\nPod names before restart:\n${originalNames}`);
     }
+    console.log("functions pods successfully restarted")
 }
 
 async function provisionPlatform(creds, svcatPlatform) {

--- a/tests/fast-integration/utils/index.js
+++ b/tests/fast-integration/utils/index.js
@@ -908,6 +908,7 @@ function ignore404(e) {
   }
 }
 
+// NOTE: this no longer works, it relies on kube-api sending `selfLink` but the field has been deprecated
 async function deleteAllK8sResources(
   path,
   query = {},
@@ -939,6 +940,11 @@ async function deleteAllK8sResources(
   }
 }
 
+async function deleteK8sPod(o) {
+  return await k8sCoreV1Api.deleteNamespacedPod(o.metadata.name, o.metadata.namespace);
+}
+
+// NOTE: this no longer works, it relies on kube-api sending `selfLink` but the field has been deprecated
 async function deleteK8sResource(o, keepFinalizer = false) {
   if (o.metadata.finalizers && o.metadata.finalizers.length && !keepFinalizer) {
     const options = {
@@ -1678,6 +1684,7 @@ module.exports = {
   printContainerLogs,
   kubectlExecInPod,
   deleteK8sResource,
+  deleteK8sPod,
   listPods,
   switchEventingBackend,
   waitForEventingBackendToReady,


### PR DESCRIPTION

<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

* improving logging and tracing for the migration SKR test
* introduce new method for pod deletion, the `deleteK8sResource()`
  relies on `selfLink` which has been deprecated kubernetes/kubernetes#94397
* output from manual trigger showing [success](https://status.build.kyma-project.io/log?container=test&id=1463783417576427520&job=wozniakjan_test_of_prowjob_skr-aws-svcat-migration-dev)

**Related issue(s)**
fixes: https://github.com/kyma-project/kyma/issues/12671
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
