### PR TITLE
Fix NATS servers discovery

### DIFF
--- a/resources/eventing/charts/nats/templates/service.yaml
+++ b/resources/eventing/charts/nats/templates/service.yaml
@@ -15,6 +15,7 @@ metadata:
 spec:
   selector:
     {{- include "nats.selectorLabels" . | nindent 4 }}
+  clusterIP: None
   ports:
   {{- if .Values.nats.profiling.enabled }}
   - name: profiling


### PR DESCRIPTION
**Description**

Fix NATS servers discovery by making the NATS service headless.

> This is a revert of NATS service changes done here 9a289bc4cd115e0a2ae81853a6e9baa9401212aa.

**Related issue(s)**

- https://github.com/kyma-project/kyma/issues/12825
