### PR TITLE
Revert port customisations

### DIFF
--- a/resources/tracing/templates/deployment.yaml
+++ b/resources/tracing/templates/deployment.yaml
@@ -1,5 +1,5 @@
 {{- /*
-  Customization: Adjusted metrics port to 8080 as upstream has wrong port configured
+  Customization: Set default metrics port of jaeger-operator to 8383
 */ -}}
 apiVersion: apps/v1
 kind: Deployment
@@ -36,9 +36,11 @@ spec:
           image: "{{ include "imageurl" (dict "reg" .Values.global.containerRegistry "img" .Values.global.images.jaeger_operator) }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           ports:
-          - containerPort: 8080
+          - containerPort: 8383
             name: metrics
-          args: ["start"]
+          args:
+          - start
+          - --metrics-port=8383
           env:
             - name: WATCH_NAMESPACE
               {{- if .Values.rbac.clusterRole }}

--- a/resources/tracing/templates/service.yaml
+++ b/resources/tracing/templates/service.yaml
@@ -1,6 +1,3 @@
-{{- /*
-  Customization: Adjusted port from 8383->8080
-*/ -}}
 apiVersion: v1
 kind: Service
 metadata:
@@ -10,9 +7,9 @@ metadata:
 spec:
   ports:
   - name: metrics
-    port: 8080
+    port: 8383
     protocol: TCP
-    targetPort: 8080
+    targetPort: 8383
   selector:
     app.kubernetes.io/name: {{ include "jaeger-operator.fullname" . }}-jaeger-operator
   type: ClusterIP


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

[This PR](https://github.com/kyma-project/kyma/pull/12915) fixed a bug in the upstream `jaeger-operator` chart. The problem was a mismatch between the metrics port defined in the Helm chart (8383) and the operator itself (8080), resulting
in Prometehus not being able to scrape the operator metrics. Unfortunately, this change introduced another problem -  Reconciler is not able to handle a port change when upgrading Kyma.

Changes proposed in this pull request:
- Revert custom ports in the Helm change
- Set the default port as a flag to compensate for the upstream bug

**Related issue(s)**
https://github.com/kyma-project/kyma/pull/12915
