### PR TITLE
Introduce priority class for DaemonSets (#12751)

### DIFF
--- a/resources/cluster-essentials/templates/priorityclass-high.yaml
+++ b/resources/cluster-essentials/templates/priorityclass-high.yaml
@@ -1,0 +1,9 @@
+{{- if .Values.global.highPriorityClassName }}
+apiVersion: scheduling.k8s.io/v1
+kind: PriorityClass
+metadata:
+  name: {{ .Values.global.highPriorityClassName }}
+value: {{ .Values.global.highPriorityClassValue }}
+globalDefault: false
+description: "Global scheduling priority of Kyma DaemonSet components. Must not be blocked by unschedulable non-daemonset workloads."
+{{- end }}

--- a/resources/cluster-essentials/values.yaml
+++ b/resources/cluster-essentials/values.yaml
@@ -7,8 +7,9 @@ global:
   podSecurityPolicy:
     privileged: false
   priorityClassName: ""
+  highPriorityClassName: "kyma-system-priority"
   priorityClassValue: 2000000
-
+  highPriorityClassValue: 2100000
   containerRegistry:
     path: eu.gcr.io/kyma-project
   images:

--- a/resources/eventing/charts/nats/templates/statefulset.yaml
+++ b/resources/eventing/charts/nats/templates/statefulset.yaml
@@ -36,6 +36,9 @@ spec:
         {{ toYaml .Values.statefulSetPodLabels | indent 8 }}
         {{- end }}
     spec:
+{{- if or .Values.priorityClassName .Values.global.priorityClassName }}
+      priorityClassName: {{ coalesce .Values.priorityClassName .Values.global.priorityClassName }}
+{{- end }}
 {{- with .Values.securityContext }}
       securityContext:
 {{ toYaml . | indent 8 }}

--- a/resources/istio-configuration/values.yaml
+++ b/resources/istio-configuration/values.yaml
@@ -1,6 +1,7 @@
 ---
 helmValues:
   global:
+    priorityClassName: "kyma-system-priority"
     imagePullPolicy: IfNotPresent
     proxy:
       readinessFailureThreshold: 40

--- a/resources/kiali/templates/kyma-additions/auth-proxy-deployment.yaml
+++ b/resources/kiali/templates/kyma-additions/auth-proxy-deployment.yaml
@@ -27,6 +27,9 @@ spec:
           configMap:
             name: {{ template "kiali-server.fullname" . }}-auth-proxy
       serviceAccountName: {{ template "kiali-server.fullname" . }}-auth-proxy
+      {{- if or .Values.kiali.spec.deployment.priority_class_name .Values.global.priorityClassName }}
+      priorityClassName: {{ coalesce .Values.kiali.spec.deployment.priority_class_name .Values.global.priorityClassName }}
+      {{- end }}
       containers:
       - image: {{ include "imageurl" (dict "reg" .Values.global.containerRegistry "img" .Values.global.images.oauth2_proxy) }}
         imagePullPolicy: {{ .Values.authProxy.image.pullPolicy }}

--- a/resources/logging/charts/fluent-bit/templates/_pod.tpl
+++ b/resources/logging/charts/fluent-bit/templates/_pod.tpl
@@ -3,8 +3,8 @@
 imagePullSecrets:
   {{- toYaml . | nindent 2 }}
 {{- end }}
-{{- if or .Values.priorityClassName .Values.global.priorityClassName -}}
-priorityClassName: {{ coalesce .Values.priorityClassName .Values.global.priorityClassName }}
+{{- if or .Values.priorityClassName .Values.global.highPriorityClassName -}}
+priorityClassName: {{ coalesce .Values.priorityClassName .Values.global.highPriorityClassName }}
 {{- end }}
 serviceAccountName: {{ include "fluent-bit.serviceAccountName" . }}
 securityContext:

--- a/resources/logging/values.yaml
+++ b/resources/logging/values.yaml
@@ -43,3 +43,4 @@ global:
       namespace: kyma-system
   tracing:
     enabled: true
+  highPriorityClassName: "kyma-system-priority"

--- a/resources/monitoring/charts/grafana/templates/kyma-additions/auth-proxy-deployment.yaml
+++ b/resources/monitoring/charts/grafana/templates/kyma-additions/auth-proxy-deployment.yaml
@@ -32,6 +32,9 @@ spec:
         configMap:
           name: {{ .Release.Name }}-auth-proxy-{{ template "grafana.name" . }}-templates
       serviceAccountName: {{ .Release.Name }}-auth-proxy-{{ template "grafana.name" . }}
+      {{- if or .Values.priorityClassName .Values.global.priorityClassName }}
+      priorityClassName: {{ coalesce .Values.priorityClassName .Values.global.priorityClassName }}
+      {{- end }}
       containers:
       - image: "{{ include "imageurl" (dict "reg" .Values.global.containerRegistry "img" .Values.global.images.oauth2_proxy) }}"
         imagePullPolicy: {{ .Values.kyma.authProxy.image.pullPolicy }}

--- a/resources/monitoring/charts/prometheus-node-exporter/templates/daemonset.yaml
+++ b/resources/monitoring/charts/prometheus-node-exporter/templates/daemonset.yaml
@@ -28,8 +28,8 @@ spec:
       securityContext:
 {{ toYaml .Values.podSecurityContext | indent 8 }}
 {{- end }}
-{{- if .Values.priorityClassName }}
-      priorityClassName: {{ .Values.priorityClassName }}
+{{- if or .Values.priorityClassName .Values.global.highPriorityClassName }}
+      priorityClassName: {{ coalesce .Values.priorityClassName .Values.global.highPriorityClassName }}
 {{- end }}
       {{- if .Values.extraInitContainers }}
       initContainers:

--- a/resources/monitoring/values.yaml
+++ b/resources/monitoring/values.yaml
@@ -60,7 +60,7 @@ global:
       version: "7.2.0-59f3431d"
       directory: "tpi"
       sha: ""
-        
+
   istio:
     tls:
       secretName: istio-ingress-certs
@@ -105,6 +105,8 @@ global:
   ##
   imagePullSecrets: []
   # - name: "image-pull-secret"
+
+  highPriorityClassName: "kyma-system-priority"
 
 # Default values for kube-prometheus-stack.
 # This is a YAML-formatted file.
@@ -420,7 +422,7 @@ alertmanager:
 
     ## tlsConfig: TLS configuration to use when scraping the endpoint. For example if using istio mTLS.
     ## Of type: https://github.com/coreos/prometheus-operator/blob/master/Documentation/api.md#tlsconfig
-    tlsConfig: 
+    tlsConfig:
       caFile: /etc/prometheus/secrets/istio.default/root-cert.pem
       certFile: /etc/prometheus/secrets/istio.default/cert-chain.pem
       keyFile: /etc/prometheus/secrets/istio.default/key.pem
@@ -746,7 +748,7 @@ grafana:
 ##
 kubeApiServer:
   enabled: true
-  tlsConfig: 
+  tlsConfig:
     insecureSkipVerify: false
     serverName: kubernetes
 
@@ -2021,12 +2023,12 @@ prometheus:
     #    selector: {}
 
     # Additional volumes on the output StatefulSet definition.
-    volumes: 
+    volumes:
       - emptyDir:
           medium: Memory
         name: istio-certs
     # Additional VolumeMounts on the output StatefulSet definition.
-    volumeMounts: 
+    volumeMounts:
       - mountPath: /etc/prometheus/secrets/istio.default/
         name: istio-certs
 

--- a/resources/serverless/charts/docker-registry/templates/deployment.yaml
+++ b/resources/serverless/charts/docker-registry/templates/deployment.yaml
@@ -37,8 +37,8 @@ spec:
       imagePullSecrets:
 {{ toYaml .Values.imagePullSecrets | indent 8 }}
       {{- end }}
-{{- if or .Values.priorityClassName .Values.global.priorityClassName }}
-      priorityClassName: "{{ coalesce .Values.priorityClassName .Values.global.priorityClassName }}"
+{{- if or .Values.priorityClassName .Values.global.highPriorityClassName }}
+      priorityClassName: "{{ coalesce .Values.priorityClassName .Values.global.highPriorityClassName }}"
 {{- end }}
 {{- if .Values.securityContext.enabled }}
       securityContext:

--- a/resources/serverless/charts/webhook/templates/deployment.yaml
+++ b/resources/serverless/charts/webhook/templates/deployment.yaml
@@ -85,6 +85,6 @@ spec:
               {{ include "tplValue" ( dict "value" .Values.container.envs.configObservabilityName "context" . ) | nindent 14 }}
             - name: KUBERNETES_MIN_VERSION # TODO: Delete this env after all CI pipelines are using k8s >1.17.0
               value: "1.16.0"
-    {{- if .Values.global.priorityClassName }}
-      priorityClassName: {{ .Values.global.priorityClassName }}
+    {{- if .Values.global.highPriorityClassName }}
+      priorityClassName: {{ .Values.global.highPriorityClassName }}
     {{- end }}

--- a/resources/serverless/templates/daemonset-certs.yaml
+++ b/resources/serverless/templates/daemonset-certs.yaml
@@ -60,7 +60,7 @@ spec:
               cpu: 30m
               memory: 30Mi
       terminationGracePeriodSeconds: 30
-    {{- if .Values.global.priorityClassName }}
-      priorityClassName: {{ .Values.global.priorityClassName }}
+    {{- if or .Values.priorityClassName .Values.global.highPriorityClassName }}
+      priorityClassName: {{ coalesce .Values.priorityClassName .Values.global.highPriorityClassName }}
     {{- end }}
 {{- end }}

--- a/resources/serverless/values.yaml
+++ b/resources/serverless/values.yaml
@@ -115,8 +115,7 @@ global:
     git_server:
       name: "gitserver"
       version: "c0aa144a"
-
-
+  highPriorityClassName: "kyma-system-priority"
 
 images:
   function_controller:

--- a/resources/service-catalog/values.yaml
+++ b/resources/service-catalog/values.yaml
@@ -15,7 +15,6 @@ global:
       version: "bd223692"
       directory: "incubator/develop"
 
-
   istio:
     gateway:
       name: kyma-gateway

--- a/resources/telemetry/charts/fluent-bit/templates/_pod.tpl
+++ b/resources/telemetry/charts/fluent-bit/templates/_pod.tpl
@@ -3,8 +3,8 @@
 imagePullSecrets:
   {{- toYaml . | nindent 2 }}
 {{- end }}
-{{- if .Values.priorityClassName }}
-priorityClassName: {{ .Values.priorityClassName }}
+{{- if or .Values.priorityClassName .Values.global.highPriorityClassName -}}
+priorityClassName: {{ coalesce .Values.priorityClassName .Values.global.highPriorityClassName }}
 {{- end }}
 serviceAccountName: {{ include "fluent-bit.serviceAccountName" . }}
 securityContext:

--- a/resources/telemetry/charts/operator/templates/deployment.yaml
+++ b/resources/telemetry/charts/operator/templates/deployment.yaml
@@ -19,6 +19,9 @@ spec:
     spec:
       serviceAccountName: {{ include "operator.serviceAccountName" . }}-controller-manager
       terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds }}
