### PR TITLE
Add managed-by label to apps and configmap to skr

### DIFF
--- a/components/compass-runtime-agent/internal/kyma/applications/converter.go
+++ b/components/compass-runtime-agent/internal/kyma/applications/converter.go
@@ -11,7 +11,9 @@ import (
 const defaultDescription = "Description not provided"
 
 const (
-	connectedApp = "connected-app"
+	connectedAppLabelKey = "connected-app"
+	managedByLabelKey    = "applicationconnector.kyma-project.io/managed-by"
+	managedByLabelValue  = "compass-runtime-agent"
 )
 
 //go:generate mockery --name=Converter
@@ -35,9 +37,7 @@ func (c converter) Do(application model.Application) v1alpha1.Application {
 
 	prepareLabels := func(directorLabels model.Labels) map[string]string {
 		labels := make(map[string]string)
-
-		labels[connectedApp] = application.Name
-
+		labels[connectedAppLabelKey] = application.Name
 		return labels
 	}
 
@@ -52,7 +52,8 @@ func (c converter) Do(application model.Application) v1alpha1.Application {
 			APIVersion: "applicationconnector.kyma-project.io/v1alpha1",
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name: application.Name,
+			Name:   application.Name,
+			Labels: map[string]string{managedByLabelKey: managedByLabelValue},
 		},
 		Spec: v1alpha1.ApplicationSpec{
 			Description:      description,

--- a/components/compass-runtime-agent/internal/kyma/applications/converter_test.go
+++ b/components/compass-runtime-agent/internal/kyma/applications/converter_test.go
@@ -38,14 +38,15 @@ func TestConverter(t *testing.T) {
 				APIVersion: "applicationconnector.kyma-project.io/v1alpha1",
 			},
 			ObjectMeta: metav1.ObjectMeta{
-				Name: "Appname1",
+				Name:   "Appname1",
+				Labels: map[string]string{managedByLabelKey: managedByLabelValue},
 			},
 			Spec: v1alpha1.ApplicationSpec{
 				Description:      "Description not provided",
 				SkipInstallation: false,
 				Services:         []v1alpha1.Service{},
 				Labels: map[string]string{
-					connectedApp: "Appname1",
+					connectedAppLabelKey: "Appname1",
 				},
 				CompassMetadata: &v1alpha1.CompassMetadata{ApplicationID: "App1", Authentication: v1alpha1.Authentication{ClientIds: []string{"auth1", "auth2"}}},
 			},
@@ -144,13 +145,14 @@ func TestConverter(t *testing.T) {
 				APIVersion: "applicationconnector.kyma-project.io/v1alpha1",
 			},
 			ObjectMeta: metav1.ObjectMeta{
-				Name: "Appname1",
+				Name:   "Appname1",
+				Labels: map[string]string{managedByLabelKey: managedByLabelValue},
 			},
 			Spec: v1alpha1.ApplicationSpec{
 				Description:      "Description",
 				SkipInstallation: false,
 				Labels: map[string]string{
-					connectedApp: "Appname1",
+					connectedAppLabelKey: "Appname1",
 				},
 				CompassMetadata: &v1alpha1.CompassMetadata{ApplicationID: "App1", Authentication: v1alpha1.Authentication{ClientIds: []string{"auth1", "auth2"}}},
 				Services: []v1alpha1.Service{
@@ -276,13 +278,14 @@ func TestConverter(t *testing.T) {
 				APIVersion: "applicationconnector.kyma-project.io/v1alpha1",
 			},
 			ObjectMeta: metav1.ObjectMeta{
-				Name: "Appname1",
+				Name:   "Appname1",
+				Labels: map[string]string{managedByLabelKey: managedByLabelValue},
 			},
 			Spec: v1alpha1.ApplicationSpec{
 				Description:      "Description",
 				SkipInstallation: false,
 				Labels: map[string]string{
-					connectedApp: "Appname1",
+					connectedAppLabelKey: "Appname1",
 				},
 				CompassMetadata: &v1alpha1.CompassMetadata{ApplicationID: "App1", Authentication: v1alpha1.Authentication{ClientIds: nil}},
 				Services: []v1alpha1.Service{

--- a/components/compass-runtime-agent/internal/kyma/applications/repository.go
+++ b/components/compass-runtime-agent/internal/kyma/applications/repository.go
@@ -48,6 +48,7 @@ func (m manager) Update(application *v1alpha1.Application) (*v1alpha1.Applicatio
 		}
 	}
 
+	currentApp.Labels = application.Labels
 	currentApp.Spec.Description = application.Spec.Description
 	currentApp.Spec.Labels = application.Spec.Labels
 	currentApp.Spec.Services = application.Spec.Services

--- a/resources/compass-runtime-agent/templates/skr-configmap.yaml
+++ b/resources/compass-runtime-agent/templates/skr-configmap.yaml
@@ -3,12 +3,5 @@ kind: ConfigMap
 metadata:
   name: skr-configmap
   namespace: {{ .Values.global.skrConfigmapNamespace }}
-  labels:
-    app: { { .Chart.Name } }
-    release: { { .Release.Name } }
-    helm.sh/chart: { { .Chart.Name } }-{{ .Chart.Version | replace "+" "_" }}
-    app.kubernetes.io/name: { { template "name" . } }
-    app.kubernetes.io/managed-by: { { .Release.Service } }
-    app.kubernetes.io/instance: { { .Release.Name } }
 data:
   isManagedKymaRuntime: true

--- a/resources/compass-runtime-agent/templates/skr-configmap.yaml
+++ b/resources/compass-runtime-agent/templates/skr-configmap.yaml
@@ -4,4 +4,4 @@ metadata:
   name: skr-configmap
   namespace: {{ .Values.global.skrConfigmapNamespace }}
 data:
-  isManagedKymaRuntime: true
+  is-managed-kyma-runtime: "true"

--- a/resources/compass-runtime-agent/templates/skr-configmap.yaml
+++ b/resources/compass-runtime-agent/templates/skr-configmap.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: skr-configmap
+  namespace: {{ .Values.global.skrConfigmapNamespace }}
+  labels:
+    app: { { .Chart.Name } }
+    release: { { .Release.Name } }
+    helm.sh/chart: { { .Chart.Name } }-{{ .Chart.Version | replace "+" "_" }}
+    app.kubernetes.io/name: { { template "name" . } }
+    app.kubernetes.io/managed-by: { { .Release.Service } }
+    app.kubernetes.io/instance: { { .Release.Name } }
+data:
+  isManagedKymaRuntime: true

--- a/resources/compass-runtime-agent/values.yaml
+++ b/resources/compass-runtime-agent/values.yaml
@@ -5,7 +5,7 @@ global:
   images:
     compass_runtime_agent:
       name: "compass-runtime-agent"
-      version: "5e1e226f"
+      version: "PR-12876"
   istio:
     gateway:
       name: kyma-gateway

--- a/resources/compass-runtime-agent/values.yaml
+++ b/resources/compass-runtime-agent/values.yaml
@@ -10,6 +10,7 @@ global:
     gateway:
       name: kyma-gateway
       namespace: kyma-system
+  skrConfigmapNamespace: kyma-system
 
 managementPlane: {} # default value
 


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- Add `applicationconnector.kyma-project.io/managed-by: compass-runtime-agent` label to SKR apps and skr-configmap to the SKR in the `kyma-system` namespace

See https://github.com/kyma-project/busola/issues/712
