### PR TITLE
Upgrade Kiali

### DIFF
--- a/resources/kiali/Chart.yaml
+++ b/resources/kiali/Chart.yaml
@@ -4,3 +4,6 @@ name: kiali
 version: 1.0.0
 home: https://kyma-project.io
 icon: https://github.com/kyma-project/kyma/blob/main/logo.png?raw=true
+keywords:
+  - istio
+  - kiali

--- a/resources/kiali/templates/_helpers.tpl
+++ b/resources/kiali/templates/_helpers.tpl
@@ -1,6 +1,13 @@
 {{/* vim: set filetype=mustache: */}}
 
 {{/*
+Expand the name of the chart.
+*/}}
+{{- define "kiali-server.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
 Create a default fully qualified instance name.
 We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
 To simulate the way the operator works, use deployment.instance_name rather than the old fullnameOverride.

--- a/resources/kiali/templates/_helpers.tpl
+++ b/resources/kiali/templates/_helpers.tpl
@@ -1,10 +1,10 @@
 {{/* vim: set filetype=mustache: */}}
 
 {{/*
-Expand the name of the chart.
+Short name used by kyma additions, compatible with old versions of the chart.
 */}}
 {{- define "kiali-server.name" -}}
-{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- .Chart.Name | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 
 {{/*

--- a/resources/kiali/templates/_helpers.tpl
+++ b/resources/kiali/templates/_helpers.tpl
@@ -8,10 +8,10 @@ For backwards compatibility, if fullnameOverride is not kiali but deployment.ins
 use fullnameOverride, otherwise use deployment.instance_name.
 */}}
 {{- define "kiali-server.fullname" -}}
-{{- if (and (eq .Values.kiali.spec.deployment.instance_name "kiali") (ne .Values.fullnameOverride "kiali")) }}
+{{- if (and (eq .Values.deployment.instance_name "kiali") (ne .Values.fullnameOverride "kiali")) }}
   {{- .Values.fullnameOverride | trunc 63 }}
 {{- else }}
-  {{- .Values.kiali.spec.deployment.instance_name | trunc 63 }}
+  {{- .Values.deployment.instance_name | trunc 63 }}
 {{- end }}
 {{- end }}
 
@@ -26,10 +26,10 @@ Create chart name and version as used by the chart label.
 Identifies the log_level with the old verbose_mode and the new log_level considered.
 */}}
 {{- define "kiali-server.logLevel" -}}
-{{- if .Values.kiali.spec.deployment.verbose_mode -}}
-{{- .Values.kiali.spec.deployment.verbose_mode -}}
+{{- if .Values.deployment.verbose_mode -}}
+{{- .Values.deployment.verbose_mode -}}
 {{- else -}}
-{{- .Values.kiali.spec.deployment.logger.log_level -}}
+{{- .Values.deployment.logger.log_level -}}
 {{- end -}}
 {{- end }}
 
@@ -40,8 +40,8 @@ Common labels
 helm.sh/chart: {{ include "kiali-server.chart" . }}
 app: kiali
 {{ include "kiali-server.selectorLabels" . }}
-version: {{ .Values.kiali.spec.deployment.version_label | default .Chart.AppVersion | quote }}
-app.kubernetes.io/version: {{ .Values.kiali.spec.deployment.version_label | default .Chart.AppVersion | quote }}
+version: {{ .Values.deployment.version_label | default .Chart.AppVersion | quote }}
+app.kubernetes.io/version: {{ .Values.deployment.version_label | default .Chart.AppVersion | quote }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
 app.kubernetes.io/part-of: "kiali"
 {{- end }}
@@ -51,15 +51,15 @@ Selector labels
 */}}
 {{- define "kiali-server.selectorLabels" -}}
 app.kubernetes.io/name: kiali
-app.kubernetes.io/instance: {{ .Release.Name }}
+app.kubernetes.io/instance: {{ include "kiali-server.fullname" . }}
 {{- end }}
 
 {{/*
 Determine the default login token signing key.
 */}}
 {{- define "kiali-server.login_token.signing_key" -}}
-{{- if .Values.kiali.spec.login_token.signing_key }}
-  {{- .Values.kiali.spec.login_token.signing_key }}
+{{- if .Values.login_token.signing_key }}
+  {{- .Values.login_token.signing_key }}
 {{- else }}
   {{- randAlphaNum 16 }}
 {{- end }}
@@ -69,8 +69,12 @@ Determine the default login token signing key.
 Determine the default web root.
 */}}
 {{- define "kiali-server.server.web_root" -}}
-{{- if .Values.kiali.spec.server.web_root  }}
-  {{- .Values.kiali.spec.server.web_root | trimSuffix "/" }}
+{{- if .Values.server.web_root  }}
+  {{- if (eq .Values.server.web_root "/") }}
+    {{- .Values.server.web_root }}
+  {{- else }}
+    {{- .Values.server.web_root | trimSuffix "/" }}
+  {{- end }}
 {{- else }}
   {{- if .Capabilities.APIVersions.Has "route.openshift.io/v1" }}
     {{- "/" }}
@@ -84,8 +88,8 @@ Determine the default web root.
 Determine the default identity cert file. There is no default if on k8s; only on OpenShift.
 */}}
 {{- define "kiali-server.identity.cert_file" -}}
-{{- if hasKey .Values.kiali.spec.identity "cert_file" }}
-  {{- .Values.kiali.spec.identity.cert_file }}
+{{- if hasKey .Values.identity "cert_file" }}
+  {{- .Values.identity.cert_file }}
 {{- else }}
   {{- if .Capabilities.APIVersions.Has "route.openshift.io/v1" }}
     {{- "/kiali-cert/tls.crt" }}
@@ -99,8 +103,8 @@ Determine the default identity cert file. There is no default if on k8s; only on
 Determine the default identity private key file. There is no default if on k8s; only on OpenShift.
 */}}
 {{- define "kiali-server.identity.private_key_file" -}}
-{{- if hasKey .Values.kiali.spec.identity "private_key_file" }}
-  {{- .Values.kiali.spec.identity.private_key_file }}
+{{- if hasKey .Values.identity "private_key_file" }}
+  {{- .Values.identity.private_key_file }}
 {{- else }}
   {{- if .Capabilities.APIVersions.Has "route.openshift.io/v1" }}
     {{- "/kiali-cert/tls.key" }}
@@ -111,11 +115,26 @@ Determine the default identity private key file. There is no default if on k8s; 
 {{- end }}
 
 {{/*
+Determine the default deployment.ingress.enabled. Disable it on k8s; enable it on OpenShift.
+*/}}
+{{- define "kiali-server.deployment.ingress.enabled" -}}
+{{- if hasKey .Values.deployment.ingress "enabled" }}
+  {{- .Values.deployment.ingress.enabled }}
+{{- else }}
+  {{- if .Capabilities.APIVersions.Has "route.openshift.io/v1" }}
+    {{- true }}
+  {{- else }}
+    {{- false }}
+  {{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
 Determine the istio namespace - default is where Kiali is installed.
 */}}
 {{- define "kiali-server.istio_namespace" -}}
-{{- if .Values.kiali.spec.istio_namespace }}
-  {{- .Values.kiali.spec.istio_namespace }}
+{{- if .Values.istio_namespace }}
+  {{- .Values.istio_namespace }}
 {{- else }}
   {{- .Release.Namespace }}
 {{- end }}
@@ -125,20 +144,31 @@ Determine the istio namespace - default is where Kiali is installed.
 Determine the auth strategy to use - default is "token" on Kubernetes and "openshift" on OpenShift.
 */}}
 {{- define "kiali-server.auth.strategy" -}}
-{{- if .Values.kiali.spec.auth.strategy }}
-  {{- if (and (eq .Values.kiali.spec.auth.strategy "openshift") (not .Values.kiali.spec.kiali_route_url)) }}
+{{- if .Values.auth.strategy }}
+  {{- if (and (eq .Values.auth.strategy "openshift") (not .Values.kiali_route_url)) }}
     {{- fail "You did not define what the Kiali Route URL will be (--set kiali_route_url=...). Without this set, the openshift auth strategy will not work. Either set that or use a different auth strategy via the --set auth.strategy=... option." }}
   {{- end }}
-  {{- .Values.kiali.spec.auth.strategy }}
+  {{- .Values.auth.strategy }}
 {{- else }}
   {{- if .Capabilities.APIVersions.Has "route.openshift.io/v1" }}
-    {{- if not .Values.kiali.spec.kiali_route_url }}
+    {{- if not .Values.kiali_route_url }}
       {{- fail "You did not define what the Kiali Route URL will be (--set kiali_route_url=...). Without this set, the openshift auth strategy will not work. Either set that or explicitly indicate another auth strategy you want via the --set auth.strategy=... option." }}
     {{- end }}
     {{- "openshift" }}
   {{- else }}
     {{- "token" }}
   {{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Determine the root namespace - default is where Kiali is installed.
+*/}}
+{{- define "kiali-server.external_services.istio.root_namespace" -}}
+{{- if .Values.external_services.istio.root_namespace }}
+  {{- .Values.external_services.istio.root_namespace }}
+{{- else }}
+  {{- .Release.Namespace }}
 {{- end }}
 {{- end }}
 

--- a/resources/kiali/templates/configmap.yaml
+++ b/resources/kiali/templates/configmap.yaml
@@ -14,7 +14,7 @@ metadata:
 data:
   config.yaml: |
     {{- /* Most of .Values is simply the ConfigMap - strip out the keys that are not part of the ConfigMap */}}
-    {{- $cm := omit .Values "nameOverride" "fullnameOverride" "kiali_route_url" "global" "authProxy" }}
+    {{- $cm := omit .Values "nameOverride" "fullnameOverride" "kiali_route_url" "global" "authProxy" "virtualservice" }}
     {{- /* The helm chart defines namespace for us, but pass it to the ConfigMap in case the server needs it */}}
     {{- $_ := set $cm.deployment "namespace" .Release.Namespace }}
     {{- /* Some values of the ConfigMap are generated, but might not be identical, from .Values */}}

--- a/resources/kiali/templates/configmap.yaml
+++ b/resources/kiali/templates/configmap.yaml
@@ -1,3 +1,6 @@
+{{- /*
+    Customization: exclude "global" and "authProxy" sections from being rendered as a part of the config.
+  */ -}}
 ---
 apiVersion: v1
 kind: ConfigMap
@@ -9,7 +12,7 @@ metadata:
 data:
   config.yaml: |
     {{- /* Most of .Values is simply the ConfigMap - strip out the keys that are not part of the ConfigMap */}}
-    {{- $cm := omit .Values "nameOverride" "fullnameOverride" "kiali_route_url" }}
+    {{- $cm := omit .Values "nameOverride" "fullnameOverride" "kiali_route_url" "global" "authProxy" }}
     {{- /* The helm chart defines namespace for us, but pass it to the ConfigMap in case the server needs it */}}
     {{- $_ := set $cm.deployment "namespace" .Release.Namespace }}
     {{- /* Some values of the ConfigMap are generated, but might not be identical, from .Values */}}

--- a/resources/kiali/templates/configmap.yaml
+++ b/resources/kiali/templates/configmap.yaml
@@ -1,6 +1,7 @@
 {{- /*
     Customization:
-    * exclude "global" and "authProxy" sections from being rendered as a part of the config
+    * exclude "global", "authProxy", and "virtualservices" sections from being rendered as a part of the config
+    * enable or disable tracing based on .Values.global.tracing.enabled
     * call tpl before toYaml since some values contain templates
   */ -}}
 ---
@@ -27,5 +28,6 @@ data:
     {{- $_ := set $cm.login_token "signing_key" (include "kiali-server.login_token.signing_key" .) }}
     {{- $_ := set $cm.external_services.istio "root_namespace" (include "kiali-server.external_services.istio.root_namespace" .) }}
     {{- $_ := set $cm.server "web_root" (include "kiali-server.server.web_root" .) }}
+    {{- $_ := set $cm.external_services.tracing "enabled" .Values.global.tracing.enabled }}
     {{- tpl (toYaml $cm | nindent 4) . }}
 ...

--- a/resources/kiali/templates/configmap.yaml
+++ b/resources/kiali/templates/configmap.yaml
@@ -1,5 +1,7 @@
 {{- /*
-    Customization: exclude "global" and "authProxy" sections from being rendered as a part of the config.
+    Customization:
+    * exclude "global" and "authProxy" sections from being rendered as a part of the config
+    * call tpl before toYaml since some values contain templates
   */ -}}
 ---
 apiVersion: v1
@@ -25,5 +27,5 @@ data:
     {{- $_ := set $cm.login_token "signing_key" (include "kiali-server.login_token.signing_key" .) }}
     {{- $_ := set $cm.external_services.istio "root_namespace" (include "kiali-server.external_services.istio.root_namespace" .) }}
     {{- $_ := set $cm.server "web_root" (include "kiali-server.server.web_root" .) }}
