### PR TITLE
Remove excessive logs from fast-integration tests - `execa` calls

### DIFF
--- a/tests/fast-integration/skr-svcat-migration-test/skr-svcat-migration-test.js
+++ b/tests/fast-integration/skr-svcat-migration-test/skr-svcat-migration-test.js
@@ -28,13 +28,13 @@ describe("SKR SVCAT migration test", function() {
   const suffix = genRandom(4);
   const appName = `app-${suffix}`;
   const runtimeName = `kyma-${suffix}`;
-  const runtimeID = uuid.v4();
+  const instanceID = uuid.v4();
   
   const svcatPlatform = `svcat-${suffix}`
   const btpOperatorInstance = `btp-operator-${suffix}`
   const btpOperatorBinding = `btp-operator-binding-${suffix}`
   switchDebug(on = true)
-  debug(`RuntimeID ${runtimeID}`, `Runtime ${runtimeName}`, `Application ${appName}`, `Suffix ${suffix}`);
+  debug(`InstanceID ${instanceID}`, `Runtime ${runtimeName}`, `Application ${appName}`, `Suffix ${suffix}`);
 
   this.timeout(60 * 60 * 1000 * 3); // 3h
   this.slow(5000);
@@ -51,7 +51,7 @@ describe("SKR SVCAT migration test", function() {
 
   let skr;
   it(`Should provision SKR`, async function() {
-    skr = await provisionSKR(keb, gardener, runtimeID, runtimeName, platformCreds, btpOperatorCreds);
+    skr = await provisionSKR(keb, gardener, instanceID, runtimeName, platformCreds, btpOperatorCreds);
   });
 
   it(`Should save kubeconfig for the SKR to ~/.kube/config`, async function() {
@@ -125,7 +125,7 @@ describe("SKR SVCAT migration test", function() {
   });
 
   it(`Should deprovision SKR`, async function() {
-    await deprovisionSKR(keb, runtimeID);
+    await deprovisionSKR(keb, instanceID);
   });
 
   it(`Should cleanup platform --cascade, operator instances and bindings`, async function() {

--- a/tests/fast-integration/skr-svcat-migration-test/test-helpers.js
+++ b/tests/fast-integration/skr-svcat-migration-test/test-helpers.js
@@ -56,8 +56,9 @@ async function installBTPOperatorHelmChart(creds, clusterId) {
         await helmInstallUpgrade(btp, btpChart, btp, btpValues, null, ["--create-namespace"]);
     } catch (error) {
         if (error.stderr === undefined) {
-            throw new Error(`failed to install ${btp}: ${error}`);
+            throw new Error(`failed to install ${btp}: failed to process output of "helm upgrade"`);
         }
+        console.log(error)
         throw new Error(`failed to install ${btp}: ${error.stderr}`);
     }
 }
@@ -70,7 +71,7 @@ async function installBTPServiceOperatorMigrationHelmChart() {
         await helmInstallUpgrade(btp, chart, "sap-btp-operator", null, null, ["--create-namespace"]);
     } catch (error) {
         if (error.stderr === undefined) {
-            throw new Error(`failed to install ${btp}: ${error}`);
+            throw new Error(`failed to install ${btp}: : failed to process output of "helm upgrade"`);
         }
         throw new Error(`failed to install ${btp}: ${error.stderr}`);
     }
@@ -203,7 +204,7 @@ async function provisionPlatform(creds, svcatPlatform) {
 
     } catch (error) {
         if (error.stderr === undefined) {
-            throw new Error(`failed to process output of "smctl ${args.join(' ')}": ${error}`);
+            throw new Error(`failed to process output of "smctl ${args.join(' ')}"`);
         }
         throw new Error(`failed "smctl ${args.join(' ')}": ${error.stderr}`);
     }
@@ -233,7 +234,7 @@ async function smInstanceBinding(btpOperatorInstance, btpOperatorBinding) {
 
     } catch (error) {
         if (error.stderr === undefined) {
-            throw new Error(`failed to process output of "smctl ${args.join(' ')}": ${error}`);
+            throw new Error(`failed to process output of "smctl ${args.join(' ')}"`);
         }
         throw new Error(`failed "smctl ${args.join(' ')}": ${error.stderr}`);
     }
@@ -246,7 +247,7 @@ async function markForMigration(creds, svcatPlatform, btpOperatorInstanceId) {
         args = [`login`, `-a`, creds.url, `--param`, `subdomain=e2etestingscmigration`, `--auth-flow`, `client-credentials`]
         await execa(`smctl`, args.concat([`--client-id`, creds.clientid, `--client-secret`, creds.clientsecret]));
     } catch (error) {
-        errors = errors.concat([`failed "smctl ${args.join(' ')}": ${error.stderr}\n${error}`]);
+        errors = errors.concat([`failed "smctl ${args.join(' ')}": ${error.stderr}\n`]);
     }
 
     try {
@@ -255,7 +256,7 @@ async function markForMigration(creds, svcatPlatform, btpOperatorInstanceId) {
         args = ['curl', '-X', 'PUT', '-d', JSON.stringify(data), '/v1/migrate/service_operator/' + btpOperatorInstanceId]
         await execa('smctl', args)
     } catch (error) {
-        errors = errors.concat([`failed "smctl ${args.join(' ')}": ${error.stderr}\n${error}`]);
+        errors = errors.concat([`failed "smctl ${args.join(' ')}": ${error.stderr}\n`]);
     }
     if (errors.length > 0) {
         throw new Error(errors.join(", "));
@@ -269,7 +270,7 @@ async function cleanupInstanceBinding(creds, svcatPlatform, btpOperatorInstance,
         args = [`login`, `-a`, creds.url, `--param`, `subdomain=e2etestingscmigration`, `--auth-flow`, `client-credentials`]
         await execa(`smctl`, args.concat([`--client-id`, creds.clientid, `--client-secret`, creds.clientsecret]));
     } catch (error) {
-        errors = errors.concat([`failed "smctl ${args.join(' ')}": ${error.stderr}\n${error}`]);
+        errors = errors.concat([`failed "smctl ${args.join(' ')}": ${error.stderr}\n`]);
     }
 
     try {
@@ -279,7 +280,7 @@ async function cleanupInstanceBinding(creds, svcatPlatform, btpOperatorInstance,
              errors = errors.concat([`failed "smctl ${args.join(' ')}": ${stdout}`])
         }
     } catch (error) {
-        errors = errors.concat([`failed "smctl ${args.join(' ')}": ${error.stderr}\n${error}`]);
+        errors = errors.concat([`failed "smctl ${args.join(' ')}": ${error.stderr}\n`]);
     }
 
     try {
@@ -290,7 +291,7 @@ async function cleanupInstanceBinding(creds, svcatPlatform, btpOperatorInstance,
             errors = errors.concat([`failed "smctl ${args.join(' ')}": ${stdout}`])
         }
     } catch (error) {
-        errors = errors.concat([`failed "smctl ${args.join(' ')}": ${error.stderr}\n${error}`]);
+        errors = errors.concat([`failed "smctl ${args.join(' ')}": ${error.stderr}\n}`]);
     }
 
     try {
@@ -300,7 +301,7 @@ async function cleanupInstanceBinding(creds, svcatPlatform, btpOperatorInstance,
         //     errors = errors.concat([`failed "smctl ${args.join(' ')}": ${stdout}`])
         // }
     } catch (error) {
-        errors = errors.concat([`failed "smctl ${args.join(' ')}": ${error.stderr}\n${error}`]);
+        errors = errors.concat([`failed "smctl ${args.join(' ')}": ${error.stderr}\n`]);
     }
 
     if (errors.length > 0) {


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**
When using `execa()` function, the whole error should not be printed or logged for security reasons - the `error` contains the whole command with exit code status in case of failure and does not introduce any other useful information. All needed information from the command call is in `error.stderr`.

Changes proposed in this pull request:

- Removed excessive logging of `error` when catching it from `execa()` function call

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
