### PR TITLE
Increase memory limit of eventing controller

### DIFF
--- a/resources/eventing/profile-evaluation.yaml
+++ b/resources/eventing/profile-evaluation.yaml
@@ -2,7 +2,7 @@ controller:
   resources:
     limits:
       cpu: 20m
-      memory: 128Mi
+      memory: 256Mi
     requests:
       cpu: 10m
       memory: 32Mi


### PR DESCRIPTION
Increase memory limit of eventing controller in the evaluation profile

<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

As part of https://github.com/kyma-project/kyma/issues/12893, it seems when the eventing controller does a high number of reconciliations due to erroneous subscriptions, the memory limit is not enough.

Changes proposed in this pull request:

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
