### PR TITLE
Revert #12787

### DIFF
--- a/tests/fast-integration/kcp/client.js
+++ b/tests/fast-integration/kcp/client.js
@@ -86,9 +86,6 @@ class KCPWrapper {
         if (query.state) {
             args = args.concat(`--state`, `${query.state}`);
         }
-        if (query.ops) {
-            args = args.concat(`--ops`);
-        }
         let result = await this.exec(args);
         return JSON.parse(result)
     }
@@ -148,13 +145,6 @@ class KCPWrapper {
             throw new Error(`failed during upgradeKyma`);
         }
     };
-
-    async getRuntimeStatusOperations(instanceID) {
-        await this.login();
-        let runtimeStatus = await this.runtimes({instanceID: instanceID, ops: true})
-
-        return JSON.stringify(runtimeStatus, null, `\t`)
-    }
 
     async getOrchestrationsOperations(orchestrationID) {
         // debug(`Running getOrchestrationsOperations...`)

--- a/tests/fast-integration/skr-kyma-to-kyma2-upgrade/index.js
+++ b/tests/fast-integration/skr-kyma-to-kyma2-upgrade/index.js
@@ -61,12 +61,12 @@ describe("SKR-Upgrade-test", function () {
   const subAccountID = keb.subaccountID
 
   debug(
-      `PlanID ${getEnvOrThrow("KEB_PLAN_ID")}`,
-      `SubAccountID ${subAccountID}`,
-      `InstanceID ${instanceID}`,
-      `Scenario ${scenarioName}`,
-      `Runtime ${runtimeName}`,
-      `Application ${appName}`
+    `PlanID ${getEnvOrThrow("KEB_PLAN_ID")}`,
+    `SubAccountID ${subAccountID}`,
+    `InstanceID ${instanceID}`,
+    `Scenario ${scenarioName}`,
+    `Runtime ${runtimeName}`,
+    `Application ${appName}`
   );
 
   // debug(
@@ -78,14 +78,14 @@ describe("SKR-Upgrade-test", function () {
   //   `KEB_USER_ID: ${getEnvOrThrow("KEB_USER_ID")}`,
   //   `KEB_PLAN_ID: ${getEnvOrThrow("KEB_PLAN_ID")}`      
   // );
-
+  
   // debug(
   //   `COMPASS_HOST: ${getEnvOrThrow("COMPASS_HOST")}`,
   //   `COMPASS_CLIENT_ID: ${getEnvOrThrow("COMPASS_CLIENT_ID")}`,
   //   `COMPASS_CLIENT_SECRET: ${getEnvOrThrow("COMPASS_CLIENT_SECRET")}`,
   //   `COMPASS_TENANT: ${getEnvOrThrow("COMPASS_TENANT")}`,
   // )
-
+  
   // debug(
   //   `KCP_TECH_USER_LOGIN: ${KCP_TECH_USER_LOGIN}\n`,
   //   `KCP_TECH_USER_PASSWORD: ${KCP_TECH_USER_PASSWORD}\n`,
@@ -96,17 +96,17 @@ describe("SKR-Upgrade-test", function () {
   // )
 
   // Credentials for KCP ODIC Login
-
+  
   // process.env.KCP_TECH_USER_LOGIN    = 
   // process.env.KCP_TECH_USER_PASSWORD = 
-  process.env.KCP_OIDC_ISSUER_URL = "https://kymatest.accounts400.ondemand.com";
+  process.env.KCP_OIDC_ISSUER_URL    = "https://kymatest.accounts400.ondemand.com";
   // process.env.KCP_OIDC_CLIENT_ID     = 
   // process.env.KCP_OIDC_CLIENT_SECRET = 
-  process.env.KCP_KEB_API_URL = "https://kyma-env-broker.cp.dev.kyma.cloud.sap";
+  process.env.KCP_KEB_API_URL        = "https://kyma-env-broker.cp.dev.kyma.cloud.sap";
   process.env.KCP_GARDENER_NAMESPACE = "garden-kyma-dev";
   process.env.KCP_MOTHERSHIP_API_URL = "https://mothership-reconciler.cp.dev.kyma.cloud.sap/v1"
   process.env.KCP_KUBECONFIG_API_URL = "https://kubeconfig-service.cp.dev.kyma.cloud.sap"
-
+  
   const kcp = new KCPWrapper(KCPConfig.fromEnv());
 
   const kymaUpgradeVersion = getEnvOrThrow("KYMA_UPGRADE_VERSION")
@@ -114,29 +114,21 @@ describe("SKR-Upgrade-test", function () {
   this.timeout(60 * 60 * 1000 * 3); // 3h
   this.slow(5000);
 
-  const provisioningTimeout = 1000 * 60 * 60 // 1h
-  const deprovisioningTimeout = 1000 * 60 * 30 // 30m
-
   let skr;
 
   // SKR Provisioning
 
   it(`Perform kcp login`, async function () {
-
+    
     let version = await kcp.version([])
     debug(version)
-
+    
     await kcp.login()
     // debug(loginOutput)
   });
 
   it(`Provision SKR with ID ${instanceID}`, async function () {
-    skr = await provisionSKR(keb, kcp, gardener, instanceID, runtimeName, null, null, null, provisioningTimeout);
-  });
-
-  it(`Should get Runtime Status after provisioning`, async function () {
-    let runtimeStatus = await kcp.getRuntimeStatusOperations(instanceID)
-    console.log(`\nRuntime status: ${runtimeStatus}`)
+    skr = await provisionSKR(keb, gardener, instanceID, runtimeName, null, null, null);
   });
 
   it(`Should save kubeconfig for the SKR to ~/.kube/config`, async function() {
@@ -205,9 +197,9 @@ describe("SKR-Upgrade-test", function () {
     debug("Upgrade Done!")
   });
 
-  it(`Should get Runtime Status after upgrade`, async function () {
-    let runtimeStatus = await kcp.getRuntimeStatusOperations(instanceID)
-    console.log(`\nRuntime status: ${runtimeStatus}`)
+  it(`Get Runtime Status`, async function () {
+    let runtimeStatus = await kcp.runtimes({instanceID: instanceID})
+    debug(inspect(runtimeStatus, false, null, false))
   });
 
   // Perform Tests after Upgrade
@@ -243,7 +235,7 @@ describe("SKR-Upgrade-test", function () {
   // Cleanup
   const skip_cleanup = getEnvOrThrow("SKIP_CLEANUP")
 
-  if (skip_cleanup === "FALSE"){
+  if (skip_cleanup === "FALSE") {
     it("Unregister Kyma resources from Compass", async function() {
       await unregisterKymaFromCompass(director, scenarioName);
     });
@@ -257,7 +249,7 @@ describe("SKR-Upgrade-test", function () {
     });
 
     it("Deprovision SKR", async function () {
-      await deprovisionSKR(keb, kcp, instanceID, deprovisioningTimeout);
+      await deprovisionSKR(keb, instanceID);
     });
   }
 });

--- a/tests/fast-integration/skr-nightly/provision/provision-skr-nightly.js
+++ b/tests/fast-integration/skr-nightly/provision/provision-skr-nightly.js
@@ -32,10 +32,6 @@ const kcp = new KCPWrapper(KCPConfig.fromEnv());
 describe("SKR nightly", function () {
   this.timeout(3600000 * 3); // 3h
   this.slow(5000);
-
-  const provisioningTimeout = 1000 * 60 * 60 // 1h
-  const deprovisioningTimeout = 1000 * 60 * 30 // 30m
-
   before(`Fetch last SKR and deprovision if needed`, async function () {
     try {
       let runtime;
@@ -55,8 +51,7 @@ describe("SKR nightly", function () {
       }
       if (runtime) {
         console.log('Deprovision last SKR.')
-        await deprovisionSKR(keb, kcp, runtime.instanceID, deprovisioningTimeout);
-
+        await deprovisionSKR(keb, runtime.instanceID);
         await unregisterKymaFromCompass(director, this.options.scenarioName);
       } else {
         console.log("Deprovisioning not needed - no previous SKR found.");
@@ -67,11 +62,7 @@ describe("SKR nightly", function () {
         oidc: this.options.oidc0,
       };
 
-      let skr = await provisionSKR(keb, kcp, gardener, this.options.instanceID, this.options.runtimeName, null, null, customParams, provisioningTimeout);
-
-      let runtimeStatus = await kcp.getRuntimeStatusOperations(this.options.instanceID)
-      console.log(`\nRuntime status after provisioning: ${runtimeStatus}`)
-
+      let skr = await provisionSKR(keb, gardener, this.options.instanceID, this.options.runtimeName, null, null, customParams);
       this.shoot = skr.shoot;
       await addScenarioInCompass(director, this.options.scenarioName);
       await assignRuntimeToScenario(director, this.shoot.compassID, this.options.scenarioName);

--- a/tests/fast-integration/skr-svcat-migration-test/skr-svcat-migration-test.js
+++ b/tests/fast-integration/skr-svcat-migration-test/skr-svcat-migration-test.js
@@ -19,9 +19,6 @@ const {
 } = require("../utils");
 const t = require("./test-helpers");
 const sampleResources = require("./deploy-sample-resources");
-const {KCPWrapper, KCPConfig} = require("../kcp/client");
-
-const kcp = new KCPWrapper(KCPConfig.fromEnv());
 
 describe("SKR SVCAT migration test", function() {
   const keb = new KEBClient(KEBConfig.fromEnv());
@@ -31,19 +28,16 @@ describe("SKR SVCAT migration test", function() {
   const suffix = genRandom(4);
   const appName = `app-${suffix}`;
   const runtimeName = `kyma-${suffix}`;
-  const instanceID = uuid.v4();
+  const runtimeID = uuid.v4();
   
   const svcatPlatform = `svcat-${suffix}`
   const btpOperatorInstance = `btp-operator-${suffix}`
   const btpOperatorBinding = `btp-operator-binding-${suffix}`
   switchDebug(on = true)
-  debug(`InstanceID ${instanceID}`, `Runtime ${runtimeName}`, `Application ${appName}`, `Suffix ${suffix}`);
+  debug(`RuntimeID ${runtimeID}`, `Runtime ${runtimeName}`, `Application ${appName}`, `Suffix ${suffix}`);
 
   this.timeout(60 * 60 * 1000 * 3); // 3h
   this.slow(5000);
-
-  const provisioningTimeout = 1000 * 60 * 60 // 1h
-  const deprovisioningTimeout = 1000 * 60 * 30 // 30m
 
   let platformCreds;
   it(`Should provision new ServiceManager platform`, async function() {
@@ -57,12 +51,7 @@ describe("SKR SVCAT migration test", function() {
 
   let skr;
   it(`Should provision SKR`, async function() {
-    skr = await provisionSKR(keb, kcp, gardener, instanceID, runtimeName, platformCreds, btpOperatorCreds, provisioningTimeout);
-  });
-
-  it(`Should get Runtime Status after provisioning`, async function () {
-    let runtimeStatus = await kcp.getRuntimeStatusOperations(instanceID)
-    console.log(`\nRuntime status: ${runtimeStatus}`)
+    skr = await provisionSKR(keb, gardener, runtimeID, runtimeName, platformCreds, btpOperatorCreds);
   });
 
   it(`Should save kubeconfig for the SKR to ~/.kube/config`, async function() {
@@ -136,7 +125,7 @@ describe("SKR SVCAT migration test", function() {
   });
 
   it(`Should deprovision SKR`, async function() {
-    await deprovisionSKR(keb, kcp, instanceID, deprovisioningTimeout);
+    await deprovisionSKR(keb, runtimeID);
   });
 
   it(`Should cleanup platform --cascade, operator instances and bindings`, async function() {

--- a/tests/fast-integration/skr-test/skr-test.js
+++ b/tests/fast-integration/skr-test/skr-test.js
@@ -21,13 +21,8 @@ const {
 } = require("../audit-log");
 const {keb, gardener, director} = require('./helpers');
 const {prometheusPortForward} = require("../monitoring/client");
-const {KCPWrapper, KCPConfig} = require("../kcp/client");
-
-const kcp = new KCPWrapper(KCPConfig.fromEnv());
 
 function OIDCE2ETest() {
-  const updateTimeout = 1000 * 60 * 20 // 20m
-
   describe('OIDCE2ETest()', function () {
     it(`Assure initial OIDC config is applied on shoot cluster`, async function () {
       ensureValidShootOIDCConfig(this.shoot, this.options.oidc0);
@@ -46,13 +41,8 @@ function OIDCE2ETest() {
         oidc: this.options.oidc1,
       };
 
-      let skr = await updateSKR(keb, kcp, gardener, this.options.instanceID, this.shoot.name, customParams, updateTimeout);
+      let skr = await updateSKR(keb, gardener, this.options.instanceID, this.shoot.name, customParams);
       this.shoot = skr.shoot;
-    });
-
-    it(`Should get Runtime Status after updating OIDC config`, async function () {
-      let runtimeStatus = await kcp.getRuntimeStatusOperations(this.options.instanceID)
-      console.log(`\nRuntime status: ${runtimeStatus}`)
     });
 
     it(`Assure updated OIDC config is applied on shoot cluster`, async function () {
@@ -72,13 +62,8 @@ function OIDCE2ETest() {
         administrators: this.options.administrators1,
       };
 
-      let skr = await updateSKR(keb, kcp, gardener, this.options.instanceID, this.shoot.name, customParams, updateTimeout);
+      let skr = await updateSKR(keb, gardener, this.options.instanceID, this.shoot.name, customParams);
       this.shoot = skr.shoot;
-    });
-
-    it(`Should get Runtime Status after updating admins`, async function () {
-      let runtimeStatus = await kcp.getRuntimeStatusOperations(this.options.instanceID)
-      console.log(`\nRuntime status: ${runtimeStatus}`)
     });
 
     it(`Assure only new cluster admins are configured`, async function () {

--- a/tests/fast-integration/skr-test/test.js
+++ b/tests/fast-integration/skr-test/test.js
@@ -6,35 +6,23 @@ const {keb, gardener, director} = require('./helpers');
 const {initializeK8sClient} = require('../utils');
 const {unregisterKymaFromCompass, addScenarioInCompass, assignRuntimeToScenario} = require('../compass');
 const {OIDCE2ETest, CommerceMockTest} = require('./skr-test');
-const {KCPWrapper, KCPConfig} = require("../kcp/client");
-
-const kcp = new KCPWrapper(KCPConfig.fromEnv());
 
 describe(`Execute SKR test`, function () {
     this.timeout(60 * 60 * 1000 * 3); // 3h
     this.slow(5000);
-
-    const provisioningTimeout = 1000 * 60 * 1 // 30m
-    const deprovisioningTimeout = 1000 * 60 * 30 // 30m
-
     before('Provision SKR', async function () {
         try {
             this.options = GatherOptions();
-            console.log(`Provision SKR with instance ID ${this.options.instanceID}`);
+            console.log(`Provision SKR with runtime ID ${this.options.instanceID}`);
             const customParams = {
                 oidc: this.options.oidc0,
             };
-            let skr = await provisionSKR(keb, kcp, gardener,
+            let skr = await provisionSKR(keb, gardener,
                 this.options.instanceID,
                 this.options.runtimeName,
                 null,
                 null,
-                customParams,
-                provisioningTimeout);
-
-            let runtimeStatus = await kcp.getRuntimeStatusOperations(this.options.instanceID)
-            console.log(`\nRuntime status after provisioning: ${runtimeStatus}`)
-
+                customParams);
             this.shoot = skr.shoot;
             await addScenarioInCompass(director, this.options.scenarioName);
             await assignRuntimeToScenario(director, this.shoot.compassID, this.options.scenarioName);
@@ -46,7 +34,7 @@ describe(`Execute SKR test`, function () {
     OIDCE2ETest();
     CommerceMockTest();
     after(`Deprovision SKR`, async function () {
-        await deprovisionSKR(keb, kcp, this.options.instanceID, deprovisioningTimeout);
+        await deprovisionSKR(keb, this.options.instanceID);
         await unregisterKymaFromCompass(director, this.options.scenarioName);
     });
 });


### PR DESCRIPTION
**Description:**
After merging https://github.com/kyma-project/kyma/pull/12787, SKR tests started failing with
```
Error: Env KCP_KEB_API_URL not present
```
Initially, it didn't look like the PR could be the culprit because it didn't do much with env variables, but after reverting the PR and test running with pjtester, tests no longer fail with this error.

https://status.build.kyma-project.io/?job=wozniakjan_test_of_prowjob_skr-aws-svcat-migration-dev

**Related Issues:**
https://github.com/kyma-project/kyma/pull/12829, https://github.com/kyma-project/test-infra/pull/4486