### PR TITLE
Dockerfile lint 1

### DIFF
--- a/components/application-broker/cmd/broker/Dockerfile
+++ b/components/application-broker/cmd/broker/Dockerfile
@@ -1,7 +1,7 @@
 FROM eu.gcr.io/kyma-project/external/golang:1.17.6-alpine3.15 as builder
 
 ENV SRC_DIR=/go/src/github.com/kyma-project/kyma/components/application-broker
-ADD . $SRC_DIR
+COPY . $SRC_DIR
 
 # creates a non-root user to give him write permissions to tmp folder
 # needs for logger which saves logs under tmp dir

--- a/components/application-connectivity-certs-setup-job/Dockerfile
+++ b/components/application-connectivity-certs-setup-job/Dockerfile
@@ -14,6 +14,8 @@ RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -o appconnectivityce
 FROM scratch
 LABEL source=git@github.com:kyma-project/kyma.git
 
+WORKDIR /app
+
 COPY --from=builder /go/src/github.com/kyma-project/kyma/components/application-connectivity-certs-setup-job/appconnectivitycertssetupjob .
 COPY --from=builder /go/src/github.com/kyma-project/kyma/components/application-connectivity-certs-setup-job/licenses ./licenses
 

--- a/components/application-connectivity-validator/Dockerfile
+++ b/components/application-connectivity-validator/Dockerfile
@@ -14,6 +14,8 @@ RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -o applicationconnec
 FROM scratch
 LABEL source=git@github.com:kyma-project/kyma.git
 
+WORKDIR /app
+
 COPY --from=builder /go/src/github.com/kyma-project/kyma/components/application-connectivity-validator/applicationconnectivityvalidator .
 COPY --from=builder /app/licenses /app/licenses
 

--- a/components/application-gateway/Dockerfile
+++ b/components/application-gateway/Dockerfile
@@ -17,6 +17,8 @@ RUN apk add -U --no-cache ca-certificates
 FROM scratch
 LABEL source=git@github.com:kyma-project/kyma.git
 
+WORKDIR /app
+
 COPY --from=certs /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
 COPY --from=builder /go/src/github.com/kyma-project/kyma/components/application-gateway/applicationgateway .
 COPY --from=builder /app/licenses /app/licenses

--- a/components/application-operator/Dockerfile
+++ b/components/application-operator/Dockerfile
@@ -14,6 +14,8 @@ RUN CGO_ENABLED=0 GOOS=linux go build -a -o manager ./cmd/manager
 FROM scratch
 LABEL source=git@github.com:kyma-project/kyma.git
 
+WORKDIR /app
+
 COPY charts/application application/
 COPY charts/gateway gateway/
 COPY --from=builder /go/src/github.com/kyma-project/kyma/components/application-operator/manager .

--- a/components/application-registry/Dockerfile
+++ b/components/application-registry/Dockerfile
@@ -16,6 +16,8 @@ RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -o applicationregist
 FROM scratch
 LABEL source=git@github.com:kyma-project/kyma.git
 
+WORKDIR /app
+
 COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
 
 COPY ./docs/api/api.yaml .

--- a/tests/application-connector-tests/Dockerfile
+++ b/tests/application-connector-tests/Dockerfile
@@ -11,8 +11,10 @@ FROM eu.gcr.io/kyma-project/external/alpine:3.12.0
 
 LABEL source=git@github.com:kyma-project/kyma.git
 
+WORKDIR /app
+
 COPY --from=builder /go/src/github.com/kyma-project/kyma/tests/application-connector-tests/scripts/entrypoint.sh .
 COPY --from=builder /go/src/github.com/kyma-project/kyma/tests/application-connector-tests/applicationaccess.test .
 COPY --from=builder /go/src/github.com/kyma-project/kyma/tests/application-connector-tests/licenses ./licenses
 
-ENTRYPOINT ./entrypoint.sh
+ENTRYPOINT ["./entrypoint.sh"]

--- a/tests/application-gateway-legacy-tests/test/executor/Dockerfile
+++ b/tests/application-gateway-legacy-tests/test/executor/Dockerfile
@@ -11,9 +11,11 @@ FROM alpine:3.13
 
 LABEL source=git@github.com:kyma-project/kyma.git
 
