### PR TITLE
Fix the titles of the "Revoke a client cert" tutorials

### DIFF
--- a/docs/01-overview/main-areas/application-connectivity/ac-05-useful-links.md
+++ b/docs/01-overview/main-areas/application-connectivity/ac-05-useful-links.md
@@ -15,7 +15,7 @@ If you're interested in learning more about the Application Connectivity area, f
   - [Register a secured API](../../../03-tutorials/00-application-connectivity/ac-04-register-secured-api.md)
   - [Call a registered external service from Kyma](../../../03-tutorials/00-application-connectivity/ac-05-call-registered-service-from-kyma.md)
   - [Renew a client certificate](../../../03-tutorials/00-application-connectivity/ac-06-renew-client-cert.md)
-  - [Revoke a client certificate](../../../03-tutorials/00-application-connectivity/ac-07-revoke-client-cert.md)
+  - [Revoke a client certificate (AC)](../../../03-tutorials/00-application-connectivity/ac-07-revoke-client-cert.md)
   - [Rotate the Root certificate and the key issued by the Certificate Authority](../../../03-tutorials/00-application-connectivity/ac-08-rotate-root-ca.md)
   - [Get the API specification for AC components](../../../03-tutorials/00-application-connectivity/ac-09-get-api-specification.md)
   - [Get subscribed events](../../../03-tutorials/00-application-connectivity/ac-10-get-subscribed-events.md)

--- a/docs/01-overview/main-areas/application-connectivity/ra-02-useful-links.md
+++ b/docs/01-overview/main-areas/application-connectivity/ra-02-useful-links.md
@@ -9,7 +9,7 @@ If you're interested in learning more about Runtime Agent, follow these links to
     - [Enable Kyma with Runtime Agent](../../../04-operation-guides/operations/ra-01-enable-kyma-with-runtime-agent.md)
     - [Establish a secure connection with Compass](../../../03-tutorials/00-application-connectivity/ra-01-establish-secure-connection-with-compass.md)
     - [Maintain a secure connection with Compass](../../../03-tutorials/00-application-connectivity/ra-02-maintain-secure-connection-with-compass.md)
-    - [Revoke a client certificate](../../../03-tutorials/00-application-connectivity/ra-03-revoke-client-certificate.md)
+    - [Revoke a client certificate (RA)](../../../03-tutorials/00-application-connectivity/ra-03-revoke-client-certificate.md)
     - [Configure Runtime Agent with Compass](../../../03-tutorials/00-application-connectivity/ra-04-configure-runtime-agent-with-compass.md)
     - [Reconnect Runtime Agent with Compass](../../../03-tutorials/00-application-connectivity/ra-05-reconnect-runtime-agent-with-compass.md)
     

--- a/docs/03-tutorials/00-application-connectivity/ac-07-revoke-client-cert.md
+++ b/docs/03-tutorials/00-application-connectivity/ac-07-revoke-client-cert.md
@@ -1,5 +1,5 @@
 ---
-title: Revoke a client certificate
+title: Revoke a client certificate (AC)
 ---
 
 You can revoke a client certificate generated for your Application. Revocation prevents a certificate from being [renewed](ac-06-renew-client-cert.md). A revoked certificate, however, continues to be valid until it expires. 

--- a/docs/03-tutorials/00-application-connectivity/ra-03-revoke-client-certificate.md
+++ b/docs/03-tutorials/00-application-connectivity/ra-03-revoke-client-certificate.md
@@ -1,5 +1,5 @@
 ---
-title: Revoke a client certificate
+title: Revoke a client certificate (RA)
 ---
 
 After you have established a secure connection with Compass and generated a client certificate, you may want to revoke this certificate at some point. To revoke a client certificate, follow the steps in this tutorial.
@@ -16,20 +16,18 @@ After you have established a secure connection with Compass and generated a clie
 
 > **NOTE**: See how to [maintain a secure connection with Compass and renew a client certificate](ra-02-maintain-secure-connection-with-compass.md).
 
-## Steps
+## Revoke the certificate
 
-1. Revoke the client certificate
+To revoke a client certificate, make a call to the Certificate-Secured Connector URL using the client certificate.
+The Certificate-Secured Connector URL is the `certificateSecuredConnectorURL` obtained when establishing a secure connection with Compass.
+Send this mutation with the call:
 
-    To revoke a client certificate, make a call to the Certificate-Secured Connector URL using the client certificate.
-    The Certificate-Secured Connector URL is the `certificateSecuredConnectorURL` obtained when establishing a secure connection with Compass.
-    Send this mutation with the call:
+```graphql
+mutation { result: revokeCertificate }
+```
 
-    ```graphql
-    mutation { result: revokeCertificate }
-    ```
+A successful call returns the following response:
 
-    A successful call returns the following response:
-
-    ```json
-    {"data":{"result":true}}
-    ```
+```json
+{"data":{"result":true}}
+```


### PR DESCRIPTION
**Description**

In the Application Connectivity tutorials, there are two **different** tutorials on how to revoke a client certificate; [one for Application Connector](https://kyma-project.io/docs/kyma/latest/03-tutorials/00-application-connectivity/ac-07-revoke-client-cert/), and [one for Runtime Agent](https://kyma-project.io/docs/kyma/latest/03-tutorials/00-application-connectivity/ra-03-revoke-client-certificate/), and they both have the same title. Since in the old version of the documentation they were in different sections, it wasn't a problem, but now it's confusing and the title must be adjusted to indicate the difference.

Changes proposed in this pull request:

- Modify the tutorials' titles to indicate the difference between them
- Adjust the RA tutorial's structure, as there's just one step, so it doesn't make sense to make a list out of it.

**Related issue(s)**
#11047 

**Attachments**

![image](https://user-images.githubusercontent.com/53601578/145016492-b440b0ab-9cd8-4613-9c83-6949bf69b502.png)