-    {{- toYaml $cm | nindent 4 }}
+    {{- tpl (toYaml $cm | nindent 4) . }}
 ...

--- a/resources/kiali/templates/configmap.yaml
+++ b/resources/kiali/templates/configmap.yaml
@@ -1,17 +1,15 @@
-{{- /*
-  Taken from https://github.com/kiali/helm-charts/tree/master/kiali-server
-  */ -}}
+---
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ include "kiali-server.fullname" . }}-server
+  name: {{ include "kiali-server.fullname" . }}
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "kiali-server.labels" . | nindent 4 }}
 data:
   config.yaml: |
     {{- /* Most of .Values is simply the ConfigMap - strip out the keys that are not part of the ConfigMap */}}
-    {{- $cm := omit .Values.kiali.spec "nameOverride" "fullnameOverride" "kiali_route_url" }}
+    {{- $cm := omit .Values "nameOverride" "fullnameOverride" "kiali_route_url" }}
     {{- /* The helm chart defines namespace for us, but pass it to the ConfigMap in case the server needs it */}}
     {{- $_ := set $cm.deployment "namespace" .Release.Namespace }}
     {{- /* Some values of the ConfigMap are generated, but might not be identical, from .Values */}}
@@ -22,6 +20,7 @@ data:
     {{- $_ := set $cm.identity "cert_file" (include "kiali-server.identity.cert_file" .) }}
     {{- $_ := set $cm.identity "private_key_file" (include "kiali-server.identity.private_key_file" .) }}
     {{- $_ := set $cm.login_token "signing_key" (include "kiali-server.login_token.signing_key" .) }}
+    {{- $_ := set $cm.external_services.istio "root_namespace" (include "kiali-server.external_services.istio.root_namespace" .) }}
     {{- $_ := set $cm.server "web_root" (include "kiali-server.server.web_root" .) }}
-    {{- $_ := set $cm.external_services.tracing "enabled" .Values.global.tracing.enabled }}
-    {{- tpl (toYaml $cm | nindent 4) . }}
+    {{- toYaml $cm | nindent 4 }}
+...

--- a/resources/kiali/templates/deployment.yaml
+++ b/resources/kiali/templates/deployment.yaml
@@ -53,7 +53,7 @@ spec:
       {{- toYaml .Values.deployment.host_aliases | nindent 6 }}
       {{- end }}
       containers:
-      - image: {{ include "imageurl" (dict "reg" .Values.global.containerRegistry "img" .Values.global.images.oauth2_proxy) }}
+      - image: {{ include "imageurl" (dict "reg" .Values.global.containerRegistry "img" .Values.global.images.kiali) }}
         imagePullPolicy: {{ .Values.deployment.image_pull_policy | default "Always" }}
         name: {{ include "kiali-server.fullname" . }}
         command:

--- a/resources/kiali/templates/deployment.yaml
+++ b/resources/kiali/templates/deployment.yaml
@@ -1,15 +1,13 @@
-{{- /*
-  Taken from https://github.com/kiali/helm-charts/tree/master/kiali-server
-  */ -}}
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ include "kiali-server.fullname" . }}-server
+  name: {{ include "kiali-server.fullname" . }}
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "kiali-server.labels" . | nindent 4 }}
 spec:
-  replicas: {{ .Values.kiali.spec.deployment.replicas }}
+  replicas: {{ .Values.deployment.replicas }}
   selector:
     matchLabels:
       {{- include "kiali-server.selectorLabels" . | nindent 6 }}
@@ -23,50 +21,56 @@ spec:
       name: {{ include "kiali-server.fullname" . }}
       labels:
         {{- include "kiali-server.labels" . | nindent 8 }}
-        {{- if .Values.kiali.spec.deployment.pod_labels }}
-        {{- toYaml .Values.kiali.spec.deployment.pod_labels | nindent 8 }}
+        {{- if .Values.deployment.pod_labels }}
+        {{- toYaml .Values.deployment.pod_labels | nindent 8 }}
         {{- end }}
       annotations:
-        {{- if .Values.kiali.spec.server.metrics_enabled }}
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+        {{- if .Values.server.metrics_enabled }}
         prometheus.io/scrape: "true"
-        prometheus.io/port: {{ .Values.kiali.spec.server.metrics_port | quote }}
+        prometheus.io/port: {{ .Values.server.metrics_port | quote }}
         {{- else }}
         prometheus.io/scrape: "false"
-        prometheus.io/port: null
+        prometheus.io/port: ""
         {{- end }}
-        kiali.io/runtimes: go,kiali
-        {{- if .Values.kiali.spec.deployment.pod_annotations }}
-        {{- toYaml .Values.kiali.spec.deployment.pod_annotations | nindent 8 }}
+        kiali.io/dashboards: go,kiali
+        {{- if .Values.deployment.pod_annotations }}
+        {{- toYaml .Values.deployment.pod_annotations | nindent 8 }}
         {{- end }}
     spec:
       serviceAccountName: {{ include "kiali-server.fullname" . }}
-      {{- if or .Values.kiali.spec.deployment.priority_class_name .Values.global.priorityClassName }}
-      priorityClassName: {{ coalesce .Values.kiali.spec.deployment.priority_class_name .Values.global.priorityClassName }}
+      {{- if .Values.deployment.priority_class_name }}
+      priorityClassName: {{ .Values.deployment.priority_class_name | quote }}
       {{- end }}
-      {{- if .Values.kiali.spec.deployment.image_pull_secrets }}
+      {{- if .Values.deployment.image_pull_secrets }}
       imagePullSecrets:
-      {{- range .Values.kiali.spec.deployment.image_pull_secrets }}
+      {{- range .Values.deployment.image_pull_secrets }}
       - name: {{ . }}
       {{- end }}
       {{- end }}
+      {{- if .Values.deployment.host_aliases }}
+      hostAliases:
+      {{- toYaml .Values.deployment.host_aliases | nindent 6 }}
+      {{- end }}
       containers:
-      - image: {{ include "imageurl" (dict "reg" .Values.global.containerRegistry "img" .Values.global.images.kiali) }}
-        imagePullPolicy: {{ .Values.kiali.spec.deployment.image_pull_policy | default "Always" }}
+      - image: {{ include "imageurl" (dict "reg" .Values.global.containerRegistry "img" .Values.global.images.oauth2_proxy) }}
+        imagePullPolicy: {{ .Values.deployment.image_pull_policy | default "Always" }}
         name: {{ include "kiali-server.fullname" . }}
         command:
         - "/opt/kiali/kiali"
         - "-config"
         - "/kiali-configuration/config.yaml"
-        {{- if .Values.kiali.spec.server.securityContext }}
         securityContext:
-        {{- toYaml .Values.kiali.spec.server.securityContext | nindent 10 }}
-        {{- end }}
+          allowPrivilegeEscalation: false
+          privileged: false
+          readOnlyRootFilesystem: true
+          runAsNonRoot: true
         ports:
         - name: api-port
-          containerPort: {{ .Values.kiali.spec.server.port | default 20001 }}
-        {{- if .Values.kiali.spec.server.metrics_enabled }}
+          containerPort: {{ .Values.server.port | default 20001 }}
+        {{- if .Values.server.metrics_enabled }}
         - name: http-metrics
-          containerPort: {{ .Values.kiali.spec.server.metrics_port | default 9090 }}
+          containerPort: {{ .Values.server.metrics_port | default 9090 }}
         {{- end }}
         readinessProbe:
           httpGet:
@@ -98,11 +102,11 @@ spec:
         - name: LOG_LEVEL
           value: "{{ include "kiali-server.logLevel" . }}"
         - name: LOG_FORMAT
-          value: "{{ .Values.kiali.spec.deployment.logger.log_format }}"
+          value: "{{ .Values.deployment.logger.log_format }}"
         - name: LOG_TIME_FIELD_FORMAT
-          value: "{{ .Values.kiali.spec.deployment.logger.time_field_format }}"
+          value: "{{ .Values.deployment.logger.time_field_format }}"
         - name: LOG_SAMPLER_RATE
-          value: "{{ .Values.kiali.spec.deployment.logger.sampler_rate }}"
+          value: "{{ .Values.deployment.logger.sampler_rate }}"
         volumeMounts:
         - name: {{ include "kiali-server.fullname" . }}-configuration
           mountPath: "/kiali-configuration"
@@ -110,18 +114,20 @@ spec:
           mountPath: "/kiali-cert"
         - name: {{ include "kiali-server.fullname" . }}-secret
           mountPath: "/kiali-secret"
-        {{- if .Capabilities.APIVersions.Has "route.openshift.io/v1" }}
         - name: {{ include "kiali-server.fullname" . }}-cabundle
           mountPath: "/kiali-cabundle"
+        {{- range .Values.deployment.custom_secrets }}
+        - name: {{ .name }}
+          mountPath: "{{ .mount }}"
         {{- end }}
-        {{- if .Values.kiali.spec.deployment.resources }}
+        {{- if .Values.deployment.resources }}
         resources:
-        {{- toYaml .Values.kiali.spec.deployment.resources | nindent 10 }}
+        {{- toYaml .Values.deployment.resources | nindent 10 }}
         {{- end }}
       volumes:
       - name: {{ include "kiali-server.fullname" . }}-configuration
         configMap:
-          name: {{ include "kiali-server.fullname" . }}-server
+          name: {{ include "kiali-server.fullname" . }}
       - name: {{ include "kiali-server.fullname" . }}-cert
         secret:
           {{- if .Capabilities.APIVersions.Has "route.openshift.io/v1" }}
@@ -134,34 +140,41 @@ spec:
           {{- end }}
       - name: {{ include "kiali-server.fullname" . }}-secret
         secret:
-          secretName: {{ .Values.kiali.spec.deployment.secret_name }}
+          secretName: {{ .Values.deployment.secret_name }}
           optional: true
-      {{- if .Capabilities.APIVersions.Has "route.openshift.io/v1" }}
       - name: {{ include "kiali-server.fullname" . }}-cabundle
         configMap:
           name: {{ include "kiali-server.fullname" . }}-cabundle
+      {{- if not (.Capabilities.APIVersions.Has "route.openshift.io/v1") }}
+          optional: true
       {{- end }}
-      {{- if or (.Values.kiali.spec.deployment.affinity.node) (or (.Values.kiali.spec.deployment.affinity.pod) (.Values.kiali.spec.deployment.affinity.pod_anti)) }}
+      {{- range .Values.deployment.custom_secrets }}
+      - name: {{ .name }}
+        secret:
+          secretName: {{ .name }}
+          optional: {{ .optional | default false }}
+      {{- end }}
+      {{- if or (.Values.deployment.affinity.node) (or (.Values.deployment.affinity.pod) (.Values.deployment.affinity.pod_anti)) }}
       affinity:
-        {{- if .Values.kiali.spec.deployment.affinity.node }}
+        {{- if .Values.deployment.affinity.node }}
         nodeAffinity:
-        {{- toYaml .Values.kiali.spec.deployment.affinity.node | nindent 10 }}
+        {{- toYaml .Values.deployment.affinity.node | nindent 10 }}
         {{- end }}
-        {{- if .Values.kiali.spec.deployment.affinity.pod }}
+        {{- if .Values.deployment.affinity.pod }}
         podAffinity:
-        {{- toYaml .Values.kiali.spec.deployment.affinity.pod | nindent 10 }}
+        {{- toYaml .Values.deployment.affinity.pod | nindent 10 }}
         {{- end }}
-        {{- if .Values.kiali.spec.deployment.affinity.pod_anti }}
+        {{- if .Values.deployment.affinity.pod_anti }}
         podAntiAffinity:
-        {{- toYaml .Values.kiali.spec.deployment.affinity.pod_anti | nindent 10 }}
+        {{- toYaml .Values.deployment.affinity.pod_anti | nindent 10 }}
         {{- end }}
       {{- end }}
-      {{- if .Values.kiali.spec.deployment.tolerations }}
+      {{- if .Values.deployment.tolerations }}
       tolerations:
-      {{- toYaml .Values.kiali.spec.deployment.tolerations | nindent 8 }}
+      {{- toYaml .Values.deployment.tolerations | nindent 8 }}
       {{- end }}
-      {{- if .Values.kiali.spec.deployment.node_selector }}
+      {{- if .Values.deployment.node_selector }}
       nodeSelector:
-      {{- toYaml .Values.kiali.spec.deployment.node_selector | nindent 8 }}
+      {{- toYaml .Values.deployment.node_selector | nindent 8 }}
       {{- end }}
 ...