+      {{- if or .Values.priorityClassName .Values.global.priorityClassName -}}
+      priorityClassName: {{ coalesce .Values.priorityClassName .Values.global.priorityClassName }}
+      {{- end }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       containers:

--- a/resources/telemetry/values.yaml
+++ b/resources/telemetry/values.yaml
@@ -13,3 +13,4 @@ global:
       name: "busybox"
       version: "1.34.1"
       directory: "external"
+  highPriorityClassName: "kyma-system-priority"

--- a/resources/tracing/templates/kyma-additions/auth-proxy-deployment.yaml
+++ b/resources/tracing/templates/kyma-additions/auth-proxy-deployment.yaml
@@ -28,6 +28,9 @@ spec:
           configMap:
             name: {{ .Release.Name }}-auth-proxy-{{ template "jaeger-operator.fullname" . }}-templates
       serviceAccountName: {{ include "jaeger-operator.fullname" . }}-auth-proxy
+      {{- if .Values.global.priorityClassName }}
+      priorityClassName: {{ .Values.global.priorityClassName }}
+      {{- end }}
       containers:
       - image: "{{ include "imageurl" (dict "reg" .Values.global.containerRegistry "img" .Values.global.images.oauth2_proxy) }}"
         imagePullPolicy: {{ .Values.authProxy.image.pullPolicy }}


### PR DESCRIPTION
Description

Since the installation of Kyma components do not have a particular order, nodes might end up in the state where no sufficient resources for DaemonSet pods are left. This PR increases the priority of DaemonSet pods to get other pods evicted if necessary. Having a cluster-autoscaler, this would cause scaling up the nodes and the installation should be fine.

Changes proposed in this pull request:

Introduce dedicated PriorityClass with higher priority for DaemonSets in kyma-system namespace
Related issue(s)
Fixes #12720