### PR TITLE
Fix "retry sending an event to sink" for NATS dispatcher

### DIFF
--- a/components/eventing-controller/README.md
+++ b/components/eventing-controller/README.md
@@ -57,10 +57,13 @@ This section explains how to use the Eventing Controller. It expects the followi
 | **For NATS**                  |                                                                                     |
 | `NATS_URL`                    | The URL for the NATS server.                                                        |
 | `EVENT_TYPE_PREFIX`           | The Event Type Prefix for the NATS backend.                                         |
-| `MAX_IDLE_CONNS`              | The maximum number of idle connecttions for the HTTP transport of the NATS backend. |
+| `MAX_IDLE_CONNS`              | The maximum number of idle connections for the HTTP transport of the NATS backend.  |
 | `MAX_CONNS_PER_HOST`          | The maximum connections per host for the HTTP transport of the NATS backend.        |
 | `MAX_IDLE_CONNS_PER_HOST`     | The maximum idle connections per host for the HTTP transport of the NATS backend.   |
 | `IDLE_CONN_TIMEOUT`           | The idle timeout duration for the HTTP transport of the NATS backend.               |
+| `DEFAULT_MAX_IN_FLIGHT_MESSAGES` | The idle maximum "in flight messages" send by NATS to the Sink without waiting to a response. |
+| `DEFAULT_DISPATCHER_RETRY_PERIOD`| The retry period for resending an event to a sink, if the sink doesn't return 2XX. |
+| `DEFAULT_DISPATCHER_MAX_RETRIES` | The maximum number of retries to send an event to a sink in case of errors.      |
 | **For BEB**                   |                                                                                     |
 | `TOKEN_ENDPOINT`              | The Authentication Server Endpoint to provide Access Tokens.                        |
 | `WEBHOOK_ACTIVATION_TIMEOUT`  | The timeout duration used for webhook activation to acquire Access Tokens for Kyma. |

--- a/components/eventing-controller/README.md
+++ b/components/eventing-controller/README.md
@@ -61,7 +61,7 @@ This section explains how to use the Eventing Controller. It expects the followi
 | `MAX_CONNS_PER_HOST`          | The maximum connections per host for the HTTP transport of the NATS backend.        |
 | `MAX_IDLE_CONNS_PER_HOST`     | The maximum idle connections per host for the HTTP transport of the NATS backend.   |
 | `IDLE_CONN_TIMEOUT`           | The idle timeout duration for the HTTP transport of the NATS backend.               |
-| `DEFAULT_MAX_IN_FLIGHT_MESSAGES` | The idle maximum "in flight messages" send by NATS to the Sink without waiting to a response. |
+| `DEFAULT_MAX_IN_FLIGHT_MESSAGES` | The maximum idle "in-flight messages" sent by NATS to the sink without waiting for a response. |
 | `DEFAULT_DISPATCHER_RETRY_PERIOD`| The retry period for resending an event to a sink, if the sink doesn't return 2XX. |
 | `DEFAULT_DISPATCHER_MAX_RETRIES` | The maximum number of retries to send an event to a sink in case of errors.      |
 | **For BEB**                   |                                                                                     |

--- a/components/eventing-controller/controllers/subscription/nats/reconciler_test.go
+++ b/components/eventing-controller/controllers/subscription/nats/reconciler_test.go
@@ -577,7 +577,7 @@ var cfg *rest.Config
 var k8sClient client.Client
 var testEnv *envtest.Environment
 var natsServer *natsserver.Server
-var defaultSubsConfig = env.DefaultSubscriptionConfig{MaxInFlightMessages: 1,  DispatchRetryPeriod: time.Second, DispatcherMaxRetries: 1}
+var defaultSubsConfig = env.DefaultSubscriptionConfig{MaxInFlightMessages: 1, DispatchRetryPeriod: time.Second, DispatcherMaxRetries: 1}
 var reconciler *Reconciler
 var natsBackend *handlers.Nats
 var cancel context.CancelFunc

