### PR TITLE
Restore Istio PeerAuthentications (with strict mode)

### DIFF
--- a/resources/eventing/charts/controller/templates/peerauthentication.yaml
+++ b/resources/eventing/charts/controller/templates/peerauthentication.yaml
@@ -10,4 +10,4 @@ spec:
     matchLabels: {{- include "controller.peerAuth.selectorLabels" . | nindent 6 }}
   portLevelMtls:
     {{ .Values.metrics.config.port }}:
-      mode: "STRICT"
+      mode: STRICT

--- a/resources/eventing/charts/controller/templates/peerauthentication.yaml
+++ b/resources/eventing/charts/controller/templates/peerauthentication.yaml
@@ -1,0 +1,13 @@
+# Used by publisher proxy for NATS backend
+apiVersion: security.istio.io/v1beta1
+kind: PeerAuthentication
+metadata:
+  name: {{ include "controller.fullname" . }}{{ .Values.metrics.config.nameSuffix }}
+  namespace: {{ .Release.Namespace }}
+  labels: {{- include "controller.labels" . | nindent 4 }}
+spec:
+  selector:
+    matchLabels: {{- include "controller.peerAuth.selectorLabels" . | nindent 6 }}
+  portLevelMtls:
+    {{ .Values.metrics.config.port }}:
+      mode: "STRICT"

--- a/resources/eventing/charts/publisher-proxy/templates/peerauthentication.yaml
+++ b/resources/eventing/charts/publisher-proxy/templates/peerauthentication.yaml
@@ -1,0 +1,12 @@
+apiVersion: security.istio.io/v1beta1
+kind: PeerAuthentication
+metadata:
+  name: {{ include "publisher-proxy.fullname" . }}{{ .Values.metrics.config.nameSuffix }}
+  namespace: {{ .Release.Namespace }}
+  labels: {{- include "publisher-proxy.labels" . | nindent 4 }}
+spec:
+  selector:
+    matchLabels: {{- include "publisher-proxy.peerauth.selectorLabels" . | nindent 6 }}
+  portLevelMtls:
+    {{ .Values.metrics.config.port }}:
+      mode: "STRICT"

--- a/resources/eventing/charts/publisher-proxy/templates/peerauthentication.yaml
+++ b/resources/eventing/charts/publisher-proxy/templates/peerauthentication.yaml
@@ -9,4 +9,4 @@ spec:
     matchLabels: {{- include "publisher-proxy.peerauth.selectorLabels" . | nindent 6 }}
   portLevelMtls:
     {{ .Values.metrics.config.port }}:
-      mode: "STRICT"
+      mode: STRICT

--- a/resources/kiali/templates/kyma-additions/peerauthentication.yaml
+++ b/resources/kiali/templates/kyma-additions/peerauthentication.yaml
@@ -13,6 +13,6 @@ spec:
     mode: "UNSET"
   portLevelMtls:
     9090:
-      mode: "STRICT"
+      mode: STRICT
     {{ .Values.kiali.spec.server.port }}:
-    mode: "STRICT"
+    mode: STRICT

--- a/resources/kiali/templates/kyma-additions/peerauthentication.yaml
+++ b/resources/kiali/templates/kyma-additions/peerauthentication.yaml
@@ -1,0 +1,18 @@
+apiVersion: security.istio.io/v1beta1
+kind: PeerAuthentication
+metadata:
+  name: {{ template "kiali-server.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "kiali-server.labels" . | nindent 4 }}
+spec:
+  selector:
+    matchLabels:
+      app: {{ template "kiali-server.fullname" . }}
+  mtls:
+    mode: "UNSET"
+  portLevelMtls:
+    9090:
+      mode: "STRICT"
+    {{ .Values.kiali.spec.server.port }}:
+    mode: "STRICT"

--- a/resources/kiali/templates/kyma-additions/peerauthentication.yaml
+++ b/resources/kiali/templates/kyma-additions/peerauthentication.yaml
@@ -15,4 +15,4 @@ spec:
     9090:
       mode: STRICT
     {{ .Values.kiali.spec.server.port }}:
-    mode: STRICT
+      mode: STRICT

--- a/resources/logging/charts/fluent-bit/templates/kyma-additions/peerauthentication.yaml
+++ b/resources/logging/charts/fluent-bit/templates/kyma-additions/peerauthentication.yaml
@@ -1,15 +1,19 @@
-{{- if .Values.istio.permissiveMtls -}}
+{{- if .Values.serviceMonitor.enabled }}
 apiVersion: security.istio.io/v1beta1
 kind: PeerAuthentication
 metadata:
-  name: {{ template "fluent-bit.fullname" . }}
+  name: {{ template "fluent-bit.fullname" . }}-metrics
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "fluent-bit.labels" . | nindent 4 }}
 spec:
   mtls:
