### PR TITLE
Fix the horizontal communication between NATS nodes in a NATS cluster (production profile)

### DIFF
--- a/resources/eventing/charts/nats/templates/statefulset.yaml
+++ b/resources/eventing/charts/nats/templates/statefulset.yaml
@@ -33,7 +33,9 @@ spec:
       labels:
         {{- include "nats.selectorLabels" . | nindent 8 }}
         {{- if .Values.statefulSetPodLabels }}
-        {{ toYaml .Values.statefulSetPodLabels | indent 8 }}
+        {{- range $key, $value := .Values.statefulSetPodLabels }}
+        {{ $key }}: {{ $value | quote }}
+        {{- end }}
         {{- end }}
     spec:
 {{- with .Values.securityContext }}

--- a/resources/eventing/charts/nats/templates/statefulset.yaml
+++ b/resources/eventing/charts/nats/templates/statefulset.yaml
@@ -33,9 +33,7 @@ spec:
       labels:
         {{- include "nats.selectorLabels" . | nindent 8 }}
         {{- if .Values.statefulSetPodLabels }}
-        {{- range $key, $value := .Values.statefulSetPodLabels }}
-        {{ $key }}: {{ $value | quote }}
-        {{- end }}
+        {{ toYaml .Values.statefulSetPodLabels | nindent 8 }}
         {{- end }}
     spec:
 {{- with .Values.securityContext }}

--- a/resources/eventing/charts/nats/values.yaml
+++ b/resources/eventing/charts/nats/values.yaml
@@ -163,9 +163,8 @@ podAnnotations: {
 statefulSetAnnotations: {}
 
 # Labels to add to the pods of the NATS StatefulSet
-statefulSetPodLabels: {
+statefulSetPodLabels:
   nats_cluster: eventing-nats
-}
 
 # Annotations to add to the NATS Service
 serviceAnnotations: {}

--- a/resources/eventing/charts/nats/values.yaml
+++ b/resources/eventing/charts/nats/values.yaml
@@ -64,8 +64,8 @@ nats:
   terminationGracePeriodSeconds: 120
 
   logging:
-    debug: false
-    trace: false
+    debug: true
+    trace: true
     logtime:
     connectErrorReports:
     reconnectErrorReports:
@@ -171,7 +171,7 @@ statefulSetPodLabels: {
 serviceAnnotations: {}
 
 cluster:
-  enabled: true
+  enabled: false
   name: eventing-nats
   replicas: 3
   noAdvertise: false

--- a/resources/eventing/charts/nats/values.yaml
+++ b/resources/eventing/charts/nats/values.yaml
@@ -163,7 +163,9 @@ podAnnotations: {
 statefulSetAnnotations: {}
 
 # Labels to add to the pods of the NATS StatefulSet
-statefulSetPodLabels: {}
+statefulSetPodLabels: {
+  nats_cluster: eventing-nats
+}
 
 # Annotations to add to the NATS Service
 serviceAnnotations: {}

--- a/resources/eventing/charts/nats/values.yaml
+++ b/resources/eventing/charts/nats/values.yaml
@@ -64,8 +64,8 @@ nats:
   terminationGracePeriodSeconds: 120
 
   logging:
-    debug: true
-    trace: true
+    debug: false
+    trace: false
     logtime:
     connectErrorReports:
     reconnectErrorReports:
@@ -169,7 +169,8 @@ statefulSetPodLabels: {}
 serviceAnnotations: {}
 
 cluster:
-  enabled: false
+  enabled: true
+  name: eventing-nats
   replicas: 3
   noAdvertise: false
 


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- All NATS nodes in a production cluster should use the same cluster name
- The "podAntiAffinity" should work again

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
See also: 
https://github.com/kyma-project/kyma/issues/12866
https://github.com/kyma-project/kyma/issues/12825