### PR TITLE
Increase memory limits for a few monitoring components

### DIFF
--- a/resources/monitoring/charts/kube-state-metrics/values.yaml
+++ b/resources/monitoring/charts/kube-state-metrics/values.yaml
@@ -152,7 +152,7 @@ resources:
   # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
   limits:
     cpu: 100m
-    memory: 126Mi
+    memory: 256Mi
   requests:
     cpu: 10m
     memory: 32Mi

--- a/resources/monitoring/profile-production.yaml
+++ b/resources/monitoring/profile-production.yaml
@@ -23,7 +23,6 @@ prometheusOperator:
       memory: "128Mi"
     limits:
       cpu: "500m"
-      memory: "1Gi"
 
 alertmanager:
   alertmanagerSpec:

--- a/resources/monitoring/values.yaml
+++ b/resources/monitoring/values.yaml
@@ -1408,7 +1408,7 @@ prometheusOperator:
   resources:
     limits:
       cpu: 300m
-      memory: 500Mi
+      memory: 1Gi
     requests:
       cpu: 10m
       memory: 90Mi


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

We found out that `kube-state-metrics` and `prometheus-operator` containers were in the CrashLoopBackOff state, constantly OOMKilled. The memory consumption actually grew over the limits upon application startup and then stabilized. As a workaround, we will increase memory limits for those 2 containers.

Changes proposed in this pull request:

- Increase memory limits for `kube-state-metrics` and `prometheus-operator`

**Related issue(s)**
https://github.com/kyma-incubator/reconciler/issues/592