### PR TITLE
Add permissive mTLS policy for Fluent Bit

### DIFF
--- a/resources/logging/charts/fluent-bit/templates/kyma-additions/peerauthentication.yaml
+++ b/resources/logging/charts/fluent-bit/templates/kyma-additions/peerauthentication.yaml
@@ -1,0 +1,13 @@
+apiVersion: security.istio.io/v1beta1
+kind: PeerAuthentication
+metadata:
+  name: {{ template "fluent-bit.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "fluent-bit.labels" . | nindent 4 }}
+spec:
+  mtls:
+    mode: PERMISSIVE
+  selector:
+    matchLabels:
+      {{- include "fluent-bit.selectorLabels" . | nindent 6 }}

--- a/resources/logging/charts/fluent-bit/templates/kyma-additions/peerauthentication.yaml
+++ b/resources/logging/charts/fluent-bit/templates/kyma-additions/peerauthentication.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.istio.permissiveMtls -}}
 apiVersion: security.istio.io/v1beta1
 kind: PeerAuthentication
 metadata:
@@ -11,3 +12,4 @@ spec:
   selector:
     matchLabels:
       {{- include "fluent-bit.selectorLabels" . | nindent 6 }}
+{{- end -}}

--- a/resources/logging/charts/fluent-bit/values.yaml
+++ b/resources/logging/charts/fluent-bit/values.yaml
@@ -369,3 +369,8 @@ config:
 #      name: https
 #      protocol: TLS
 #  resolution: DNS
+
+istio:
+# Allows you to loosen strict mTLS for exposed HTTP endpoint (basically, the /metrics endpoint)
+# If omitted or set to false the mesh-wide policy is applied which sets mTLS mode to strict
+  permissiveMtls: false


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- Add an option to loosen strict mTLS mode for the /metrics endpoint exposed by Fluent Bit

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