-    mode: PERMISSIVE
+    {{- if .Values.istio.permissiveMtls }}
+    mode: "PERMISSIVE"
+    {{- else }}
+    mode: "STRICT"
+    {{- end }}
   selector:
     matchLabels:
       {{- include "fluent-bit.selectorLabels" . | nindent 6 }}
-{{- end -}}
+{{- end }}

--- a/resources/logging/charts/fluent-bit/templates/kyma-additions/peerauthentication.yaml
+++ b/resources/logging/charts/fluent-bit/templates/kyma-additions/peerauthentication.yaml
@@ -9,9 +9,9 @@ metadata:
 spec:
   mtls:
     {{- if .Values.istio.permissiveMtls }}
-    mode: "PERMISSIVE"
+    mode: PERMISSIVE
     {{- else }}
-    mode: "STRICT"
+    mode: STRICT
     {{- end }}
   selector:
     matchLabels:

--- a/resources/logging/charts/loki/templates/kyma-additions/peerauthentication.yaml
+++ b/resources/logging/charts/loki/templates/kyma-additions/peerauthentication.yaml
@@ -1,0 +1,15 @@
+apiVersion: security.istio.io/v1beta1
+kind: PeerAuthentication
+metadata:
+  labels:
+    app: {{ template "loki.name" . }}
+    chart: {{ template "loki.chart" . }}
+    release: {{ .Release.Name }}
+  name: {{ template "loki.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+spec:
+  selector:
+    matchLabels:
+      app: {{ template "loki.name" . }}
+  mtls:
+    mode: "STRICT"

--- a/resources/logging/charts/loki/templates/kyma-additions/peerauthentication.yaml
+++ b/resources/logging/charts/loki/templates/kyma-additions/peerauthentication.yaml
@@ -12,4 +12,4 @@ spec:
     matchLabels:
       app: {{ template "loki.name" . }}
   mtls:
-    mode: "STRICT"
+    mode: STRICT

--- a/resources/monitoring/charts/grafana/templates/kyma-additions/peerauthentication.yaml
+++ b/resources/monitoring/charts/grafana/templates/kyma-additions/peerauthentication.yaml
@@ -7,4 +7,4 @@ spec:
     matchLabels:
       app.kubernetes.io/name: grafana
   mtls:
-    mode: "STRICT"
+    mode: STRICT

--- a/resources/monitoring/charts/grafana/templates/kyma-additions/peerauthentication.yaml
+++ b/resources/monitoring/charts/grafana/templates/kyma-additions/peerauthentication.yaml
@@ -1,0 +1,10 @@
+apiVersion: security.istio.io/v1beta1
+kind: PeerAuthentication
+metadata:
+  name: {{ template "grafana.fullname" . }}-policy
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: grafana
+  mtls:
+    mode: "STRICT"

--- a/resources/ory/templates/monitoring-hydra.yaml
+++ b/resources/ory/templates/monitoring-hydra.yaml
@@ -41,4 +41,4 @@ spec:
       app.kubernetes.io/name: hydra-maester
   portLevelMtls:
     {{ index .Values "hydra" "hydra-maester" "port" "metrics" }}:
-      mode: "STRICT"
+      mode: STRICT

--- a/resources/ory/templates/monitoring-hydra.yaml
+++ b/resources/ory/templates/monitoring-hydra.yaml
@@ -29,3 +29,16 @@ spec:
     matchLabels:
       app.kubernetes.io/instance: {{ .Release.Name }}
       app.kubernetes.io/name: hydra-maester
+---
+apiVersion: security.istio.io/v1beta1
+kind: PeerAuthentication
+metadata:
+  name: {{ include "ory.fullname" . }}-hydra-maester-metrics
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/instance: {{ .Release.Name }}
+      app.kubernetes.io/name: hydra-maester
+  portLevelMtls:
+    {{ index .Values "hydra" "hydra-maester" "port" "metrics" }}:
+      mode: "STRICT"

--- a/resources/ory/templates/monitoring-oathkeeper.yaml
+++ b/resources/ory/templates/monitoring-oathkeeper.yaml
@@ -29,3 +29,16 @@ spec:
     matchLabels:
       app.kubernetes.io/instance: {{ .Release.Name }}
       app.kubernetes.io/name: oathkeeper-maester
+---
+apiVersion: security.istio.io/v1beta1
+kind: PeerAuthentication
+metadata:
+  name: {{ include "oathkeeper.fullname" . }}-oathkeeper-maester-metrics
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/instance: {{ .Release.Name }}
+      app.kubernetes.io/name: oathkeeper
+  portLevelMtls:
+    {{ .Values.oathkeeper.sidecar.port.metrics }}:
+      mode: "STRICT"

--- a/resources/ory/templates/monitoring-oathkeeper.yaml
+++ b/resources/ory/templates/monitoring-oathkeeper.yaml
@@ -41,4 +41,4 @@ spec:
       app.kubernetes.io/name: oathkeeper
   portLevelMtls:
     {{ .Values.oathkeeper.sidecar.port.metrics }}:
-      mode: "STRICT"
+      mode: STRICT

--- a/resources/service-catalog-addons/charts/service-binding-usage-controller/templates/peerauthentication.yaml
+++ b/resources/service-catalog-addons/charts/service-binding-usage-controller/templates/peerauthentication.yaml
@@ -7,4 +7,4 @@ spec:
     matchLabels:
       app: {{ template "fullname" . }}
   mtls:
-    mode: "STRICT"
+    mode: STRICT

--- a/resources/service-catalog-addons/charts/service-binding-usage-controller/templates/peerauthentication.yaml
+++ b/resources/service-catalog-addons/charts/service-binding-usage-controller/templates/peerauthentication.yaml
@@ -1,0 +1,10 @@
+apiVersion: security.istio.io/v1beta1
+kind: PeerAuthentication
+metadata:
+  name: {{ template "fullname" . }}
+spec:
+  selector:
+    matchLabels:
+      app: {{ template "fullname" . }}
+  mtls:
+    mode: "STRICT"

--- a/resources/tracing/templates/kyma-additions/peerauthentication.yaml
+++ b/resources/tracing/templates/kyma-additions/peerauthentication.yaml
@@ -1,38 +1,57 @@
+apiVersion: security.istio.io/v1beta1
+kind: PeerAuthentication
+metadata:
+  name: {{ template "jaeger-operator.fullname" . }}-jaeger-operator-metrics
+  labels:
+  {{ include "jaeger-operator.labels" . | indent 4 }}
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ include "jaeger-operator.fullname" . }}-jaeger-operator
+  mtls:
+    mode: STRICT
+
 {{- if eq .Values.jaeger.spec.strategy "allInOne" }}
 ---
 apiVersion: security.istio.io/v1beta1
 kind: PeerAuthentication
 metadata:
