### PR TITLE
Fix the link to the migration script

### DIFF
--- a/docs/migration-guide-1.24-2.0.md
+++ b/docs/migration-guide-1.24-2.0.md
@@ -18,7 +18,7 @@ Kyma 2.0 provides architectural simplification and switches to the native Kubern
 
 To use the native Kubernetes authentication in Kyma, you need to remove the deprecated components manually.
 
-After the successful upgrade to Kyma 2.0, run the following [script](assets/1.24-2.0-remove-deprecated-resources.sh), which uninstalls and deletes the unsupported items.
+After the successful upgrade to Kyma 2.0, run the following [script](https://github.com/kyma-project/kyma/blob/main/docs/assets/1.24-2.0-remove-deprecated-resources.sh), which uninstalls and deletes the unsupported items.
 
 >**CAUTION:** The script deletes the authentication and authorization components mentioned above, as well as the Cluster Roles that are not needed anymore. If you use these roles in your bindings, make sure to create a custom role by duplicating it, or uncomment it from deletion. If you want to keep any of the authentication and authorization components, modify the script accordingly before running it.
 


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

When linking to assets on our website, we need to link directly to GitHub, otherwise, the link will not work. Since the migration script was still in PR, we couldn't link to it. This PR fixes this. 

Changes proposed in this pull request:

- Fix the link to the migration script

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