+WORKDIR /app
+
 COPY --from=builder /go/src/github.com/kyma-project/kyma/tests/application-gateway-legacy-tests/spec.json .
 COPY --from=builder /go/src/github.com/kyma-project/kyma/tests/application-gateway-legacy-tests/scripts/executor-entrypoint.sh .
 COPY --from=builder /go/src/github.com/kyma-project/kyma/tests/application-gateway-legacy-tests/proxytestsexecutor.test .
 COPY --from=builder /go/src/github.com/kyma-project/kyma/tests/application-gateway-legacy-tests/licenses ./licenses
 
-ENTRYPOINT ./executor-entrypoint.sh
+ENTRYPOINT ["./executor-entrypoint.sh"]

--- a/tests/application-gateway-legacy-tests/test/executor/Dockerfile
+++ b/tests/application-gateway-legacy-tests/test/executor/Dockerfile
@@ -11,11 +11,9 @@ FROM alpine:3.13
 
 LABEL source=git@github.com:kyma-project/kyma.git
 
-WORKDIR /app
-
 COPY --from=builder /go/src/github.com/kyma-project/kyma/tests/application-gateway-legacy-tests/spec.json .
 COPY --from=builder /go/src/github.com/kyma-project/kyma/tests/application-gateway-legacy-tests/scripts/executor-entrypoint.sh .
 COPY --from=builder /go/src/github.com/kyma-project/kyma/tests/application-gateway-legacy-tests/proxytestsexecutor.test .
 COPY --from=builder /go/src/github.com/kyma-project/kyma/tests/application-gateway-legacy-tests/licenses ./licenses
 
-ENTRYPOINT ["./executor-entrypoint.sh"]
+ENTRYPOINT ./executor-entrypoint.sh

--- a/tests/application-gateway-legacy-tests/test/helmtest/Dockerfile
+++ b/tests/application-gateway-legacy-tests/test/helmtest/Dockerfile
@@ -11,8 +11,6 @@ FROM eu.gcr.io/kyma-project/external/alpine:3.14.2
 
 LABEL source=git@github.com:kyma-project/kyma.git
 
-WORKDIR /app
-
 COPY --from=builder /go/src/github.com/kyma-project/kyma/tests/application-gateway-legacy-tests/scripts/helm-test-entrypoint.sh .
 COPY --from=builder /go/src/github.com/kyma-project/kyma/tests/application-gateway-legacy-tests/proxyhelmtests.test .
 COPY --from=builder /go/src/github.com/kyma-project/kyma/tests/application-gateway-legacy-tests/licenses ./licenses
@@ -20,4 +18,4 @@ COPY --from=builder /go/src/github.com/kyma-project/kyma/tests/application-gatew
 ARG TEST_EXECUTOR_IMAGE
 ENV TEST_EXECUTOR_IMAGE=$TEST_EXECUTOR_IMAGE
 
-ENTRYPOINT ["./helm-test-entrypoint.sh"]
+ENTRYPOINT ./helm-test-entrypoint.sh

--- a/tests/application-gateway-legacy-tests/test/helmtest/Dockerfile
+++ b/tests/application-gateway-legacy-tests/test/helmtest/Dockerfile
@@ -11,6 +11,8 @@ FROM eu.gcr.io/kyma-project/external/alpine:3.14.2
 
 LABEL source=git@github.com:kyma-project/kyma.git
 
+WORKDIR /app
+
 COPY --from=builder /go/src/github.com/kyma-project/kyma/tests/application-gateway-legacy-tests/scripts/helm-test-entrypoint.sh .
 COPY --from=builder /go/src/github.com/kyma-project/kyma/tests/application-gateway-legacy-tests/proxyhelmtests.test .
 COPY --from=builder /go/src/github.com/kyma-project/kyma/tests/application-gateway-legacy-tests/licenses ./licenses
@@ -18,4 +20,4 @@ COPY --from=builder /go/src/github.com/kyma-project/kyma/tests/application-gatew
 ARG TEST_EXECUTOR_IMAGE
 ENV TEST_EXECUTOR_IMAGE=$TEST_EXECUTOR_IMAGE
 
-ENTRYPOINT ./helm-test-entrypoint.sh
+ENTRYPOINT ["./helm-test-entrypoint.sh"]

