### PR TITLE
Re-add the Disable TLS certificate verification tutorial

### DIFF
--- a/docs/01-overview/main-areas/application-connectivity/ac-04-security.md
+++ b/docs/01-overview/main-areas/application-connectivity/ac-04-security.md
@@ -9,9 +9,7 @@ To provide maximum security, Application Connector uses the TLS protocol with Cl
 ## TLS certificate verification
 
 By default, the TLS certificate verification is enabled when sending data and requests to every application.
-<!-- NOT WORKING FOR NOW, RE-ADD IT WHEN FIXED
 You can [disable the TLS certificate verification] (../../../03-tutorials/00-application-connectivity/ac-11-disable-tls-certificate-verification.md) in the communication between Kyma and an application to allow Kyma to send requests and data to an unsecured application. Disabling the certificate verification can be useful in certain testing scenarios.
--->
 
 ## API security type
 

--- a/docs/01-overview/main-areas/application-connectivity/ac-04-security.md
+++ b/docs/01-overview/main-areas/application-connectivity/ac-04-security.md
@@ -9,7 +9,7 @@ To provide maximum security, Application Connector uses the TLS protocol with Cl
 ## TLS certificate verification
 
 By default, the TLS certificate verification is enabled when sending data and requests to every application.
-You can [disable the TLS certificate verification] (../../../03-tutorials/00-application-connectivity/ac-11-disable-tls-certificate-verification.md) in the communication between Kyma and an application to allow Kyma to send requests and data to an unsecured application. Disabling the certificate verification can be useful in certain testing scenarios.
+You can [disable the TLS certificate verification](../../../03-tutorials/00-application-connectivity/ac-11-disable-tls-certificate-verification.md) in the communication between Kyma and an application to allow Kyma to send requests and data to an unsecured application. Disabling the certificate verification can be useful in certain testing scenarios.
 
 ## API security type
 

--- a/docs/01-overview/main-areas/application-connectivity/ac-05-useful-links.md
+++ b/docs/01-overview/main-areas/application-connectivity/ac-05-useful-links.md
@@ -19,9 +19,7 @@ If you're interested in learning more about the Application Connectivity area, f
   - [Rotate the Root certificate and the key issued by the Certificate Authority](../../../03-tutorials/00-application-connectivity/ac-08-rotate-root-ca.md)
   - [Get the API specification for AC components](../../../03-tutorials/00-application-connectivity/ac-09-get-api-specification.md)
   - [Get subscribed events](../../../03-tutorials/00-application-connectivity/ac-10-get-subscribed-events.md)
-<!-- NOT WORKING FOR NOW, RE-ADD IT WHEN FIXED
-  - [Disable TLS certificate verification] (../../../03-tutorials/00-application-connectivity/ac-11-disable-tls-certificate-verification.md)
--->
+  - [Disable TLS certificate verification](../../../03-tutorials/00-application-connectivity/ac-11-disable-tls-certificate-verification.md)
 
 - Check Application Connectivity troubleshooting guides for:
 

--- a/docs/03-tutorials/00-application-connectivity/ac-11-disable-tls-certificate-verification.md
+++ b/docs/03-tutorials/00-application-connectivity/ac-11-disable-tls-certificate-verification.md
@@ -2,9 +2,9 @@
 title: Disable TLS certificate verification
 ---
 
-You can disable the [TLS certificate verification](../../01-overview/main-areas/application-connectivity/ac-04-security.md#tls-certificate-verification) for the connections between Kyma and external solution represented by an application. This allows Kyma to send requests and data to an unsecured application without verifying its presented TLS certificate. Disabling the certificate verification can be useful in certain testing scenarios.
+You can disable the [TLS certificate verification](../../01-overview/main-areas/application-connectivity/ac-04-security.md#tls-certificate-verification) for the connections between Kyma and an external solution represented by an Application. This allows Kyma to send requests and data to an unsecured Application without verifying its presented TLS certificate. Disabling the certificate verification can be useful in certain testing scenarios.
 
->**NOTE:** By default, the TLS certificate verification is enabled when sending data and requests to every application.
+>**NOTE:** By default, the TLS certificate verification is enabled when sending data and requests to every Application.
 Follow these steps to disable TLS certificate verification:
 
 1. Edit the `{APPLICATION_CR_NAME}` Application CR. Run:

--- a/docs/03-tutorials/00-application-connectivity/ac-11-disable-tls-certificate-verification.md
+++ b/docs/03-tutorials/00-application-connectivity/ac-11-disable-tls-certificate-verification.md
@@ -1,0 +1,17 @@
+---
+title: Disable TLS certificate verification
+---
+
+You can disable the [TLS certificate verification](../../01-overview/main-areas/application-connectivity/ac-04-security.md#tls-certificate-verification) for the connections between Kyma and external solution represented by an application. This allows Kyma to send requests and data to an unsecured application without verifying its presented TLS certificate. Disabling the certificate verification can be useful in certain testing scenarios.
+
+>**NOTE:** By default, the TLS certificate verification is enabled when sending data and requests to every application.
+Follow these steps to disable TLS certificate verification:
+
+1. Edit the `{APPLICATION_CR_NAME}` Application CR. Run:
+
+   ```bash
+   kubectl -n kyma-integration edit application {APPLICATION_CR_NAME}
+   ```
+
+2. Edit the Application by setting the **skipVerify** parameter to `true`.
+3. Save the changes and quit.

--- a/docs/03-tutorials/00-application-connectivity/ac-11-disable-tls-certificate-verification.md
+++ b/docs/03-tutorials/00-application-connectivity/ac-11-disable-tls-certificate-verification.md
@@ -10,7 +10,7 @@ Follow these steps to disable TLS certificate verification:
 1. Edit the `{APPLICATION_CR_NAME}` Application CR. Run:
 
    ```bash
-   kubectl -n kyma-integration edit application {APPLICATION_CR_NAME}
+   kubectl edit application {APPLICATION_CR_NAME}
    ```
 
 2. Edit the Application by setting the **skipVerify** parameter to `true`.

--- a/docs/05-technical-reference/00-custom-resources/ac-01-application.md
+++ b/docs/05-technical-reference/00-custom-resources/ac-01-application.md
@@ -40,6 +40,7 @@ This table lists all the possible parameters of a given resource together with t
 |----------|:-------------:|------|
 | **metadata.name** | Yes | Specifies the name of the CR. |
 | **spec.description** | No | Describes the connected Application.  |
+| **spec.skipVerify** | No | Determines whether to skip TLS certificate verification for the Application.  |
 | **spec.labels** | No | Defines the labels of the Application. |
 | **spec.services** | No | Contains all services that the Application provides. |
 | **spec.services.id** | Yes | Identifies the service that the Application provides. |


### PR DESCRIPTION
**Description**

As the bug with disabling TLS certificate verification has been fixed, the tutorial instructing the user how to do it should be re-added. 

Changes proposed in this pull request:

- Re-add the "Disable TLS certificate verification" tutorial
- Add the **spec.skipVerify** field to the Application CR documentation

**Related issue(s)**
#11946 