--- a/resources/kiali/templates/hpa.yaml
+++ b/resources/kiali/templates/hpa.yaml
@@ -1,11 +1,9 @@
-{{- /*
-  Taken from https://github.com/kiali/helm-charts/tree/master/kiali-server
-  */ -}}
-{{- if .Values.kiali.spec.deployment.hpa.spec }}
-apiVersion: {{ .Values.kiali.spec.deployment.hpa.api_version }}
+{{- if .Values.deployment.hpa.spec }}
+---
+apiVersion: {{ .Values.deployment.hpa.api_version }}
 kind: HorizontalPodAutoscaler
 metadata:
-  name: {{ include "kiali-server.fullname" . }}-server
+  name: {{ include "kiali-server.fullname" . }}
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "kiali-server.labels" . | nindent 4 }}
@@ -14,5 +12,6 @@ spec:
     apiVersion: apps/v1
     kind: Deployment
     name: {{ include "kiali-server.fullname" . }}
-  {{- toYaml .Values.kiali.spec.deployment.hpa.spec | nindent 2 }}
+  {{- toYaml .Values.deployment.hpa.spec | nindent 2 }}
+...
 {{- end }}

--- a/resources/kiali/templates/kyma-additions/auth-proxy-configmap.yaml
+++ b/resources/kiali/templates/kyma-additions/auth-proxy-configmap.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ template "kiali-server.fullname" . }}-auth-proxy
+  name: {{ template "kiali-server.name" . }}-auth-proxy
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "kiali-server.labels" . | nindent 4 }}

--- a/resources/kiali/templates/kyma-additions/auth-proxy-deployment.yaml
+++ b/resources/kiali/templates/kyma-additions/auth-proxy-deployment.yaml
@@ -36,7 +36,7 @@ spec:
         name: auth-proxy
         args:
         - --http-address=0.0.0.0:{{ .Values.authProxy.port }}
-        - --upstream=http://{{ template "kiali-server.fullname" . }}-server:{{ .Values.kiali.spec.server.port }}
+        - --upstream=http://{{ template "kiali-server.fullname" . }}-server:{{ .Values.server.port }}
         - --cookie-secure=true
         - --cookie-domain=kiali.{{ .Values.global.domainName }}
         - --cookie-name=KYMA_KIALI_OAUTH2_PROXY_TOKEN

--- a/resources/kiali/templates/kyma-additions/auth-proxy-deployment.yaml
+++ b/resources/kiali/templates/kyma-additions/auth-proxy-deployment.yaml
@@ -27,8 +27,8 @@ spec:
           configMap:
             name: {{ template "kiali-server.name" . }}-auth-proxy
       serviceAccountName: {{ template "kiali-server.name" . }}-auth-proxy
-      {{- if or .Values.authProxy.priorityClassName .Values.global.priorityClassName }}
-      priorityClassName: {{ coalesce .Values.authProxy.priorityClassName .Values.global.priorityClassName }}
+      {{- if or .Values.authProxy.priorityClassName .Values.global.highPriorityClassName }}
+      priorityClassName: {{ coalesce .Values.authProxy.priorityClassName .Values.global.highPriorityClassName }}
       {{- end }}
       containers:
       - image: {{ include "imageurl" (dict "reg" .Values.global.containerRegistry "img" .Values.global.images.oauth2_proxy) }}

--- a/resources/kiali/templates/kyma-additions/auth-proxy-deployment.yaml
+++ b/resources/kiali/templates/kyma-additions/auth-proxy-deployment.yaml
@@ -2,7 +2,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ template "kiali-server.fullname" . }}-auth-proxy
+  name: {{ template "kiali-server.name" . }}-auth-proxy
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "kiali-server.labels" . | nindent 4 }}
@@ -10,11 +10,11 @@ spec:
   replicas: {{ .Values.authProxy.replicaCount }}
   selector:
     matchLabels:
-      app: {{ template "kiali-server.fullname" . }}-auth-proxy
+      app: {{ template "kiali-server.name" . }}-auth-proxy
   template:
     metadata:
       labels:
-        app: {{ template "kiali-server.fullname" . }}-auth-proxy
+        app: {{ template "kiali-server.name" . }}-auth-proxy
       annotations:
         checksum/config: {{ tpl (toYaml .Values.authProxy) . | sha256sum }}
     spec:
@@ -25,10 +25,10 @@ spec:
       volumes:
         - name: templates-cm
           configMap:
-            name: {{ template "kiali-server.fullname" . }}-auth-proxy
-      serviceAccountName: {{ template "kiali-server.fullname" . }}-auth-proxy
-      {{- if or .Values.kiali.spec.deployment.priority_class_name .Values.global.priorityClassName }}
-      priorityClassName: {{ coalesce .Values.kiali.spec.deployment.priority_class_name .Values.global.priorityClassName }}
+            name: {{ template "kiali-server.name" . }}-auth-proxy
+      serviceAccountName: {{ template "kiali-server.name" . }}-auth-proxy
+      {{- if or .Values.authProxy.priorityClassName .Values.global.priorityClassName }}
+      priorityClassName: {{ coalesce .Values.authProxy.priorityClassName .Values.global.priorityClassName }}
       {{- end }}
       containers:
       - image: {{ include "imageurl" (dict "reg" .Values.global.containerRegistry "img" .Values.global.images.oauth2_proxy) }}
@@ -36,7 +36,7 @@ spec:
         name: auth-proxy
         args:
         - --http-address=0.0.0.0:{{ .Values.authProxy.port }}
-        - --upstream=http://{{ template "kiali-server.fullname" . }}-server:{{ .Values.server.port }}
+        - --upstream=http://{{ template "kiali-server.fullname" . }}:{{ .Values.server.port }}
         - --cookie-secure=true
         - --cookie-domain=kiali.{{ .Values.global.domainName }}
         - --cookie-name=KYMA_KIALI_OAUTH2_PROXY_TOKEN
@@ -47,10 +47,10 @@ spec:
         - --pass-host-header={{ .Values.authProxy.config.passHostHeader }}
         envFrom:
         - secretRef:
-            name: {{ template "kiali-server.fullname" . }}-auth-proxy
+            name: {{ template "kiali-server.name" . }}-auth-proxy
             optional: false
         - secretRef:
-            name: {{ template "kiali-server.fullname" . }}-auth-proxy-user
+            name: {{ template "kiali-server.name" . }}-auth-proxy-user
             optional: true
         ports:
         - name: http

--- a/resources/kiali/templates/kyma-additions/auth-proxy-secret.yaml
+++ b/resources/kiali/templates/kyma-additions/auth-proxy-secret.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ template "kiali-server.fullname" . }}-auth-proxy
+  name: {{ template "kiali-server.name" . }}-auth-proxy
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "kiali-server.labels" . | nindent 4 }}

--- a/resources/kiali/templates/kyma-additions/auth-proxy-service.yaml
+++ b/resources/kiali/templates/kyma-additions/auth-proxy-service.yaml
@@ -7,7 +7,7 @@ metadata:
       {{- include "kiali-server.labels" . | nindent 4 }}
 spec:
   ports:
-    - port: {{ .Values.kiali.spec.server.port }}
+    - port: {{ .Values.server.port }}
       targetPort: http
       protocol: TCP
       name: http

--- a/resources/kiali/templates/kyma-additions/auth-proxy-service.yaml
+++ b/resources/kiali/templates/kyma-additions/auth-proxy-service.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ template "kiali-server.fullname" . }}-secured
+  name: {{ template "kiali-server.name" . }}-secured
   labels:
       {{- include "kiali-server.labels" . | nindent 4 }}
 spec:
@@ -12,5 +12,5 @@ spec:
       protocol: TCP
       name: http
   selector:
-      app: {{ template "kiali-server.fullname" . }}-auth-proxy
+      app: {{ template "kiali-server.name" . }}-auth-proxy
 {{end}}

--- a/resources/kiali/templates/kyma-additions/auth-proxy-serviceaccount.yaml
+++ b/resources/kiali/templates/kyma-additions/auth-proxy-serviceaccount.yaml
@@ -4,5 +4,5 @@ kind: ServiceAccount
 metadata:
   labels:
     {{- include "kiali-server.labels" . | nindent 4 }}
-  name: {{ template "kiali-server.fullname" . }}-auth-proxy
+  name: {{ template "kiali-server.name" . }}-auth-proxy
 {{ end }}

--- a/resources/kiali/templates/kyma-additions/authorization-policy.yaml
+++ b/resources/kiali/templates/kyma-additions/authorization-policy.yaml
@@ -32,4 +32,4 @@ spec:
         - /metrics
   selector:
     matchLabels:
-      {{- include "kiali-server.labels" . | nindent 6 }}
+      {{- include "kiali-server.selectorLabels" . | nindent 6 }}

--- a/resources/kiali/templates/kyma-additions/authorization-policy.yaml
+++ b/resources/kiali/templates/kyma-additions/authorization-policy.yaml
@@ -3,7 +3,7 @@ kind: AuthorizationPolicy
 metadata:
   labels:
     {{- include "kiali-server.labels" . | nindent 4 }}
-  name: {{ include "kiali-server.fullname" . }}
+  name: {{ include "kiali-server.name" . }}
   namespace: {{ .Release.Namespace }}
 spec:
   action: ALLOW
@@ -16,7 +16,7 @@ spec:
     from:
     - source:
         principals:
-          - cluster.local/ns/{{ .Release.Namespace }}/sa/{{ template "kiali-server.fullname" . }}-auth-proxy
+          - cluster.local/ns/{{ .Release.Namespace }}/sa/{{ template "kiali-server.name" . }}-auth-proxy
 {{ end }}
   - from:
     - source:

--- a/resources/kiali/templates/kyma-additions/peerauthentication.yaml
+++ b/resources/kiali/templates/kyma-additions/peerauthentication.yaml
@@ -8,7 +8,7 @@ metadata:
 spec:
   selector:
     matchLabels:
-      app.kubernetes.io/instance: {{ template "kiali-server.fullname" . }}
+      {{- include "kiali-server.selectorLabels" . | nindent 6 }}
   mtls:
     mode: "UNSET"
   portLevelMtls:

--- a/resources/kiali/templates/kyma-additions/peerauthentication.yaml
+++ b/resources/kiali/templates/kyma-additions/peerauthentication.yaml
@@ -8,7 +8,7 @@ metadata:
 spec:
   selector:
     matchLabels:
-      app: {{ template "kiali-server.fullname" . }}
+      app.kubernetes.io/instance: {{ template "kiali-server.fullname" . }}
   mtls:
     mode: "UNSET"
   portLevelMtls:

--- a/resources/kiali/templates/kyma-additions/peerauthentication.yaml
+++ b/resources/kiali/templates/kyma-additions/peerauthentication.yaml
@@ -14,5 +14,5 @@ spec:
   portLevelMtls:
     9090:
       mode: STRICT
-    {{ .Values.kiali.spec.server.port }}:
+    {{ .Values.server.port }}:
       mode: STRICT

--- a/resources/kiali/templates/kyma-additions/peerauthentication.yaml
+++ b/resources/kiali/templates/kyma-additions/peerauthentication.yaml
@@ -1,7 +1,7 @@
 apiVersion: security.istio.io/v1beta1
 kind: PeerAuthentication
 metadata:
-  name: {{ template "kiali-server.fullname" . }}
+  name: {{ template "kiali-server.name" . }}
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "kiali-server.labels" . | nindent 4 }}

--- a/resources/kiali/templates/kyma-additions/servicemonitor.yaml
+++ b/resources/kiali/templates/kyma-additions/servicemonitor.yaml
@@ -1,7 +1,7 @@
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
-  name: {{ template "kiali-server.fullname" . }}
+  name: {{ template "kiali-server.name" . }}
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "kiali-server.labels" . | nindent 4 }}

--- a/resources/kiali/templates/kyma-additions/servicemonitor.yaml
+++ b/resources/kiali/templates/kyma-additions/servicemonitor.yaml
@@ -8,7 +8,7 @@ metadata:
 spec:
   selector:
     matchLabels:
-      app: {{ template "kiali-server.fullname" . }}
+      {{- include "kiali-server.selectorLabels" . | nindent 6 }}
   namespaceSelector:
     matchNames:
       - {{ .Release.Namespace | quote }}

--- a/resources/kiali/templates/kyma-additions/virtualservice.yaml
+++ b/resources/kiali/templates/kyma-additions/virtualservice.yaml
@@ -2,7 +2,7 @@
 apiVersion: networking.istio.io/v1alpha3
 kind: VirtualService
 metadata:
-  name: {{ template "kiali-server.fullname" . }}
+  name: {{ template "kiali-server.name" . }}
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "kiali-server.labels" . | nindent 4 }}
@@ -15,9 +15,9 @@ spec:
   - route:
     - destination:
         {{- if .Values.authProxy.enabled}}
-        host: {{ template "kiali-server.fullname" . }}-secured
+        host: {{ template "kiali-server.name" . }}-secured
         {{- else}}
-        host: {{ template "kiali-server.fullname" . }}-server
+        host: {{ template "kiali-server.fullname" . }}
         {{- end}}
         port:
           number: {{ .Values.server.port }}

