### PR TITLE
Add tests for valid sink

### DIFF
--- a/components/eventing-controller/controllers/subscription/beb/reconciler_test.go
+++ b/components/eventing-controller/controllers/subscription/beb/reconciler_test.go
@@ -1023,9 +1023,16 @@ func ensureSubscriptionCreated(ctx context.Context, subscription *eventingv1alph
 	Expect(err).Should(BeNil())
 }
 
+// ensureSubscriptionUpdated conducts an update of a Subscription.
+func ensureSubscriptionUpdated(ctx context.Context, subscription *eventingv1alpha1.Subscription) {
+	By(fmt.Sprintf("Ensuring the subscription %q is updated", subscription.Name))
+	// update subscription
+	err := k8sClient.Update(ctx, subscription)
+	Expect(err).Should(BeNil())
+}
+
 // ensureSubscriberSvcCreated creates a Service in the k8s cluster. If a custom namespace is used, it will be created as well.
 func ensureSubscriberSvcCreated(ctx context.Context, svc *v1.Service) {
-
 	By(fmt.Sprintf("Ensuring the test namespace %q is created", svc.Namespace))
 	if svc.Namespace != "default " {
 		// create testing namespace
@@ -1214,7 +1221,7 @@ var _ = BeforeSuite(func(done Done) {
 	Expect(err).NotTo(HaveOccurred())
 	// +kubebuilder:scaffold:scheme
 
-	bebMock := startBEBMock()
+	mock := startBEBMock()
 	// client, err := client.New()
 	// Source: https://book.kubebuilder.io/cronjob-tutorial/writing-tests.html
 	syncPeriod := time.Second * 2
@@ -1225,10 +1232,10 @@ var _ = BeforeSuite(func(done Done) {
 	})
 	Expect(err).ToNot(HaveOccurred())
 	envConf := env.Config{
-		BEBAPIURL:                bebMock.MessagingURL,
+		BEBAPIURL:                mock.MessagingURL,
 		ClientID:                 "foo-id",
 		ClientSecret:             "foo-secret",
-		TokenEndpoint:            bebMock.TokenURL,
+		TokenEndpoint:            mock.TokenURL,
 		WebhookActivationTimeout: 0,
 		WebhookTokenEndpoint:     "foo-token-endpoint",
 		Domain:                   domain,

--- a/components/eventing-controller/controllers/subscription/beb/reconciler_test.go
+++ b/components/eventing-controller/controllers/subscription/beb/reconciler_test.go
@@ -1023,14 +1023,6 @@ func ensureSubscriptionCreated(ctx context.Context, subscription *eventingv1alph
 	Expect(err).Should(BeNil())
 }
 
-// ensureSubscriptionUpdated conducts an update of a Subscription.
-func ensureSubscriptionUpdated(ctx context.Context, subscription *eventingv1alpha1.Subscription) {
-	By(fmt.Sprintf("Ensuring the subscription %q is updated", subscription.Name))
-	// update subscription
-	err := k8sClient.Update(ctx, subscription)
-	Expect(err).Should(BeNil())
-}
-
 // ensureSubscriberSvcCreated creates a Service in the k8s cluster. If a custom namespace is used, it will be created as well.
 func ensureSubscriberSvcCreated(ctx context.Context, svc *v1.Service) {
 	By(fmt.Sprintf("Ensuring the test namespace %q is created", svc.Namespace))

--- a/components/eventing-controller/controllers/subscription/beb/reconciler_test.go
+++ b/components/eventing-controller/controllers/subscription/beb/reconciler_test.go
@@ -101,6 +101,113 @@ var _ = Describe("Subscription Reconciliation Tests", func() {
 		testID++
 	})
 
+	When("Updating the clean event types in the Subscription status", func() {
+		It("should mark the Subscription as ready", func() {
+			// create a subscriber service
+			subscriberSvc := reconcilertesting.NewSubscriberSvc("webhook", namespaceName)
+			ensureSubscriberSvcCreated(ctx, subscriberSvc)
+
+			// create a Subscription
+			subscriptionName := "test-valid-subscription-1"
+			optFilter := reconcilertesting.WithEmptyFilter
+			optWebhook := reconcilertesting.WithWebhookAuthForBEB
+			subscription := reconcilertesting.NewSubscription(subscriptionName, namespaceName, optFilter, optWebhook)
+			reconcilertesting.WithValidSink(namespaceName, subscriberSvc.Name, subscription)
+			ensureSubscriptionCreated(ctx, subscription)
+
+			Context("a Subscription without filters", func() {
+				By("should have no clean event types", func() {
+					getSubscription(ctx, subscription).Should(And(
+						reconcilertesting.HaveSubscriptionName(subscriptionName),
+						reconcilertesting.HaveCondition(eventingv1alpha1.MakeCondition(
+							eventingv1alpha1.ConditionSubscriptionActive,
+							eventingv1alpha1.ConditionReasonSubscriptionActive,
+							v1.ConditionTrue, "")),
+						reconcilertesting.HaveCleanEventTypes(nil),
+					))
+				})
+			})
+
+			Context("Addition of filters to a Subscription", func() {
+				publishToSubjects := []string{
+					fmt.Sprintf("%s0", reconcilertesting.OrderCreatedEventType),
+					fmt.Sprintf("%s1", reconcilertesting.OrderCreatedEventType),
+				}
+				subscribeToEventTypes := []string{
+					fmt.Sprintf("%s0", reconcilertesting.OrderCreatedEventTypeNotClean),
+					fmt.Sprintf("%s1", reconcilertesting.OrderCreatedEventTypeNotClean),
+				}
+
+				By("adding filters to a Subscription", func() {
+					for _, f := range subscribeToEventTypes {
+						addFilter := reconcilertesting.WithFilter(reconcilertesting.EventSource, f)
+						addFilter(subscription)
+					}
+					ensureSubscriptionUpdated(ctx, subscription)
+				})
+
+				By("checking if Subscription status has 'cleanEventTypes' with the correct cleaned filter values", func() {
+					getSubscription(ctx, subscription).Should(And(
+						reconcilertesting.HaveSubscriptionName(subscriptionName),
+						reconcilertesting.HaveCondition(eventingv1alpha1.MakeCondition(
+							eventingv1alpha1.ConditionSubscriptionActive,
+							eventingv1alpha1.ConditionReasonSubscriptionActive,
+							v1.ConditionTrue, "")),
+						reconcilertesting.HaveCleanEventTypes(publishToSubjects),
+					))
+				})
+			})
+
+			Context("Updating Subscription filters", func() {
+				cleanEventTypes := []string{
+					fmt.Sprintf("%s0alpha", reconcilertesting.OrderCreatedEventType),
+					fmt.Sprintf("%s1alpha", reconcilertesting.OrderCreatedEventType),
+				}
+
+				By("updating the Subscription filters", func() {
+					for _, f := range subscription.Spec.Filter.Filters {
+						f.EventType.Value = fmt.Sprintf("%salpha", f.EventType.Value)
+					}
+
+					ensureSubscriptionUpdated(ctx, subscription)
+				})
+
+				By("checking if Subscription status has 'cleanEventTypes' with the correct cleaned and updated filter values", func() {
+					getSubscription(ctx, subscription).Should(And(
+						reconcilertesting.HaveSubscriptionName(subscriptionName),
+						reconcilertesting.HaveCondition(eventingv1alpha1.MakeCondition(
+							eventingv1alpha1.ConditionSubscriptionActive,
+							eventingv1alpha1.ConditionReasonSubscriptionActive,
+							v1.ConditionTrue, "")),
+						reconcilertesting.HaveCleanEventTypes(cleanEventTypes),
+					))
+				})
+			})
+
+			Context("Deletion Subscription filters", func() {
+				cleanEventTypes := []string{
+					fmt.Sprintf("%s0alpha", reconcilertesting.OrderCreatedEventType),
+				}
+
+				By("deleting Subscription filters", func() {
+					subscription.Spec.Filter.Filters = subscription.Spec.Filter.Filters[:1]
+					ensureSubscriptionUpdated(ctx, subscription)
+				})
+
+				By("checking if Subscription status has 'cleanEventTypes' with the correct cleaned filter values", func() {
+					getSubscription(ctx, subscription).Should(And(
+						reconcilertesting.HaveSubscriptionName(subscriptionName),
+						reconcilertesting.HaveCondition(eventingv1alpha1.MakeCondition(
+							eventingv1alpha1.ConditionSubscriptionActive,
+							eventingv1alpha1.ConditionReasonSubscriptionActive,
+							v1.ConditionTrue, "")),
+						reconcilertesting.HaveCleanEventTypes(cleanEventTypes),
+					))
+				})
+			})
+		})
+	})
+
 	When("Creating a Subscription with invalid Sink and fixing it", func() {
 		createAndFixTheSubscription := func(sinkFormat string) {
 			// Ensuring subscriber svc
@@ -1020,6 +1127,14 @@ func ensureSubscriptionCreated(ctx context.Context, subscription *eventingv1alph
 	By(fmt.Sprintf("Ensuring the subscription %q is created", subscription.Name))
 	// create subscription
 	err := k8sClient.Create(ctx, subscription)
+	Expect(err).Should(BeNil())
+}
+
+// ensureSubscriptionUpdated conducts an update of a Subscription.
+func ensureSubscriptionUpdated(ctx context.Context, subscription *eventingv1alpha1.Subscription) {
+	By(fmt.Sprintf("Ensuring the subscription %q is updated", subscription.Name))
+	// update subscription
+	err := k8sClient.Update(ctx, subscription)
 	Expect(err).Should(BeNil())
 }
 

--- a/components/eventing-controller/controllers/subscription/nats/reconciler_test.go
+++ b/components/eventing-controller/controllers/subscription/nats/reconciler_test.go
@@ -62,149 +62,17 @@ type testCase func(id int, eventTypePrefix, natsSubjectToPublish, eventTypeToSub
 var (
 	reconcilerTestCases = []testCase{
 		testCreateDeleteSubscription,
+		testCreateSubscriptionWithValidSink,
 		testCreateSubscriptionWithInvalidSink,
 		testCreateSubscriptionWithEmptyProtocolProtocolSettingsDialect,
 		testChangeSubscriptionConfiguration,
 		testCreateSubscriptionWithEmptyEventType,
-		testCleanEventTypes,
 	}
 
 	dispatcherTestCases = []testCase{
 		testDispatcherWithMultipleSubscribers,
 	}
 )
-
-// testCleanEventTypes tests if the reconciler can create the correct cleanEventTypes from the filters of a Subscription.
-func testCleanEventTypes(id int, eventTypePrefix, natsSubjectToPublish, eventTypeToSubscribe string) bool {
-	return When("updating the clean event types in the Subscription status", func() {
-		It("should mark the Subscription as ready", func() {
-			//  set default expectations
-			defaultCondition := eventingv1alpha1.MakeCondition(
-				eventingv1alpha1.ConditionSubscriptionActive,
-				eventingv1alpha1.ConditionReasonNATSSubscriptionActive,
-				v1.ConditionTrue, "")
-			defaultConfiguration := &eventingv1alpha1.SubscriptionConfig{
-				MaxInFlightMessages: defaultSubsConfig.MaxInFlightMessages}
-
-			// create a context
-			ctx := context.Background()
-			cancel = startReconciler(eventTypePrefix, defaultSinkValidator)
-			defer cancel()
-
-			// create a subscriber service
-			subscriberName := fmt.Sprintf(subscriberNameFormat, id)
-			subscriberSvc := reconcilertesting.NewSubscriberSvc(subscriberName, namespaceName)
-
-			ensureSubscriberSvcCreated(ctx, subscriberSvc)
-
-			// create a Subscription
-			subscriptionName := fmt.Sprintf(subscriptionNameFormat, id)
-			optFilter := reconcilertesting.WithEmptyFilter
-			optWebhook := reconcilertesting.WithWebhookForNats
-			subscription := reconcilertesting.NewSubscription(subscriptionName, namespaceName, optFilter, optWebhook)
-			reconcilertesting.WithValidSink(namespaceName, subscriberSvc.Name, subscription)
-
-			ensureSubscriptionCreated(ctx, subscription)
-
-			Context("A Subscription without filters", func() {
-				By("should have no clean event types", func() {
-					getSubscription(ctx, subscription).Should(reconcilertesting.HaveCleanEventTypes(nil))
-				})
-				By("should have the assigned subscription name", func() {
-					getSubscription(ctx, subscription).Should(reconcilertesting.HaveSubscriptionName(subscriptionName))
-				})
-				By("should have the default condition", func() {
-					getSubscription(ctx, subscription).Should(reconcilertesting.HaveCondition(defaultCondition))
-				})
-				By("should have the default configuration", func() {
-					getSubscription(ctx, subscription).Should(reconcilertesting.HaveSubsConfiguration(defaultConfiguration))
-				})
-			})
-
-			Context("A Subscription without filters to which filters are added", func() {
-				// the nats subject list to publish to; these are supposed to be equal to the cleanEventTypes
-				natsSubjectsToPublish := []string{
-					fmt.Sprintf("%s0", natsSubjectToPublish),
-					fmt.Sprintf("%s1", natsSubjectToPublish),
-				}
-				// the filter that are getting added to the subscription
-				eventTypesToSubscribe := []string{
-					fmt.Sprintf("%s0", eventTypeToSubscribe),
-					fmt.Sprintf("%s1", eventTypeToSubscribe),
-				}
-				By("should have been updated after the addition", func() {
-					for _, f := range eventTypesToSubscribe {
-						addFilter := reconcilertesting.WithFilter(reconcilertesting.EventSource, f)
-						addFilter(subscription)
-					}
-					ensureSubscriptionUpdated(ctx, subscription)
-				})
-				By("should have clean event types corresponding to the added filters", func() {
-					getSubscription(ctx, subscription).Should(reconcilertesting.HaveCleanEventTypes(natsSubjectsToPublish))
-				})
-				By("should have the same subscription name", func() {
-					getSubscription(ctx, subscription).Should(reconcilertesting.HaveSubscriptionName(subscriptionName))
-				})
-				By("should have the same default condition", func() {
-					getSubscription(ctx, subscription).Should(reconcilertesting.HaveCondition(defaultCondition))
-				})
-				By("should have the same default configuration", func() {
-					getSubscription(ctx, subscription).Should(reconcilertesting.HaveSubsConfiguration(defaultConfiguration))
-				})
-			})
-
-			Context("A Subscription with filters that are being modified", func() {
-				// the nats subject list to publish to; these are supposed to be equal to the cleanEventTypes
-				natsSubjectsToPublish := []string{
-					fmt.Sprintf("%s0alpha", natsSubjectToPublish),
-					fmt.Sprintf("%s1alpha", natsSubjectToPublish),
-				}
-				By("should have been updated after the modification", func() {
-					for _, f := range subscription.Spec.Filter.Filters {
-						f.EventType.Value = fmt.Sprintf("%salpha", f.EventType.Value)
-					}
-					ensureSubscriptionUpdated(ctx, subscription)
-				})
-				By("should have changed the clean event types according the modified filters", func() {
-					getSubscription(ctx, subscription).Should(reconcilertesting.HaveCleanEventTypes(natsSubjectsToPublish))
-				})
-				By("should have the same subscription name", func() {
-					getSubscription(ctx, subscription).Should(reconcilertesting.HaveSubscriptionName(subscriptionName))
-				})
-				By("should have the same default condition", func() {
-					getSubscription(ctx, subscription).Should(reconcilertesting.HaveCondition(defaultCondition))
-				})
-				By("should have the same default configuration", func() {
-					getSubscription(ctx, subscription).Should(reconcilertesting.HaveSubsConfiguration(defaultConfiguration))
-				})
-			})
-
-			Context("A Subscription with filters of which one is getting deleted", func() {
-				// the nats subject list to publish to; these are supposed to be equal to the cleanEventTypes
-				natsSubjectsToPublish := []string{
-					fmt.Sprintf("%s0alpha", natsSubjectToPublish),
-				}
-				By("should have been updated after the deletion", func() {
-					// remove one of the two filters
-					subscription.Spec.Filter.Filters = subscription.Spec.Filter.Filters[:1]
-					ensureSubscriptionUpdated(ctx, subscription)
-				})
-				By("should have removed one clean event type according the deletion of one the filters", func() {
-					getSubscription(ctx, subscription).Should(reconcilertesting.HaveCleanEventTypes(natsSubjectsToPublish))
-				})
-				By("should have the same subscription name", func() {
-					getSubscription(ctx, subscription).Should(reconcilertesting.HaveSubscriptionName(subscriptionName))
-				})
-				By("should have the same default condition", func() {
-					getSubscription(ctx, subscription).Should(reconcilertesting.HaveCondition(defaultCondition))
-				})
-				By("should have the same default configuration", func() {
-					getSubscription(ctx, subscription).Should(reconcilertesting.HaveSubsConfiguration(defaultConfiguration))
-				})
-			})
-		})
-	})
-}
 
 func testCreateDeleteSubscription(id int, eventTypePrefix, natsSubjectToPublish, eventTypeToSubscribe string) bool {
 	return When("Create/Delete Subscription", func() {
@@ -245,6 +113,47 @@ func testCreateDeleteSubscription(id int, eventTypePrefix, natsSubjectToPublish,
 
 			Expect(k8sClient.Delete(ctx, subscription)).Should(BeNil())
 			isSubscriptionDeleted(ctx, subscription).Should(reconcilertesting.HaveNotFoundSubscription(true))
+		})
+	})
+}
+
+func testCreateSubscriptionWithValidSink(id int, eventTypePrefix, _, eventTypeToSubscribe string) bool {
+	subscriptionName := fmt.Sprintf(subscriptionNameFormat, id) + "-valid"
+	subscriberName := fmt.Sprintf(subscriberNameFormat, id) + "-valid"
+	sink := reconcilertesting.GetValidSink(namespaceName, subscriberName)
+	testCreatingSubscription := func(sink string) {
+		ctx := context.Background()
+		cancel = startReconciler(eventTypePrefix, defaultSinkValidator)
+		defer cancel()
+
+		// create subscriber svc
+		subscriberSvc := reconcilertesting.NewSubscriberSvc(subscriberName, namespaceName)
+		ensureSubscriberSvcCreated(ctx, subscriberSvc)
+
+		// create subscription
+		subscription := reconcilertesting.NewSubscription(subscriptionName, namespaceName, reconcilertesting.WithFilter("", eventTypeToSubscribe))
+		subscription.Spec.Sink = sink
+		ensureSubscriptionCreated(ctx, subscription)
+
+		getSubscription(ctx, subscription).Should(And(
+			reconcilertesting.HaveSubscriptionName(subscriptionName),
+			reconcilertesting.HaveCondition(eventingv1alpha1.MakeCondition(
+				eventingv1alpha1.ConditionSubscriptionActive,
+				eventingv1alpha1.ConditionReasonNATSSubscriptionActive,
+				v1.ConditionTrue, "")),
+		))
+
+		Expect(k8sClient.Delete(ctx, subscription)).Should(BeNil())
+		isSubscriptionDeleted(ctx, subscription).Should(reconcilertesting.HaveNotFoundSubscription(true))
+
+		Expect(k8sClient.Delete(ctx, subscriberSvc)).Should(BeNil())
+	}
+	return When("Create Subscription with valid sink", func() {
+		It("Should mark the Subscription with valid sink as ready", func() {
+			testCreatingSubscription(sink)
+		})
+		It("Should mark the Subscription with valid sink with the port suffix as ready", func() {
+			testCreatingSubscription(sink + ":8080")
 		})
 	})
 }
@@ -633,13 +542,6 @@ func ensureSubscriptionCreated(ctx context.Context, subscription *eventingv1alph
 	By(fmt.Sprintf("Ensuring the subscription %q is created", subscription.Name))
 	// create subscription
 	err := k8sClient.Create(ctx, subscription)
-	Expect(err).Should(BeNil())
-}
-
-func ensureSubscriptionUpdated(ctx context.Context, subscription *eventingv1alpha1.Subscription) {
-	By(fmt.Sprintf("Ensuring the subscription %q is updated", subscription.Name))
-	// create subscription
-	err := k8sClient.Update(ctx, subscription)
 	Expect(err).Should(BeNil())
 }
 


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- add tests for sink containing port number for both beb and nats backends

**Related issue(s)**
https://github.com/kyma-project/kyma/issues/12812