### PR TITLE
Fix central-application-connectivity-validator legacy gatewayName in VirtualService

### DIFF
--- a/resources/application-connector/charts/central-application-connectivity-validator/templates/virtual-service.yaml
+++ b/resources/application-connector/charts/central-application-connectivity-validator/templates/virtual-service.yaml
@@ -14,7 +14,7 @@ spec:
   hosts:
     - gateway.{{ .Values.global.domainName }}
   gateways:
-    - {{ .Values.istio.gateway.nameMtls }}.{{ .Values.istio.gateway.namespace }}.svc.cluster.local
+    - {{ .Values.istio.gateway.namespace }}/{{ .Values.istio.gateway.nameMtls }}
   http:
     - match:
         - uri:


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- fix `central-application-connectivity-validator` legacy gatewayName VirtualService - change format to `<namespace>/<name>`
- get rid of following errors:

```bash
Error [IST0101] (VirtualService central-application-connectivity-validator.kyma-system) Referenced gateway not found: "kyma-gateway-application-connector.kyma-system.svc.cluster.local"
Warning [IST0132] (VirtualService central-application-connectivity-validator.kyma-system) one or more host [gateway.mj-istio.goatz.shoot.canary.k8s-hana.ondemand.com] defined in VirtualService kyma-system/central-application-connectivity-validator not found in Gateway kyma-system/kyma-gateway-application-connector.kyma-system.svc.cluster.local.
Warning [IST0133] (VirtualService central-application-connectivity-validator.kyma-system) Schema validation warning: using legacy gatewayName format "kyma-gateway-application-connector.kyma-system.svc.cluster.local"; prefer the <namespace>/<name> format: "kyma-system/kyma-gateway-application-connector"
```

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
See: https://github.com/kyma-project/kyma/issues/11686
