### PR TITLE
Replace individual code owners with teams

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -82,7 +82,7 @@
 /resources/api-gateway/ @strekm @werdes72 @Tomasz-Smelcerz-SAP @mjakobczyk @dariusztutaj @cnvergence @veichtj @piotrkpc
 
 # The `compass-runtime-agent` chart
-/resources/compass-runtime-agent/ @PK85 @tgorgol @dbadura @akgalwas @janmedrek @franpog859 @Maladie @rafalpotempa @koala7659 @ralikio @everesio
+/resources/compass-runtime-agent/ @PK85 @tgorgol @dbadura @kyma-project/connectivity
 
 # The `kiali` chart
 /resources/kiali/ @kyma-project/observability
@@ -140,18 +140,6 @@ components/etcd-tls-setup-job/ @PK85 @piotrmiskiewicz @ksputo @szwedm @voigt @wo
 # Application Connectivity Certs Setup Job Component
 /components/application-connectivity-certs-setup-job/ @akgalwas @janmedrek @franpog859 @Maladie @rafalpotempa @koala7659 @ralikio
 
-# UAA Component
-/components/uaa-activator/ @ksputo @piotrmiskiewicz @PK85 @szwedm @voigt @wozniakjan
-
-# Xip Patch Component
-/components/xip-patch/ @strekm @werdes72 @Tomasz-Smelcerz-SAP @mjakobczyk @dariusztutaj
-
-# Permission Controller Component
-/components/permission-controller/ @strekm @werdes72 @Tomasz-Smelcerz-SAP @mjakobczyk @dariusztutaj
-
-# Dex Static User Configurer
-/components/dex-static-user-configurer/ @strekm @werdes72 @Tomasz-Smelcerz-SAP @mjakobczyk @dariusztutaj
-
 # Function Controller
 /components/function-controller/ @m00g3n @pPrecel @dbadura @rJankowski93 @kwiatekus
 
@@ -183,44 +171,37 @@ components/etcd-tls-setup-job/ @PK85 @piotrmiskiewicz @ksputo @szwedm @voigt @wo
 # Service Catalog acceptance tests
 /tests/service-catalog/ @ksputo @piotrmiskiewicz @PK85 @szwedm @voigt @wozniakjan @adamwalach
 
-# Dex integration tests
-/tests/integration/dex/ @strekm @werdes72 @Tomasz-Smelcerz-SAP @mjakobczyk @dariusztutaj
-
 # api-gateway integration tests
 /tests/integration/api-gateway/ @strekm @werdes72 @Tomasz-Smelcerz-SAP @mjakobczyk @dariusztutaj
-
-# apiserver-proxy tests
-/tests/integration/apiserver-proxy/ @strekm @werdes72 @Tomasz-Smelcerz-SAP @mjakobczyk @dariusztutaj
 
 # Rafter tests
 /tests/rafter/ @m00g3n @pPrecel @dbadura @tgorgol @rJankowski93
 
 # Function Controller tests
-/tests/function-controller/ @m00g3n @pPrecel @dbadura @tgorgol @rJankowski93
+/tests/function-controller/ @kyma-project/serverless
 
 # Connector Service Tests
-/tests/connector-service-tests/ @akgalwas @janmedrek @franpog859 @Maladie @rafalpotempa @koala7659 @ralikio @everesio
-
+/tests/connector-service-tests/ @kyma-project/connectivity
 # Application Registry Tests
-/tests/application-registry-tests/ @akgalwas @janmedrek @franpog859 @Maladie @rafalpotempa @koala7659 @ralikio @everesio
+/tests/application-registry-tests/ @kyma-project/connectivity
 
 # Application Gateway Tests
-/tests/application-gateway-tests/ @akgalwas @janmedrek @franpog859 @Maladie @rafalpotempa @koala7659 @ralikio @everesio
+/tests/application-gateway-tests/ @kyma-project/connectivity
 
 # Application Gateway Legacy Tests
-/tests/application-gateway-legacy-tests/ @akgalwas @janmedrek @franpog859 @Maladie @rafalpotempa @koala7659 @ralikio @everesio
+/tests/application-gateway-legacy-tests/ @kyma-project/connectivity
 
 # Application Operator Tests
