### PR TITLE
 Add tests for valid sink with path (#12810)

### DIFF
--- a/components/eventing-controller/controllers/subscription/nats/reconciler_test.go
+++ b/components/eventing-controller/controllers/subscription/nats/reconciler_test.go
@@ -288,6 +288,9 @@ func testCreateSubscriptionWithValidSink(id int, eventTypePrefix, _, eventTypeTo
 		It("Should mark the Subscription with valid sink with the port suffix as ready", func() {
 			testCreatingSubscription(sink + ":8080")
 		})
+		It("Should mark the Subscription with valid sink with the port suffix and path as ready", func() {
+			testCreatingSubscription(sink + ":8080" + "/myEndpoint")
+		})
 	})
 }
 


### PR DESCRIPTION
Add a new test case to avoid the case of #12810 