### PR TITLE
Add wait for ClusterServiceBroker func in fast-integration test

### DIFF
--- a/tests/fast-integration/skr-svcat-migration-test/deploy-sample-resources.js
+++ b/tests/fast-integration/skr-svcat-migration-test/deploy-sample-resources.js
@@ -4,6 +4,7 @@ const {
     kubectlDeleteDir,
     waitForPodWithLabel,
     waitForFunction,
+    waitForClusterServiceBroker,
     waitForServiceInstance,
     waitForServiceBinding,
     waitForServiceBindingUsage,
@@ -242,6 +243,11 @@ async function deploy() {
   await waitForPodWithLabel("app", "service-catalog-catalog-controller-manager", "kyma-system");
   await waitForPodWithLabel("app", "service-catalog-catalog-webhook", "kyma-system");
   await waitForPodWithLabel("app", "service-broker-proxy-k8s", "kyma-system");
+
+  await waitForClusterServiceBroker("helm-broker", 5 * 60 * 1000);
+  await waitForClusterServiceBroker("sm-auditlog-api", 5 * 60 * 1000);
+  await waitForClusterServiceBroker("sm-html5-apps-repo", 5 * 60 * 1000);
+  await waitForClusterServiceBroker("sm-auditlog-management", 5 * 60 * 1000);
 
   times.push(installRedisExample())
   times.push(installAuditlogExample())

--- a/tests/fast-integration/utils/index.js
+++ b/tests/fast-integration/utils/index.js
@@ -491,6 +491,23 @@ function waitForSubscription(name, namespace = "default", timeout = 180000) {
   );
 }
 
+function waitForClusterServiceBroker(name, timeout = 90000) {
+  return waitForK8sObject(
+      `/apis/servicecatalog.k8s.io/v1beta1/clusterservicebrokers`,
+      {},
+      (_type, _apiObj, watchObj) => {
+        return (
+            watchObj.object.metadata.name.includes(name) &&
+            watchObj.object.status.conditions.some(
+                (c) => c.type == "Ready" && c.status == "True"
+            )
+        );
+      },
+      timeout,
+      `Waiting for ${name} cluster service broker (${timeout} ms)`
+  );
+}
+
 function waitForServiceClass(name, namespace = "default", timeout = 90000) {
   return waitForK8sObject(
     `/apis/servicecatalog.k8s.io/v1beta1/namespaces/${namespace}/serviceclasses`,
@@ -1647,6 +1664,7 @@ module.exports = {
   k8sDelete,
   waitForK8sObject,
   waitForClusterAddonsConfiguration,
+  waitForClusterServiceBroker,
   waitForServiceClass,
   waitForServicePlanByServiceClass,
   waitForServiceInstance,


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- add waitForClusterServiceBroker() and run it before trying to provision Service Instance in skr-svcat-migration-test

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