--- a/tests/application-gateway-tests/Dockerfile
+++ b/tests/application-gateway-tests/Dockerfile
@@ -17,6 +17,9 @@ RUN CGO_ENABLED=0 GOOS=linux go test -c ./test/gateway/tests
 FROM eu.gcr.io/kyma-project/external/alpine:3.12.0
 
 LABEL source=git@github.com:kyma-project/kyma.git
+
+WORKDIR /app
+
 RUN apk add --no-cache curl
 
 COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
@@ -24,4 +27,4 @@ COPY --from=builder /go/src/github.com/kyma-project/kyma/tests/application-gatew
 COPY --from=builder /go/src/github.com/kyma-project/kyma/tests/application-gateway-tests/tests.test .
 COPY --from=builder /go/src/github.com/kyma-project/kyma/tests/application-gateway-tests/licenses ./licenses
 
-ENTRYPOINT ./entrypoint.sh
+ENTRYPOINT ["./entrypoint.sh"]

--- a/tests/application-operator-tests/Dockerfile
+++ b/tests/application-operator-tests/Dockerfile
@@ -17,10 +17,12 @@ FROM eu.gcr.io/kyma-project/external/alpine:3.12.0
 
 LABEL source=git@github.com:kyma-project/kyma.git
 
+WORKDIR /app
+
 COPY --from=builder /go/src/github.com/kyma-project/kyma/tests/application-operator-tests/scripts/entrypoint.sh .
 COPY --from=builder /go/src/github.com/kyma-project/kyma/tests/application-operator-tests/applicationcontroller.test .
 COPY --from=builder /go/src/github.com/kyma-project/kyma/tests/application-operator-tests/serviceinstancecontroller.test .
 COPY --from=builder /go/src/github.com/kyma-project/kyma/tests/application-operator-tests/applicationtests.test .
 COPY --from=builder /go/src/github.com/kyma-project/kyma/tests/application-operator-tests/licenses ./licenses
 
-ENTRYPOINT ./entrypoint.sh
+ENTRYPOINT ["./entrypoint.sh"]

--- a/tests/application-registry-tests/Dockerfile
+++ b/tests/application-registry-tests/Dockerfile
@@ -12,9 +12,11 @@ FROM eu.gcr.io/kyma-project/external/alpine:3.12.0
 
 LABEL source=git@github.com:kyma-project/kyma.git
 
+WORKDIR /app
+
 COPY --from=builder /go/src/github.com/kyma-project/kyma/tests/application-registry-tests/scripts/entrypoint.sh .
 COPY --from=builder /go/src/github.com/kyma-project/kyma/tests/application-registry-tests/apitests.test .
 COPY --from=builder /go/src/github.com/kyma-project/kyma/tests/application-registry-tests/k8stests.test .
 COPY --from=builder /go/src/github.com/kyma-project/kyma/tests/application-registry-tests/licenses ./licenses
 
-ENTRYPOINT ./entrypoint.sh
+ENTRYPOINT ["./entrypoint.sh"]

--- a/tests/compass-runtime-agent/Dockerfile
+++ b/tests/compass-runtime-agent/Dockerfile
@@ -14,9 +14,11 @@ FROM eu.gcr.io/kyma-project/external/alpine:3.12.0
 LABEL source=git@github.com:kyma-project/kyma.git
 RUN apk add --no-cache curl
 
+WORKDIR /app
+
 COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
 COPY --from=builder /go/src/github.com/kyma-project/kyma/tests/compass-runtime-agent/scripts/entrypoint.sh .
 COPY --from=builder /go/src/github.com/kyma-project/kyma/tests/compass-runtime-agent/test.test .
 COPY --from=builder /go/src/github.com/kyma-project/kyma/tests/compass-runtime-agent/licenses ./licenses
 
-ENTRYPOINT ./entrypoint.sh
+ENTRYPOINT ["./entrypoint.sh"]


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- Fixing linting errors in Dockerfiles. Patch 1 includes the components:
  - components/application-broker
  - components/application-connectivity-certs-setup-job
  - components/application-connectivity-validator
  - components/application-gateway
  - components/application-operator
  - components/application-registry
  - tests/application-connector-tests
  - tests/application-gateway-legacy-tests
  - tests/application-gateway-tests
  - tests/application-operator-tests
  - tests/application-registry-tests
  - tests/compass-runtime-agent

**Related issue(s)**
Related to #12854
