### PR TITLE
Fix cluster admin role name typo in busola migrator

### DIFF
--- a/components/busola-migrator/internal/kubernetes/client.go
+++ b/components/busola-migrator/internal/kubernetes/client.go
@@ -25,7 +25,7 @@ var rbacConfig = map[model.UserPermission]struct {
 }{
 	model.UserPermissionAdmin: {
 		clusterRoleBindingName: "cluster-admin-users",
-		clusterRoleName:        "cluser-admin",
+		clusterRoleName:        "cluster-admin",
 	},
 	model.UserPermissionDeveloper: {
 		clusterRoleBindingName: "cluster-developer-users",


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Fix typo in admin role name (`cluser-admin` -> `cluster-admin` ) in busola migrator
