### PR TITLE
Adding namespace kyma-integration in compass-runtime-agent chart

### DIFF
--- a/resources/compass-runtime-agent/templates/integration-namespace.yaml
+++ b/resources/compass-runtime-agent/templates/integration-namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: {{ .Values.compassRuntimeAgent.resources.integrationNamespace }}


### PR DESCRIPTION
Results from running 10 times full set of testing jobs:

3 times failed job pre-main-kyma-gardener-azure-alpha-prod
1 time failed job pre-main-kyma-gardener-azure-alpha-eval
0 times failed jobs pre-main-kyma-integration-k3d-central-app-connectivity-compass
0 times failed jobs kyma-integration-k3d-compass-dev