### PR TITLE
Enable healthz endpoints in service-catalog-webhook and sm-proxy init container probes it

### DIFF
--- a/resources/service-catalog/charts/catalog/templates/webhook-service.yaml
+++ b/resources/service-catalog/charts/catalog/templates/webhook-service.yaml
@@ -17,6 +17,10 @@ spec:
   selector:
     app: {{ template "fullname" . }}-webhook
   ports:
+  - name: healthz
+    port: 8081
+    protocol: TCP
+    targetPort: 8081
   - name: https-secure
     protocol: TCP
     port: {{ .Values.webhook.service.port }}

--- a/resources/service-catalog/charts/catalog/values.yaml
+++ b/resources/service-catalog/charts/catalog/values.yaml
@@ -24,7 +24,7 @@ webhook:
   nodeSelector:
   # healthcheck configures the readiness and liveliness probes for the webhook pod.
   healthcheck:
-    enabled: true # in Kyma we are using svc-cat together with istio and default healtcheck is not supported
+    enabled: true # when using svc-cat together with istio the healthcheck is not supported
   # Attributes of the webhook's service resource
   service:
     port: 443

--- a/resources/service-catalog/charts/catalog/values.yaml
+++ b/resources/service-catalog/charts/catalog/values.yaml
@@ -24,7 +24,7 @@ webhook:
   nodeSelector:
   # healthcheck configures the readiness and liveliness probes for the webhook pod.
   healthcheck:
-    enabled: false # in Kyma we are using svc-cat together with istio and default healtcheck is not supported
+    enabled: true # in Kyma we are using svc-cat together with istio and default healtcheck is not supported
   # Attributes of the webhook's service resource
   service:
     port: 443

--- a/resources/service-manager-proxy/templates/deployment.yaml
+++ b/resources/service-manager-proxy/templates/deployment.yaml
@@ -85,8 +85,9 @@ spec:
           - "--file.format={{ .Values.file.format }}"
       initContainers:
       - name: init-service-catalog
-        image: "{{ include "imageurl" (dict "reg" .Values.global.containerRegistry "img" .Values.global.images.busybox) }}"
-        command: ['sh', '-c', "until nslookup service-catalog-catalog-webhook.{{ .Release.Namespace }}.svc.cluster.local; do echo waiting for service catalog webhook availability; sleep 2; done"]
+        image: "{{ include "imageurl" (dict "reg" .Values.global.containerRegistry "img" .Values.global.images.alpine) }}"
+        command: ["/bin/sh", "-c"]
+        args: ['apk update && apk add --no-cache curl; while [ `curl -Lk --write-out "%{http_code}\n" --silent --output /dev/null "service-catalog-catalog-webhook.{{ .Release.Namespace }}.svc.cluster.local:8081/healthz/ready"` -ne 200 ]; do sleep 2; done']
     {{- if .Values.global.priorityClassName }}
       priorityClassName: {{ .Values.global.priorityClassName }}
     {{- end }}

--- a/resources/service-manager-proxy/templates/deployment.yaml
+++ b/resources/service-manager-proxy/templates/deployment.yaml
@@ -90,11 +90,11 @@ spec:
           - "bin/sh"
           - "-c"
           - |
-          apk --no-cache add --update curl --repository=http://dl-cdn.alpinelinux.org/alpine/v3.14/main;
-          while [ `curl -Lk --write-out "%{http_code}\n" --silent --output /dev/null "service-catalog-catalog-webhook.{{ .Release.Namespace }}.svc.cluster.local:8081/healthz/ready"` -ne 200 ]; do
-          echo "Waiting for service catalog webhook server availability..."
-          sleep 2;
-          done
+            apk --no-cache add --update curl --repository=http://dl-cdn.alpinelinux.org/alpine/v3.14/main;
+            while [ `curl -Lk --write-out "%{http_code}\n" --silent --output /dev/null "service-catalog-catalog-webhook.{{ .Release.Namespace }}.svc.cluster.local:8081/healthz/ready"` -ne 200 ]; do
+              echo "Waiting for service catalog webhook server availability..."
+              sleep 2;
+            done
     {{- if .Values.global.priorityClassName }}
       priorityClassName: {{ .Values.global.priorityClassName }}
     {{- end }}

--- a/resources/service-manager-proxy/templates/deployment.yaml
+++ b/resources/service-manager-proxy/templates/deployment.yaml
@@ -86,8 +86,15 @@ spec:
       initContainers:
       - name: init-service-catalog
         image: "{{ include "imageurl" (dict "reg" .Values.global.containerRegistry "img" .Values.global.images.alpine) }}"
-        command: ["/bin/sh", "-c"]
-        args: ['apk update && apk add --no-cache curl; while [ `curl -Lk --write-out "%{http_code}\n" --silent --output /dev/null "service-catalog-catalog-webhook.{{ .Release.Namespace }}.svc.cluster.local:8081/healthz/ready"` -ne 200 ]; do sleep 2; done']
+        command:
+          - "bin/sh"
+          - "-c"
+          - |
+          apk --no-cache add --update curl --repository=http://dl-cdn.alpinelinux.org/alpine/v3.14/main;
+          while [ `curl -Lk --write-out "%{http_code}\n" --silent --output /dev/null "service-catalog-catalog-webhook.{{ .Release.Namespace }}.svc.cluster.local:8081/healthz/ready"` -ne 200 ]; do
+          echo "Waiting for service catalog webhook server availability..."
+          sleep 2;
+          done
     {{- if .Values.global.priorityClassName }}
       priorityClassName: {{ .Values.global.priorityClassName }}
     {{- end }}

--- a/resources/service-manager-proxy/values.yaml
+++ b/resources/service-manager-proxy/values.yaml
@@ -62,5 +62,5 @@ global:
       directory: "external/quay.io/service-manager"
     alpine:
       name: "alpine"
-      version: "3.15"
+      version: "3.14.2"
       directory: "external"

--- a/resources/service-manager-proxy/values.yaml
+++ b/resources/service-manager-proxy/values.yaml
@@ -60,7 +60,7 @@ global:
       name: "sb-proxy-k8s"
       version: "v0.9.1"
       directory: "external/quay.io/service-manager"
-    busybox:
-      name: "busybox"
-      version: "1.34.1"
+    alpine:
+      name: "alpine"
+      version: "3.15"
       directory: "external"


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**
The istio sidecar injection was meant to be disabled for service catalog webhook, so we can enable healthz probes. To 

Changes proposed in this pull request:

- Enabled `/healthz/ready` endpoint for service-catalog-webhook server
- Changed logic in init container for `service-manager-proxy` to avoid false-positive result described here: https://github.com/kyma-project/kyma/pull/12976#pullrequestreview-845476027 ; now sm-proxy probes healthz endpoint for service catalog webhook server


**Related issue(s)**
fast-integration pipelines failing when waiting for ClusterServiceBrokers which were not properly validated on service-manager-proxy startup against mutatin webhook from service-catalog
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
