### PR TITLE
disabled ingressgateway autoscaling for evaluation profile

### DIFF
--- a/resources/istio-configuration/profile-evaluation.yaml
+++ b/resources/istio-configuration/profile-evaluation.yaml
@@ -29,23 +29,14 @@ helmValues:
           memory: 10Mi
   pilot:
     autoscaleEnabled: false
+  gateways:
+    istio-ingressgateway:
+      autoscaleEnabled: false
 
 components:
   ingressGateways:
     enabled: true
     config:
-      hpaSpec:
-        maxReplicas: 1
-        minReplicas: 1
-        metrics:
-          - resource:
-              name: cpu
-              targetAverageUtilization: 80
-            type: Resource
-          - resource:
-              name: memory
-              targetAverageUtilization: 80
-            type: Resource
       resources:
         limits:
           cpu: 500m

--- a/resources/istio-configuration/templates/istio-operator.yaml
+++ b/resources/istio-configuration/templates/istio-operator.yaml
@@ -44,6 +44,7 @@ spec:
     gateways:
       istio-ingressgateway:
         name: istio-ingressgateway
+        autoscaleEnabled: {{ index .Values "helmValues" "gateways" "istio-ingressgateway" "autoscaleEnabled" }}
         podAnnotations:
           reconciler.kyma-project.io/managed-by-reconciler-disclaimer: |
             DO NOT EDIT - This resource is managed by Kyma.

--- a/resources/istio-configuration/values.yaml
+++ b/resources/istio-configuration/values.yaml
@@ -22,6 +22,9 @@ helmValues:
         requests:
           cpu: 10m
           memory: 10Mi
+  gateways:
+    istio-ingressgateway:
+      autoscaleEnabled: true
 
   sidecarInjectorWebhook:
     enableNamespacesByDefault: true


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

For evaluation profile the HPA config for the ingressgateway was changed to maxReplica 1. Instead, the autoscaling should be simply disabled so that no HPA gets active.

Changes proposed in this pull request:

- remove hpaSpec for evaluation profile
- disable autoscaling for evaluation profile
- ...

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
