### PR TITLE
Fix endless reconciliation of the Publisher proxy deployment

### DIFF
--- a/components/eventing-controller/pkg/object/equality.go
+++ b/components/eventing-controller/pkg/object/equality.go
@@ -96,16 +96,26 @@ func publisherProxyDeploymentEqual(d1, d2 *appsv1.Deployment) bool {
 
 	cst1 := d1.Spec.Template
 	cst2 := d2.Spec.Template
-	if !reflect.DeepEqual(cst1.Annotations, cst2.Annotations) {
+	if !mapDeepEqual(cst1.Annotations, cst2.Annotations) {
 		return false
 	}
-	if !reflect.DeepEqual(cst1.Labels, cst2.Labels) {
+	if !mapDeepEqual(cst1.Labels, cst2.Labels) {
 		return false
 	}
 
 	ps1 := &cst1.Spec
 	ps2 := &cst2.Spec
 	return podSpecEqual(ps1, ps2)
+}
+
+// mapDeepEqual returns true if two non-empty maps are equal, otherwise returns false.
+// If length of both maps evaluates to zero, it returns true.
+func mapDeepEqual(m1, m2 map[string]string) bool {
+	if len(m1) == 0 && len(m2) == 0 {
+		return true
+	}
+
+	return reflect.DeepEqual(m1, m2)
 }
 
 // podSpecEqual asserts the equality of two PodSpec objects.

--- a/components/eventing-controller/pkg/object/equality_test.go
+++ b/components/eventing-controller/pkg/object/equality_test.go
@@ -369,6 +369,58 @@ func TestPublisherProxyDeploymentEqual(t *testing.T) {
 			},
 			expectedResult: false,
 		},
+		"should be equal if spec annotations are nil and empty": {
+			getPublisher1: func() *appsv1.Deployment {
+				p := defaultNATSPublisher.DeepCopy()
+				p.Spec.Template.Annotations = nil
+				return p
+			},
+			getPublisher2: func() *appsv1.Deployment {
+				p := defaultNATSPublisher.DeepCopy()
+				p.Spec.Template.Annotations = map[string]string{}
+				return p
+			},
+			expectedResult: true,
+		},
+		"should be unequal if spec annotations changes": {
+			getPublisher1: func() *appsv1.Deployment {
+				p := defaultNATSPublisher.DeepCopy()
+				p.Spec.Template.Annotations = map[string]string{"key": "value1"}
+				return p
+			},
+			getPublisher2: func() *appsv1.Deployment {
+				p := defaultNATSPublisher.DeepCopy()
+				p.Spec.Template.Annotations = map[string]string{"key": "value2"}
+				return p
+			},
+			expectedResult: false,
+		},
+		"should be equal if spec Labels are nil and empty": {
+			getPublisher1: func() *appsv1.Deployment {
+				p := defaultNATSPublisher.DeepCopy()
+				p.Spec.Template.Labels = nil
+				return p
+			},
+			getPublisher2: func() *appsv1.Deployment {
+				p := defaultNATSPublisher.DeepCopy()
+				p.Spec.Template.Labels = map[string]string{}
+				return p
+			},
+			expectedResult: true,
+		},
+		"should be unequal if spec Labels changes": {
+			getPublisher1: func() *appsv1.Deployment {
+				p := defaultNATSPublisher.DeepCopy()
+				p.Spec.Template.Labels = map[string]string{"key": "value1"}
+				return p
+			},
+			getPublisher2: func() *appsv1.Deployment {
+				p := defaultNATSPublisher.DeepCopy()
+				p.Spec.Template.Labels = map[string]string{"key": "value2"}
+				return p
+			},
+			expectedResult: false,
+		},
 	}
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {

--- a/resources/eventing/values.yaml
+++ b/resources/eventing/values.yaml
@@ -5,7 +5,7 @@ global:
   images:
     eventing_controller:
       name: eventing-controller
-      version: PR-12769
+      version: PR-12833
       pullPolicy: "IfNotPresent"
     publisher_proxy:
       name: event-publisher-proxy


### PR DESCRIPTION
**Description**

Publisher deployment reconciler keeps reconciling the publisher deployment endlessly, because it compares the current vs desired state of the publisher deployment annotations and returns that both are not equal if one of the annotations are empty and the other is nil. This PR introduces a fix for this by treating both empty and nil annotations the same.

**Related issue(s)**

- https://github.com/kyma-project/kyma/issues/12825.