--- a/resources/kiali/templates/kyma-additions/virtualservice.yaml
+++ b/resources/kiali/templates/kyma-additions/virtualservice.yaml
@@ -20,5 +20,5 @@ spec:
         host: {{ template "kiali-server.fullname" . }}-server
         {{- end}}
         port:
-          number: {{ .Values.kiali.spec.server.port }}
+          number: {{ .Values.server.port }}
 {{- end }}

--- a/resources/kiali/templates/role-controlplane.yaml
+++ b/resources/kiali/templates/role-controlplane.yaml
@@ -1,0 +1,30 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ include "kiali-server.fullname" . }}-controlplane
+  namespace: {{ include "kiali-server.istio_namespace" . }}
+  labels:
+    {{- include "kiali-server.labels" . | nindent 4 }}
+rules:
+{{- if .Values.kiali_feature_flags.clustering.enabled }}
+- apiGroups: [""]
+  resources:
+  - secrets
+  verbs:
+  - list
+{{- end }}
+{{- if .Values.kiali_feature_flags.certificates_information_indicators.enabled }}
+- apiGroups: [""]
+  resourceNames:
+  {{- range .Values.kiali_feature_flags.certificates_information_indicators.secrets }}
+  - {{ . }}
+  {{- end }}
+  resources:
+  - secrets
+  verbs:
+  - get
+  - list
+  - watch
+{{- end }}
+...

--- a/resources/kiali/templates/role-viewer.yaml
+++ b/resources/kiali/templates/role-viewer.yaml
@@ -1,10 +1,8 @@
-{{- /*
-  Taken from https://github.com/kiali/helm-charts/tree/master/kiali-server
-  */ -}}
+---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: {{ include "kiali-server.fullname" . }}-server-viewer
+  name: {{ include "kiali-server.fullname" . }}-viewer
   labels:
     {{- include "kiali-server.labels" . | nindent 4 }}
 rules:
@@ -88,3 +86,4 @@ rules:
   - tokenreviews
   verbs:
   - create
+...

--- a/resources/kiali/templates/role.yaml
+++ b/resources/kiali/templates/role.yaml
@@ -1,10 +1,8 @@
-{{- /*
-  Taken from https://github.com/kiali/helm-charts/tree/master/kiali-server
-  */ -}}
+---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: {{ include "kiali-server.fullname" . }}-server
+  name: {{ include "kiali-server.fullname" . }}
   labels:
     {{- include "kiali-server.labels" . | nindent 4 }}
 rules:
@@ -98,3 +96,4 @@ rules:
   - tokenreviews
   verbs:
   - create
+...

--- a/resources/kiali/templates/rolebinding-controlplane.yaml
+++ b/resources/kiali/templates/rolebinding-controlplane.yaml
@@ -1,18 +1,15 @@
 ---
 apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
+kind: RoleBinding
 metadata:
-  name: {{ include "kiali-server.fullname" . }}
+  name: {{ include "kiali-server.fullname" . }}-controlplane
+  namespace: {{ include "kiali-server.istio_namespace" . }}
   labels:
     {{- include "kiali-server.labels" . | nindent 4 }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  {{- if .Values.deployment.view_only_mode }}
-  name: {{ include "kiali-server.fullname" . }}-viewer
-  {{- else }}
-  name: {{ include "kiali-server.fullname" . }}
-  {{- end }}
+  kind: Role
+  name: {{ include "kiali-server.fullname" . }}-controlplane
 subjects:
 - kind: ServiceAccount
   name: {{ include "kiali-server.fullname" . }}

--- a/resources/kiali/templates/service.yaml
+++ b/resources/kiali/templates/service.yaml
@@ -1,10 +1,8 @@
-{{- /*
-  Taken from https://github.com/kiali/helm-charts/tree/master/kiali-server
-  */ -}}
+---
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ include "kiali-server.fullname" . }}-server
+  name: {{ include "kiali-server.fullname" . }}
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "kiali-server.labels" . | nindent 4 }}
@@ -12,20 +10,19 @@ metadata:
     {{- if .Capabilities.APIVersions.Has "route.openshift.io/v1" }}
     service.beta.openshift.io/serving-cert-secret-name: {{ include "kiali-server.fullname" . }}-cert-secret
     {{- end }}
-    {{- if and (not (empty .Values.kiali.spec.server.web_fqdn)) (not (empty .Values.kiali.spec.server.web_schema)) }}
-    {{- if empty .Values.kiali.spec.server.web_port }}
-    kiali.io/external-url: {{ .Values.kiali.spec.server.web_schema }}://{{ .Values.kiali.spec.server.web_fqdn }}{{ default "" .Values.kiali.spec.server.web_root }}
+    {{- if and (not (empty .Values.server.web_fqdn)) (not (empty .Values.server.web_schema)) }}
+    {{- if empty .Values.server.web_port }}
+    kiali.io/external-url: {{ .Values.server.web_schema }}://{{ .Values.server.web_fqdn }}{{ include "kiali-server.server.web_root" . }}
     {{- else }}
-    kiali.io/external-url: {{ .Values.kiali.spec.server.web_schema }}://{{ .Values.kiali.spec.server.web_fqdn }}:{{ .Values.kiali.spec.server.web_port }}{{(default "" .Values.kiali.spec.server.web_root) }}
+    kiali.io/external-url: {{ .Values.server.web_schema }}://{{ .Values.server.web_fqdn }}:{{ .Values.server.web_port }}{{ include "kiali-server.server.web_root" . }}
     {{- end }}
     {{- end }}
-
-    {{- if .Values.kiali.spec.deployment.service_annotations }}
-    {{- toYaml .Values.kiali.spec.deployment.service_annotations | nindent 4  }}
+    {{- if .Values.deployment.service_annotations }}
+    {{- toYaml .Values.deployment.service_annotations | nindent 4  }}
     {{- end }}
 spec:
-  {{- if .Values.kiali.spec.deployment.service_type }}
-  type: {{ .Values.kiali.spec.deployment.service_type }}
+  {{- if .Values.deployment.service_type }}
+  type: {{ .Values.deployment.service_type }}
   {{- end }}
   ports:
   {{- if (include "kiali-server.identity.cert_file" .) }}
@@ -34,14 +31,14 @@ spec:
   - name: http
   {{- end }}
     protocol: TCP
-    port: {{ .Values.kiali.spec.server.port }}
-  {{- if .Values.kiali.spec.server.metrics_enabled }}
+    port: {{ .Values.server.port }}
+  {{- if .Values.server.metrics_enabled }}
   - name: http-metrics
     protocol: TCP
-    port: {{ .Values.kiali.spec.server.metrics_port }}
+    port: {{ .Values.server.metrics_port }}
   {{- end }}
   selector:
     {{- include "kiali-server.selectorLabels" . | nindent 4 }}
-  {{- if .Values.kiali.spec.deployment.additional_service_yaml }}
-  {{- toYaml .Values.kiali.spec.deployment.additional_service_yaml | nindent 2  }}
+  {{- if .Values.deployment.additional_service_yaml }}
+  {{- toYaml .Values.deployment.additional_service_yaml | nindent 2  }}
   {{- end }}

--- a/resources/kiali/templates/serviceaccount.yaml
+++ b/resources/kiali/templates/serviceaccount.yaml
@@ -1,6 +1,4 @@
-{{- /*
-  Taken from https://github.com/kiali/helm-charts/tree/master/kiali-server
-  */ -}}
+---
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -8,3 +6,4 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "kiali-server.labels" . | nindent 4 }}
+...

--- a/resources/kiali/values.yaml
+++ b/resources/kiali/values.yaml
@@ -1,6 +1,3 @@
-nameOverride: "kiali"
-fullnameOverride: "kiali"
-
 global:
   domainName: "kyma.example.com"
   istio:
@@ -25,8 +22,10 @@ global:
     namespaceAdminGroup: runtimeNamespaceAdmin
   tracing:
     enabled: true
+
 virtualservice:
     enabled: true
+
 authProxy:
   enabled: true
   replicaCount: 1
@@ -59,964 +58,146 @@ authProxy:
       cpu: 10m
       memory: 5Mi
 
-kiali:
-  spec:
-    # Taken from https://github.com/kiali/kiali-operator/blob/master/deploy/kiali/kiali_cr.yaml
-    ###################################################################
-    # kiali_cr.yaml
-    #
-    # This is a fully documented Kiali custom resource yaml file.
-    # It can be used to tell the Kiali Operator to install Kiali.
-    #
-    # This is actually an empty Kiali CR, however, it provides
-    # documentation on all available settings.
-    # In each documented section, you will see a "---" marker;
-    # below that marker you will see the names of the settings along
-    # with their default values. If the setting is not defined by
-    # default, its name will be prefixed with "#".
-    ###################################################################
+# 'fullnameOverride' is deprecated. Use 'deployment.instance_name' instead.
+# This is only supported for backward compatibility and will be removed in a future version.
+# If 'fullnameOverride' is not "kiali" and 'deployment.instance_name' is "kiali",
+# then 'deployment.instance_name' will take the value of 'fullnameOverride' value.
+# Otherwise, 'fullnameOverride' is ignored and 'deployment.instance_name' is used.
+fullnameOverride: "kiali"
 
-    ##########
-    #  ---
-    #  additional_display_details:
-    #  - title: "API Documentation"
-    #    annotation: "kiali.io/api-spec"
-    #    icon_annotation: "kiali.io/api-type"
-    #
-    # A list of additional details that Kiali will look for in annotations and display, for every workload and service, in their respective details pages.
-    # It can typically be used to inject some CI metadata or documentation links into Kiali views.
-    # Each item in the list is an object with "annotation", "title" and "icon_annotation" fields to indicate which annotation Kiali needs to look for, and how it should be displayed.
-    # "icon_annotation" is optional and would display an icon next to the text.
-    # At the moment, the value of the icon annotation can only be one of "rest", "grpc" or "graphql"; otherwise, it is ignored.
-    # By default, these settings recognize API Documentation links via annotation "kiali.io/api-spec" and icon-annotation "kiali.io/api-type".
-    # For example, it would make Kiali recognize these annotations in a service or a workload definition (Deployment, StatefulSet, etc.) to display the appropriate link and text:
-    #    annotations:
-    #      kiali.io/api-spec: http://link/to/my/doc
-    #      kiali.io/api-type: rest
-    # Should you change this setting for your own custom annotations, keep in mind that it would override the current default.
-    # So you would have to copy the "API Documentation" setting as shown above if you want to preserve these links.
+# This is required for "openshift" auth strategy.
+# You have to know ahead of time what your Route URL will be because
+# right now the helm chart can't figure this out at runtime (it would
+# need to wait for the Kiali Route to be deployed and for OpenShift
+# to start it up). If someone knows how to update this helm chart to
+# do this, a PR would be welcome.
+kiali_route_url: ""
 
-    ##########
-    # Tag used to identify a particular instance/installation of the Kiali server.
-    # This is merely a human-readable string that will be used within Kiali to
-    # help a user identify the Kiali being used (e.g. in the Kiali UI title bar).
-    # See deployment.instance_name for the setting used to customize Kiali resource names that are created.
-    #  ---
-    #  installation_tag: ""
+#
+# Settings that mimic the Kiali CR which are placed in the ConfigMap.
+# Note that only those values used by the Helm Chart will be here.
+#
 
-    ##########
-    # The namespace where Istio is installed. If left empty, it is assumed to be the
-    # same namespace as where Kiali is installed (i.e. deployment.namespace).
-    #  ---
-    istio_namespace: "istio-system"
+istio_namespace: "istio-system" # default is where Kiali is installed
 
-    ##########
-    # The version of the Ansible playbook to execute in order to install that version of Kiali.
-    # It is rare you will want to set this - if you are thinking of setting this, know what you are doing first.
-    # If not specified, a default version of Kiali will be installed which will be the most recent release of Kiali.
-    # Refer to this file to see where these values are defined in the master branch:
-    # https://github.com/kiali/kiali-operator/tree/master/playbooks/default-supported-images.yml
-    #
-    # This version setting affects the defaults of the deployment.image_name and
-    # deployment.image_version settings. See the comments for those settings
-    # below for additional details. But in short, this version setting will
-    # dictate which version of the Kiali image will be deployed by default.
-    # Note that if you explicitly set deployment.image_name and/or
-    # deployment.image_version you are responsible for ensuring those settings
-    # are compatible with this setting (i.e. the Kiali image must be compatible
-    # with the rest of the configuration and resources the operator will install).
-    #
-    # See the Kiali documentation to determine which of these versions support
-    # the version of Istio you are installing Kiali with.
-    #
-    #  ---
-    #  version: "default"
+auth:
+  openid: {}
+  openshift: {}
+  strategy: "anonymous"
 
