### PR TITLE
Retry reconciling subscriptions on NATS disconnect

### DIFF
--- a/components/eventing-controller/controllers/subscription/nats/reconciler_test.go
+++ b/components/eventing-controller/controllers/subscription/nats/reconciler_test.go
@@ -68,12 +68,59 @@ var (
 		testChangeSubscriptionConfiguration,
 		testCreateSubscriptionWithEmptyEventType,
 		testCleanEventTypes,
+		testNATSUnavailabilityReflectedInSubscriptionStatus,
 	}
 
 	dispatcherTestCases = []testCase{
 		testDispatcherWithMultipleSubscribers,
 	}
 )
+
+func testNATSUnavailabilityReflectedInSubscriptionStatus(id int, eventTypePrefix, _, eventTypeToSubscribe string) bool {
+	return When("NATS server is not reachable and max retries are exceeded", func() {
+		It("Should mark the Subscription as not ready until NATS is reachable again", func() {
+			subscriptionName := fmt.Sprintf(subscriptionNameFormat, id) + "-valid"
+			subscriberName := fmt.Sprintf(subscriberNameFormat, id) + "-valid"
+			sink := reconcilertesting.GetValidSink(namespaceName, subscriberName)
+
+			ctx := context.Background()
+			natsPort := natsPort + id
+			natsServer, natsURL := startNATS(natsPort)
+			defer reconcilertesting.ShutDownNATSServer(natsServer)
+			cancel = startReconciler(eventTypePrefix, defaultSinkValidator, natsURL)
+			defer cancel()
+
+			// create subscriber svc
+			subscriberSvc := reconcilertesting.NewSubscriberSvc(subscriberName, namespaceName)
+			ensureSubscriberSvcCreated(ctx, subscriberSvc)
+
+			// create subscription
+			subscription := reconcilertesting.NewSubscription(subscriptionName, namespaceName, reconcilertesting.WithFilter("", eventTypeToSubscribe))
+			subscription.Spec.Sink = sink
+			ensureSubscriptionCreated(ctx, subscription)
+
+			getSubscription(ctx, subscription).Should(And(
+				reconcilertesting.HaveSubscriptionName(subscriptionName),
+				reconcilertesting.HaveCondition(eventingv1alpha1.MakeCondition(
+					eventingv1alpha1.ConditionSubscriptionActive,
+					eventingv1alpha1.ConditionReasonNATSSubscriptionActive,
+					v1.ConditionTrue, "")),
+			))
+
+			natsServer.Shutdown()
+			getSubscription(ctx, subscription, timeout, pollingInterval).Should(And(
+				reconcilertesting.HaveSubscriptionName(subscriptionName),
+				reconcilertesting.HaveSubscriptionNotReady()),
+			)
+
+			_, _ = startNATS(natsPort)
+			getSubscription(ctx, subscription, timeout, pollingInterval).Should(And(
+				reconcilertesting.HaveSubscriptionName(subscriptionName),
+				reconcilertesting.HaveSubscriptionReady()),
+			)
+		})
+	})
+}
 
 // testCleanEventTypes tests if the reconciler can create the correct cleanEventTypes from the filters of a Subscription.
 func testCleanEventTypes(id int, eventTypePrefix, natsSubjectToPublish, eventTypeToSubscribe string) bool {
@@ -89,7 +136,7 @@ func testCleanEventTypes(id int, eventTypePrefix, natsSubjectToPublish, eventTyp
 
 			// create a context
 			ctx := context.Background()
-			cancel = startReconciler(eventTypePrefix, defaultSinkValidator)
+			cancel = startReconciler(eventTypePrefix, defaultSinkValidator, natsURL)
 			defer cancel()
 
 			// create a subscriber service
@@ -211,7 +258,7 @@ func testCreateDeleteSubscription(id int, eventTypePrefix, natsSubjectToPublish,
 	return When("Create/Delete Subscription", func() {
 		It("Should create/delete NATS Subscription", func() {
 			ctx := context.Background()
-			cancel = startReconciler(eventTypePrefix, defaultSinkValidator)
+			cancel = startReconciler(eventTypePrefix, defaultSinkValidator, natsURL)
 			defer cancel()
 			subscriptionName := fmt.Sprintf(subscriptionNameFormat, id)
 			subscriberName := fmt.Sprintf(subscriberNameFormat, id)
@@ -256,7 +303,7 @@ func testCreateSubscriptionWithValidSink(id int, eventTypePrefix, _, eventTypeTo
 	sink := reconcilertesting.GetValidSink(namespaceName, subscriberName)
 	testCreatingSubscription := func(sink string) {
 		ctx := context.Background()
-		cancel = startReconciler(eventTypePrefix, defaultSinkValidator)
+		cancel = startReconciler(eventTypePrefix, defaultSinkValidator, natsURL)
 		defer cancel()
 
 		// create subscriber svc
@@ -297,7 +344,7 @@ func testCreateSubscriptionWithValidSink(id int, eventTypePrefix, _, eventTypeTo
 func testCreateSubscriptionWithInvalidSink(id int, eventTypePrefix, _, eventTypeToSubscribe string) bool {
 	invalidSinkMsgCheck := func(sink, subConditionMsg, k8sEventMsg string) {
 		ctx := context.Background()
-		cancel = startReconciler(eventTypePrefix, defaultSinkValidator)
+		cancel = startReconciler(eventTypePrefix, defaultSinkValidator, natsURL)
 		defer cancel()
 		subscriptionName := fmt.Sprintf(subscriptionNameFormat, id)
 
@@ -376,7 +423,7 @@ func testCreateSubscriptionWithEmptyProtocolProtocolSettingsDialect(id int, even
 	return When("Create Subscription with empty protocol, protocolsettings and dialect", func() {
 		It("Should mark the Subscription as ready", func() {
 			ctx := context.Background()
-			cancel = startReconciler(eventTypePrefix, defaultSinkValidator)
+			cancel = startReconciler(eventTypePrefix, defaultSinkValidator, natsURL)
 			defer cancel()
 			subscriptionName := fmt.Sprintf(subscriptionNameFormat, id)
 			subscriberName := fmt.Sprintf(subscriberNameFormat, id)
@@ -412,7 +459,7 @@ func testChangeSubscriptionConfiguration(id int, eventTypePrefix, natsSubjectToP
 		It("Should reflect the new config in the subscription status", func() {
 			By("Creating the subscription using the default config")
 			ctx := context.Background()
-			cancel = startReconciler(eventTypePrefix, defaultSinkValidator)
+			cancel = startReconciler(eventTypePrefix, defaultSinkValidator, natsURL)
 			defer cancel()
 			subscriptionName := fmt.Sprintf(subscriptionNameFormat, id)
 			subscriberName := fmt.Sprintf(subscriberNameFormat, id)
@@ -475,7 +522,7 @@ func testCreateSubscriptionWithEmptyEventType(id int, eventTypePrefix, _, _ stri
 	return When("Create Subscription with empty event type", func() {
 		It("Should mark the subscription as not ready", func() {
 			ctx := context.Background()
-			cancel = startReconciler(eventTypePrefix, defaultSinkValidator)
+			cancel = startReconciler(eventTypePrefix, defaultSinkValidator, natsURL)
 			defer cancel()
 			subscriptionName := fmt.Sprintf(subscriptionNameFormat, id)
 			subscriberName := fmt.Sprintf(subscriberNameFormat, id)
@@ -508,7 +555,7 @@ func testDispatcherWithMultipleSubscribers(id int, eventTypePrefix, natsSubjectT
 			// Start reconciler with empty checkSink function
 			cancel = startReconciler(eventTypePrefix, func(ctx context.Context, r *Reconciler, subscription *eventingv1alpha1.Subscription) error {
 				return nil
-			})
+			}, natsURL)
 			defer cancel()
 
 			subName1 := fmt.Sprintf(subscriptionNameFormat, id)
@@ -716,7 +763,10 @@ func subscriptionGetter(ctx context.Context, name, namespace string) func() (*ev
 }
 
 // getSubscription fetches a subscription using the lookupKey and allows making assertions on it
-func getSubscription(ctx context.Context, subscription *eventingv1alpha1.Subscription) AsyncAssertion {
+func getSubscription(ctx context.Context, subscription *eventingv1alpha1.Subscription, intervals ...interface{}) AsyncAssertion {
+	if len(intervals) == 0 {
+		intervals = []interface{}{smallTimeout, smallPollingInterval}
+	}
 	return Eventually(func() *eventingv1alpha1.Subscription {
 		lookupKey := types.NamespacedName{
 			Namespace: subscription.Namespace,
@@ -726,7 +776,7 @@ func getSubscription(ctx context.Context, subscription *eventingv1alpha1.Subscri
 			return &eventingv1alpha1.Subscription{}
 		}
 		return subscription
-	}, smallTimeout, smallPollingInterval)
+	}, intervals...)
 }
 
 // isSubscriptionDeleted checks a subscription is deleted and allows making assertions on it
@@ -808,7 +858,7 @@ func startNATS(port int) (*natsserver.Server, string) {
 	return natsServer, clientURL
 }
 
-func startReconciler(eventTypePrefix string, sinkValidator sinkValidator) context.CancelFunc {
+func startReconciler(eventTypePrefix string, sinkValidator sinkValidator, natsURL string) context.CancelFunc {
 	ctx, cancel := context.WithCancel(context.Background())
 	logf.SetLogger(zap.New(zap.UseDevMode(true), zap.WriteTo(GinkgoWriter)))
 

--- a/components/eventing-controller/options/options.go
+++ b/components/eventing-controller/options/options.go
@@ -55,7 +55,7 @@ func New() *Options {
 func (o *Options) Parse() error {
 	flag.IntVar(&o.MaxReconnects, argNameMaxReconnects, 10, "Maximum number of reconnect attempts (NATS).")
 	flag.StringVar(&o.MetricsAddr, argNameMetricsAddr, ":8080", "The address the metric endpoint binds to.")
-	flag.DurationVar(&o.ReconnectWait, argNameReconnectWait, time.Second, "Wait time between reconnect attempts (NATS).")
+	flag.DurationVar(&o.ReconnectWait, argNameReconnectWait, 3*time.Second, "Wait time between reconnect attempts (NATS).")
 	flag.DurationVar(&o.ReconcilePeriod, argNameReconcilePeriod, time.Minute*10, "Period between triggering of reconciling calls (BEB).")
 	flag.StringVar(&o.ProbeAddr, argNameProbeAddr, ":8081", "The TCP address that the controller should bind to for serving health probes.")
 	flag.StringVar(&o.ReadyEndpoint, argNameReadyEndpoint, "readyz", "The endpoint of the readiness probe.")

--- a/components/eventing-controller/pkg/subscriptionmanager/nats/nats_test.go
+++ b/components/eventing-controller/pkg/subscriptionmanager/nats/nats_test.go
@@ -58,7 +58,7 @@ func TestCleanup(t *testing.T) {
 		EventTypePrefix: controllertesting.EventTypePrefix,
 	}
 	subsConfig := env.DefaultSubscriptionConfig{MaxInFlightMessages: 9}
-	natsBackend := handlers.NewNats(envConf, subsConfig, defaultLogger)
+	natsBackend := handlers.NewNats(envConf, subsConfig, nil, defaultLogger)
 	natsSubMgr.Backend = natsBackend
 	err = natsSubMgr.Backend.Initialize(env.Config{})
 	g.Expect(err).To(gomega.BeNil())

--- a/components/eventing-controller/testing/matchers.go
+++ b/components/eventing-controller/testing/matchers.go
@@ -150,6 +150,12 @@ func HaveSubscriptionReady() gomegatypes.GomegaMatcher {
 	}, BeTrue())
 }
 
+func HaveSubscriptionNotReady() gomegatypes.GomegaMatcher {
+	return WithTransform(func(s *eventingv1alpha1.Subscription) bool {
+		return s.Status.Ready
+	}, BeFalse())
+}
+
 func HaveCondition(condition eventingv1alpha1.Condition) gomegatypes.GomegaMatcher {
 	return WithTransform(func(s *eventingv1alpha1.Subscription) []eventingv1alpha1.Condition { return s.Status.Conditions }, ContainElement(MatchFields(IgnoreExtras|IgnoreMissing, Fields{
 		"Type":    Equal(condition.Type),

--- a/components/eventing-controller/testing/subscriber.go
+++ b/components/eventing-controller/testing/subscriber.go
@@ -5,6 +5,7 @@ import (
 	"io/ioutil"
 	"log"
 	"net/http"
+	"strconv"
 	"time"
 
 	"github.com/avast/retry-go/v3"
@@ -21,8 +22,8 @@ type Subscriber struct {
 }
 
 const (
-	maxNoOfData = 5
-	maxAttempts = 5
+	maxNoOfData = 10
+	maxAttempts = 10
 )
 
 func NewSubscriber(addr string) *Subscriber {
@@ -155,8 +156,12 @@ func (s Subscriber) CheckRetries(expectedNoOfRetries int, expectedData, subscrib
 			if err != nil {
 				return pkgerrors.Wrapf(err, "read data failed")
 			}
-			if string(body) != fmt.Sprintf("%d", expectedNoOfRetries) {
-				return fmt.Errorf("total retries not received")
+			actualRetires, err := strconv.Atoi(string(body))
+			if err != nil {
+				return pkgerrors.Wrapf(err, "read data failed")
+			}
+			if actualRetires < expectedNoOfRetries {
+				return fmt.Errorf("total retries not received. ActualRetires=%d, ExpectedRetries=%d", actualRetires, expectedNoOfRetries)
 			}
 			return nil
 		},

--- a/resources/eventing/values.yaml
+++ b/resources/eventing/values.yaml
@@ -5,7 +5,7 @@ global:
   images:
     eventing_controller:
       name: eventing-controller
-      version: PR-12488
+      version: PR-12997
       pullPolicy: "IfNotPresent"
     publisher_proxy:
       name: event-publisher-proxy


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

If the NATS server is down and the NATS subscription reconciler exceeds the retry
attempts configured, the Kyma subscription would still be reported as ready, even
though no messages could be delivered. The PR fixes this by forcing reconciliation
of the Kyma subscriptions after reconnection attempts have been exhausted. This
would move the subscriptions to a not ready state, which would cause periodic reconciliation
of the subscriptions until NATS is available again.

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
Closes #12930 