-  name: {{ template "jaeger-operator.fullname" . }}-jaeger
+  name: {{ template "jaeger-operator.fullname" . }}-jaeger-metrics
   labels:
-{{ include "jaeger-operator.labels" . | indent 4 }}
+  {{ include "jaeger-operator.labels" . | indent 4 }}
 spec:
   selector:
     matchLabels:
       app.kubernetes.io/name: {{ include "jaeger-operator.fullname" . }}-jaeger
   mtls:
-    mode: "PERMISSIVE"
-  portLevelMtls: #keep metrics and query port strict
-    "14269":
-      mode: STRICT
-    "16686":
-      mode: STRICT
+    mode: STRICT
 {{- end }}
+
 {{- if eq .Values.jaeger.spec.strategy "production" }}
 ---
 apiVersion: security.istio.io/v1beta1
 kind: PeerAuthentication
 metadata:
-  name: {{ template "jaeger-operator.fullname" . }}-jaeger-collector
+  name: {{ template "jaeger-operator.fullname" . }}-jaeger-collector-metrics
   labels:
-{{ include "jaeger-operator.labels" . | indent 4 }}
+  {{ include "jaeger-operator.labels" . | indent 4 }}
 spec:
   selector:
     matchLabels:
       app.kubernetes.io/name: {{ include "jaeger-operator.fullname" . }}-jaeger-collector
   mtls:
