### PR TITLE
Update the k3d version in Prerequisites for Kyma installation and Get Started

### DIFF
--- a/docs/02-get-started/README.md
+++ b/docs/02-get-started/README.md
@@ -11,7 +11,7 @@ All the steps are performed in the `default` Namespace.
 
 - [kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl/) (v1.19 or higher)
 - [curl](https://github.com/curl/curl)
-- [k3d](https://k3d.io) (v4.0.0 or higher with [Kubernetes](https://kubernetes.io/docs/setup/) v1.19 - for higher Kubernetes versions, see the [Install Kyma](../04-operation-guides/operations/02-install-kyma.md) document)
+- [k3d](https://k3d.io) (v5.0.0 or higher with [a Kubernetes version supported by Kyma](../04-operation-guides/operations/02-install-kyma.md))
 - [Kyma CLI](../04-operation-guides/operations/01-install-kyma-CLI.md)
 
 ## Steps

--- a/docs/04-operation-guides/operations/02-install-kyma.md
+++ b/docs/04-operation-guides/operations/02-install-kyma.md
@@ -11,7 +11,7 @@ Meet the prerequisites, provision a k3d cluster, and use the `deploy` command to
 >**CAUTION:** As of version 1.20, [Kubernetes deprecated Docker](https://kubernetes.io/blog/2020/12/02/dont-panic-kubernetes-and-docker/) as a container runtime in favor of [containerd](https://containerd.io/). Due to a different way in which containerd handles certificate authorities, Kyma's built-in Docker registry does not work correctly on clusters running with a self-signed TLS certificate on top of Kubernetes installation where containerd is used as a container runtime. If that is your case, either upgrade the cluster to use Docker instead of containerd, generate a valid TLS certificate for your Kyma instance or [configure an external Docker registry](https://kyma-project.io/docs/kyma/latest/03-tutorials/00-serverless/svls-07-set-external-registry/).
 
 - [Kubernetes](https://kubernetes.io/docs/setup/) (v1.19 - recommended, 1.20, or 1.21)
-  - [k3d](https://k3d.io) (for local installation only)
+  - [k3d](https://k3d.io) (for local installation only, v5.0.0 or higher)
 - [Kyma CLI](https://github.com/kyma-project/cli)
 
 ## Provision and install


### PR DESCRIPTION
**Description**

With the latest changes to Kyma CLI, we now require k3d in version 5.0.0 or higher. Previously, our documentation mentioned version 4 in the prerequisites, so it needs to be updated. 

Changes proposed in this pull request:

- Update required k3d version in [Get Started guides](https://kyma-project.io/docs/kyma/latest/02-get-started/)
- Update required k3d version in [Kyma installation](https://kyma-project.io/docs/kyma/latest/04-operation-guides/operations/02-install-kyma/) guide

**Related issue(s)**

