### PR TITLE
Fix auth-proxy restart command

### DIFF
--- a/docs/04-operation-guides/security/sec-06-access-expose-kiali-grafana.md
+++ b/docs/04-operation-guides/security/sec-06-access-expose-kiali-grafana.md
@@ -139,7 +139,7 @@ The following example shows how to use an OpenID Connect (OIDC) compliant identi
   </summary>
 
   ```bash
-  kubectl -n kyma-system delete pod -l app=kiali-auth-proxy
+  kubectl -n kyma-system rollout restart deployment kiali-auth-proxy
   ```
 
   </details>
@@ -149,7 +149,7 @@ The following example shows how to use an OpenID Connect (OIDC) compliant identi
   </summary>
 
   ```bash
-  kubectl -n kyma-system delete pod -l app.kubernetes.io/name=auth-proxy,app.kubernetes.io/instance=monitoring
+  kubectl -n kyma-system rollout restart deployment monitoring-auth-proxy-grafana
   ```
 
   </details>
@@ -159,7 +159,7 @@ The following example shows how to use an OpenID Connect (OIDC) compliant identi
   </summary>
 
   ```bash
-  kubectl -n kyma-system delete pod -l app.kubernetes.io/name=auth-proxy,app.kubernetes.io/instance=tracing
+  kubectl -n kyma-system rollout restart deployment tracing-auth-proxy
   ```
 
   </details>


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

The shows labels in the docs did not mathch the actual labels for the
`tracing-auth-proxy deployment`. This PR changes the restart command in
the docs to `kubectl rollout restart` as a cleaner approach.

Changes proposed in this pull request:

- Update auth-proxy restart command in docs docs

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
Fixes #12774