### PR TITLE
Add the kubelogin plugin to prerequisites

### DIFF
--- a/docs/02-get-started/README.md
+++ b/docs/02-get-started/README.md
@@ -9,7 +9,7 @@ All the steps are performed in the `default` Namespace.
 
 ## Prerequisites
 
-- [kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl/) (v1.19 or higher)
+- [kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl/) (v1.19 or higher) together with the [kubelogin](https://github.com/int128/kubelogin) plugin
 - [curl](https://github.com/curl/curl)
 - [k3d](https://k3d.io) (v5.0.0 or higher with [a Kubernetes version supported by Kyma](../04-operation-guides/operations/02-install-kyma.md))
 - [Kyma CLI](../04-operation-guides/operations/01-install-kyma-CLI.md)


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Since most of the time the kubelogin plugin is necessary when using Kyma, we should add it to prerequisites along kubeclt. 

Changes proposed in this pull request:

- Add the kubelogin plugin to prerequisites