-    ##########
-    #  ---
-    #  api:
-    #
-    # Allows for controlling what namespaces/projects are returned by Kiali.
-    #
-    # 'exclude' is optional and takes a list of namespaces to be excluded from the list
-    # of namespaces provided by the API and UI. Regex is supported. This does not affect
-    # explicit namespace access.
-    #
-    # 'label_selector' is optional and takes a string value of a Kubernetes label selector
-    # (e.g. "myLabel=myValue") which is used when fetching the list of available namespaces.
-    # This does not affect explicit namespace access.
-    # Note that if you do not set this but deployment.accessible_namespaces does not have the
-    # special "all namespaces" entry of "**" then this label_selector will be set
-    # to a default value of "kiali.io/[<deployment.instance_name>.]member-of=<deployment.namespace>"
-    # where [<deployment.instance_name>.] is the instance name assigned to the Kiali installation
-    # if it is not the default 'kiali' (otherwise, this is omitted) and <deployment.namespace>
-    # is the namespace where Kiali is to be installed.
-    # If deployment.accessible_namespaces does not have the special value of "**"
-    # then the Kiali operator will add a new label to all accessible namespaces - that new
-    # label will be this label_selector.
-    #
-    #    ---
-    #    namespaces:
-    #      exclude:
-    #      - "istio-operator"
-    #      - "kube-.*"
-    #      - "openshift.*"
-    #      - "ibm.*"
-    #      - "kiali-operator"
-    #      #label_selector:
+deployment:
+  # This only limits what Kiali will attempt to see, but Kiali Service Account has permissions to see everything.
+  # For more control over what the Kial Service Account can see, use the Kiali Operator
+  accessible_namespaces:
+  - "**"
+  additional_service_yaml: {}
+  affinity:
+    node: {}
+    pod: {}
+    pod_anti: {}
+  custom_secrets: []
+  host_aliases: []
+  hpa:
+    api_version: "autoscaling/v2beta2"
+    spec: {}
+  image_pull_policy: "Always"
+  image_pull_secrets: []
+  ingress:
+    additional_labels: {}
+    class_name: "nginx"
+    #enabled:
+    override_yaml:
+      metadata: {}
+  instance_name: "kiali"
+  logger:
+    log_format: "text"
+    log_level: "info"
+    time_field_format: "2006-01-02T15:04:05Z07:00"
+    sampler_rate: "1"
+  node_selector: {}
+  pod_annotations:
+    "sidecar.istio.io/inject": "true"
+  pod_labels: {}
+  priority_class_name: ""
+  replicas: 1
+  resources:
+    limits:
+      cpu: 100m
+      memory: 140Mi
+    requests:
+      cpu: 10m
+      memory: 20Mi
+  secret_name: "kiali"
+  # Containers securityContext, not defined in upstream chart
+  securityContext:
+    allowPrivilegeEscalation: false
+    privileged: false
+    readOnlyRootFilesystem: true
+    runAsNonRoot: true
+  service_annotations: {}
+  service_type: ""
+  tolerations: []
+  version_label: ${HELM_IMAGE_TAG}
+  view_only_mode: true
 
-    ##########
-    #  ---
-    auth:
-    #
-    # Determines what authentication strategy to use when users log into Kiali.
-    # Options are "anonymous", "token", "openshift", "openid", "header".
-    # Choose "anonymous" to allow full access to Kiali without requiring any credentials.
-    # Choose "token" to allow access to Kiali using service account tokens, which controls
-    #  access based on RBAC roles assigned to the service account.
-    # Choose "openshift" to use the OpenShift OAuth login which controls access based on
-    #  the individual's  RBAC roles in OpenShift. Not valid for non-OpenShift environments.
-    # Choose "header" when Kiali is running behind a reverse proxy that will inject an
-    #  Authorization header and potentially impersonation headers.
-    # Choose "openid" to enable OpenID connect based authentication. Your cluster is required to
-    #  be configured to accept the tokens issued by your IdP. There are additional required
-    #  configurations for this strategy. See below for the additional OpenID configuration section.
-    # When empty, its value will default to "openshift" on OpenShift and "token" on Kubernetes.
-    #    ---
-      strategy: "anonymous"
-    #
-    # To learn how to configure the OpenId authentication strategy, read the documentation
-    # at the website on https://kiali.io/documentation/latest/configuration/authentication/openid/
-    #
-    #    ---
-    #    openid:
-    #      additional_request_params: {}
-    #      api_proxy: ""
-    #      api_proxy_ca_data: ""
-    #      api_token: "id_token"
-    #      authentication_timeout: 300
-    #      authorization_endpoint: ""
-    #      client_id: ""
-    #      disable_rbac: false
-    #      http_proxy: ""
-    #      https_proxy: ""
-    #      insecure_skip_verify_tls: false
-    #      issuer_uri: ""
-    #      scopes: ["openid", "profile", "email"]
-    #      username_claim: "sub"
-    #
-    # The Route resource name and OAuthClient resource name will have this value as its prefix.
-    # This value normally should never change. The installer will ensure this value is set correctly.
-    #    ---
-      openshift: {}
-    #      client_id_prefix: kiali
+external_services:
+  custom_dashboards:
+    enabled: false
 
-    ##########
-    # A list of user-defined custom monitoring dashboards that you can use to generate metrics charts for your applications.
-    # The server has some built-in dashboards; if you define a custom dashboard here with the same name as a built-in
-    # dashboard, your custom dashboard takes precedence and will overwrite the built-in dashboard.
-    # You can disable one or more of the built-in dashboards by simply defining an empty dashboard.
-    #
-    # An example of an additional user-defined dashboard:
-    #   - name: myapp
-    #     title: My App Metrics
-    #     items:
-    #     - chart
-    #         name: "Thread Count"
-    #         spans: 4
-    #         metricName: "thread-count"
-    #         dataType: "raw"
-    #
-    # An example of disabling a built-in dashboard:
-    #   - name: envoy
-    #
-    # See the Kiali documentation for more details on custom monitoring dashboards.
-    #  ---
-    #  custom_dashboards: []
+  grafana:
+    enabled: false
+    in_cluster_url: "http://monitoring-grafana.kyma-system:80"
+    url: "https://grafana.{{ .Values.global.domainName }}"
 
-    ##########
-    #  ---
-    deployment:
-    #
-    # A list of namespaces Kiali is to be given access to.
-    # These namespaces have service mesh components that are to be observed by Kiali.
-    # You can provide names using regex expressions matched against all namespaces the operator can see.
-    # The default makes all namespaces accessible except for some internal namespaces that typically should be ignored.
-    # NOTE! If this has an entry with the special value of "**" (two asterisks), that will denote you want
-    # Kiali to be given access to all namespaces via a single cluster role (if using this special value of "**",
-    # you are required to have already granted the operator permissions to create cluster roles and cluster role bindings).
-    #    ---
-      accessible_namespaces:
-      - "**"
-    #
-    # Additional custom yaml to add to the service definition. This is used mainly to customize the service type.
-    # For example, if the deployment.service_type is set to "LoadBalancer" and you want to set the loadBalancerIP,
-    # you can do so here with: additional_service_yaml: { "loadBalancerIP": "78.11.24.19" }.
-    # Another example would be if the deployment.service_type is set to "ExternalName" you will need to configure
-    # the name via: additional_service_yaml: { "externalName": "my.kiali.example.com" }.
-    # A final example would be if external IPs need to be set: additional_service_yaml: { "externalIPs": ["80.11.12.10"] }
-    #    ---
-    #    #additional_service_yaml:
-    #
-    # Affinity definitions that are to be used to define the nodes where the Kiali pod should be contrained.
-    # See the Kubernetes documentation on Assigning Pods to Nodes for the proper syntax for these three
-    # different affinity types.
-    #    ---
-      affinity:
-        node: {}
-        pod: {}
-        pod_anti: {}
-    #
-    # Determines what (if any) HorizontalPodAutoscaler should be created to autoscale the Kiali pod.
-    # A typical way to configure HPA for Kiali is:
-    #
-    #    hpa:
-    #      spec:
-    #        maxReplicas: 2
-    #        minReplicas: 1
-    #        targetCPUUtilizationPercentage: 80
-    #
-    # If "spec" is left empty, no HPA resource will be created. Otherwise, the "spec" yaml specified
-    # here will be placed in the created HPA resource's spec section.
-    # NOTE: do not specify the "scaleTargetRef" section in "spec"; the Kiali Operator will populate that for you.
-    # You can optionally specify a specific HPA api_version in case there is some HPA feature
-    # you want to use that is only supported in that specific version.
-    #    ---
-      hpa:
-        api_version: "autoscaling/v2beta2"
-        spec: {}
-    #
-    #.   ATTENTION: This setting will not be effective. It has been replaced with the global.images.kiali setting.
-    # Determines which Kiali image to download and install.
-    # If you set this to a specific name (i.e. you do not leave it as the default empty string),
-    # you must make sure that image is supported by the operator.
-    # If empty, the operator will use a known supported image name based on which "version" was defined.
-    # Note that, as a security measure, a cluster admin may have configured the Kiali operator to
-    # ignore this setting. A cluster admin may do this to ensure the Kiali operator only installs
-    # a single, specific Kiali version, thus this setting may have no effect depending on how the
-    # operator itself was configured.
-    #    ---
-    #    image_name: ""
-    #
-    # The Kubernetes pull policy for the Kiali deployment.
-    # This is overridden to be "Always" if image_version is set to "latest".
-    #    ---
-    #    image_pull_policy: "IfNotPresent"
-    #
-    # The names of the secrets to be used when container images are to be pulled.
-    #    ---
-    #    image_pull_secrets: []
-    #
-    #.   ATTENTION: This setting will not be effective. It has been replaced with the global.images.kiali setting.
-    # Determines which version of Kiali to install.
-    # Choose "lastrelease" to use the last Kiali release.
-    # Choose "latest" to use the latest image (which may or may not be a released version of Kiali).
-    # Choose "operator_version" to use the image whose version is the same as the operator version.
-    # Otherwise, you can set this to any valid Kiali version (such as "v1.0").
-    # Note that if this is set to "latest" then the image_pull_policy will be "Always".
-    # If you set this to a specific version (i.e. you do not leave it as the default empty string),
-    # you must make sure that image is supported by the operator.
-    # If empty, the operator will use a known supported image version based on which "version" was defined.
-    # Note that, as a security measure, a cluster admin may have configured the Kiali operator to
-    # ignore this setting. A cluster admin may do this to ensure the Kiali operator only installs
-    # a single, specific Kiali version, thus this setting may have no effect depending on how the
-    # operator itself was configured.
-    #    ---
-    #    image_version: ""
-    #
-    # Determines if the Kiali endpoint should be exposed externally.
-    # If true, an Ingress will be created if on Kubernetes or a Route if on OpenShift.
-    #    ---
-    #    ingress_enabled: true
-    #
-    # The instance name of this Kiali installation. This instance name will be the prefix
-    # prepended to the names of all Kiali resources created by the operator and will be used
-    # to label those resources as belonging to this Kiali installation instance.
-    # You cannot change this instance name after a Kiali CR is created. If you attempt
-    # to change it, the operator will abort with an error. If you want to change it,
-    # you must first delete the original Kiali CR and create a new one.
-    # Note that this does not affect the name of the auto-generated signing key secret. If
-    # you do not supply a signing key, the operator will create one for you in a secret,
-    # but that secret will always be named "kiali-signing-key" and shared across all
-    # Kiali instances in the same deployment namespace. If you want a different
-    # signing key secret, you are free to create your own and tell the operator about it via
-    # the login_token.signing_key setting. See the docs on that setting for more details.
-    # Note also that if you are setting this value, you may also want to change
-    # the installation_tag setting, but this is not required.
-    #    ---
-      instance_name: "kiali"
-    #
-    # Determines the logger configuration.
-    # log_format supports text and json.
-    # log_level supports trace, debug, info, warn, error, fatal.
-    # time_field_format supports a golang time format (https://golang.org/pkg/time/)
-    # sampler_rate defines a basic log sampler setting as an integer. With this setting every sampler_rate-th
-    #    message will be logged. By default, every message is logged.
-    #    ---
-      logger:
-        log_level: info
-        log_format: text
-        sampler_rate: "1"
-        time_field_format: "2006-01-02T15:04:05Z07:00"
-    #
-    # The namespace into which Kiali is to be installed. If this is empty or not defined,
-    # the default will be the namespace where the Kiali CR is located.
-    #    ---
-    #    namespace: ""
-    #
-    # A set of node labels that dictate onto which node the Kiali pod will be deployed.
-    #    ---
-    #    node_selector: {}
-    #
-    # Because an ingress into a cluster can vary wildly in its desired configuration,
-    # this setting provides a way to override complete portions of the ingress resource
-    # configuration (Ingress on Kubernetes and Route on OpenShift). It is up to the user
-    # to ensure this override YAML configuration is valid and supports the cluster environment
-    # since the operator will blindly copy this custom configuration into the resource it
-    # creates.
-    # This setting is not used if deployment.ingress_enabled is set to 'false'.
-    # Note that only 'metadata.annotations' and 'spec' is valid and only they will
-    # be used to override those same sections in the created resource. You can define
-    # either one or both.
-    # Example:
-    #   override_ingress_yaml:
-    #     metadata:
-    #       annotations:
-    #         nginx.ingress.kubernetes.io/secure-backends: "true"
-    #         nginx.ingress.kubernetes.io/backend-protocol: "HTTPS"
-    #     spec:
-    #       rules:
-    #       - http:
-    #           paths:
-    #           - path: /kiali
-    #             backend:
-    #               serviceName: kiali
-    #               servicePort: 20001
-    #    ---
-    #    #override_ingress_yaml:
-    #
-    # Custom annotations to be created on the Kiali pod.
-    #    ---
-      pod_annotations:
-        "sidecar.istio.io/inject": "true"
-    #
-    # Custom labels to be created on the Kiali pod.
-    #    ---
-    #    pod_labels: {}
-    #
-    # The priorityClassName used to assign the priority of the Kiali pod.
-    #    ---
-    #    priority_class_name: ""
-    #
-    # The replica count for the Kiail deployment.
-    #    ---
-    #    replicas: 1
-    #
-    # Defines compute resources that are to be given to the Kiali pod's container.
-    # The value is a dict as defined by Kubernetes. See the Kubernetes documentation
-    # https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container
-    #    ---
-      resources:
-        limits:
-          cpu: 100m
-          memory: 140Mi
-        requests:
-          cpu: 10m
-          memory: 20Mi
-    #
-    # The name of a secret used by the Kiali.
-    # This secret is optionally used when configuring the OpenID authentication strategy.
-    # Consult the OpenID docs for more information:
-    #   https://kiali.io/documentation/latest/configuration/authentication/openid/
-    #    ---
-      secret_name: "kiali"
-    #
-    # Custom annotations to be created on the Kiali Service resource.
-    #    ---
-    #    service_annotations: {}
-    #
-    # The Kiali service type. Kubernetes determines what values are valid.
-    # Common values are "NodePort", "ClusterIP", and "LoadBalancer".
-    #    ---
-    #    #service_type:
-    #
-    # A list of tolerations which declare which node taints Kiali can tolerate.
-    # See the Kubernetes documentation on Taints and Tolerations for more details.
-    #    ---
-    #    tolerations: []
-    #
-    # DEPRECATED - use the logger.log_level setting.
-    # Determines which priority levels of log messages Kiali will output.
-    # Typical values are "3" for INFO and higher priority, "4" for DEBUG and higher priority.
-    #    ---
-    #    verbose_mode: "3"
-    #
-    # Kiali resources will be assigned a "version" label when they are deployed.
-    # This determines what value those "version" labels will have.
-    # When empty, its default will be determined as follows:
-    #   If image_version is "latest", version_label will be fixed to "master".
-    #   If image_version is "lastrelease", version_label will be fixed to
-    #   the last Kiali release version string.
-    #   If the image_version is anything else, version_label will be that value, too.
-    #    ---
-    #    version_label: ""
-    #
-    # When true, Kiali will be in "view only" mode, allowing the user to view and retrieve
-    # management and monitoring data for the service mesh, but not allow the user to
-    # modify the service mesh.
-    #    ---
-      view_only_mode: true
+  istio:
+    enabled: true
+    root_namespace: ""
+    component_status:
+      components:
+      - app_label: istiod
+        is_core: true
+        is_proxy: false
+      - app_label: istio-ingressgateway
+        is_core: true
+        is_proxy: true
 