-/tests/application-operator-tests/ @akgalwas @janmedrek @franpog859 @Maladie @rafalpotempa @koala7659 @ralikio @everesio
+/tests/application-operator-tests/ @kyma-project/connectivity
 
 # Application Connector Tests
-/tests/application-connector-tests/ @akgalwas @janmedrek @franpog859 @Maladie @rafalpotempa @koala7659 @ralikio @everesio
+/tests/application-connector-tests/ @kyma-project/connectivity
 
 # Connection Token Handler Tests
-/tests/connection-token-handler-tests/ @akgalwas @janmedrek @franpog859 @Maladie @rafalpotempa @koala7659 @ralikio @everesio
+/tests/connection-token-handler-tests/ @kyma-project/connectivity
 
 # Compass Runtime Agent Tests
-/tests/compass-runtime-agent/ @PK85 @tgorgol @dbadura @akgalwas @janmedrek @franpog859 @Maladie @rafalpotempa @koala7659 @ralikio @everesio
+/tests/compass-runtime-agent/ @PK85 @tgorgol @dbadura @kyma-project/connectivity
 
 # Fast Integration Tests
 /tests/fast-integration/ @crabtree @pbochynski @adamwalach @voigt @skhalash @shorim @rakesh-garimella @jeremyharisch @lindnerby
@@ -235,16 +216,13 @@ components/etcd-tls-setup-job/ @PK85 @piotrmiskiewicz @ksputo @szwedm @voigt @wo
 
 
 # Fast Integration Eventing Tests
-/tests/fast-integration/eventing-test @k15r @lilitgh @marcobebway @nachtmaar @radufa @sayanh @pxsalehi @mfaizanse @friedrichwilken @vladislavpaskar
+/tests/fast-integration/eventing-test @kyma-project/eventing
 
 # Tools
 
 # The failery directory
 /tools/failery/ @m00g3n @pPrecel @dbadura @tgorgol @rJankowski93
 
-# The tools/kyma-installer directory
-/tools/kyma-installer/ @strekm @werdes72 @Tomasz-Smelcerz-SAP @mjakobczyk @dariusztutaj
-#
 # The tools/event-subscriber directory
 /tools/event-subscriber/ @kyma-project/eventing
 

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -5,12 +5,12 @@
 # For more details, read the following article on GitHub: https://help.github.com/articles/about-codeowners/.
 
 # These are the default owners for the whole content of the `kyma` repository. The default owners are automatically added as reviewers when you open a pull request, unless different owners are specified in the file.
-* @pbochynski @PK85 @a-thaler
+* @kyma-project/kyma-steering-committee
 
-/common/ @piotrmiskiewicz @Tomasz-Smelcerz-SAP @strekm @akgalwas @janmedrek @sayanh @radufa @suleymanakbas91
+/common/ @piotrmiskiewicz @Tomasz-Smelcerz-SAP @strekm @sayanh @radufa @kyma-project/connectivity
 
 # Logging library
-/common/logging @franpog859 @dbadura @janmedrek
+/common/logging @dbadura @kyma-project/connectivity
 
 # developer tools: linting
 /hack @clebs @suleymanakbas91 @adamwalach
@@ -19,7 +19,7 @@
 /installation/ @Tomasz-Smelcerz-SAP @strekm @werdes72 @adamwalach @mjakobczyk @m00g3n @pPrecel @dariusztutaj
 
 # The eventing crds
-/installation/resources/crds/eventing/ @k15r @lilitgh @sayanh @marcobebway @pxsalehi @mfaizanse @friedrichwilken @vladislavpaskar @radufa
+/installation/resources/crds/eventing/ @kyma-project/eventing
 
 # The `cluster-essentials` chart
 /resources/cluster-essentials/ @PK85 @janmedrek @a-thaler @suleymanakbas91 @strekm @dariusztutaj @cnvergence @veichtj @piotrkpc
@@ -37,40 +37,22 @@
 /resources/rafter/ @m00g3n @pPrecel @dbadura @rJankowski93 @kwiatekus
 
 # The `application-connector` chart
