### PR TITLE
Move initial check for SBU before the migration

### DIFF
--- a/tests/fast-integration/skr-svcat-migration-test/skr-svcat-migration-test.js
+++ b/tests/fast-integration/skr-svcat-migration-test/skr-svcat-migration-test.js
@@ -85,6 +85,15 @@ describe("SKR SVCAT migration test", function() {
   it(`Should install sample Service Catalog resources`, async function() {
     await sampleResources.deploy()
   });
+  
+  let secretsAndPresets
+  it(`Should store secrets and presets of sample resources`, async function() {
+    secretsAndPresets = await sampleResources.storeSecretsAndPresets()
+  });
+
+  it(`Should check if pod presets injected secrets to functions containers`, async function() {
+    await t.checkPodPresetEnvInjected();
+  });
 
   it('Should mark the platform for migration in Service Manager', async function() {
     await t.markForMigration(smAdminCreds, platformCreds.clusterId, btpOperatorCreds.instanceId)
@@ -96,15 +105,6 @@ describe("SKR SVCAT migration test", function() {
 
   it(`Should wait for btp-operator deployment availability`, async function() {
     await waitForDeployment("sap-btp-operator-controller-manager", "kyma-system", 10 * 60 * 1000); //10 minutes
-  });
-
-  let secretsAndPresets
-  it(`Should store secrets and presets of sample resources`, async function() {
-    secretsAndPresets = await sampleResources.storeSecretsAndPresets()
-  });
-
-  it(`Should check if pod presets injected secrets to functions containers`, async function() {
-    await t.checkPodPresetEnvInjected();
   });
 
   it(`Should wait for migration job to finish`, async function() {


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**
Pre https://github.com/kyma-project/kyma/pull/12900, we installed btp-operator helm charts manually in the test iteslf and the initial check happened before. Since we call KEB to call reconciler to install btp-operator, this initial check should happen before.

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
https://github.com/kyma-project/kyma/pull/12900