### PR TITLE
Add init container to service-manager-proxy deployment

### DIFF
--- a/resources/service-manager-proxy/templates/deployment.yaml
+++ b/resources/service-manager-proxy/templates/deployment.yaml
@@ -46,6 +46,10 @@ spec:
         - name: config-volume
           mountPath: {{ .Values.file.location }}
           readOnly: true
+      initContainers:
+      - name: init-service-catalog
+        image: busybox:1.31.1
+        command: ['sh', '-c', "until nslookup service-catalog-catalog-webhook.{{ .Release.Namespace }}.svc.cluster.local; do echo waiting for service catalog webhook availability; sleep 2; done"]
         env:
         - name: K8S_SECRET_NAME
           value: {{ template "service-broker-proxy.fullname" . }}-regsecret

--- a/resources/service-manager-proxy/templates/deployment.yaml
+++ b/resources/service-manager-proxy/templates/deployment.yaml
@@ -48,7 +48,7 @@ spec:
           readOnly: true
       initContainers:
       - name: init-service-catalog
-        image: busybox:1.31.1
+        image: "{{ .Values.global.images.initContainer.name }}:{{ .Values.global.images.initContainer.version }}"
         command: ['sh', '-c', "until nslookup service-catalog-catalog-webhook.{{ .Release.Namespace }}.svc.cluster.local; do echo waiting for service catalog webhook availability; sleep 2; done"]
         env:
         - name: K8S_SECRET_NAME

--- a/resources/service-manager-proxy/templates/deployment.yaml
+++ b/resources/service-manager-proxy/templates/deployment.yaml
@@ -48,7 +48,7 @@ spec:
           readOnly: true
       initContainers:
       - name: init-service-catalog
-        image: "{{ include "imageurl" (dict "reg" .Values.global.images.initContainer.containerRegistry "img" .Values.global.images.initContainer) }}"
+        image: "{{ include "imageurl" (dict "reg" .Values.global.containerRegistry "img" .Values.global.images.busybox) }}"
         command: ['sh', '-c', "until nslookup service-catalog-catalog-webhook.{{ .Release.Namespace }}.svc.cluster.local; do echo waiting for service catalog webhook availability; sleep 2; done"]
         env:
         - name: K8S_SECRET_NAME

--- a/resources/service-manager-proxy/templates/deployment.yaml
+++ b/resources/service-manager-proxy/templates/deployment.yaml
@@ -48,7 +48,7 @@ spec:
           readOnly: true
       initContainers:
       - name: init-service-catalog
-        image: "{{ .Values.global.images.initContainer.name }}:{{ .Values.global.images.initContainer.version }}"
+        image: "{{ include "imageurl" (dict "reg" .Values.global.images.initContainer.containerRegistry "img" .Values.global.images.initContainer) }}"
         command: ['sh', '-c', "until nslookup service-catalog-catalog-webhook.{{ .Release.Namespace }}.svc.cluster.local; do echo waiting for service catalog webhook availability; sleep 2; done"]
         env:
         - name: K8S_SECRET_NAME

--- a/resources/service-manager-proxy/values.yaml
+++ b/resources/service-manager-proxy/values.yaml
@@ -60,3 +60,6 @@ global:
       name: "sb-proxy-k8s"
       version: "v0.9.1"
       directory: "external/quay.io/service-manager"
+    initContainer:
+      name: "busybox"
+      version: "1.31.1"

--- a/resources/service-manager-proxy/values.yaml
+++ b/resources/service-manager-proxy/values.yaml
@@ -60,8 +60,7 @@ global:
       name: "sb-proxy-k8s"
       version: "v0.9.1"
       directory: "external/quay.io/service-manager"
-    initContainer:
-      containerRegistry: ""
+    busybox:
       name: "busybox"
-      version: "1.31.1"
-      directory: ""
+      version: "1.34.1"
+      directory: "external"

--- a/resources/service-manager-proxy/values.yaml
+++ b/resources/service-manager-proxy/values.yaml
@@ -61,5 +61,7 @@ global:
       version: "v0.9.1"
       directory: "external/quay.io/service-manager"
     initContainer:
+      containerRegistry: ""
       name: "busybox"
       version: "1.31.1"
+      directory: ""


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**
`service-manager-proxy` cannot be started until service catalog components are ready, because it tries to create `ClusterServiceBroker` instances. If the mutating webhook from service catalog is not ready, not all CSBs are created and yet the process is not retriggered (`service-manager-proxy` chart does not contain Job definition, it's just simple deployment and the logic in binary does not provide retries). Example error:

```
time="2021-12-30T09:45:54Z" level=error msg="Internal error occurred: failed calling webhook \"mutating.clusterservicebrokers.servicecatalog.k8s.io\": Post \"https://service-catalog-catalog-webhook.kyma-system.svc:443/mutating-clusterservicebrokers?timeout=30s\": no endpoints available for service \"service-catalog-catalog-webhook\"" component="reconcile/task_scheduler.go:43" correlation_id=0293c363-71ef-4222-a4ef-5faf97ad4bd3
```

Changes proposed in this pull request:

- Added init container waiting for dependencies of `service-manager-proxy` component

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
