### PR TITLE
Scrape Fluent Bit via HTTP if permissive mTLS is set

### DIFF
--- a/resources/logging/charts/fluent-bit/templates/servicemonitor.yaml
+++ b/resources/logging/charts/fluent-bit/templates/servicemonitor.yaml
@@ -8,9 +8,9 @@ metadata:
   {{- end }}
   labels:
     {{- include "fluent-bit.labels" . | nindent 4 }}
-      {{- with .Values.serviceMonitor.selector }}
-      {{- toYaml . | nindent 4 }}
-      {{- end }}
+    {{- with .Values.serviceMonitor.selector }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
 spec:
   endpoints:
     - port: http
@@ -19,14 +19,19 @@ spec:
       interval: {{ . }}
       {{- end }}
       metricRelabelings:
-        - sourceLabels: [ __name__ ]
-          regex: ^(fluentbit_.*|go_.*|process_.*)$
-          action: keep
+      - sourceLabels: [ __name__ ]
+        regex: ^(fluentbit_.*|go_.*|process_.*)$
+        action: keep
       {{- with .Values.serviceMonitor.scrapeTimeout }}
       scrapeTimeout: {{ . }}
       {{- end }}
+      {{- if .Values.istio.permissiveMtls }}
+      scheme: http
+      {{- else }}
       ## scheme: HTTP scheme to use for scraping. Can be used with `tlsConfig` for example if using istio mTLS.
       scheme: https
+      {{- end }}
+      {{- if not .Values.istio.permissiveMtls }}
       ## tlsConfig: TLS configuration to use when scraping the endpoint. For example if using istio mTLS.
       ## Of type: https://github.com/coreos/prometheus-operator/blob/master/Documentation/api.md#tlsconfig
       tlsConfig:
@@ -34,10 +39,11 @@ spec:
         certFile: /etc/prometheus/secrets/istio.default/cert-chain.pem
         keyFile: /etc/prometheus/secrets/istio.default/key.pem
         insecureSkipVerify: true  # Prometheus does not support Istio security naming, thus skip verifying target pod ceritifcate
+      {{- end }}
   namespaceSelector:
     matchNames:
       - {{ .Release.Namespace }}
   selector:
     matchLabels:
       {{- include "fluent-bit.selectorLabels" . | nindent 6 }}
-  {{- end }}
+{{- end }}

--- a/resources/logging/charts/fluent-bit/templates/servicemonitor.yaml
+++ b/resources/logging/charts/fluent-bit/templates/servicemonitor.yaml
@@ -8,9 +8,9 @@ metadata:
   {{- end }}
   labels:
     {{- include "fluent-bit.labels" . | nindent 4 }}
-    {{- with .Values.serviceMonitor.selector }}
-    {{- toYaml . | nindent 4 }}
-    {{- end }}
+      {{- with .Values.serviceMonitor.selector }}
+      {{- toYaml . | nindent 4 }}
+      {{- end }}
 spec:
   endpoints:
     - port: http
@@ -19,9 +19,9 @@ spec:
       interval: {{ . }}
       {{- end }}
       metricRelabelings:
-      - sourceLabels: [ __name__ ]
-        regex: ^(fluentbit_.*|go_.*|process_.*)$
-        action: keep
+        - sourceLabels: [ __name__ ]
+          regex: ^(fluentbit_.*|go_.*|process_.*)$
+          action: keep
       {{- with .Values.serviceMonitor.scrapeTimeout }}
       scrapeTimeout: {{ . }}
       {{- end }}
@@ -29,7 +29,7 @@ spec:
       scheme: https
       ## tlsConfig: TLS configuration to use when scraping the endpoint. For example if using istio mTLS.
       ## Of type: https://github.com/coreos/prometheus-operator/blob/master/Documentation/api.md#tlsconfig
-      tlsConfig: 
+      tlsConfig:
         caFile: /etc/prometheus/secrets/istio.default/root-cert.pem
         certFile: /etc/prometheus/secrets/istio.default/cert-chain.pem
         keyFile: /etc/prometheus/secrets/istio.default/key.pem
@@ -40,4 +40,4 @@ spec:
   selector:
     matchLabels:
       {{- include "fluent-bit.selectorLabels" . | nindent 6 }}
-{{- end }}
+  {{- end }}

--- a/resources/logging/charts/fluent-bit/templates/servicemonitor.yaml
+++ b/resources/logging/charts/fluent-bit/templates/servicemonitor.yaml
@@ -30,8 +30,6 @@ spec:
       {{- else }}
       ## scheme: HTTP scheme to use for scraping. Can be used with `tlsConfig` for example if using istio mTLS.
       scheme: https
-      {{- end }}
-      {{- if not .Values.istio.permissiveMtls }}
       ## tlsConfig: TLS configuration to use when scraping the endpoint. For example if using istio mTLS.
       ## Of type: https://github.com/coreos/prometheus-operator/blob/master/Documentation/api.md#tlsconfig
       tlsConfig:


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- Fixes a problem introduced in https://github.com/kyma-project/kyma/pull/12739, when Prometheus fails to scrape an endpoint over https if the permissive mode is applied

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
