### PR TITLE
Extend svcat migration fast-integration test timeout and improve stability

### DIFF
--- a/tests/fast-integration/skr-svcat-migration-test/skr-svcat-migration-test.js
+++ b/tests/fast-integration/skr-svcat-migration-test/skr-svcat-migration-test.js
@@ -46,7 +46,7 @@ describe("SKR SVCAT migration test", function() {
 
   const provisioningTimeout = 1000 * 60 * 60 // 1h
   const deprovisioningTimeout = 1000 * 60 * 30 // 30m
-  const updateTimeout = 1000 * 60 * 15 // 15m
+  const updateTimeout = 1000 * 60 * 45 // 45m
 
   let platformCreds;
   it(`Should provision new ServiceManager platform`, async function() {
@@ -69,7 +69,7 @@ describe("SKR SVCAT migration test", function() {
   });
 
   it(`Should save kubeconfig for the SKR to ~/.kube/config`, async function() {
-    t.saveKubeconfig(skr.shoot.kubeconfig);
+    await t.saveKubeconfig(skr.shoot.kubeconfig);
   });
 
   it(`Should initialize K8s client`, async function() {

--- a/tests/fast-integration/skr-svcat-migration-test/test-helpers.js
+++ b/tests/fast-integration/skr-svcat-migration-test/test-helpers.js
@@ -39,8 +39,10 @@ const functions = [
 ];
 
 async function saveKubeconfig(kubeconfig) {
-    fs.mkdirSync(`${os.homedir()}/.kube`, true);
-    fs.writeFileSync(`${os.homedir()}/.kube/config`, kubeconfig);
+    if (!fs.existsSync(`${os.homedir()}/.kube`)) {
+      fs.mkdirSync(`${os.homedir()}/.kube`, true)
+    }
+    fs.writeFileSync(`${os.homedir()}/.kube/config`, kubeconfig)
 }
 
 async function readClusterID() {


### PR DESCRIPTION

<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

The update operation at 15 minutes occasionally times out even before btp-operator is fully installed and sc-migration can try to execute. Also newly the `~/.kube` directory is already present on the prow job filesystem so creating this only conditionally.

Should take care of these two reported errors:
```
  1) SKR SVCAT migration test
       Should save kubeconfig for the SKR to ~/.kube/config:
     Error: EEXIST: file already exists, mkdir '/root/.kube'
      at Object.mkdirSync (fs.js:1013:3)
      at Object.saveKubeconfig (skr-svcat-migration-test/test-helpers.js:42:8)
      at Context.<anonymous> (skr-svcat-migration-test/skr-svcat-migration-test.js:72:13)
      at processImmediate (internal/timers.js:464:21)

  2) SKR SVCAT migration test
       Should check if pod presets injected secrets to functions containers:
     Error: failed to execute kubectl exec svcat-auditlog-api-1-zppcs-768d49ffdd-h894v -c function -n default -- sh -c for v in uaa url vendor; do x="$(eval echo \$$v)"; if [[ -z "$x" ]]; then echo missing $v env variable; exit 1; else echo found $v env variable; fi; done:
,
The connection to the server localhost:8080 was refused - did you specify the right host or port?
      at kubectlExecInPod (utils/index.js:693:11)
      at processTicksAndRejections (internal/process/task_queues.js:95:5)
      at async Object.checkPodPresetEnvInjected (skr-svcat-migration-test/test-helpers.js:76:9)
      at async Context.<anonymous> (skr-svcat-migration-test/skr-svcat-migration-test.js:110:5)
```

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
https://github.com/kyma-project/kyma/issues/12843