### PR TITLE
Enable healthz endpoints in service-catalog-webhook and sm-proxy init container probes it (release-2.0)

### DIFF
--- a/resources/service-catalog/charts/catalog/templates/webhook-service.yaml
+++ b/resources/service-catalog/charts/catalog/templates/webhook-service.yaml
@@ -17,6 +17,10 @@ spec:
   selector:
     app: {{ template "fullname" . }}-webhook
   ports:
+  - name: healthz
+    port: 8081
+    protocol: TCP
+    targetPort: 8081
   - name: https-secure
     protocol: TCP
     port: {{ .Values.webhook.service.port }}

--- a/resources/service-catalog/charts/catalog/values.yaml
+++ b/resources/service-catalog/charts/catalog/values.yaml
@@ -24,7 +24,7 @@ webhook:
   nodeSelector:
   # healthcheck configures the readiness and liveliness probes for the webhook pod.
   healthcheck:
-    enabled: false # in Kyma we are using svc-cat together with istio and default healtcheck is not supported
+    enabled: true # when using svc-cat together with istio the healthcheck is not supported
   # Attributes of the webhook's service resource
   service:
     port: 443

--- a/resources/service-manager-proxy/templates/deployment.yaml
+++ b/resources/service-manager-proxy/templates/deployment.yaml
@@ -83,6 +83,18 @@ spec:
           - "--file.location={{ .Values.file.location }}"
           - "--file.name={{ .Values.file.name }}"
           - "--file.format={{ .Values.file.format }}"
+      initContainers:
+      - name: init-service-catalog
+        image: "{{ include "imageurl" (dict "reg" .Values.global.containerRegistry "img" .Values.global.images.alpine) }}"
+        command:
+          - "bin/sh"
+          - "-c"
+          - |
+            apk --no-cache add --update curl --repository=http://dl-cdn.alpinelinux.org/alpine/v3.14/main;
+            while [ `curl -Lk --write-out "%{http_code}\n" --silent --output /dev/null "service-catalog-catalog-webhook.{{ .Release.Namespace }}.svc.cluster.local:8081/healthz/ready"` -ne 200 ]; do
+              echo "Waiting for service catalog webhook server availability..."
+              sleep 2;
+            done
     {{- if .Values.global.priorityClassName }}
       priorityClassName: {{ .Values.global.priorityClassName }}
     {{- end }}

--- a/resources/service-manager-proxy/values.yaml
+++ b/resources/service-manager-proxy/values.yaml
@@ -60,3 +60,7 @@ global:
       name: "sb-proxy-k8s"
       version: "v0.9.1"
       directory: "external/quay.io/service-manager"
+    alpine:
+      name: "alpine"
+      version: "3.14.2"
+      directory: "external"


### PR DESCRIPTION
… container probes it (#13023)

* Enable healthz endpoints in service-catalog-webhook

* Fix commnet

* Change sm-proxy init container logic to probe svcat-webhook health

* Use same image tag version as in ory

* Cleanup init container command

* Fix intendation in sm-proxy deployment

<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- cherry-pick from #13023 

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