-    ##########
-    #  ---
-    #  extensions:
-    #
-    # Kiali enabled integration with Iter8 project.
-    # If this extension is enabled, Kiali will communicate with Iter8 controller allowing to manage Experiments and review results.
-    # Additional documentation https://iter8.tools/
-    #    ---
-    #    iter_8:
-    #
-    # Flag to indicate if iter8 extension is enabled in Kiali
-    #      ---
-    #      enabled: false
+  prometheus:
+    component_status:
+      namespace: "kyma-system"
+      # will search for deployments only but prometheus is a statefuleset, so using label of the operator instead, see https://github.com/kiali/kiali/blob/755a5f59a2e402b6c7bc0aa934d70715eb6c80c0/business/istio_status.go#L78
+      app_label: "monitoring-operator"
+      is_core: true
+    url: "http://monitoring-prometheus.kyma-system:9090"
 
-    ##########
-    #  ---
-    external_services:
-    #
-    # Note about sensitive values in the external_services "auth" sections:
-    # Some external services configured below support an "auth" sub-section in order to tell Kiali how it should
-    # authenticate with the external services. Credentials used to authenticate Kiali to those external services can
-    # be defined in the "auth.password" and "auth.token" values within the "auth" sub-section.
-    # Because these are sensitive values, you may not want to declare the actual credentials here in the Kiali CR. In
-    # this case, you may store the actual password or token string in a Kubernetes secret. If you do, you need to
-    # set the "auth.password" or "auth.token" to a value in the format "secret:<secretName>:<secretKey>" where
-    # "<secretName>" is the name of the secret object that Kiali can access, and <secretKey> is the name of the key
-    # within the named secret that contains the actual password or token string. For example, if Grafana requires a
-    # password, you can store that password in a secret named "myGrafanaCredentials" in a key named "myGrafanaPw".
-    # In this case, you would set "external_services.grafana.auth.password" to "secret:myGrafanaCredentials:myGrafanaPw".
-    #
-    # **Custom-dashboards settings:
-    # discovery_auto_threshold: Threshold of the number of pods, for a given Application or Workload, above which dashboards discovery will be skipped
-    #   This setting only takes effect when discovery_enabled is set to 'auto'.
-    # discovery_enabled: Enable, disable or set 'auto' mode to the dashboards discovery process. If set to true, Kiali
-    #   will always try to discover dashboards based on metrics. Note that it can generate performance penalties while
-    #   discovering dashboards for workloads having many pods (thus many metrics).
-    #   When set to 'auto', Kiali will skip dashboards discovery for workloads with more than a configured threshold of pods
-    #   (see 'discovery_auto_threshold'). When discovery is disabled or auto/skipped, it is still possible to tie workloads
-    #   with dashboards through annotations on pods (refer to the doc https://kiali.io/documentation/latest/runtimes-monitoring/#pods-annotations)
-    #   Allowed values: true, false, auto.
-    # enabled: Enable or disable custom dashboards, including the dashboards discovery process. Default: true.
-    # is_core: Used in the Components health feature. When true, the unhealthy scenarios will be raised as errors. Otherwise, they will be raised as a warning.
-    # namespace_label: Prometheus label name used for identifying namespaces in metrics for custom dashboards.
-    #   Default is "kubernetes_namespace". It is quite common to use just "namespace" as well, depending on your Prometheus configuration.
-    # prometheus: Please check the section below about Prometheus-specific settings: they are identical. The Prometheus
-    #   configuration defined here is dedicated to fetching custom dashboards, hence allowing to use a different instance
-    #   of Prometheus. If omitted, the same Prometheus as for Istio metrics will be reused for custom dashboards.
-    #    ---
-    #    custom_dashboards:
-    #      discovery_auto_threshold: 10
-    #      discovery_enabled: auto
-    #      enabled: true
-    #      is_core: false
-    #      namespace_label: "kubernetes_namespace"
-    #      prometheus:
-    #        auth:
-    #          ca_file: ""
-    #          insecure_skip_verify: false
-    #          password: ""
-    #          token: ""
-    #          type: "none"
-    #          use_kiali_token: false
-    #          username: ""
-    #        health_check_url: ""
-    #        url: ""
-    #
-    # **Grafana-specific settings:
-    # auth: authentication settings to connect to Grafana:
-    #   ca_file: The certificate authority file to use when accessing Grafana using https. An empty string means no extra
-    #       certificate authority file is used. Default is an empty string.
-    #   insecure_skip_verify: Set true to skip verifying certificate validity when Kiali contacts Grafana over https.
-    #   password: Password to be used when making requests to Grafana, for basic authentication. User only requires viewer permissions. May refer to a secret - see note above.
-    #   token: Token / API key to access Grafana, for token-based authentication. It only requires viewer permissions. May refer to a secret - see note above.
-    #   type: The type of authentication to use when contacting the server from the Kiali backend. Use "bearer" to send the
-    #       token to the Grafana server. Use "basic" to connect with username and password credentials. Use "none" to not use any authentication.
-    #       Default is "none"
-    #   use_kiali_token: When true and if auth.type is "bearer", the same OAuth token used for authentication in Kiali will be used for the API calls to Grafana,
-    #       and auth.token config is ignored then.
-    #   username: Username to be used when making requests to Grafana, for basic authentication. User only requires viewer permissions.
-    # dashboards: A list of Grafana dashboards that Kiali can link to. Each item contains:
-    #   name: The name of the dashboard in Grafana
-    #   variables:
-    #     app: The name of a variable that holds the app name, if used in that dashboard (else it must be omitted)
-    #     namespace: The name of a variable that holds the namespace, if used in that dashboard (else it must be omitted)
-    #     service: The name of a variable that holds the service name, if used in that dashboard (else it must be omitted)
-    #     workload: The name of a variable that holds the workload name, if used in that dashboard (else it must be omitted)
-    # enabled: When true, Grafana support will be enabled in Kiali.
-    # health_check_url: Used in the Components health feature. This is the url which kiali will ping to determine whether the component is reachable or not. It defaults to `in_cluster_url` when not provided.
-    # in_cluster_url: Set URL for in-cluster access. Example: "http://grafana.istio-system:3000". This URL can contain query parameters if needed, such as "?orgId=1". If not defined, it will default to "http://grafana.<istio_namespace>:3000".
-    # is_core: Used in the Components health feature. When true, the unhealthy scenarios will be raised as errors. Otherwise, they will be raised as a warning.
-    # url: The URL that Kiali uses when integrating with Grafana. This URL must be accessible to clients external to
-    #      the cluster in order for the integration to work properly. If empty, an attempt to auto-discover it is made.
-    #      This URL can contain query parameters if needed, such as "?orgId=1".
-    #    ---
-      grafana:
-    #      auth:
-    #        ca_file: ""
-    #        component_status:
-    #          app_label: "grafana"
-    #          is_core: false
-    #        insecure_skip_verify: false
-    #        password: ""
-    #        token: ""
-    #        type: "none"
-    #        use_kiali_token: false
-    #        username: ""
-    #      dashboards:
-    #      - name: "Istio Service Dashboard"
-    #        variables:
-    #          namespace: "var-namespace"
-    #          service: "var-service"
-    #      - name: "Istio Workload Dashboard"
-    #        variables:
-    #          namespace: "var-namespace"
-    #          workload: "var-workload"
-    #      - name: "Istio Mesh Dashboard"
-    #      - name: "Istio Control Plane Dashboard"
-    #      - name: "Istio Performance Dashboard"
-    #      - name: "Istio Wasm Extension Dashboard"
-        enabled: false
-    #      health_check_url: ""
-        in_cluster_url: "http://monitoring-grafana.kyma-system:80"
-    #      is_core: false
-        url: "https://grafana.{{ .Values.global.domainName }}"
-    #
-    # **Istio-specific settings:
-    # component_status:
-    #   enabled: Enable/Disable of istio component status into masthead indicator. It defaults to true.
-    #   components: A list of components that Kiali will check its statuses.
-    #     app_label: Istio component pod app label.
-    #     is_core: Whether the component is core for your deployment.
-    #     is_proxy: Whether the component is a native Envoy proxy.
-    #     namespace: The namespace where the component is installed in. It defaults to the 'istio_namespace' setting.
-    #                Note that the Istio documentation suggests you install the ingress and egress to different namespaces,
-    #                so you most likely will want to explicitly set this namespace value for the ingress and egress components.
-    #                For example, something like:
-    #                - app_label: istio-ingressgateway
-    #                  is_core:   false
-    #                  is_proxy:  true
-    #                  namespace: <the namespace where your ingress is deployed>
-    # config_map_name: The name of the istio control plane config map. It defaults to `istio`.
-    # envoy_admin_local_port: The port which kiali will open to fetch envoy config data information.
-    # istio_canary_revision: These values are used in Canary upgrade/downgrade functionality when istio_upgrade_action is true.
-    #   current: The current installed Istio revision.
-    #   upgrade: The installed Istio Canary revision to upgrade to.
-    # istio_identity_domain: The annotation used by Istio to identify domains.
-    # istio_injection_annotation: The annotation used by Istio to automatically inject a specific workload
-    # istio_sidecar_annotation: The pod annotation used by Istio to identify the sidecar.
-    # istio_sidecar_injector_config_map_name: The name of the istio-sidecar-injector config map.
-    # istiod_deployment_name: The name of the istiod deployment.
-    # url_service_version: The Istio service used to determine the Istio version. If empty, assumes the URL for the well-known Istio version endpoint.
-    #    ---
-      istio:
-        component_status:
-          components:
-          - app_label: istiod
-            is_core: true
-            is_proxy: false
-          - app_label: istio-ingressgateway
-            is_core: true
-            is_proxy: true
-    #        - app_label: istio-egressgateway
-    #          is_core: false
-    #          is_proxy: true
-          enabled: true
-    #      config_map_name: "istio"
-    #      envoy_admin_local_port: 15000
-    #      #istio_canary_revision:
-    #        #current:
-    #        #upgrade:
-    #      istio_identity_domain: "svc.cluster.local"
-    #      istio_injection_annotation: "sidecar.istio.io/inject"
-    #      istio_sidecar_annotation: "sidecar.istio.io/status"
-    #      istio_sidecar_injector_config_map_name: "istio-sidecar-injector"
-    #      istiod_deployment_name: "istiod"
-    #      url_service_version: ""
-    #
-    #
-    # **Prometheus-specific settings:
-    # auth: authentication settings to connect to Prometheus:
-    #   ca_file: The certificate authority file to use when accessing Prometheus using https. An empty string means no extra
-    #       certificate authority file is used. Default is an empty string.
-    #   insecure_skip_verify: Set true to skip verifying certificate validity when Kiali contacts Prometheus over https.
-    #   password: Password to be used when making requests to Prometheus, for basic authentication. May refer to a secret - see note above.
-    #   token: Token / API key to access Prometheus, for token-based authentication. May refer to a secret - see note above.
-    #   type: The type of authentication to use when contacting the server from the Kiali backend. Use "bearer" to send the
-    #       token to the Prometheus server. Use "basic" to connect with username and password credentials. Use "none" to not use any authentication.
-    #       Default is "none"
-    #   use_kiali_token: When true and if auth.type is "bearer", Kiali Service Account token will be used for the API calls to Prometheus,
-    #       and auth.token config is ignored then.
-    #   username: Username to be used when making requests to Prometheus, for basic authentication.
-    # cache_duration: Prometheus caching duration expressed in seconds
-    # cache_enabled: Enable/disable Prometheus caching used for Health services
-    # cache_expiration: Prometheus caching expiration expressed in seconds
-    # health_check_url: Used in the Components health feature. This is the url which kiali will ping to determine whether the component is reachable or not. It defaults to `url` when not provided.
-    # is_core: Used in the Components health feature. When true, the unhealthy scenarios will be raised as errors. Otherwise, they will be raised as a warning.
-    # url: The URL used to query the Prometheus Server. This URL must be accessible from the Kiali pod.
-    #      If empty, assumes it is in the istio namespace at the URL "http://prometheus.<istio_namespace>:9090"
-    #    ---
-      prometheus:
-    #      auth:
-    #        ca_file: ""
-    #        insecure_skip_verify: false
-    #        password: ""
-    #        token: ""
-    #        type: "none"
-    #        use_kiali_token: false
-    #        username: ""
-    #      cache_duration: 10
-    #      cache_enabled: true
-    #      cache_expiration: 300
-    #      health_check_url: ""
-        component_status:
-          namespace: "kyma-system"
-          # will search for deployments only but prometheus is a statefuleset, so using label of the operator instead, see https://github.com/kiali/kiali/blob/755a5f59a2e402b6c7bc0aa934d70715eb6c80c0/business/istio_status.go#L78
-          app_label: "monitoring-operator"
-          is_core: true
-        url: "http://monitoring-prometheus.kyma-system:9090"
-    #
-    # **Tracing-specific settings:
-    #  - Right now we only support Jaeger
-    # auth: authentication settings to connect to Jaeger:
-    #   ca_file: The certificate authority file to use when accessing Jaeger using https. An empty string means no extra
-    #       certificate authority file is used. Default is an empty string.
-    #   insecure_skip_verify: Set true to skip verifying certificate validity when Kiali contacts Jaeger over https.
-    #   password: Password to be used when making requests to Jaeger, for basic authentication. User only requires viewer permissions. May refer to a secret - see note above.
-    #   token: Token / API key to access Jaeger, for token-based authentication. It only requires viewer permissions. May refer to a secret - see note above.
-    #   type: The type of authentication to use when contacting the server from the Kiali backend. Use "bearer" to send the
-    #       token to Jaeger Query. Use "basic" to connect with username and password credentials. Use "none" to not use any authentication.
-    #       Default is "none"
-    #   use_kiali_token: When true and if auth.type is "bearer", the same OAuth token used for authentication in Kiali will be used for the API calls to Jaeger Query,
-    #       and auth.token config is ignored then.
-    #   username: Username to be used when making requests to Jaeger, for basic authentication. User only requires viewer permissions.
-    # enabled: When true, connections to Jaeger are enabled. "in_cluster_url" and/or "url" need to be provided.
-    # in_cluster_url: Set URL for in-cluster access, which enables further integration between Kiali and Jaeger.
-    #      When not provided, Kiali will only show external links using the "url" config.
-    #      Note: Jaeger v1.20+ has separated ports for GRPC(16685) and HTTP(16686) requests. Make sure you use the appropriate port according to the "use_grpc" value.
-    #      Example: "http://tracing.istio-system:16685".
-    # is_core: Used in the Components health feature. When true, the unhealthy scenarios will be raised as errors. Otherwise, they will be raised as a warning.
-    # namespace_selector: Kiali use this boolean to look traces with namespace selector : service.namespace. Default: true
-    # url: External URL that will be used to generate links to Jaeger. It must be accessible to clients external to
-    #      the cluster (e.g: browser) in order to generate valid links.
-    #      If tracing service is deployed in a QUERY_BASE_PATH set this in the url like https://<hostname>/<QUERY_BASE_PATH> . EX: https://tracing-service:8080/jaeger
-    # use_grpc: Set "true" to enable GRPC connection between Kiali and Jaeger, in order to speed up the queries. In some setups you might not be able to use
-    #      GRPC (e.g. if Jaeger is behind some reverse proxy that doesn't support it).
-    #      If not specified, it will be false if deployed within a Maistra/OSSM+OpenShift environment, true otherwise.
-    # whitelist_istio_system: Set whitelist services in istio-system to check their traces
-    #    ---
-      tracing:
-    #      auth:
-    #        ca_file: ""
-    #        insecure_skip_verify: false
-    #        password: ""
-    #        token: ""
-    #        type: "none"
-    #        use_kiali_token: false
-    #        username: ""
-        component_status:
-          namespace: kyma-system
-          app_label: "jaeger"
-          is_core: false
-    #      'enabled' will be overwritten with .Values.global.tracing.enabled in the template
-    #      enabled: true
-    #      health_check_url: ""
-        in_cluster_url: "http://tracing-jaeger-query.kyma-system:16686"
-    #      namespace_selector: true
-        url: "https://jaeger.{{ .Values.global.domainName }}"
-        use_grpc: false
-    #      whitelist_istio_system: ["jaeger-query", "istio-ingressgateway"]
+  tracing:
+    # 'enabled' will be overwritten with .Values.global.tracing.enabled in the template
+    #  enabled: true
+    #  health_check_url: ""
+    component_status:
+      namespace: kyma-system
+      app_label: "jaeger"
+      is_core: false
+    in_cluster_url: "http://tracing-jaeger-query.kyma-system:16686"
+    url: "https://jaeger.{{ .Values.global.domainName }}"
+    use_grpc: false
 
