### PR TITLE
Adapt observability AuthorizationPolicies for disabled auth-proxies

### DIFF
--- a/resources/kiali/templates/kyma-additions/auth-proxy-serviceaccount.yaml
+++ b/resources/kiali/templates/kyma-additions/auth-proxy-serviceaccount.yaml
@@ -1,6 +1,8 @@
+{{ if .Values.authProxy.enabled }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
   labels:
     {{- include "kiali-server.labels" . | nindent 4 }}
   name: {{ template "kiali-server.fullname" . }}-auth-proxy
+{{ end }}

--- a/resources/kiali/templates/kyma-additions/authorization-policy.yaml
+++ b/resources/kiali/templates/kyma-additions/authorization-policy.yaml
@@ -8,14 +8,16 @@ metadata:
 spec:
   action: ALLOW
   rules:
-  - from:
-    - source:
-        principals:
-        - cluster.local/ns/{{ .Release.Namespace }}/sa/{{ template "kiali-server.fullname" . }}-auth-proxy
-    to:
+  - to:
     - operation:
         ports:
         - "20001"
+{{ if .Values.authProxy.enabled }}
+    from:
+    - source:
+        principals:
+          - cluster.local/ns/{{ .Release.Namespace }}/sa/{{ template "kiali-server.fullname" . }}-auth-proxy
+{{ end }}
   - from:
     - source:
         principals:

--- a/resources/monitoring/charts/grafana/templates/kyma-additions/auth-proxy-serviceaccount.yaml
+++ b/resources/monitoring/charts/grafana/templates/kyma-additions/auth-proxy-serviceaccount.yaml
@@ -1,3 +1,4 @@
+{{ if .Values.kyma.authProxy.enabled }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -7,4 +8,4 @@ metadata:
     app.kubernetes.io/managed-by: {{ .Release.Service }}
     helm.sh/chart: {{ include "grafana.chart" . }}
   name: {{ .Release.Name }}-auth-proxy-{{ template "grafana.name" . }}
-
+{{ end }}

--- a/resources/monitoring/charts/grafana/templates/kyma-additions/authorization-policy.yaml
+++ b/resources/monitoring/charts/grafana/templates/kyma-additions/authorization-policy.yaml
@@ -1,3 +1,4 @@
+{{ if .Values.kyma.authProxy.enabled }}
 apiVersion: security.istio.io/v1beta1
 kind: AuthorizationPolicy
 metadata:
@@ -25,3 +26,4 @@ spec:
   selector:
     matchLabels:
       app: grafana
+{{ end }}

--- a/resources/tracing/templates/kyma-additions/auth-proxy-serviceaccount.yaml
+++ b/resources/tracing/templates/kyma-additions/auth-proxy-serviceaccount.yaml
@@ -1,6 +1,8 @@
+{{ if .Values.authProxy.enabled }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
   labels:
 {{ include "jaeger-operator.labels" . | indent 4 }}
   name: {{ include "jaeger-operator.fullname" . }}-auth-proxy
+{{ end }}

--- a/resources/tracing/templates/kyma-additions/authorization-policy.yaml
+++ b/resources/tracing/templates/kyma-additions/authorization-policy.yaml
@@ -8,16 +8,18 @@ metadata:
 spec:
   action: ALLOW
   rules:
-  - from:
-    - source:
-        principals:
-        - cluster.local/ns/{{ .Release.Namespace }}/sa/{{ include "jaeger-operator.fullname" . }}-auth-proxy
-        - cluster.local/ns/{{ .Release.Namespace }}/sa/kiali
-        - cluster.local/ns/{{ .Release.Namespace }}/sa/monitoring-grafana
-    to:
+  - to:
       - operation:
           ports: # Jaeger query port, limit to auth-proxy, Kiali and Grafana
           - "16686"
+{{ if .Values.authProxy.enabled }}
+    from:
+    - source:
+        principals:
+          - cluster.local/ns/{{ .Release.Namespace }}/sa/{{ include "jaeger-operator.fullname" . }}-auth-proxy
+          - cluster.local/ns/{{ .Release.Namespace }}/sa/kiali
+          - cluster.local/ns/{{ .Release.Namespace }}/sa/monitoring-grafana
+{{ end }}
   - from:
     - source:
         principals:


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- Do not restrict access to Grafana, Kiali and Jaeger if auth-proxy is disabled
- Do not create auth-proxy service accounts if disabled

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