-    mode: "PERMISSIVE"
-  portLevelMtls: #keep metrics port strict
-    "14269":
-      mode: STRICT
+    mode: STRICT
+---
+apiVersion: security.istio.io/v1beta1
+kind: PeerAuthentication
+metadata:
+  name: {{ template "jaeger-operator.fullname" . }}-jaeger-agent-query-metrics
+  labels:
+  {{ include "jaeger-operator.labels" . | indent 4 }}
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ include "jaeger-operator.fullname" . }}-jaeger-query
+  mtls:
+    mode: STRICT
 {{- end }}

--- a/resources/tracing/templates/kyma-additions/peerauthentication.yaml
+++ b/resources/tracing/templates/kyma-additions/peerauthentication.yaml
@@ -3,7 +3,7 @@ kind: PeerAuthentication
 metadata:
   name: {{ template "jaeger-operator.fullname" . }}-jaeger-operator-metrics
   labels:
-  {{ include "jaeger-operator.labels" . | indent 4 }}
+{{ include "jaeger-operator.labels" . | indent 4 }}
 spec:
   selector:
     matchLabels:
@@ -18,7 +18,7 @@ kind: PeerAuthentication
 metadata:
   name: {{ template "jaeger-operator.fullname" . }}-jaeger-metrics
   labels:
-  {{ include "jaeger-operator.labels" . | indent 4 }}
+{{ include "jaeger-operator.labels" . | indent 4 }}
 spec:
   selector:
     matchLabels:
@@ -26,7 +26,6 @@ spec:
   mtls:
     mode: STRICT
 {{- end }}
-
 {{- if eq .Values.jaeger.spec.strategy "production" }}
 ---
 apiVersion: security.istio.io/v1beta1
@@ -34,7 +33,7 @@ kind: PeerAuthentication
 metadata:
   name: {{ template "jaeger-operator.fullname" . }}-jaeger-collector-metrics
   labels:
-  {{ include "jaeger-operator.labels" . | indent 4 }}
+{{ include "jaeger-operator.labels" . | indent 4 }}
 spec:
   selector:
     matchLabels:
@@ -47,7 +46,7 @@ kind: PeerAuthentication
 metadata:
   name: {{ template "jaeger-operator.fullname" . }}-jaeger-agent-query-metrics
   labels:
-  {{ include "jaeger-operator.labels" . | indent 4 }}
+{{ include "jaeger-operator.labels" . | indent 4 }}
 spec:
   selector:
     matchLabels:

--- a/resources/tracing/templates/kyma-additions/peerauthentication.yaml
+++ b/resources/tracing/templates/kyma-additions/peerauthentication.yaml
@@ -24,7 +24,12 @@ spec:
     matchLabels:
       app.kubernetes.io/name: {{ include "jaeger-operator.fullname" . }}-jaeger
   mtls:
-    mode: STRICT
+    mode: PERMISSIVE
+  portLevelMtls: #keep metrics and query port strict
+    14269:
+      mode: STRICT
+    16686:
+      mode: STRICT
 {{- end }}
 {{- if eq .Values.jaeger.spec.strategy "production" }}
 ---
@@ -39,7 +44,10 @@ spec:
     matchLabels:
       app.kubernetes.io/name: {{ include "jaeger-operator.fullname" . }}-jaeger-collector
   mtls:
-    mode: STRICT
+    mode: PERMISSIVE
+  portLevelMtls: #keep metrics port strict
+    14269:
+      mode: STRICT
 ---
 apiVersion: security.istio.io/v1beta1
 kind: PeerAuthentication


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- [This PR](https://github.com/kyma-project/kyma/pull/11994) removes PeerAuthentication resources, which became unneeded after making Prometheus scrape the corresponding targets via HTTPS. However, when testing Kyma 1 to Kyma 2 upgrades using the Reconciler we found out that the TLS-scraped targets are down. The reason for that is the left-over PeerAuthentication resources with permissive mTLS mode set (Reconciler does not remove deleted resources when upgrading Kyma). In order to circumvent this problem, it was decided to restore the PeerAuthentication resources (with strict mode instead of permissive). 

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
Fixes https://github.com/kyma-project/kyma/issues/12743