### PR TITLE
Fix upgrade-test-cleanup test

### DIFF
--- a/tests/fast-integration/upgrade-test/upgrade-test-cleanup.js
+++ b/tests/fast-integration/upgrade-test/upgrade-test-cleanup.js
@@ -10,7 +10,7 @@ describe("Upgrade test cleanup", function () {
   const testNamespace = "test";
 
   it("Test namespaces should be deleted", async function () {
-    await cleanMockTestFixture("mocks", testNamespace, false);
+    await cleanMockTestFixture("mocks", testNamespace, true);
   });
 
 });

--- a/tests/fast-integration/utils/index.js
+++ b/tests/fast-integration/utils/index.js
@@ -832,7 +832,7 @@ async function deleteNamespaces(namespaces, wait = true) {
       }
       return namespaces.length == 0 || !wait;
     },
-    1,
+    120 * 1000,
     "Timeout for deleting namespaces: " + namespaces
   );
 


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**


**Related issues**
The upgrade-test-cleanup test has false positive result to indicate that test namespace are deleted but actually not.
```

> fast-integration-tests@0.0.1-alpha.12 upgrade-test-cleanup /home/sa_117798148653314453801/kyma/tests/fast-integration
> mocha --inline-diffs --check-leaks --reporter mocha-multi-reporters --reporter-options configFile=mocha-reporter-config.json upgrade-test/upgrade-test-cleanup.js



  Upgrade test cleanup
    ✓ Test namespaces should be deleted


  1 passing (173ms)
```
https://storage.googleapis.com/kyma-prow-logs/logs/kyma-upgrade-k3d-kyma2-to-main/1478426100341149696/build-log.txt