-/resources/application-connector/ @akgalwas @janmedrek @franpog859 @Maladie @rafalpotempa @koala7659 @ralikio @everesio
-
-# The `connector-service` subchart
-/resources/application-connector/charts/connector-service/ @akgalwas @janmedrek @franpog859 @Maladie @rafalpotempa @koala7659 @ralikio @everesio
-
-# The `connection-token-handler` subchart
-/resources/application-connector/charts/connection-token-handler/ @akgalwas @janmedrek @franpog859 @Maladie @rafalpotempa @koala7659 @ralikio @everesio
-
-# The `application-registry` subchart
-/resources/application-connector/charts/application-registry/ @akgalwas @janmedrek @franpog859 @Maladie @rafalpotempa @koala7659 @ralikio @everesio
-
-# The `application-operator` subchart
-/resources/application-connector/charts/application-operator/ @akgalwas @janmedrek @franpog859 @Maladie @rafalpotempa @koala7659 @ralikio @everesio
-
-# The `central-application-gateway` subchart
-/resources/application-connector/charts/central-application-gateway/ @akgalwas @janmedrek @franpog859 @Maladie @rafalpotempa @koala7659 @ralikio @everesio
-
-# The `central-application-connectivity-validator` subchart
-/resources/application-connector/charts/central-application-connectivity-validator/ @akgalwas @janmedrek @franpog859 @Maladie @rafalpotempa @koala7659 @ralikio @everesio
+/resources/application-connector/ @kyma-project/connectivity
 
 # The `helm-broker` subchart
 /resources/helm-broker/ @PK85 @piotrmiskiewicz @ksputo @szwedm @voigt @wozniakjan @adamwalach
 
 # The `monitoring` subchart
-/resources/monitoring/ @a-thaler @lilitgh @suleymanakbas91 @clebs @rakesh-garimella @skhalash @jeremyharisch @chrkl @shorim @lindnerby
+/resources/monitoring/ @kyma-project/observability
 
 # The `logging` subchart
-/resources/logging/ @a-thaler @lilitgh @suleymanakbas91 @clebs @rakesh-garimella @skhalash @jeremyharisch @chrkl @shorim @lindnerby
+/resources/logging/ @kyma-project/observability
 
 # The 'telemetry' chart
-/resources/telemetry @a-thaler @lilitgh @suleymanakbas91 @clebs @rakesh-garimella @skhalash @jeremyharisch @chrkl @lindnerby @shorim @lindnerby
+/resources/telemetry @kyma-project/observability
 
 # The `eventing` chart
-/resources/eventing/ @lilitgh @k15r @nachtmaar @marcobebway @radufa @sayanh @pxsalehi @mfaizanse @friedrichwilken @vladislavpaskar
+/resources/eventing/ @kyma-project/eventing
 
 # The `application-broker` subchart
 /resources/application-connector/charts/application-broker/ @PK85 @piotrmiskiewicz @ksputo @szwedm @voigt @wozniakjan @adamwalach @lilitgh
@@ -88,7 +70,7 @@
 /resources/istio-configuration/templates/monitoring @a-thaler @lilitgh @rakesh-garimella @skhalash @chrkl @shorim @lindnerby
 
 # The `tracing` chart
-/resources/tracing/ @a-thaler @lilitgh @suleymanakbas91 @clebs @rakesh-garimella @skhalash @jeremyharisch @chrkl @shorim @lindnerby
+/resources/tracing/ @kyma-project/observability
 
 # The `service-catalog` chart
 /resources/service-catalog/ @PK85 @piotrmiskiewicz @ksputo @szwedm @voigt @wozniakjan @adamwalach
@@ -103,10 +85,10 @@
 /resources/compass-runtime-agent/ @PK85 @tgorgol @dbadura @akgalwas @janmedrek @franpog859 @Maladie @rafalpotempa @koala7659 @ralikio @everesio
 
 # The `kiali` chart
-/resources/kiali/ @a-thaler @lilitgh @suleymanakbas91 @clebs @rakesh-garimella @skhalash @jeremyharisch @chrkl @shorim @lindnerby
+/resources/kiali/ @kyma-project/observability
 
 # The `serverless` chart
-/resources/serverless/ @m00g3n @pPrecel @dbadura @rJankowski93 @kwiatekus
+/resources/serverless/ @kyma-project/serverless
 
 # The `busola-migrator` chart
 /resources/busola-migrator/ @m00g3n @pPrecel @dbadura @tgorgol @rJankowski93