-    ##########
-    #  ---
-    #  health_config:
-    #
-    # rate: A list of health configurations that Kiali uses to determine what is (and is not) healthy nodes. Each item contains:
-    #   namespace: The name of the namespace that this configuration applies to. This is a regular expression.
-    #   kind: The type of resource that this configuration applies to. This is a regular expression.
-    #   name: The name of a resource that this configuration applies to. This is a regular expression.
-    #   tolerance: A list of tolerances for this configuration. Each item contains:
-    #     protocol: The protocol that applies for this tolerance (e.g. grpc or http). This is a regular expression.
-    #     direction: The direction that applies for this tolerance (e.g. inbound or outbound). This is a regular expression.
-    #     code: The status code that applies for this tolerance. This is a regular expression.
-    #     degraded: Health will be considered degraded when the telemetry reaches this value (specified as a %).
-    #     failure: A failure status will be shown when the telemetry reaches this value (specified as a %).
-    #    ---
-    #    rate: []
+identity: {}
+  #cert_file:
+  #private_key_file:
 
-    ##########
-    #  ---
-    identity: {}
-    #
-    # Certificate file used to identify the file server. If set, you must go over https to access Kiali.
-    # The operator will set these if it deploys Kiali behind https.
-    # When left undefined, the operator will attempt to generate a cluster-specific cert file that provides
-    # https by default (today, this auto-generation of a cluster-specific cert is only supported on OpenShift).
-    # When set to an empty string, https will be disabled.
-    #    ---
-    #    #cert_file:
-    #
-    # Private key file used to identify the server. If set, you must go over https to access Kiali.
-    # When left undefined, the operator will attempt to generate a cluster-specific private key file that provide
-    # https by default (today, this auto-generation of a cluster-specific private key is only supported on OpenShift).
-    # When set to an empty string, https will be disabled.
-    #    ---
-    #    #private_key_file:
+kiali_feature_flags:
+  certificates_information_indicators:
+   enabled: true
+   secrets:
+   - cacerts
+   - istio-ca-secret
+  clustering:
+    enabled: true
+login_token:
+  signing_key: ""
 
