### PR TITLE
Remove namespace from cluster wide k8s objects

### DIFF
--- a/components/application-operator/charts/application/templates/role-binding.yaml
+++ b/components/application-operator/charts/application/templates/role-binding.yaml
@@ -85,7 +85,6 @@ kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: {{ .Release.Name }}-application-gateway
-  namespace: {{ .Release.Namespace }}
   labels:
     app: {{ .Release.Name }}-application-gateway
     release: {{ .Release.Name }}
@@ -133,7 +132,6 @@ kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: {{ .Release.Name }}-connectivity-validator
-  namespace: {{ .Release.Namespace }}
   labels:
     app: {{ .Release.Name }}-connectivity-validator
     release: {{ .Release.Name }}

--- a/components/binding/charts/binding/templates/mutating-webhook.yaml
+++ b/components/binding/charts/binding/templates/mutating-webhook.yaml
@@ -18,7 +18,6 @@ apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingWebhookConfiguration
 metadata:
   name: {{ template "fullname" . }}-mutating-webhook
-  namespace: {{ .Release.Namespace }}
 webhooks:
   - name: "mutating.pods.bindings.kyma-project.io"
     rules:

--- a/resources/api-gateway/templates/rbac.yaml
+++ b/resources/api-gateway/templates/rbac.yaml
@@ -9,7 +9,6 @@ kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: {{ include "api-gateway.name" . }}-role
-  namespace:  {{ .Release.Namespace }}
 rules:
   - apiGroups: ["gateway.kyma-project.io"]
     resources: ["apirules", "apirules/status"]
@@ -32,7 +31,6 @@ kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: {{ include "api-gateway.name" . }}-role-binding
-  namespace:  {{ .Release.Namespace }}
 subjects:
   - kind: ServiceAccount
     name: {{ include "api-gateway.name" . }}-account # Service account assigned to the controller pod.

--- a/resources/application-connector/charts/central-application-connectivity-validator/templates/rbac.yaml
+++ b/resources/application-connector/charts/central-application-connectivity-validator/templates/rbac.yaml
@@ -3,7 +3,6 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: {{ .Chart.Name }}-role
-  namespace: {{ .Values.global.systemNamespace }}
   labels:
     app: {{ .Chart.Name }}
     release: {{ .Release.Name }}

--- a/resources/application-connector/charts/central-application-gateway/templates/rbac.yaml
+++ b/resources/application-connector/charts/central-application-gateway/templates/rbac.yaml
@@ -15,7 +15,6 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: {{ .Chart.Name }}-role
-  namespace: {{ .Values.global.systemNamespace }}
   labels:
     app: {{ .Chart.Name }}
     release: {{ .Release.Name }}

--- a/resources/application-connector/charts/connection-token-handler/templates/role-binding.yaml
+++ b/resources/application-connector/charts/connection-token-handler/templates/role-binding.yaml
@@ -3,7 +3,6 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: {{ .Chart.Name }}-clusterrole
-  namespace: {{ .Values.global.integrationNamespace }}
   labels:
     app: {{ .Chart.Name }}
     release: {{ .Release.Name }}
@@ -27,7 +26,6 @@ kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: {{ .Chart.Name }}-clusterrolebinding
-  namespace: {{ .Values.global.integrationNamespace }}
   labels:
     app: {{ .Chart.Name }}
     release: {{ .Release.Name }}

--- a/resources/cluster-essentials/charts/pod-preset/templates/webhook/webhook.yaml
+++ b/resources/cluster-essentials/charts/pod-preset/templates/webhook/webhook.yaml
@@ -16,7 +16,6 @@ apiVersion: admissionregistration.k8s.io/v1beta1
 kind: MutatingWebhookConfiguration
 metadata:
   name: {{ template "pod-preset.fullname" . }}-webhook
-  namespace: "{{ .Release.Namespace }}"
 webhooks:
 - clientConfig:
     caBundle: {{ $encodedCaCert }}

--- a/resources/compass-runtime-agent/templates/cluster-role-binding.yaml
+++ b/resources/compass-runtime-agent/templates/cluster-role-binding.yaml
@@ -2,7 +2,6 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
     name: {{ .Chart.Name }}
-    namespace: {{ .Release.Namespace }}
     labels:
         app: {{ .Chart.Name }}
         release: {{ .Release.Name }}
@@ -36,7 +35,6 @@ kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
     name: {{ .Chart.Name }}
-    namespace: {{ .Release.Namespace }}
     labels:
         app: {{ .Chart.Name }}
         release: {{ .Chart.Name }}

--- a/resources/helm-broker/templates/webhook-register.yaml
+++ b/resources/helm-broker/templates/webhook-register.yaml
@@ -18,7 +18,6 @@ apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingWebhookConfiguration
 metadata:
   name: {{ template "fullname" . }}-mutating-webhook
-  namespace: {{ .Release.Namespace }}
 webhooks:
   - name: mutating.helm-broker.kyma-project.io
     rules:

--- a/resources/monitoring/charts/grafana/templates/podsecuritypolicy.yaml
+++ b/resources/monitoring/charts/grafana/templates/podsecuritypolicy.yaml
@@ -3,7 +3,6 @@ apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:
   name: {{ template "grafana.fullname" . }}
-  namespace: {{ template "grafana.namespace" . }}
   labels:
     {{- include "grafana.labels" . | nindent 4 }}
   annotations:

--- a/resources/monitoring/charts/prometheus-node-exporter/templates/psp.yaml
+++ b/resources/monitoring/charts/prometheus-node-exporter/templates/psp.yaml
@@ -4,7 +4,6 @@ apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:
   name: {{ template "prometheus-node-exporter.fullname" . }}
-  namespace: {{ template "prometheus-node-exporter.namespace" . }}
   labels: {{ include "prometheus-node-exporter.labels" . | indent 4 }}
   {{- if .Values.rbac.pspAnnotations }}
   annotations:

--- a/resources/telemetry/charts/operator/templates/role-binding.yaml
+++ b/resources/telemetry/charts/operator/templates/role-binding.yaml
@@ -2,7 +2,6 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: {{ include "operator.fullname" . }}-manager-rolebinding
-  namespace: {{ .Release.Namespace }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**
Passing the attribute namespace in yaml files of cluster wide objects like `ClusterRoleBinding, ClusterRole, PodSecurityPolicy, MutatingWebhookConfiguration` could lead to problems during applying the chart multiple times on the same cluster, as they are per definition not intended to be namespace specific.
Changes proposed in this pull request:

- remove namespace attribute in manifests of cluster wide k8s objects

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
