### PR TITLE
Fix Helm Broker port names in services to comply with Istio convention

### DIFF
--- a/resources/helm-broker/charts/etcd-stateful/templates/02-service.yaml
+++ b/resources/helm-broker/charts/etcd-stateful/templates/02-service.yaml
@@ -13,9 +13,9 @@ metadata:
 spec:
   ports:
   - port: 2379
-    name: client
+    name: tcp-client
   - port: 2380
-    name: peer
+    name: tcp-peer
   clusterIP: None
   selector:
     app: {{ template "etcd-hb-fullname" . }}
@@ -35,8 +35,8 @@ metadata:
 spec:
   ports:
   - port: 2379
-    name: client
+    name: tcp-client
   - port: 2381
-    name: metrics
+    name: tcp-metrics
   selector:
     app: {{ template "etcd-hb-fullname" . }}

--- a/resources/helm-broker/charts/etcd-stateful/templates/04-servicemonitor.yaml
+++ b/resources/helm-broker/charts/etcd-stateful/templates/04-servicemonitor.yaml
@@ -10,7 +10,7 @@ metadata:
   name: {{ template "etcd-hb-fullname" . }}
 spec:
   endpoints:
-  - port: metrics
+  - port: tcp-metrics
     metricRelabelings:
     - sourceLabels: [ __name__ ]
       regex: ^(etcd_disk_backend_commit_duration_seconds_bucket|etcd_disk_wal_fsync_duration_seconds_bucket|etcd_mvcc_db_total_size_in_bytes|etcd_network_client_grpc_received_bytes_total|etcd_network_client_grpc_sent_bytes_total|etcd_network_peer_received_bytes_total|etcd_network_peer_sent_bytes_total|etcd_server_has_leader|etcd_server_leader_changes_seen_total|etcd_server_proposals_applied_total|etcd_server_proposals_committed_total|etcd_server_proposals_failed_total|etcd_server_proposals_pending|go_goroutines|go_memstats_alloc_bytes|go_memstats_heap_alloc_bytes|go_memstats_heap_inuse_bytes|go_memstats_heap_sys_bytes|go_memstats_stack_inuse_bytes|grpc_server_handled_total|grpc_server_started_total|process_cpu_seconds_total|process_max_fds|process_open_fds|process_resident_memory_bytes|process_start_time_seconds|process_virtual_memory_bytes)$


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

We should follow [official Istio documentation about port naming convention](https://istio.io/latest/docs/reference/config/analysis/ist0118/). After editing both services there is a similar spec which indicates that the used protocol is TCP.

```yaml
...
spec:
  ...
  ports:
  - name: client
    port: 2379
    protocol: TCP
    targetPort: 2379
  - name: metrics
    port: 2381
    protocol: TCP
    targetPort: 2381
  ...
```

Changes proposed in this pull request:

- fix port names in `helm-broker-etcd-stateful` service to include protocol prefix
- fix port names in `helm-broker-etcd-stateful-client` service to include protocol prefix
- get rid of the following errors:

```bash
Info [IST0118] (Service helm-broker-etcd-stateful-client.kyma-system) Port name client (port: 2379, targetPort: 2379) doesn't follow the naming convention of Istio port.
Info [IST0118] (Service helm-broker-etcd-stateful-client.kyma-system) Port name metrics (port: 2381, targetPort: 2381) doesn't follow the naming convention of Istio port.
Info [IST0118] (Service helm-broker-etcd-stateful.kyma-system) Port name client (port: 2379, targetPort: 2379) doesn't follow the naming convention of Istio port.
Info [IST0118] (Service helm-broker-etcd-stateful.kyma-system) Port name peer (port: 2380, targetPort: 2380) doesn't follow the naming convention of Istio port.
```

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
See: https://github.com/kyma-project/kyma/issues/11686
