### PR TITLE
Remove excessive debug logging from KEB client

### DIFF
--- a/tests/fast-integration/kyma-environment-broker/client.js
+++ b/tests/fast-integration/kyma-environment-broker/client.js
@@ -66,12 +66,10 @@ class KEBClient {
     try {
       const resp = await axios.request(config);
       if (resp.data.errors) {
-        debug(resp);
         throw new Error(resp.data);
       }
       return resp.data;
     } catch (err) {
-      debug(err);
       const msg = "Error calling KEB";
       if (err.response) {
         throw new Error(`${msg}: ${err.response.status} ${err.response.statusText}`);
@@ -185,12 +183,11 @@ class KEBClient {
           responseType: "stream",
         });
         if (resp.data.errors) {
-          debug(resp);
           throw new Error(resp.data);
         }
         resp.data.pipe(writeStream);
       } catch (err) {
-        debug(err);
+        debug(err.data);
         fs.unlinkSync("./shoot-kubeconfig.yaml");
         reject(err);
       }


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**
Logging whole error from axios calls is not required. This only leads to leaking information from the http request without providing any useful information about the error from KEB itself.

Changes proposed in this pull request:

- Removed `debug` usage in KEB client when making calls using `axios`
**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