-    ##########
-    #  ---
-    #  istio_labels:
-    #
-    # This section defines what labels Istio is using to indicate apps and versions.
-    # Typical values are: ("app" and "version") or ("app.kubernetes.io/name" and "app.kubernetes.io/version").
-    # Kiali needs to know what labels Istio is using to be in sync with what Istio considers applications.
-    # It adds the label used to instruct Istio to automatically inject sidecar proxies when applications are deployed.
-    #    ---
-    #    app_label_name: "app"
-    #    injection_label_name: "istio-injection"
-    #    injection_label_rev:  "istio.io/rev"
-    #    version_label_name: "version"
-
-    ##########
-    # Kiali features that can be enabled/disabled via configuration
-    #  ---
-    #  kiali_feature_flags:
-    #
-    # Flag to indicate Kiali to enable/disable an Action to label a namespace for automatic Istio Sidecar injection.
-    #    ---
-    #    istio_injection_action: true
-    #
-    # Flag to activate the Kiali functionality of upgrading namespaces to point to installed Istio Canary revision.
-    # Related Canary upgrade and current revisions of Istio should be defined in istio_canary_revision section.
-    #    ---
-    #    istio_upgrade_action: false
-    #
-    # Default settings for the UI. These defaults apply to all users.
-    #    ---
-    #    ui_defaults:
-    #
-    # Default settings for UI Graph
-    #      ---
-    #      graph:
-    #
-    # Each Find/Hide option consists of a human readable description and a valid Find/Hide expression
-    #      ---
-    #        find_options:
-    #        - description: "Find: slow edges (> 1s)"
-    #          expression: "rt > 1000"
-    #        - description: "Find: unhealthy nodes"
-    #          expression:  "! healthy"
-    #        - description: "Find: unknown nodes"
-    #          expression:  "name = unknown"
-    #        hide_options:
-    #        - description: "Hide: healthy nodes"
-    #          expression: "healthy"
-    #        - description: "Hide: unknown nodes"
-    #          expression:  "name = unknown"
-    #
-    # Traffic settings determine which rates are used to determine graph traffic. gRPC traffic is
-    # measured in requests or sent/received/total messages.  HTTP traffic is measure in requests.
-    # TCP traffic is measured in sent/received/total bytes.  Only request traffic supplies response
-    # codes.  Valid values:
-    # grpc: none | requests | sent | received | total
-    # http: none | requests
-    # tcp:  none | sent | received | total
-    #        ---
-    #        traffic:
-    #          grpc: "requests"
-    #          http: "requests"
-    #          tcp:  "sent"
-    #
-    # Duration of metrics to fetch on each refresh. Omit for default.
-    # Valid values: 1m, 5m, 10m, 30m, 1h, 3h, 6h, 12h, 1d, 7d, 30d
-    #      ---
-    #      metrics_per_refresh: "1m"
-    #
-    # Default selections for the namespace selection dropdown. Non-existent or
-    # inaccessible namespaces will be ignored. Omit, or set to an empty array for no
-    # default namespaces.
-    #      ---
-    #      namespaces: []
-    #
-    # The automatic refresh interval for pages offering automatic refresh.
-    #
-    # Valid values: pause, 10s, 15s, 30s, 1m, 5m, 15m
-    #      ---
-    #      refresh_interval: "15s"
-    #
-    #   Features specific to the validations subsystem.
-    #    ---
-    #    validations:
-    #
-    #      If you wish to ignore one or more validation errors, put their validation codes (e.g. KIA0101) in this list.
-    #      ---
-    #      ignore: []
-
-    ##########
-    #  ---
-    kubernetes_config:
-    #
-    # The Burst value of the Kubernetes client.
-    #    ---
-    #    burst: 200
-    #
-    # The ratio interval (expressed in seconds) used for the cache to perform a full refresh.
-    # Only used when cache_enabled is true.
-    #    ---
-    #    cache_duration: 300
-    #
-    # Flag to use a Kubernetes cache for watching changes and updating pods and controllers data asynchronously.
-    #    ---
-    #    cache_enabled: true
-    #
-    # Kiali can cache VirtualService,DestinationRule,Gateway and ServiceEntry Istio resources if they are present
-    # on this list of Istio types. Other Istio types are not yet supported.
-    #    ---
-    #    cache_istio_types:
-    #    - "AuthorizationPolicy"
-    #    - "DestinationRule"
-    #    - "EnvoyFilter"
-    #    - "Gateway"
-    #    - "PeerAuthentication"
-    #    - "RequestAuthentication"
-    #    - "ServiceEntry"
-    #    - "Sidecar"
-    #    - "VirtualService"
-    #    - "WorkloadEntry"
-    #    - "WorkloadGroup"
-
-    #
-    # List of namespaces or regex defining namespaces to include in a cache.
-    #    ---
-    #    cache_namespaces:
-    #    - ".*"
-    #
-    # Cache duration expressed in seconds
-    # Kiali cache list of namespaces per user, this is typically short lived cache compared with the duration of the
-    # namespace cache defined by previous CacheDuration parameter
-    #    ---
-    #    cache_token_namespace_duration: 10
-    #
-    # List of controllers that won't be used for Workload calculation.
-    # Kiali queries Deployment,ReplicaSet,ReplicationController,DeploymentConfig,StatefulSet,Job and CronJob controllers.
-    # Deployment and ReplicaSet will be always queried, but ReplicationController,DeploymentConfig,StatefulSet,Job and CronJobs
-    # can be skipped from Kiali workloads query if they are present in this list.
-    #    ---
-    #    excluded_workloads:
-    #    - "CronJob"
-    #    - "DeploymentConfig"
-    #    - "Job"
-    #    - "ReplicationController"
-    #
-    # The QPS value of the Kubernetes client.
-    #    ---
-      qps: 50
-
-    ##########
-    #  ---
-    login_token:
-    #
-    # The token expiration in seconds.
-    #    ---
-    #    expiration_seconds: 86400
-    #
-    # The signing key used to generate tokens for user authentication.
-    # Because this is potentially sensitive, you have the option to store this
-    # value in a secret. If you store this signing key value in a secret, you
-    # must indicate what key in what secret by setting this value to a string
-    # in the form of "secret:<secretName>:<secretKey>"
-    # If left as an empty string, a secret with a random signing key will be
-    # generated for you.
-    #    ---
-      signing_key: ""
-
-    ##########
-    #  ---
-    server:
-    #
-    # Where the Kiali server is bound. The console and API server are accessible on this host.
-    #    ---
-    #    address: ""
-    #
-    # When true, allows additional audit logging on write operations.
-    #    ---
-    #    audit_log: true
-    #
-    # When true, allows the web console to send requests to other domains other than where the console came from.
-    # Typically used for development environments only.
-    #    ---
-    #    cors_allow_all: false
-    #
-    # When true, Kiali serves http requests with gzip enabled (if the browser supports it) when the requests are
-    #  over 1400 bytes.
-    #    ---
-    #    gzip_enabled: true
-    #
-    # When true, the metrics endpoint will be available for Prometheus to scrape.
-    #    ---
-      metrics_enabled: true
-    #
-    # The port that the server will bind to in order to receive metric requests.
-    # This is the port Prometheus will need to scrape when collecting metrics from Kiali.
-    #    ---
-      metrics_port: 9090
-    #
-    # The port that the server will bind to in order to receive console and API requests.
-    #    ---
-      port: 20001
-    #
-    # Defines the public domain where Kiali is being served. This is the "domain" part
-    # of the URL (usually it's a fully-qualified domain name).
-    # For example, "kiali.example.org".
-    # When empty, Kiali will try to guess this value from HTTP headers.
-    # On non-OpenShift clusters, you must populate this value if you want to enable
-    # cross-linking between Kiali instances in a multi-cluster setup.
-    #    ---
-    #    web_fqdn: ""
-    #
-    # Define the history mode of kiali UI. This can only take
-    # two possible values: either "browser" or "hash".
-    # When empty, it will always be considered as browser
-    #    ---
-    #    web_history_mode: ""
-    #
-    # Defines the ingress port where the connections come from. This is usually
-    # necessary when the application responds through a proxy/ingress, and it does
-    # not forward the correct headers so Kiali can guess the port.
-    #
-    # When empty, Kiali will try to guess this value from HTTP headers.
-    #    ---
-    #    web_port: ""
-    #
-    # Defines the context root path for the Kiali console and API endpoints and readiness probes.
-    # When providing a context root path that is not "/", do not add a trailing slash.
-    # For example, use "/kiali" not "/kiali/".
-    # When empty, will default to "/" on OpenShift and "/kiali" on Kubernetes.
-    #    ---
-      web_root: ""
-    #
-    # Defines the public HTTP schema used to serve Kiali. This can only take
-    # two possible values: either "http" or "https".
-    # When empty, Kiali will try to guess this value from HTTP headers.
-    # On non-OpenShift clusters, you must populate this value if you want to enable
-    # cross-linking between Kiali instances in a multi-cluster setup.
-    #    ---
-    #    web_schema: ""
-    #
-
-    # Containers securityContext, not defined in upstream chart
-      securityContext:
-        allowPrivilegeEscalation: false
-        privileged: false
-        readOnlyRootFilesystem: true
-        runAsNonRoot: true
+server:
+  port: 20001
+  metrics_enabled: true
+  metrics_port: 9090
+  web_root: ""

--- a/resources/kiali/values.yaml
+++ b/resources/kiali/values.yaml
@@ -59,8 +59,6 @@ authProxy:
       cpu: 10m
       memory: 5Mi
 
-nameOverride: "kiali"
-
 # 'fullnameOverride' is deprecated. Use 'deployment.instance_name' instead.
 # This is only supported for backward compatibility and will be removed in a future version.
 # If 'fullnameOverride' is not "kiali" and 'deployment.instance_name' is "kiali",

--- a/resources/kiali/values.yaml
+++ b/resources/kiali/values.yaml
@@ -182,12 +182,12 @@ identity: {}
 
 kiali_feature_flags:
   certificates_information_indicators:
-   enabled: true
+   enabled: false
    secrets:
    - cacerts
    - istio-ca-secret
   clustering:
-    enabled: true
+    enabled: false
 login_token:
   signing_key: ""
 

--- a/resources/kiali/values.yaml
+++ b/resources/kiali/values.yaml
@@ -166,7 +166,8 @@ external_services:
     url: "http://monitoring-prometheus.kyma-system:9090"
 
   tracing:
-    enabled: "{{ .Values.global.tracing.enabled }}"
+    # 'enabled' will be overwritten by .Values.global.tracing.enabled in the configmap template
+    # enabled: true
     component_status:
       namespace: kyma-system
       app_label: "jaeger"

--- a/resources/kiali/values.yaml
+++ b/resources/kiali/values.yaml
@@ -63,7 +63,7 @@ authProxy:
 # If 'fullnameOverride' is not "kiali" and 'deployment.instance_name' is "kiali",
 # then 'deployment.instance_name' will take the value of 'fullnameOverride' value.
 # Otherwise, 'fullnameOverride' is ignored and 'deployment.instance_name' is used.
-fullnameOverride: "kiali"
+fullnameOverride: "kiali-server"
 
 # This is required for "openshift" auth strategy.
 # You have to know ahead of time what your Route URL will be because

--- a/resources/kiali/values.yaml
+++ b/resources/kiali/values.yaml
@@ -50,6 +50,7 @@ authProxy:
     runAsNonRoot: true
   image:
     pullPolicy: IfNotPresent
+  priorityClassName: ""
   resources:
     limits:
       cpu: 50m
@@ -57,6 +58,8 @@ authProxy:
     requests:
       cpu: 10m
       memory: 5Mi
+
+nameOverride: "kiali"
 
 # 'fullnameOverride' is deprecated. Use 'deployment.instance_name' instead.
 # This is only supported for backward compatibility and will be removed in a future version.

--- a/resources/kiali/values.yaml
+++ b/resources/kiali/values.yaml
@@ -166,9 +166,7 @@ external_services:
     url: "http://monitoring-prometheus.kyma-system:9090"
 
   tracing:
-    # 'enabled' will be overwritten with .Values.global.tracing.enabled in the template
-    #  enabled: true
-    #  health_check_url: ""
+    enabled: "{{ .Values.global.tracing.enabled }}"
     component_status:
       namespace: kyma-system
       app_label: "jaeger"

--- a/resources/kiali/values.yaml
+++ b/resources/kiali/values.yaml
@@ -50,7 +50,7 @@ authProxy:
     runAsNonRoot: true
   image:
     pullPolicy: IfNotPresent
-  priorityClassName: ""
+  priorityClassName: "kyma-system-priority"
   resources:
     limits:
       cpu: 50m
@@ -122,7 +122,7 @@ deployment:
   pod_annotations:
     "sidecar.istio.io/inject": "true"
   pod_labels: {}
-  priority_class_name: ""
+  priority_class_name: "kyma-system-priority"
   replicas: 1
   resources:
     limits:

--- a/resources/kiali/values.yaml
+++ b/resources/kiali/values.yaml
@@ -9,7 +9,7 @@ global:
   images:
     kiali:
       name: kiali
-      version: 1.38.1-e0da5a68
+      version: 1.44.0-efa628c6
       directory: tpi
     oauth2_proxy:
       name: oauth2-proxy

--- a/resources/kiali/values.yaml
+++ b/resources/kiali/values.yaml
@@ -130,12 +130,6 @@ deployment:
       cpu: 10m
       memory: 20Mi
   secret_name: "kiali"
-  # Containers securityContext, not defined in upstream chart
-  securityContext:
-    allowPrivilegeEscalation: false
-    privileged: false
-    readOnlyRootFilesystem: true
-    runAsNonRoot: true
   service_annotations: {}
   service_type: ""
   tolerations: []
@@ -153,7 +147,7 @@ external_services:
 
   istio:
     enabled: true
-    root_namespace: ""
+    root_namespace: "istio-system"
     component_status:
       components:
       - app_label: istiod

--- a/resources/kiali/values.yaml
+++ b/resources/kiali/values.yaml
@@ -75,6 +75,7 @@ kiali_route_url: ""
 
 #
 # Settings that mimic the Kiali CR which are placed in the ConfigMap.
+# See https://github.com/kiali/kiali-operator/blob/master/deploy/kiali/kiali_cr to see all possible values (and what they mean).
 # Note that only those values used by the Helm Chart will be here.
 #
 
@@ -137,7 +138,7 @@ deployment:
   service_annotations: {}
   service_type: ""
   tolerations: []
-  version_label: ${HELM_IMAGE_TAG}
+  version_label: ""
   view_only_mode: true
 
 external_services:

--- a/resources/tracing/templates/kyma-additions/authorization-policy.yaml
+++ b/resources/tracing/templates/kyma-additions/authorization-policy.yaml
@@ -17,7 +17,7 @@ spec:
     - source:
         principals:
           - cluster.local/ns/{{ .Release.Namespace }}/sa/{{ include "jaeger-operator.fullname" . }}-auth-proxy
-          - cluster.local/ns/{{ .Release.Namespace }}/sa/kiali
+          - cluster.local/ns/{{ .Release.Namespace }}/sa/kiali-server
           - cluster.local/ns/{{ .Release.Namespace }}/sa/monitoring-grafana
 {{ end }}
   - from:


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- Upgrade Kiali to version 1.44.0
- Change the structure of the values file, which was incompatible with the upstream chart
- Remove openshift-specific resources
- Introduce a new `kiali-server.name` template to keep old resource names for kyma additions

Some interesting Kiali features since 1.38.1 (https://kiali.io/news/release-notes/):

- [Calculate graph importance score ](https://github.com/kiali/kiali/issues/2888)
- [Add a “Trendlines” option in the metrics tab](https://github.com/kiali/kiali/issues/2997)
- [Add SRE style metrics in the Overview namespace chart](https://github.com/kiali/kiali/issues/2947)
- [Be able to set the logging level for Istio and envoy logs from Kiali UI](https://github.com/kiali/kiali/issues/1525)

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