--- a/components/eventing-controller/controllers/subscription/nats/reconciler_test.go
+++ b/components/eventing-controller/controllers/subscription/nats/reconciler_test.go
@@ -577,7 +577,7 @@ var cfg *rest.Config
 var k8sClient client.Client
 var testEnv *envtest.Environment
 var natsServer *natsserver.Server
-var defaultSubsConfig = env.DefaultSubscriptionConfig{MaxInFlightMessages: 1}
+var defaultSubsConfig = env.DefaultSubscriptionConfig{MaxInFlightMessages: 1,  DispatchRetryPeriod: time.Second, DispatcherMaxRetries: 1}
 var reconciler *Reconciler
 var natsBackend *handlers.Nats
 var cancel context.CancelFunc

--- a/components/eventing-controller/controllers/subscription/nats/reconciler_test.go
+++ b/components/eventing-controller/controllers/subscription/nats/reconciler_test.go
@@ -577,7 +577,7 @@ var cfg *rest.Config
 var k8sClient client.Client
 var testEnv *envtest.Environment
 var natsServer *natsserver.Server
-var defaultSubsConfig = env.DefaultSubscriptionConfig{MaxInFlightMessages: 1, DispatchRetryPeriod: time.Second, DispatcherMaxRetries: 1}
+var defaultSubsConfig = env.DefaultSubscriptionConfig{MaxInFlightMessages: 1, DispatcherRetryPeriod: time.Second, DispatcherMaxRetries: 1}
 var reconciler *Reconciler
 var natsBackend *handlers.Nats
 var cancel context.CancelFunc

--- a/components/eventing-controller/pkg/env/backend_config.go
+++ b/components/eventing-controller/pkg/env/backend_config.go
@@ -1,9 +1,9 @@
 package env
 
 import (
-	"log"
-
 	"github.com/kelseyhightower/envconfig"
+	"log"
+	"time"
 )
 
 // BackendConfig represents the environment config for the Backend Controller.
