### PR TITLE
Add deprecated auth-proxy Secrets to cleanup script

### DIFF
--- a/docs/assets/1.24-2.0-remove-deprecated-resources.sh
+++ b/docs/assets/1.24-2.0-remove-deprecated-resources.sh
@@ -25,7 +25,7 @@ kubectl -n kyma-system delete service helm-broker-addons-ui
 echo "
 Deleting orphaned Deployments"
 kubectl -n kyma-system delete deployment logging-log-ui
-kubectl -n kyma-system delete deployment helm-broker-addons-ui 
+kubectl -n kyma-system delete deployment helm-broker-addons-ui
 kubectl -n kyma-system delete deployment service-catalog-addons-service-catalog-ui
 kubectl -n kyma-system delete deployment application-connector-certs-sync --ignore-not-found
 
@@ -112,6 +112,9 @@ kubectl -n kyma-system delete secret test-no-rights-user
 kubectl -n kyma-system delete secret test-read-only-user
 kubectl -n kyma-system delete secret admin-user
 kubectl -n kyma-system delete secret apiserver-proxy-tls-cert
+kubectl -n kyma-system delete secret kiali-auth-proxy --ignore-not-found
+kubectl -n kyma-system delete secret monitoring-auth-proxy-grafana --ignore-not-found
+kubectl -n kyma-system delete secret tracing-auth-proxy --ignore-not-found
 
 echo "
 Deleting orphaned ConfigMaps"
@@ -175,7 +178,7 @@ kubectl delete clusterrolebinding service-catalog-tests
 kubectl delete clusterrolebinding serverless-tests
 kubectl delete clusterrolebinding monitoring-tests
 kubectl delete clusterrolebinding logging-tests
-kubectl delete clusterrolebinding istio-job 
+kubectl delete clusterrolebinding istio-job
 kubectl delete clusterrolebinding istio-kyma-validate
 kubectl delete clusterrolebinding istio-proxy-reset
 kubectl delete clusterrolebinding rafter-tests
@@ -187,9 +190,9 @@ Deleting orphaned Kyma modules"
 helm -n kyma-system uninstall apiserver-proxy
 helm -n kyma-system uninstall console
 helm -n kyma-system uninstall core
-helm -n kyma-system uninstall dex 
-helm -n kyma-system uninstall iam-kubeconfig-service 
-helm -n kyma-system uninstall permission-controller 
+helm -n kyma-system uninstall dex
+helm -n kyma-system uninstall iam-kubeconfig-service
+helm -n kyma-system uninstall permission-controller
 helm -n kyma-installer uninstall xip-patch
 helm -n kyma-system uninstall testing
 


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

The Secrets with the oauth2-proxy default configuration has been renamed
by PR #13010 to mitigate issues when upgrading from Kyma 1.x. This PR
extends the cleanup script to remove the old Secrets.

Changes proposed in this pull request:

- Delete deprecated auth-proxy Secrets by cleanup script

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
See also https://github.com/kyma-incubator/reconciler/issues/650