### PR TITLE
Set istio inject to false for service catalog webhook

### DIFF
--- a/resources/service-catalog/charts/catalog/values.yaml
+++ b/resources/service-catalog/charts/catalog/values.yaml
@@ -19,7 +19,7 @@ webhook:
   minReadySeconds: 1
   # annotations is a collection of annotations to add to the webhook pods.
   annotations:
-    sidecar.istio.io/inject: "true"
+    sidecar.istio.io/inject: "false"
   # nodeSelector to apply to the webhook pods
   nodeSelector:
   # healthcheck configures the readiness and liveliness probes for the webhook pod.


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->
followup to https://github.com/kyma-project/kyma/pull/13017, where the annotation was accidentally set to `"true"` instead of `"false"`