@@ -180,10 +162,10 @@ components/etcd-tls-setup-job/ @PK85 @piotrmiskiewicz @ksputo @szwedm @voigt @wo
 /components/compass-runtime-agent/ @PK85 @tgorgol @dbadura @akgalwas @janmedrek @franpog859 @Maladie @rafalpotempa @koala7659 @ralikio
 
 # Event Publisher Proxy
-/components/event-publisher-proxy @k15r @lilitgh @marcobebway @nachtmaar @radufa @sayanh @pxsalehi @mfaizanse @friedrichwilken @vladislavpaskar
+/components/event-publisher-proxy @kyma-project/eventing
 
 # Eventing Controller
-/components/eventing-controller @k15r @lilitgh @marcobebway @nachtmaar @radufa @sayanh @pxsalehi @mfaizanse @friedrichwilken @vladislavpaskar
+/components/eventing-controller @kyma-project/eventing
 
 # Busola Migrator Component
 /components/busola-migrator/ @m00g3n @pPrecel @dbadura @tgorgol @rJankowski93
@@ -264,7 +246,7 @@ components/etcd-tls-setup-job/ @PK85 @piotrmiskiewicz @ksputo @szwedm @voigt @wo
 /tools/kyma-installer/ @strekm @werdes72 @Tomasz-Smelcerz-SAP @mjakobczyk @dariusztutaj
 #
 # The tools/event-subscriber directory
-/tools/event-subscriber/ @lilitgh @k15r @nachtmaar @marcobebway @radufa @sayanh @pxsalehi @mfaizanse @friedrichwilken @vladislavpaskar
+/tools/event-subscriber/ @kyma-project/eventing
 
 # The tools/gitserver directory
 /tools/gitserver/ @m00g3n @pPrecel @tgorgol @dbadura @rJankowski93
@@ -279,16 +261,16 @@ components/etcd-tls-setup-job/ @PK85 @piotrmiskiewicz @ksputo @szwedm @voigt @wo
 /tests/end-to-end/upgrade/pkg/tests/rafter/ @m00g3n @pPrecel @dbadura @tgorgol @rJankowski93
 
 # All .md files
-*.md @klaudiagrz @mmitoraj @majakurcius @alexandra-simeonova @NHingerl
+*.md @kyma-project/documentation
 
 # All files and subdirectories in /docs
-/docs/ @klaudiagrz @mmitoraj @majakurcius @alexandra-simeonova @NHingerl
+/docs/ @kyma-project/documentation
 
 # Owners of the .kyma-project-io folder
 /.kyma-project-io/ @m00g3n @pPrecel @dbadura @tgorgol @rJankowski93
 
 # Config file for MILV - milv.config.yaml
-milv.config.yaml @m00g3n @pPrecel @klaudiagrz @mmitoraj @majakurcius @alexandra-simeonova @NHingerl
+milv.config.yaml @m00g3n @pPrecel @kyma-project/documentation
 
 # performance tests
 /tests/perf/ @a-thaler @lilitgh @suleymanakbas91 @clebs @rakesh-garimella

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -239,7 +239,7 @@ components/etcd-tls-setup-job/ @PK85 @piotrmiskiewicz @ksputo @szwedm @voigt @wo
 /tests/end-to-end/upgrade/pkg/tests/rafter/ @m00g3n @pPrecel @dbadura @tgorgol @rJankowski93
 
 # All .md files
-*.md @kyma-project/documentation
+*.md @kyma-project/technical-writers
 
 # All files and subdirectories in /docs
 /docs/ @kyma-project/documentation

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -248,7 +248,7 @@ components/etcd-tls-setup-job/ @PK85 @piotrmiskiewicz @ksputo @szwedm @voigt @wo
 /.kyma-project-io/ @m00g3n @pPrecel @dbadura @tgorgol @rJankowski93
 
 # Config file for MILV - milv.config.yaml
-milv.config.yaml @m00g3n @pPrecel @kyma-project/documentation
+milv.config.yaml @m00g3n @pPrecel @kyma-project/technical-writers
 
 # performance tests
 /tests/perf/ @a-thaler @lilitgh @suleymanakbas91 @clebs @rakesh-garimella


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- propose new CODEOWNERS file structure based on area teams

**Related issue(s)**
- https://github.com/kyma-project/community/issues/613