@@ -32,6 +32,8 @@ type PublisherConfig struct {
 
 type DefaultSubscriptionConfig struct {
 	MaxInFlightMessages int `envconfig:"DEFAULT_MAX_IN_FLIGHT_MESSAGES" default:"10"`
+	DispatchRetryPeriod time.Duration `envconfig:"DEFAULT_DISPATCHER_RETRY_PERIOD" default:"5m"`
+	DispatcherMaxRetries int `envconfig:"DEFAULT_DISPATCHER_MAX_RETRIES" default:"10"`
 }
 
 func GetBackendConfig() BackendConfig {

--- a/components/eventing-controller/pkg/env/backend_config.go
+++ b/components/eventing-controller/pkg/env/backend_config.go
@@ -1,9 +1,10 @@
 package env
 
 import (
-	"github.com/kelseyhightower/envconfig"
 	"log"
 	"time"
+
+	"github.com/kelseyhightower/envconfig"
 )
 
 // BackendConfig represents the environment config for the Backend Controller.
@@ -31,9 +32,9 @@ type PublisherConfig struct {
 }
 
 type DefaultSubscriptionConfig struct {
-	MaxInFlightMessages int `envconfig:"DEFAULT_MAX_IN_FLIGHT_MESSAGES" default:"10"`
-	DispatchRetryPeriod time.Duration `envconfig:"DEFAULT_DISPATCHER_RETRY_PERIOD" default:"5m"`
-	DispatcherMaxRetries int `envconfig:"DEFAULT_DISPATCHER_MAX_RETRIES" default:"10"`
+	MaxInFlightMessages  int           `envconfig:"DEFAULT_MAX_IN_FLIGHT_MESSAGES" default:"10"`
+	DispatchRetryPeriod  time.Duration `envconfig:"DEFAULT_DISPATCHER_RETRY_PERIOD" default:"5m"`
+	DispatcherMaxRetries int           `envconfig:"DEFAULT_DISPATCHER_MAX_RETRIES" default:"10"`
 }
 
 func GetBackendConfig() BackendConfig {

--- a/components/eventing-controller/pkg/env/backend_config.go
+++ b/components/eventing-controller/pkg/env/backend_config.go
@@ -32,9 +32,9 @@ type PublisherConfig struct {
 }
 
 type DefaultSubscriptionConfig struct {
-	MaxInFlightMessages  int           `envconfig:"DEFAULT_MAX_IN_FLIGHT_MESSAGES" default:"10"`
-	DispatchRetryPeriod  time.Duration `envconfig:"DEFAULT_DISPATCHER_RETRY_PERIOD" default:"5m"`
-	DispatcherMaxRetries int           `envconfig:"DEFAULT_DISPATCHER_MAX_RETRIES" default:"10"`
+	MaxInFlightMessages   int           `envconfig:"DEFAULT_MAX_IN_FLIGHT_MESSAGES" default:"10"`
+	DispatcherRetryPeriod time.Duration `envconfig:"DEFAULT_DISPATCHER_RETRY_PERIOD" default:"5m"`
+	DispatcherMaxRetries  int           `envconfig:"DEFAULT_DISPATCHER_MAX_RETRIES" default:"10"`
 }
 
 func GetBackendConfig() BackendConfig {

--- a/components/eventing-controller/pkg/handlers/nats.go
+++ b/components/eventing-controller/pkg/handlers/nats.go
@@ -209,7 +209,7 @@ func (n *Nats) getCallback(sink string) nats.MsgHandler {
 		retryParams := cev2context.RetryParams{
 			Strategy: backoffStrategy,
 			MaxTries: n.defaultSubsConfig.DispatcherMaxRetries,
-			Period:   n.defaultSubsConfig.DispatchRetryPeriod,
+			Period:   n.defaultSubsConfig.DispatcherRetryPeriod,
 		}
 		if result := n.doWithRetry(traceCtxWithCE, retryParams, ce); !cev2.IsACK(result) {
 			n.namedLogger().Errorw("event dispatch failed after retries", "id", ce.ID(), "source", ce.Source(), "type", ce.Type(), "sink", sink, "error", result)

--- a/components/eventing-controller/pkg/handlers/nats.go
+++ b/components/eventing-controller/pkg/handlers/nats.go
@@ -206,7 +206,11 @@ func (n *Nats) getCallback(sink string) nats.MsgHandler {
 		// Add tracing headers to the subsequent request
 		traceCtxWithCE := tracing.AddTracingHeadersToContext(ctxWithCE, ce)
 		// set retries parameters
-		retryParams := cev2context.RetryParams{backoffStrategy, n.defaultSubsConfig.DispatcherMaxRetries, n.defaultSubsConfig.DispatchRetryPeriod}
+		retryParams := cev2context.RetryParams{
+			Strategy: backoffStrategy,
+			MaxTries: n.defaultSubsConfig.DispatcherMaxRetries,
+			Period:   n.defaultSubsConfig.DispatchRetryPeriod,
+		}
 		if result := n.doWithRetry(traceCtxWithCE, retryParams, ce); !cev2.IsACK(result) {
 			n.namedLogger().Errorw("event dispatch failed after retries", "id", ce.ID(), "source", ce.Source(), "type", ce.Type(), "sink", sink, "error", result)
 			return

--- a/components/eventing-controller/pkg/handlers/nats.go
+++ b/components/eventing-controller/pkg/handlers/nats.go
@@ -4,12 +4,13 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"github.com/kyma-project/kyma/components/eventing-controller/pkg/tracing"
-	"github.com/kyma-project/kyma/components/eventing-controller/utils"
-	"k8s.io/apimachinery/pkg/types"
 	"net/http"
 	"strconv"
 	"strings"
+
+	"github.com/kyma-project/kyma/components/eventing-controller/pkg/tracing"
+	"github.com/kyma-project/kyma/components/eventing-controller/utils"
+	"k8s.io/apimachinery/pkg/types"
 
 	cev2 "github.com/cloudevents/sdk-go/v2"
 	cev2context "github.com/cloudevents/sdk-go/v2/context"

--- a/components/eventing-controller/pkg/handlers/nats_test.go
+++ b/components/eventing-controller/pkg/handlers/nats_test.go
@@ -615,7 +615,7 @@ func TestRetryUsingCESDK(t *testing.T) {
 	subscriberPort := 8080
 	subscriberCheckDataURL := fmt.Sprintf("http://127.0.0.1:%d/check", subscriberPort)
 	subscriberCheckRetriesURL := fmt.Sprintf("http://127.0.0.1:%d/check_retries", subscriberPort)
-	subscriberReturns500ORL := fmt.Sprintf("http://127.0.0.1:%d/return500", subscriberPort)
+	subscriberServerErrorURL := fmt.Sprintf("http://127.0.0.1:%d/return500", subscriberPort)
 
 	// Start Nats server
 	natsServer := eventingtesting.RunNatsServerOnPort(natsPort)
@@ -658,7 +658,7 @@ func TestRetryUsingCESDK(t *testing.T) {
 
 	// Create a subscription
 	sub := eventingtesting.NewSubscription("sub", "foo", eventingtesting.WithEventTypeFilter)
-	sub.Spec.Sink = subscriberReturns500ORL
+	sub.Spec.Sink = subscriberServerErrorURL
 	_, err = natsClient.SyncSubscription(sub, cleaner)
 	g.Expect(err).To(BeNil())
 	g.Expect(sub.Status.Config).NotTo(BeNil()) // It should apply the defaults

--- a/components/eventing-controller/pkg/handlers/nats_test.go
+++ b/components/eventing-controller/pkg/handlers/nats_test.go
@@ -609,6 +609,76 @@ func TestSubscriptionUsingCESDK(t *testing.T) {
 	g.Expect(err).To(BeNil())
 }
 
+func TestRetryUsingCESDK(t *testing.T) {
+	g := NewWithT(t)
+	natsPort := 5222
+	subscriberPort := 8080
+	//subscriberReceiveURL := fmt.Sprintf("http://127.0.0.1:%d/store", subscriberPort)
+	subscriberCheckURL := fmt.Sprintf("http://127.0.0.1:%d/check", subscriberPort)
+	subscriberCheckRetriesURL := fmt.Sprintf("http://127.0.0.1:%d/check_retries", subscriberPort)
+	subscriberReturns500ORL := fmt.Sprintf("http://127.0.0.1:%d/return500", subscriberPort)
+
+	// Start Nats server
+	natsServer := eventingtesting.RunNatsServerOnPort(natsPort)
+	defer natsServer.Shutdown()
+
+	defaultLogger, err := logger.New(string(kymalogger.JSON), string(kymalogger.INFO))
+	g.Expect(err).To(BeNil())
+
+	natsConfig := env.NatsConfig{
+		URL:           natsServer.ClientURL(),
+		MaxReconnects: 2,
+		ReconnectWait: time.Second,
+	}
+	maxRetries := 3
+	defaultSubscriptionConfig := env.DefaultSubscriptionConfig{
+		MaxInFlightMessages: 1,
+		DispatchRetryPeriod: time.Second,
+		DispatcherMaxRetries: maxRetries,
+	}
+	natsClient := NewNats(natsConfig, defaultSubscriptionConfig, defaultLogger)
+
+	err = natsClient.Initialize(env.Config{})
+	g.Expect(err).To(BeNil())
+
+	// Create a new subscriber
+	subscriber := eventingtesting.NewSubscriber(fmt.Sprintf(":%d", subscriberPort))
+	subscriber.Start()
+
+	// Shutting down subscriber
+	defer subscriber.Shutdown()
+
+	// Check subscriber is running or not by checking the store
+	err = subscriber.CheckEvent("", subscriberCheckURL)
+	g.Expect(err).To(BeNil())
+
+	// Prepare event-type cleaner
+	application := applicationtest.NewApplication(eventingtesting.ApplicationNameNotClean, nil)
+	applicationLister := fake.NewApplicationListerOrDie(context.Background(), application)
+	cleaner := eventtype.NewCleaner(eventingtesting.EventTypePrefix, applicationLister, defaultLogger)
+
+	// Create a subscription
+	sub := eventingtesting.NewSubscription("sub", "foo", eventingtesting.WithEventTypeFilter)
+	sub.Spec.Sink = subscriberReturns500ORL
+	_, err = natsClient.SyncSubscription(sub, cleaner)
+	g.Expect(err).To(BeNil())
+	g.Expect(sub.Status.Config).NotTo(BeNil()) // It should apply the defaults
+
+	subject := eventingtesting.CloudEventType
+
+	//  Send a structured CE
+	err = SendStructuredCloudEventToNATS(natsClient, subject)
+	g.Expect(err).To(BeNil())
+
+	// Check for retries
+	err = subscriber.CheckRetries(maxRetries, subscriberCheckRetriesURL)
+	g.Expect(err).To(BeNil())
+
+	// Delete subscription
+	err = natsClient.DeleteSubscription(sub)
+	g.Expect(err).To(BeNil())
+}
+
 func checkIsNotValid(sub *nats.Subscription, t *testing.T) error {
 	return checkValidity(sub, false, t)
 }

--- a/components/eventing-controller/pkg/handlers/nats_test.go
+++ b/components/eventing-controller/pkg/handlers/nats_test.go
@@ -632,9 +632,9 @@ func TestRetryUsingCESDK(t *testing.T) {
 	}
 	maxRetries := 3
 	defaultSubscriptionConfig := env.DefaultSubscriptionConfig{
-		MaxInFlightMessages:  1,
-		DispatcherRetryPeriod:  time.Second,
-		DispatcherMaxRetries: maxRetries,
+		MaxInFlightMessages:   1,
+		DispatcherRetryPeriod: time.Second,
+		DispatcherMaxRetries:  maxRetries,
 	}
 	natsClient := NewNats(natsConfig, defaultSubscriptionConfig, defaultLogger)
 

--- a/components/eventing-controller/pkg/handlers/nats_test.go
+++ b/components/eventing-controller/pkg/handlers/nats_test.go
@@ -632,8 +632,8 @@ func TestRetryUsingCESDK(t *testing.T) {
 	}
 	maxRetries := 3
 	defaultSubscriptionConfig := env.DefaultSubscriptionConfig{
-		MaxInFlightMessages: 1,
-		DispatchRetryPeriod: time.Second,
+		MaxInFlightMessages:  1,
+		DispatchRetryPeriod:  time.Second,
 		DispatcherMaxRetries: maxRetries,
 	}
 	natsClient := NewNats(natsConfig, defaultSubscriptionConfig, defaultLogger)

--- a/components/eventing-controller/pkg/handlers/nats_test.go
+++ b/components/eventing-controller/pkg/handlers/nats_test.go
@@ -633,7 +633,7 @@ func TestRetryUsingCESDK(t *testing.T) {
 	maxRetries := 3
 	defaultSubscriptionConfig := env.DefaultSubscriptionConfig{
 		MaxInFlightMessages:  1,
-		DispatchRetryPeriod:  time.Second,
+		DispatcherRetryPeriod:  time.Second,
 		DispatcherMaxRetries: maxRetries,
 	}
 	natsClient := NewNats(natsConfig, defaultSubscriptionConfig, defaultLogger)

--- a/components/eventing-controller/testing/subscriber.go
+++ b/components/eventing-controller/testing/subscriber.go
@@ -16,6 +16,8 @@ type Subscriber struct {
 	server        *http.Server
 	StoreEndpoint string
 	CheckEndpoint string
+	Return500Endpoint string
+	CheckRetriesEndpoint string
 }
 
 func NewSubscriber(addr string) *Subscriber {
@@ -23,11 +25,14 @@ func NewSubscriber(addr string) *Subscriber {
 		addr:          addr,
 		StoreEndpoint: "/store",
 		CheckEndpoint: "/check",
+		Return500Endpoint: "/return500",
+		CheckRetriesEndpoint: "/check_retries",
 	}
 }
 
 func (s *Subscriber) Start() {
 	store := make(chan string, 5)
+	retries := 0
 	mux := http.NewServeMux()
 	mux.HandleFunc("/store", func(w http.ResponseWriter, r *http.Request) {
 		data, err := ioutil.ReadAll(r.Body)
@@ -49,6 +54,22 @@ func (s *Subscriber) Start() {
 		_, err := w.Write([]byte(msg))
 		if err != nil {
 			log.Printf("write data failed: %v", err)
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+	})
+	mux.HandleFunc("/return500", func(w http.ResponseWriter, r *http.Request) {
+		_, err := ioutil.ReadAll(r.Body)
+		if err != nil {
+			log.Printf("read data failed: %v", err)
+		}
+		retries++
+		w.WriteHeader(http.StatusInternalServerError)
+	})
+	mux.HandleFunc("/check_retries", func(w http.ResponseWriter, r *http.Request) {
+		_, err := w.Write([]byte(fmt.Sprintf("%d",retries)))
+		if err != nil {
+			log.Printf("check_retries failed: %v", err)
 			w.WriteHeader(http.StatusInternalServerError)
 			return
 		}
@@ -108,6 +129,40 @@ func (s Subscriber) CheckEvent(expectedData, subscriberCheckURL string) error {
 	}
 
 	log.Print("event received")
+	return nil
+}
+
+func (s Subscriber) CheckRetries(expectedData int, subscriberCheckRetriesURL string) error {
+	var body []byte
+	maxAttempts := uint(5)
+	delay := time.Second
+	err := retry.Do(
+		func() error {
+			resp, err := http.Get(subscriberCheckRetriesURL) //nolint:gosec
+			if err != nil {
+				return pkgerrors.Wrapf(err, "get HTTP request failed")
+			}
+			if !is2XXStatusCode(resp.StatusCode) {
+				return fmt.Errorf("response code is not 2xx, received response code is: %d", resp.StatusCode)
+			}
+			defer func() { _ = resp.Body.Close() }()
+			body, err = ioutil.ReadAll(resp.Body)
+			if err != nil {
+				return pkgerrors.Wrapf(err, "read data failed")
+			}
+			if string(body) != fmt.Sprintf("%d", expectedData){
+				return fmt.Errorf("total retries not received")
+			}
+			return nil
+		},
+		retry.Delay(delay),
+		retry.DelayType(retry.FixedDelay),
+		retry.Attempts(maxAttempts),
+		retry.OnRetry(func(n uint, err error) { log.Printf("[%v] try failed: %s", n, err) }),
+	)
+	if err != nil {
+		return pkgerrors.Wrapf(err, "check event after retries failed")
+	}
 	return nil
 }
 

--- a/components/eventing-controller/testing/subscriber.go
+++ b/components/eventing-controller/testing/subscriber.go
@@ -12,20 +12,20 @@ import (
 )
 
 type Subscriber struct {
-	addr          string
-	server        *http.Server
-	StoreEndpoint string
-	CheckEndpoint string
-	Return500Endpoint string
+	addr                 string
+	server               *http.Server
+	StoreEndpoint        string
+	CheckEndpoint        string
+	Return500Endpoint    string
 	CheckRetriesEndpoint string
 }
 
 func NewSubscriber(addr string) *Subscriber {
 	return &Subscriber{
-		addr:          addr,
-		StoreEndpoint: "/store",
-		CheckEndpoint: "/check",
-		Return500Endpoint: "/return500",
+		addr:                 addr,
+		StoreEndpoint:        "/store",
+		CheckEndpoint:        "/check",
+		Return500Endpoint:    "/return500",
 		CheckRetriesEndpoint: "/check_retries",
 	}
 }
@@ -67,7 +67,7 @@ func (s *Subscriber) Start() {
 		w.WriteHeader(http.StatusInternalServerError)
 	})
 	mux.HandleFunc("/check_retries", func(w http.ResponseWriter, r *http.Request) {
-		_, err := w.Write([]byte(fmt.Sprintf("%d",retries)))
+		_, err := w.Write([]byte(fmt.Sprintf("%d", retries)))
 		if err != nil {
 			log.Printf("check_retries failed: %v", err)
 			w.WriteHeader(http.StatusInternalServerError)
@@ -150,7 +150,7 @@ func (s Subscriber) CheckRetries(expectedData int, subscriberCheckRetriesURL str
 			if err != nil {
 				return pkgerrors.Wrapf(err, "read data failed")
 			}
-			if string(body) != fmt.Sprintf("%d", expectedData){
+			if string(body) != fmt.Sprintf("%d", expectedData) {
 				return fmt.Errorf("total retries not received")
 			}
 			return nil

--- a/components/eventing-controller/testing/subscriber.go
+++ b/components/eventing-controller/testing/subscriber.go
@@ -19,6 +19,7 @@ type Subscriber struct {
 	Return500Endpoint    string
 	CheckRetriesEndpoint string
 }
+
 const (
 	maxNoOfData = 5
 	maxAttempts = 5

--- a/resources/eventing/charts/controller/templates/deployment.yaml
+++ b/resources/eventing/charts/controller/templates/deployment.yaml
@@ -50,6 +50,10 @@ spec:
             value: "{{ .Values.publisherProxy.requestTimeout }}"
           - name: DEFAULT_MAX_IN_FLIGHT_MESSAGES
             value: "{{ .Values.eventingBackend.defaultMaxInflightMessages }}"
+          - name: DEFAULT_DISPATCHER_RETRY_PERIOD
+            value: "{{ .Values.eventingBackend.defaultDispatcherRetryPeriod }}"
+          - name: DEFAULT_DISPATCHER_MAX_RETRIES
+            value: "{{ .Values.eventingBackend.defaultDispatcherMaxRetries }}"
           - name: APP_LOG_FORMAT
             value: {{ .Values.global.log.format | quote }}
           - name: APP_LOG_LEVEL

--- a/resources/eventing/charts/controller/values.yaml
+++ b/resources/eventing/charts/controller/values.yaml
@@ -51,6 +51,8 @@ clusterRoleBindingSuffix: ""
 eventingBackend:
   name: eventing-backend
   defaultMaxInflightMessages: 10
+  defaultDispatcherRetryPeriod: 5m
+  defaultDispatcherMaxRetries: 10
 
 healthProbe:
   port: 8081

--- a/resources/eventing/values.yaml
+++ b/resources/eventing/values.yaml
@@ -5,7 +5,7 @@ global:
   images:
     eventing_controller:
       name: eventing-controller
-      version: PR-12833
+      version: PR-12808
       pullPolicy: "IfNotPresent"
     publisher_proxy:
       name: event-publisher-proxy


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- Add a new "retry" implementation for sending a CE event to the Sink for NATS dispatcher
- The CE "context with retry" cannot be used in the case of a POST request, cause after the first POST, the request body is empty. It was replaced with the new "retry" on CE event layer and not on http request layer.
- Make "RetryPeriod" and "MaxRetries" configurable
- Use "BackoffStrategyConstant" instead of "ExponentialBackoffStrategy" to be more aligned with the retry strategy used by EventMesh
- All 2XX HTTP response codes are considered as positive acknowledgments and are not retried (the same behavior like BEB/Webhooks). All others are retried.

**Related issue(s)**
See: https://github.com/kyma-project/kyma/issues/12788
