### PR TITLE
Remove waiting for service-catalog-ui pod in skr-svcat-migration-test

### DIFF
--- a/tests/fast-integration/skr-svcat-migration-test/deploy-sample-resources.js
+++ b/tests/fast-integration/skr-svcat-migration-test/deploy-sample-resources.js
@@ -239,7 +239,6 @@ async function deploy() {
   let times = []
 
   await waitForPodWithLabel("app", "service-catalog-addons-service-binding-usage-controller", "kyma-system");
-  await waitForPodWithLabel("app", "service-catalog-ui", "kyma-system");
   await waitForPodWithLabel("app", "service-catalog-catalog-controller-manager", "kyma-system");
   await waitForPodWithLabel("app", "service-catalog-catalog-webhook", "kyma-system");
   await waitForPodWithLabel("app", "service-broker-proxy-k8s", "kyma-system");


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- remove func waiting for service-catalog-ui
ref: https://github.com/kyma-project/kyma/blob/main/resources/service-catalog-addons/values.yaml#L2

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
