### PR TITLE
Fix cluster admin role name typo in busola migrator

### DIFF
--- a/resources/busola-migrator/values.yaml
+++ b/resources/busola-migrator/values.yaml
@@ -4,7 +4,7 @@ global:
   images:
     busola_migrator:
       name: "busola-migrator"
-      version: "ceeb73d8"
+      version: "4b0e6f77"
     k8s_tools:
       name: "k8s-tools"
       version: "20211022-85284bf9"


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Bump busola-migrator image tag to include https://github.com/kyma-project/kyma/pull/13080
