### PR TITLE
Include email scope in the oauth2-proxy setup documentation

### DIFF
--- a/docs/04-operation-guides/security/sec-06-access-expose-kiali-grafana.md
+++ b/docs/04-operation-guides/security/sec-06-access-expose-kiali-grafana.md
@@ -86,7 +86,7 @@ The following example shows how to use an OpenID Connect (OIDC) compliant identi
     --from-literal="OAUTH2_PROXY_CLIENT_SECRET=<my-client-secret>" \
     --from-literal="OAUTH2_PROXY_OIDC_ISSUER_URL=<my-token-issuer>" \
     --from-literal="OAUTH2_PROXY_PROVIDER=oidc" \
-    --from-literal="OAUTH2_PROXY_SCOPE=openid" \
+    --from-literal="OAUTH2_PROXY_SCOPE=openid email" \
     --from-literal="OAUTH2_PROXY_ALLOWED_GROUPS=<my-groups>" \
     --from-literal="OAUTH2_PROXY_SKIP_PROVIDER_BUTTON=true"
   ```
@@ -103,7 +103,7 @@ The following example shows how to use an OpenID Connect (OIDC) compliant identi
     --from-literal="OAUTH2_PROXY_CLIENT_SECRET=<my-client-secret>" \
     --from-literal="OAUTH2_PROXY_OIDC_ISSUER_URL=<my-token-issuer>" \
     --from-literal="OAUTH2_PROXY_PROVIDER=oidc" \
-    --from-literal="OAUTH2_PROXY_SCOPE=openid" \
+    --from-literal="OAUTH2_PROXY_SCOPE=openid email" \
     --from-literal="OAUTH2_PROXY_ALLOWED_GROUPS=<my-groups>" \
     --from-literal="OAUTH2_PROXY_SKIP_PROVIDER_BUTTON=true"
   ```
@@ -120,7 +120,7 @@ The following example shows how to use an OpenID Connect (OIDC) compliant identi
     --from-literal="OAUTH2_PROXY_CLIENT_SECRET=<my-client-secret>" \
     --from-literal="OAUTH2_PROXY_OIDC_ISSUER_URL=<my-token-issuer>" \
     --from-literal="OAUTH2_PROXY_PROVIDER=oidc" \
-    --from-literal="OAUTH2_PROXY_SCOPE=openid" \
+    --from-literal="OAUTH2_PROXY_SCOPE=openid email" \
     --from-literal="OAUTH2_PROXY_ALLOWED_GROUPS=<my-groups>" \
     --from-literal="OAUTH2_PROXY_SKIP_PROVIDER_BUTTON=true"
   ```


### PR DESCRIPTION
**Description**

It is very common that users are identified by email.
I have created a kyma runtime where I set a custom OIDC-enabled Identity provider with option to identify users based on email claim. In this setup I couldn't reach up to grafana via oauth2 proxy simply because email scope was not requested by default. I had to include it in the secret field and than it worked.

**Related issue(s)**
https://github.com/kyma-project/control-plane/pull/1063