### PR TITLE
Fix API Gateway metrics service port name to comply with Istio convention

### DIFF
--- a/resources/api-gateway/templates/monitoring.yaml
+++ b/resources/api-gateway/templates/monitoring.yaml
@@ -22,7 +22,7 @@ metadata:
   name: {{ include "api-gateway.name" . }}
 spec:
   endpoints:
-  - port: metrics
+  - port: tcp-metrics
     metricRelabelings:
     - sourceLabels: [ __name__ ]
       regex: ^(go_gc_duration_seconds|go_goroutines|go_memstats_alloc_bytes|go_memstats_heap_alloc_bytes|go_memstats_heap_inuse_bytes|go_memstats_heap_sys_bytes|go_memstats_stack_inuse_bytes|go_threads|http_requests_total|process_cpu_seconds_total|process_max_fds|process_open_fds|process_resident_memory_bytes|process_start_time_seconds|process_virtual_memory_bytes|rest_client_request_latency_seconds_bucket|rest_client_requests_total|workqueue_adds_total|workqueue_depth|workqueue_queue_duration_seconds_bucket)$

--- a/resources/api-gateway/templates/monitoring.yaml
+++ b/resources/api-gateway/templates/monitoring.yaml
@@ -7,7 +7,7 @@ metadata:
 {{ include "api-gateway.labels" . | indent 4 }}
 spec:
   ports:
-    - name: metrics
+    - name: tcp-metrics
       port: {{ .Values.config.ports.metrics }}
   selector:
     app.kubernetes.io/name: {{ include "api-gateway.name" . }}


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

We should follow [official Istio documentation about port naming convention](https://istio.io/latest/docs/reference/config/analysis/ist0118/). After editing `api-gateway-metrics` service there is a following spec which indicates that the used protocol is TCP.

```yaml
...
spec:
  ...
  - name: tcp-metrics
    port: 8080
    protocol: TCP
    targetPort: 8080
  ...
```

Changes proposed in this pull request:

- fix API Gateway metrics service port name to comply with Istio convention (pattern is: `<protocol>[-<suffix>])
- get rid of the following error:

```bash
Info [IST0118] (Service api-gateway-metrics.kyma-system) Port name metrics (port: 8080, targetPort: 8080) doesn't follow the naming convention of Istio port.
```

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
See: https://github.com/kyma-project/kyma/issues/11686
