### PR TITLE
Add ability to add runtime resource presets

### DIFF
--- a/components/function-controller/cmd/webhook/main.go
+++ b/components/function-controller/cmd/webhook/main.go
@@ -135,6 +135,12 @@ func readDefaultingConfig() *serverlessv1alhpa1.DefaultingConfig {
 	}
 	defaultingCfg.BuildJob.Resources.Presets = buildResourcesPresets
 
+	runtimePresets, err := serverlessv1alhpa1.ParseRuntimePresets(defaultingCfg.Function.Resources.RuntimePresetsMap)
+	if err != nil {
+		panic(errors.Wrap(err, "while parsing runtime preset"))
+	}
+	defaultingCfg.Function.Resources.RuntimePresets = runtimePresets
+
 	return defaultingCfg
 }
 

--- a/components/function-controller/pkg/apis/serverless/v1alpha1/function_defaults.go
+++ b/components/function-controller/pkg/apis/serverless/v1alpha1/function_defaults.go
@@ -3,8 +3,6 @@ package v1alpha1
 import (
 	"context"
 	"encoding/json"
-	"fmt"
-
 	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -37,8 +35,8 @@ type FunctionResourcesDefaulting struct {
 	DefaultPreset     string                     `envconfig:"default=M"`
 	Presets           map[string]ResourcesPreset `envconfig:"-"`
 	PresetsMap        string                     `envconfig:"default={}"`
-	RuntimePresetsMap string                     `envconfig:"default={}"`
 	RuntimePresets    map[string]string          `envconfig:"-"`
+	RuntimePresetsMap string                     `envconfig:"default={}"`
 }
 
 type BuildJobResourcesDefaulting struct {
@@ -192,7 +190,6 @@ func mergeResourcesPreset(fn *Function, presetLabel string, presets map[string]R
 	if preset == "" {
 		rtmPreset, ok := runtimePreset[string(fn.Spec.Runtime)]
 		if ok {
-			fmt.Println("Found Runtime specific presets")
 			return presets[rtmPreset]
 		}
 		return presets[defaultPreset]

--- a/components/function-controller/pkg/apis/serverless/v1alpha1/function_defaults.go
+++ b/components/function-controller/pkg/apis/serverless/v1alpha1/function_defaults.go
@@ -3,6 +3,7 @@ package v1alpha1
 import (
 	"context"
 	"encoding/json"
+
 	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"

--- a/components/function-controller/pkg/apis/serverless/v1alpha1/function_defaults.go
+++ b/components/function-controller/pkg/apis/serverless/v1alpha1/function_defaults.go
@@ -3,6 +3,7 @@ package v1alpha1
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 
 	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
@@ -33,11 +34,11 @@ type FunctionReplicasDefaulting struct {
 }
 
 type FunctionResourcesDefaulting struct {
-	DefaultPreset string                     `envconfig:"default=M"`
-	Presets       map[string]ResourcesPreset `envconfig:"-"`
-	PresetsMap    string                     `envconfig:"default={}"`
-	RuntimePresetsMap string 				 `envconfig:"default={}"`
-	RuntimePresets map[string]string 		 `envconfig:"-"`
+	DefaultPreset     string                     `envconfig:"default=M"`
+	Presets           map[string]ResourcesPreset `envconfig:"-"`
+	PresetsMap        string                     `envconfig:"default={}"`
+	RuntimePresetsMap string                     `envconfig:"default={}"`
+	RuntimePresets    map[string]string          `envconfig:"-"`
 }
 
 type BuildJobResourcesDefaulting struct {
@@ -103,7 +104,7 @@ func (spec *FunctionSpec) defaultFunctionResources(ctx context.Context, fn *Func
 func (spec *FunctionSpec) defaultBuildResources(ctx context.Context, fn *Function) {
 	resources := spec.BuildResources
 	defaultingConfig := ctx.Value(DefaultingConfigKey).(DefaultingConfig).BuildJob.Resources
-	resourcesPreset := mergeResourcesPreset(fn, BuildResourcesPresetLabel, defaultingConfig.Presets, defaultingConfig.DefaultPreset)
+	resourcesPreset := mergeResourcesPreset(fn, BuildResourcesPresetLabel, defaultingConfig.Presets, defaultingConfig.DefaultPreset, nil)
 
 	spec.BuildResources = defaultResources(resources, resourcesPreset.RequestMemory, resourcesPreset.RequestCpu, resourcesPreset.LimitMemory, resourcesPreset.LimitCpu)
 }
@@ -191,6 +192,7 @@ func mergeResourcesPreset(fn *Function, presetLabel string, presets map[string]R
 	if preset == "" {
 		rtmPreset, ok := runtimePreset[string(fn.Spec.Runtime)]
 		if ok {
+			fmt.Println("Found Runtime specific presets")
 			return presets[rtmPreset]
 		}
 		return presets[defaultPreset]

--- a/components/function-controller/pkg/apis/serverless/v1alpha1/function_defaults_test.go
+++ b/components/function-controller/pkg/apis/serverless/v1alpha1/function_defaults_test.go
@@ -2,8 +2,9 @@ package v1alpha1
 
 import (
 	"context"
-	"github.com/stretchr/testify/require"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 

--- a/components/function-controller/pkg/apis/serverless/v1alpha1/function_defaults_test.go
+++ b/components/function-controller/pkg/apis/serverless/v1alpha1/function_defaults_test.go
@@ -70,6 +70,17 @@ func TestSetDefaults(t *testing.T) {
 		},
 	}
 
+	fastBuildResources := corev1.ResourceRequirements{
+		Limits: corev1.ResourceList{
+			corev1.ResourceCPU:    resource.MustParse("1800m"),
+			corev1.ResourceMemory: resource.MustParse("1800Mi"),
+		},
+		Requests: corev1.ResourceList{
+			corev1.ResourceCPU:    resource.MustParse("1100m"),
+			corev1.ResourceMemory: resource.MustParse("1100Mi"),
+		},
+	}
+
 	for testName, testData := range map[string]struct {
 		givenFunc    Function
 		expectedFunc Function
@@ -474,29 +485,11 @@ func TestSetDefaults(t *testing.T) {
 					BuildResourcesPresetLabel:    "fast",
 				},
 			}, Spec: FunctionSpec{
-				Runtime: Nodejs14,
-				Resources: corev1.ResourceRequirements{
-					Limits: corev1.ResourceList{
-						corev1.ResourceCPU:    resource.MustParse("200m"),
-						corev1.ResourceMemory: resource.MustParse("256Mi"),
-					},
-					Requests: corev1.ResourceList{
-						corev1.ResourceCPU:    resource.MustParse("50m"),
-						corev1.ResourceMemory: resource.MustParse("64Mi"),
-					},
-				},
-				BuildResources: corev1.ResourceRequirements{
-					Limits: corev1.ResourceList{
-						corev1.ResourceCPU:    resource.MustParse("1800m"),
-						corev1.ResourceMemory: resource.MustParse("1800Mi"),
-					},
-					Requests: corev1.ResourceList{
-						corev1.ResourceCPU:    resource.MustParse("700m"),
-						corev1.ResourceMemory: resource.MustParse("700Mi"),
-					},
-				},
-				MinReplicas: &two,
-				MaxReplicas: &two,
+				Runtime:        Nodejs14,
+				Resources:      LRuntimeResources,
+				BuildResources: fastBuildResources,
+				MinReplicas:    &two,
+				MaxReplicas:    &two,
 			},
 			},
 		},
@@ -511,6 +504,7 @@ func TestSetDefaults(t *testing.T) {
 			},
 			expectedFunc: Function{ObjectMeta: v1.ObjectMeta{
 				Labels: map[string]string{
+					//FunctionResourcesPresetLabel: "L",
 				},
 			}, Spec: FunctionSpec{
 				Runtime:        Python39,

--- a/resources/serverless/charts/webhook/templates/configmap.yaml
+++ b/resources/serverless/charts/webhook/templates/configmap.yaml
@@ -23,7 +23,7 @@ data:
   WEBHOOK_DEFAULTING_FUNCTION_RESOURCES_PRESETS_MAP: |-
 {{ include "tplValue" ( dict "value" .Values.values.function.resources.presets "context" . ) | nindent 4 }}
   WEBHOOK_DEFAULTING_FUNCTION_RESOURCES_RUNTIMES_PRESETS_MAP: |-
-{{ include "tplValue" ( dict "value" .Values.values.function.resources.runtime "context" . ) | nindent 4 }}
+{{ include "tplValue" ( dict "value" .Values.values.function.resources.runtimePresets "context" . ) | nindent 4 }}
 
 
   WEBHOOK_VALIDATION_BUILD_JOB_RESOURCES_MIN_REQUEST_CPU: {{ include "tplValue" ( dict "value" .Values.values.buildJob.resources.minRequestCpu "context" . ) | quote }}

--- a/resources/serverless/charts/webhook/templates/configmap.yaml
+++ b/resources/serverless/charts/webhook/templates/configmap.yaml
@@ -22,6 +22,9 @@ data:
   WEBHOOK_DEFAULTING_FUNCTION_RESOURCES_DEFAULT_PRESET: {{ .Values.values.function.resources.defaultPreset | quote }}
   WEBHOOK_DEFAULTING_FUNCTION_RESOURCES_PRESETS_MAP: |-
 {{ include "tplValue" ( dict "value" .Values.values.function.resources.presets "context" . ) | nindent 4 }}
+  WEBHOOK_DEFAULTING_FUNCTION_RESOURCES_RUNTIMES_PRESETS_MAP: |-
+{{ include "tplValue" ( dict "value" .Values.values.function.resources.runtime "context" . ) | nindent 4 }}
+
 
   WEBHOOK_VALIDATION_BUILD_JOB_RESOURCES_MIN_REQUEST_CPU: {{ include "tplValue" ( dict "value" .Values.values.buildJob.resources.minRequestCpu "context" . ) | quote }}
   WEBHOOK_VALIDATION_BUILD_JOB_RESOURCES_MIN_REQUEST_MEMORY: {{ include "tplValue" ( dict "value" .Values.values.buildJob.resources.minRequestMemory "context" . ) | quote }}

--- a/resources/serverless/charts/webhook/templates/configmap.yaml
+++ b/resources/serverless/charts/webhook/templates/configmap.yaml
@@ -22,7 +22,7 @@ data:
   WEBHOOK_DEFAULTING_FUNCTION_RESOURCES_DEFAULT_PRESET: {{ .Values.values.function.resources.defaultPreset | quote }}
   WEBHOOK_DEFAULTING_FUNCTION_RESOURCES_PRESETS_MAP: |-
 {{ include "tplValue" ( dict "value" .Values.values.function.resources.presets "context" . ) | nindent 4 }}
-  WEBHOOK_DEFAULTING_FUNCTION_RESOURCES_RUNTIMES_PRESETS_MAP: |-
+  WEBHOOK_DEFAULTING_FUNCTION_RESOURCES_RUNTIME_PRESETS_MAP: |-
 {{ include "tplValue" ( dict "value" .Values.values.function.resources.runtimePresets "context" . ) | nindent 4 }}
 
 

--- a/resources/serverless/charts/webhook/values.yaml
+++ b/resources/serverless/charts/webhook/values.yaml
@@ -134,10 +134,7 @@ values:
             "limitMemory": "512Mi"
           }
         }
-      runtimePresets: |-
-        {
-          "python39":"M"
-        }
+      runtimePresets: "{}"
 
   buildJob:
     resources:

--- a/resources/serverless/charts/webhook/values.yaml
+++ b/resources/serverless/charts/webhook/values.yaml
@@ -134,6 +134,11 @@ values:
             "limitMemory": "512Mi"
           }
         }
+      runtime: |-
+        {
+          "python39":"M"
+        }
+
   buildJob:
     resources:
       minRequestCpu: "200m"

--- a/resources/serverless/charts/webhook/values.yaml
+++ b/resources/serverless/charts/webhook/values.yaml
@@ -134,7 +134,7 @@ values:
             "limitMemory": "512Mi"
           }
         }
-      runtime: |-
+      runtimePresets: |-
         {
           "python39":"M"
         }

--- a/resources/serverless/profile-evaluation.yaml
+++ b/resources/serverless/profile-evaluation.yaml
@@ -8,6 +8,11 @@ webhook:
         defaultPreset: "S"
       resources:
         defaultPreset: "XS"
+        runtimePresets: |-
+          {
+            "python39":"M",
+            "python38":"M"
+          }
   deployment:
     resources:
       requests:

--- a/resources/serverless/values.yaml
+++ b/resources/serverless/values.yaml
@@ -77,13 +77,13 @@ global:
       directory: "tpi"
     function_controller:
       name: "function-controller"
-      version: "5051e383"
+      version: "PR-12713"
     function_webhook:
       name: "function-webhook"
-      version: "5051e383"
+      version: "PR-12713"
     function_build_init:
       name: "function-build-init"
-      version: "5051e383"
+      version: "PR-12713"
     function_runtime_nodejs12:
       name: "function-runtime-nodejs12"
       version: "5051e383"


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- Add ability to set default presets per runtime
- Set profile M for python function in evaluation profile
**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
See https://github.com/kyma-project/kyma/issues/12461