### PR TITLE
Fix endless reconciliation calls

### DIFF
--- a/components/eventing-controller/controllers/subscription/nats/reconciler.go
+++ b/components/eventing-controller/controllers/subscription/nats/reconciler.go
@@ -241,18 +241,6 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 		return ctrl.Result{}, nil
 	}
 
-	// Clean up the old subscriptions
-	if err := r.Backend.DeleteSubscription(subscription); err != nil {
-		log.Errorw("delete subscription failed", "error", err)
-		if err := r.syncSubscriptionStatus(ctx, subscription, false, false, err.Error()); err != nil {
-			if k8serrors.IsConflict(err) {
-				return ctrl.Result{Requeue: true}, nil
-			}
-			return ctrl.Result{}, err
-		}
-		return ctrl.Result{}, err
-	}
-
 	// Synchronize Kyma subscription to NATS backend
 	subscriptionStatusChanged, err := r.Backend.SyncSubscription(subscription, r.eventTypeCleaner)
 	if err != nil {

--- a/components/eventing-controller/controllers/subscription/nats/reconciler.go
+++ b/components/eventing-controller/controllers/subscription/nats/reconciler.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"net/url"
 	"os"
-	"reflect"
 	"strings"
 
 	"github.com/nats-io/nats.go"
@@ -173,34 +172,24 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 
 	r.namedLogger().Debugw("received subscription reconciliation request", "namespace", req.Namespace, "name", req.Name)
 
-	actualSubscription := &eventingv1alpha1.Subscription{}
-	result := ctrl.Result{}
+	cachedSubscription := &eventingv1alpha1.Subscription{}
 
 	// Ensure the object was not deleted in the meantime
-	err := r.Client.Get(ctx, req.NamespacedName, actualSubscription)
+	err := r.Client.Get(ctx, req.NamespacedName, cachedSubscription)
 	if err != nil {
 		return ctrl.Result{}, client.IgnoreNotFound(err)
 	}
 
 	// Handle only the new subscription
-	desiredSubscription := actualSubscription.DeepCopy()
+	subscription := cachedSubscription.DeepCopy()
 
 	// Bind fields to logger
-	log := utils.LoggerWithSubscription(r.namedLogger(), desiredSubscription)
+	log := utils.LoggerWithSubscription(r.namedLogger(), subscription)
 
-	if !desiredSubscription.ObjectMeta.DeletionTimestamp.IsZero() {
-		// Clean up the subscriptions from NATS
-		if err := r.Backend.DeleteSubscription(desiredSubscription); err != nil {
-			log.Errorw("delete subscription failed", "error", err)
-			if err := r.syncSubscriptionStatus(ctx, actualSubscription, false, err.Error()); err != nil {
-				return ctrl.Result{}, err
-			}
-			return ctrl.Result{}, err
-		}
-
+	if !subscription.ObjectMeta.DeletionTimestamp.IsZero() {
 		// The object is being deleted
-		if utils.ContainsString(desiredSubscription.ObjectMeta.Finalizers, Finalizer) {
-			if err := r.Backend.DeleteSubscription(desiredSubscription); err != nil {
+		if utils.ContainsString(subscription.ObjectMeta.Finalizers, Finalizer) {
+			if err := r.Backend.DeleteSubscription(subscription); err != nil {
 				log.Errorw("delete subscription failed", "error", err)
 				// if failed to delete the external dependency here, return with error
 				// so that it can be retried
@@ -208,48 +197,70 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 			}
 
 			// remove our finalizer from the list and update it.
-			desiredSubscription.ObjectMeta.Finalizers = utils.RemoveString(desiredSubscription.ObjectMeta.Finalizers, Finalizer)
-			if err := r.Client.Update(ctx, desiredSubscription); err != nil {
-				events.Warn(r.recorder, desiredSubscription, events.ReasonUpdateFailed, "Update Subscription failed %s", desiredSubscription.Name)
+			subscription.ObjectMeta.Finalizers = utils.RemoveString(subscription.ObjectMeta.Finalizers, Finalizer)
+			if err := r.Client.Update(ctx, subscription); err != nil {
+				events.Warn(r.recorder, subscription, events.ReasonUpdateFailed, "Update Subscription failed %s", subscription.Name)
 				log.Errorw("remove finalizer from subscription failed", "error", err)
+				if k8serrors.IsConflict(err) {
+					return ctrl.Result{Requeue: true}, nil
+				}
 				return ctrl.Result{}, err
 			}
 			log.Debug("remove finalizer from subscription succeeded")
-			return ctrl.Result{}, nil
 		}
-	}
-
-	// Check for valid sink
-	if err := r.sinkValidator(ctx, r, desiredSubscription); err != nil {
-		log.Errorw("sink URL validation failed", "error", err)
-		if err := r.syncSubscriptionStatus(ctx, actualSubscription, false, err.Error()); err != nil {
-			return ctrl.Result{}, err
-		}
-		// No point in reconciling as the sink is invalid
+		// Stop reconciliation as the object is being deleted
 		return ctrl.Result{}, nil
 	}
 
 	// The object is not being deleted, so if it does not have our finalizer,
 	// then lets add the finalizer and update the object. This is equivalent
 	// registering our finalizer.
-	if !utils.ContainsString(desiredSubscription.ObjectMeta.Finalizers, Finalizer) {
-		desiredSubscription.ObjectMeta.Finalizers = append(desiredSubscription.ObjectMeta.Finalizers, Finalizer)
-		if err := r.Update(context.Background(), desiredSubscription); err != nil {
+	if !utils.ContainsString(subscription.ObjectMeta.Finalizers, Finalizer) {
+		subscription.ObjectMeta.Finalizers = append(subscription.ObjectMeta.Finalizers, Finalizer)
+		if err := r.Update(context.Background(), subscription); err != nil {
 			log.Errorw("add finalizer to subscription failed", "error", err)
+			if k8serrors.IsConflict(err) {
+				return ctrl.Result{Requeue: true}, nil
+			}
 			return ctrl.Result{}, err
 		}
 		log.Debug("add finalizer to subscription succeeded")
-		result.Requeue = true
+		return ctrl.Result{Requeue: true}, nil
 	}
 
-	if result.Requeue {
-		return result, nil
+	// Check for valid sink
+	if err := r.sinkValidator(ctx, r, subscription); err != nil {
+		log.Errorw("sink URL validation failed", "error", err)
+		if err := r.syncSubscriptionStatus(ctx, subscription, false, false, err.Error()); err != nil {
+			if k8serrors.IsConflict(err) {
+				return ctrl.Result{Requeue: true}, nil
+			}
+			return ctrl.Result{}, err
+		}
+		// No point in reconciling as the sink is invalid
+		return ctrl.Result{}, nil
 	}
 
-	_, err = r.Backend.SyncSubscription(desiredSubscription, r.eventTypeCleaner)
+	// Clean up the old subscriptions
+	if err := r.Backend.DeleteSubscription(subscription); err != nil {
+		log.Errorw("delete subscription failed", "error", err)
+		if err := r.syncSubscriptionStatus(ctx, subscription, false, false, err.Error()); err != nil {
+			if k8serrors.IsConflict(err) {
+				return ctrl.Result{Requeue: true}, nil
+			}
+			return ctrl.Result{}, err
+		}
+		return ctrl.Result{}, err
+	}
+
+	// Synchronize Kyma subscription to NATS backend
+	subscriptionStatusChanged, err := r.Backend.SyncSubscription(subscription, r.eventTypeCleaner)
 	if err != nil {
 		log.Errorw("sync subscription failed", "error", err)
-		if err := r.syncSubscriptionStatus(ctx, desiredSubscription, false, err.Error()); err != nil {
+		if err := r.syncSubscriptionStatus(ctx, subscription, false, false, err.Error()); err != nil {
+			if k8serrors.IsConflict(err) {
+				return ctrl.Result{Requeue: true}, nil
+			}
 			return ctrl.Result{}, err
 		}
 		return ctrl.Result{}, err
@@ -257,51 +268,66 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 	log.Debug("create NATS subscriptions succeeded")
 
 	// Update status
-	if err := r.syncSubscriptionStatus(ctx, desiredSubscription, true, ""); err != nil {
+	if err := r.syncSubscriptionStatus(ctx, subscription, true, subscriptionStatusChanged, ""); err != nil {
+		if k8serrors.IsConflict(err) {
+			// Requeue the Pod to try to reconciliate again,
+			return ctrl.Result{Requeue: true}, nil
+		}
 		return ctrl.Result{}, err
 	}
 
-	return result, nil
+	return ctrl.Result{}, nil
 }
 
 // syncSubscriptionStatus syncs Subscription status
-// subsConfig is the subscription configuration that was applied to the subscription. It is set only if the
-// isNatsSubReady is true.
-func (r *Reconciler) syncSubscriptionStatus(ctx context.Context, sub *eventingv1alpha1.Subscription, isNatsSubReady bool, message string) error {
-	desiredSubscription := sub.DeepCopy()
+func (r *Reconciler) syncSubscriptionStatus(ctx context.Context, sub *eventingv1alpha1.Subscription, isNatsSubReady bool, forceUpdateStatus bool, message string) error {
 	desiredConditions := make([]eventingv1alpha1.Condition, 0)
-	conditionAdded := false
+	conditionContained := false
+	conditionsUpdated := false
 	condition := eventingv1alpha1.MakeCondition(eventingv1alpha1.ConditionSubscriptionActive,
 		eventingv1alpha1.ConditionReasonNATSSubscriptionActive, corev1.ConditionFalse, message)
 	if isNatsSubReady {
 		condition = eventingv1alpha1.MakeCondition(eventingv1alpha1.ConditionSubscriptionActive,
-			eventingv1alpha1.ConditionReasonNATSSubscriptionActive, corev1.ConditionTrue, "")
+			eventingv1alpha1.ConditionReasonNATSSubscriptionActive, corev1.ConditionTrue, message)
 	}
 	for _, c := range sub.Status.Conditions {
 		var chosenCondition eventingv1alpha1.Condition
 		if c.Type == condition.Type {
-			// take given condition
-			chosenCondition = condition
-			conditionAdded = true
+			if !conditionContained {
+				if c.Status == condition.Status && c.Reason == condition.Reason && c.Message == condition.Message {
+					// take the already present condition
+					chosenCondition = c
+				} else {
+					// take the new given condition
+					chosenCondition = condition
+					conditionsUpdated = true
+				}
+				desiredConditions = append(desiredConditions, chosenCondition)
+				conditionContained = true
+			}
+			// ignore all other conditions having the same type
+			continue
 		} else {
-			// take already present condition
+			// take the already present condition
 			chosenCondition = c
 		}
 		desiredConditions = append(desiredConditions, chosenCondition)
 	}
-	if !conditionAdded {
+	if !conditionContained {
 		desiredConditions = append(desiredConditions, condition)
+		conditionsUpdated = true
 	}
-	desiredSubscription.Status.Conditions = desiredConditions
-	desiredSubscription.Status.Ready = isNatsSubReady
-
-	if !reflect.DeepEqual(sub.Status, desiredSubscription.Status) {
-		err := r.Client.Status().Update(ctx, desiredSubscription, &client.UpdateOptions{})
+	if conditionsUpdated {
+		sub.Status.Conditions = desiredConditions
+		sub.Status.Ready = isNatsSubReady
+	}
+	if conditionsUpdated || forceUpdateStatus {
+		err := r.Client.Status().Update(ctx, sub, &client.UpdateOptions{})
 		if err != nil {
-			events.Warn(r.recorder, desiredSubscription, events.ReasonUpdateFailed, "Update Subscription status failed %s", desiredSubscription.Name)
+			events.Warn(r.recorder, sub, events.ReasonUpdateFailed, "Update Subscription status failed %s", sub.Name)
 			return errors.Wrapf(err, "update subscription status failed")
 		}
-		events.Normal(r.recorder, desiredSubscription, events.ReasonUpdate, "Update Subscription status succeeded %s", desiredSubscription.Name)
+		events.Normal(r.recorder, sub, events.ReasonUpdate, "Update Subscription status succeeded %s", sub.Name)
 	}
 	return nil
 }
@@ -365,8 +391,11 @@ func (r *Reconciler) syncInvalidSubscriptions(ctx context.Context) (ctrl.Result,
 			continue
 		}
 		// mark the subscription to be not ready, it will throw a new reconcile call
-		if err := r.syncSubscriptionStatus(ctx, sub, false, "invalid subscription"); err != nil {
+		if err := r.syncSubscriptionStatus(ctx, sub, false, false, "invalid subscription"); err != nil {
 			r.namedLogger().Errorw("sync status for invalid subscription failed", "namespace", v.Namespace, "name", v.Name, "error", err)
+			if k8serrors.IsConflict(err) {
+				return ctrl.Result{Requeue: true}, nil
+			}
 			return ctrl.Result{}, err
 		}
 	}

--- a/components/eventing-controller/controllers/subscription/nats/reconciler.go
+++ b/components/eventing-controller/controllers/subscription/nats/reconciler.go
@@ -317,10 +317,7 @@ func (r *Reconciler) syncInvalidSubscriptions(ctx context.Context) (ctrl.Result,
 		// mark the subscription to be not ready, it will throw a new reconcile call
 		if err := r.syncSubscriptionStatus(ctx, sub, false, false, "invalid subscription"); err != nil {
 			r.namedLogger().Errorw("sync status for invalid subscription failed", "namespace", v.Namespace, "name", v.Name, "error", err)
-			if k8serrors.IsConflict(err) {
-				return ctrl.Result{Requeue: true}, nil
-			}
-			return ctrl.Result{}, err
+			return checkIsConflict(err)
 		}
 	}
 	return ctrl.Result{}, nil

--- a/components/eventing-controller/controllers/subscription/nats/reconciler_test.go
+++ b/components/eventing-controller/controllers/subscription/nats/reconciler_test.go
@@ -254,6 +254,83 @@ func testCleanEventTypes(id int, eventTypePrefix, natsSubjectToPublish, eventTyp
 	})
 }
 
+// testUpdateSubscriptionStatus tests if the reconciler can create and update the Status of a Subscription as expected.
+func testUpdateSubscriptionStatus(id int, eventTypePrefix, natsSubjectToPublish, eventTypeToSubscribe string) bool {
+	return When("updating the clean event types in the Subscription status", func() {
+		It("should mark the Subscription as ready", func() {
+			//  set default expectations
+			defaultCondition := eventingv1alpha1.MakeCondition(
+				eventingv1alpha1.ConditionSubscriptionActive,
+				eventingv1alpha1.ConditionReasonNATSSubscriptionActive,
+				v1.ConditionTrue, "")
+			defaultConfiguration := &eventingv1alpha1.SubscriptionConfig{
+				MaxInFlightMessages: defaultSubsConfig.MaxInFlightMessages}
+			multipleConditions := reconcilertesting.NewDefaultMultipleConditions()
+
+			// create a context
+			ctx := context.Background()
+			cancel = startReconciler(eventTypePrefix, defaultSinkValidator, natsURL)
+			defer cancel()
+
+			// create a subscriber service
+			subscriberName := fmt.Sprintf(subscriberNameFormat, id)
+			subscriberSvc := reconcilertesting.NewSubscriberSvc(subscriberName, namespaceName)
+
+			ensureSubscriberSvcCreated(ctx, subscriberSvc)
+
+			// create a Subscription
+			subscriptionName := fmt.Sprintf(subscriptionNameFormat, id)
+			optFilter := reconcilertesting.WithEmptyFilter
+			optWebhook := reconcilertesting.WithWebhookForNats
+			optConditions := reconcilertesting.WithMultipleConditions
+			subscription := reconcilertesting.NewSubscription(subscriptionName, namespaceName, optFilter, optWebhook, optConditions)
+			reconcilertesting.WithValidSink(namespaceName, subscriberSvc.Name, subscription)
+
+			ensureSubscriptionCreated(ctx, subscription)
+
+			Context("A Subscription with default fake conditions", func() {
+				// the nats subject list to publish to; these are supposed to be equal to the cleanEventTypes
+				natsSubjectsToPublish := []string{
+					fmt.Sprintf("%s0", natsSubjectToPublish),
+				}
+				// the filter that are getting added to the subscription
+				eventTypesToSubscribe := []string{
+					fmt.Sprintf("%s0", eventTypeToSubscribe),
+				}
+				By("should have been updated after the addition", func() {
+					for _, f := range eventTypesToSubscribe {
+						addFilter := reconcilertesting.WithFilter(reconcilertesting.EventSource, f)
+						addFilter(subscription)
+					}
+					ensureSubscriptionUpdated(ctx, subscription)
+				})
+
+				By("should have the assigned subscription name", func() {
+					getSubscription(ctx, subscription).Should(reconcilertesting.HaveSubscriptionName(subscriptionName))
+				})
+				By("should have the default condition", func() {
+					getSubscription(ctx, subscription).Should(reconcilertesting.HaveCondition(defaultCondition))
+				})
+				By("should not have the additional fake condition - foo", func() {
+					getSubscription(ctx, subscription).ShouldNot(reconcilertesting.HaveCondition(multipleConditions[0]))
+				})
+				By("should not have the additional fake condition - bar", func() {
+					getSubscription(ctx, subscription).ShouldNot(reconcilertesting.HaveCondition(multipleConditions[1]))
+				})
+				By("should have the default configuration", func() {
+					getSubscription(ctx, subscription).Should(reconcilertesting.HaveSubsConfiguration(defaultConfiguration))
+				})
+				By("should have clean event types corresponding to the added filters", func() {
+					getSubscription(ctx, subscription).Should(reconcilertesting.HaveCleanEventTypes(natsSubjectsToPublish))
+				})
+				By("should have subscription ready", func() {
+					getSubscription(ctx, subscription).Should(reconcilertesting.HaveSubscriptionReady())
+				})
+			})
+		})
+	})
+}
+
 func testCreateDeleteSubscription(id int, eventTypePrefix, natsSubjectToPublish, eventTypeToSubscribe string) bool {
 	return When("Create/Delete Subscription", func() {
 		It("Should create/delete NATS Subscription", func() {

--- a/components/eventing-controller/controllers/subscription/nats/reconciler_test.go
+++ b/components/eventing-controller/controllers/subscription/nats/reconciler_test.go
@@ -289,7 +289,7 @@ func testUpdateSubscriptionStatus(id int, eventTypePrefix, natsSubjectToPublish,
 
 			ensureSubscriptionCreated(ctx, subscription)
 
-			Context("A Subscription with default fake conditions", func() {
+			Context("A Subscription with muktiple conditions of the same type", func() {
 				// the nats subject list to publish to; these are supposed to be equal to the cleanEventTypes
 				natsSubjectsToPublish := []string{
 					fmt.Sprintf("%s0", natsSubjectToPublish),
@@ -312,10 +312,10 @@ func testUpdateSubscriptionStatus(id int, eventTypePrefix, natsSubjectToPublish,
 				By("should have the default condition", func() {
 					getSubscription(ctx, subscription).Should(reconcilertesting.HaveCondition(defaultCondition))
 				})
-				By("should not have the additional fake condition - foo", func() {
+				By("should not have the additional condition - cond1", func() {
 					getSubscription(ctx, subscription).ShouldNot(reconcilertesting.HaveCondition(multipleConditions[0]))
 				})
-				By("should not have the additional fake condition - bar", func() {
+				By("should not have the additional condition - cond2", func() {
 					getSubscription(ctx, subscription).ShouldNot(reconcilertesting.HaveCondition(multipleConditions[1]))
 				})
 				By("should have the default configuration", func() {

--- a/components/eventing-controller/controllers/subscription/nats/reconciler_test.go
+++ b/components/eventing-controller/controllers/subscription/nats/reconciler_test.go
@@ -289,12 +289,12 @@ func testUpdateSubscriptionStatus(id int, eventTypePrefix, natsSubjectToPublish,
 
 			ensureSubscriptionCreated(ctx, subscription)
 
-			Context("A Subscription with muktiple conditions of the same type", func() {
+			Context("A Subscription with multiple conditions of the same type", func() {
 				// the nats subject list to publish to; these are supposed to be equal to the cleanEventTypes
 				natsSubjectsToPublish := []string{
 					fmt.Sprintf("%s0", natsSubjectToPublish),
 				}
-				// the filter that are getting added to the subscription
+				// the filters that are getting added to the subscription
 				eventTypesToSubscribe := []string{
 					fmt.Sprintf("%s0", eventTypeToSubscribe),
 				}

--- a/components/eventing-controller/controllers/subscription/nats/reconciler_test.go
+++ b/components/eventing-controller/controllers/subscription/nats/reconciler_test.go
@@ -68,6 +68,7 @@ var (
 		testChangeSubscriptionConfiguration,
 		testCreateSubscriptionWithEmptyEventType,
 		testCleanEventTypes,
+		testUpdateSubscriptionStatus,
 		testNATSUnavailabilityReflectedInSubscriptionStatus,
 	}
 

--- a/components/eventing-controller/pkg/handlers/eventtype/clean.go
+++ b/components/eventing-controller/pkg/handlers/eventtype/clean.go
@@ -64,7 +64,7 @@ func (c *cleaner) Clean(eventType string) (string, error) {
 
 	// clean the event-type segments
 	eventTypeClean = cleanEventType(eventTypeClean)
-	log.Infow("clean event-type", "before", eventType, "after", eventTypeClean)
+	log.Debugw("clean event-type", "before", eventType, "after", eventTypeClean)
 
 	return eventTypeClean, nil
 }

--- a/components/eventing-controller/pkg/handlers/nats.go
+++ b/components/eventing-controller/pkg/handlers/nats.go
@@ -102,7 +102,7 @@ func newCloudeventClient(config env.NatsConfig) (cev2.Client, error) {
 }
 
 // SyncSubscription synchronizes the given Kyma subscription to NATS subscription.
-// note: the returned bool should be ignored now. It should act as a marker for changed subscription status.
+// The returned bool acts as a marker for changed subscription status.
 func (n *Nats) SyncSubscription(sub *eventingv1alpha1.Subscription, cleaner eventtype.Cleaner, _ ...interface{}) (bool, error) {
 	var filters []*eventingv1alpha1.BEBFilter
 	if sub.Spec.Filter != nil {
@@ -195,10 +195,17 @@ func (n *Nats) SyncSubscription(sub *eventingv1alpha1.Subscription, cleaner even
 	}
 
 	// Setting the clean event types
-	sub.Status.CleanEventTypes = cleanSubjects
-	sub.Status.Config = subscriptionConfig
+	statusUpdated := false
+	if !reflect.DeepEqual(sub.Status.CleanEventTypes, cleanSubjects) {
+		sub.Status.CleanEventTypes = cleanSubjects
+		statusUpdated = true
+	}
+	if !reflect.DeepEqual(sub.Status.Config, subscriptionConfig) {
+		sub.Status.Config = subscriptionConfig
+		statusUpdated = true
+	}
 
-	return false, nil
+	return statusUpdated, nil
 }
 
 // DeleteSubscription deletes all NATS subscriptions corresponding to a Kyma subscription
@@ -215,11 +222,10 @@ func (n *Nats) DeleteSubscription(sub *eventingv1alpha1.Subscription) error {
 			"subject", s.Subject,
 		)
 
-		if strings.HasPrefix(key, subKeyPrefix) {
+		if subKeyPrefix == createKymaSubscriptionNamespacedName(key, s).String() {
 			if err := n.deleteSubFromNats(s, key, log); err != nil {
 				return err
 			}
-
 			// delete subscription sink info from storage
 			n.sinks.Delete(subKeyPrefix)
 		}

--- a/components/eventing-controller/pkg/handlers/nats_test.go
+++ b/components/eventing-controller/pkg/handlers/nats_test.go
@@ -101,7 +101,7 @@ func TestSubscription(t *testing.T) {
 
 	// Start Nats server
 	natsServer := eventingtesting.RunNatsServerOnPort(natsPort)
-	defer natsServer.Shutdown()
+	defer eventingtesting.ShutDownNATSServer(natsServer)
 
 	defaultLogger, err := logger.New(string(kymalogger.JSON), string(kymalogger.INFO))
 	if err != nil {
@@ -626,7 +626,7 @@ func TestMultipleSubscriptionsToSameEvent(t *testing.T) {
 
 	// Start Nats server
 	natsServer := eventingtesting.RunNatsServerOnPort(natsPort)
-	defer natsServer.Shutdown()
+	defer eventingtesting.ShutDownNATSServer(natsServer)
 
 	defaultLogger, err := logger.New(string(kymalogger.JSON), string(kymalogger.INFO))
 	if err != nil {
@@ -727,7 +727,7 @@ func TestSubscriptionWithDuplicateFilters(t *testing.T) {
 	subscriberCheckURL := fmt.Sprintf("http://127.0.0.1:%d/check", subscriberPort)
 
 	natsServer := eventingtesting.RunNatsServerOnPort(natsPort)
-	defer natsServer.Shutdown()
+	defer eventingtesting.ShutDownNATSServer(natsServer)
 
 	defaultLogger, err := logger.New(string(kymalogger.JSON), string(kymalogger.INFO))
 	if err != nil {
@@ -886,6 +886,7 @@ func TestIsValidSubscription(t *testing.T) {
 
 	// Start NATS server
 	natsServer := eventingtesting.RunNatsServerOnPort(natsPort)
+	defer eventingtesting.ShutDownNATSServer(natsServer)
 
 	defaultLogger, err := logger.New(string(kymalogger.JSON), string(kymalogger.INFO))
 	if err != nil {
@@ -984,7 +985,7 @@ func TestSubscriptionUsingCESDK(t *testing.T) {
 
 	// Start Nats server
 	natsServer := eventingtesting.RunNatsServerOnPort(natsPort)
-	defer natsServer.Shutdown()
+	defer eventingtesting.ShutDownNATSServer(natsServer)
 
 	defaultLogger, err := logger.New(string(kymalogger.JSON), string(kymalogger.INFO))
 	g.Expect(err).To(BeNil())
@@ -1055,7 +1056,7 @@ func TestRetryUsingCESDK(t *testing.T) {
 
 	// Start Nats server
 	natsServer := eventingtesting.RunNatsServerOnPort(natsPort)
-	defer natsServer.Shutdown()
+	defer eventingtesting.ShutDownNATSServer(natsServer)
 
 	defaultLogger, err := logger.New(string(kymalogger.JSON), string(kymalogger.INFO))
 	g.Expect(err).To(BeNil())

--- a/components/eventing-controller/testing/test_helpers.go
+++ b/components/eventing-controller/testing/test_helpers.go
@@ -1,6 +1,7 @@
 package testing
 
 import (
+	"encoding/json"
 	"fmt"
 	"net/http"
 
@@ -67,6 +68,9 @@ const (
            "source":"` + EventSource + `",
            "data":"` + EventData + `"
         }`
+
+	FakeCondition1 = `{ Type: "foo", Status: "foo", Reason: "foo-reason", Message: "foo-message" }`
+	FakeCondition2 = `{ Type: "bar", Status: "bar", Reason: "bar-reason", Message: "bar-message" }`
 )
 
 type APIRuleOption func(rule *apigatewayv1alpha1.APIRule)
@@ -494,6 +498,17 @@ func WithEventingControllerPod(backend string) *corev1.Pod {
 			},
 		},
 	}
+}
+
+func WithMultipleConditions(s *eventingv1alpha1.Subscription) {
+	s.Status.Conditions = NewDefaultMultipleConditions()
+}
+
+func NewDefaultMultipleConditions() []eventingv1alpha1.Condition {
+	var cond1, cond2 eventingv1alpha1.Condition
+	json.Unmarshal([]byte(FakeCondition1), cond1)
+	json.Unmarshal([]byte(FakeCondition2), cond2)
+	return []eventingv1alpha1.Condition{cond1, cond2}
 }
 
 // ToSubscription converts an unstructured subscription into a typed one

--- a/components/eventing-controller/testing/test_helpers.go
+++ b/components/eventing-controller/testing/test_helpers.go
@@ -506,8 +506,8 @@ func WithMultipleConditions(s *eventingv1alpha1.Subscription) {
 
 func NewDefaultMultipleConditions() []eventingv1alpha1.Condition {
 	var cond1, cond2 eventingv1alpha1.Condition
-	json.Unmarshal([]byte(FakeCondition1), cond1)
-	json.Unmarshal([]byte(FakeCondition2), cond2)
+	_ = json.Unmarshal([]byte(FakeCondition1), &cond1)
+	_ = json.Unmarshal([]byte(FakeCondition2), &cond2)
 	return []eventingv1alpha1.Condition{cond1, cond2}
 }
 

--- a/components/eventing-controller/testing/test_helpers.go
+++ b/components/eventing-controller/testing/test_helpers.go
@@ -1,9 +1,10 @@
 package testing
 
 import (
-	"encoding/json"
 	"fmt"
 	"net/http"
+
+	v1 "k8s.io/api/core/v1"
 
 	k8sresource "k8s.io/apimachinery/pkg/api/resource"
 
@@ -68,9 +69,6 @@ const (
            "source":"` + EventSource + `",
            "data":"` + EventData + `"
         }`
-
-	FakeCondition1 = `{ Type: "foo", Status: "foo", Reason: "foo-reason", Message: "foo-message" }`
-	FakeCondition2 = `{ Type: "bar", Status: "bar", Reason: "bar-reason", Message: "bar-message" }`
 )
 
 type APIRuleOption func(rule *apigatewayv1alpha1.APIRule)
@@ -505,9 +503,14 @@ func WithMultipleConditions(s *eventingv1alpha1.Subscription) {
 }
 
 func NewDefaultMultipleConditions() []eventingv1alpha1.Condition {
-	var cond1, cond2 eventingv1alpha1.Condition
-	_ = json.Unmarshal([]byte(FakeCondition1), &cond1)
-	_ = json.Unmarshal([]byte(FakeCondition2), &cond2)
+	cond1 := eventingv1alpha1.MakeCondition(
+		eventingv1alpha1.ConditionSubscriptionActive,
+		eventingv1alpha1.ConditionReasonNATSSubscriptionActive,
+		v1.ConditionTrue, "cond1")
+	cond2 := eventingv1alpha1.MakeCondition(
+		eventingv1alpha1.ConditionSubscriptionActive,
+		eventingv1alpha1.ConditionReasonNATSSubscriptionActive,
+		v1.ConditionTrue, "cond2")
 	return []eventingv1alpha1.Condition{cond1, cond2}
 }
 

--- a/resources/eventing/values.yaml
+++ b/resources/eventing/values.yaml
@@ -5,7 +5,7 @@ global:
   images:
     eventing_controller:
       name: eventing-controller
-      version: PR-13050
+      version: PR-13070
       pullPolicy: "IfNotPresent"
     publisher_proxy:
       name: event-publisher-proxy


### PR DESCRIPTION

**Description**

Changes proposed in this pull request:

- Fix endless reconciliation calls if the controller runs under "heavy load"
- Cleanup the code referring to subscription status update
- Reduce the numbers of reconciliation calls
- Shutdown NATS embedded test server in all test functions

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
