### PR TITLE
Fix cluster admin role name typo in busola migrator (#13080)

### DIFF
--- a/components/busola-migrator/internal/kubernetes/client.go
+++ b/components/busola-migrator/internal/kubernetes/client.go
@@ -25,7 +25,7 @@ var rbacConfig = map[model.UserPermission]struct {
 }{
 	model.UserPermissionAdmin: {
 		clusterRoleBindingName: "cluster-admin-users",
-		clusterRoleName:        "cluser-admin",
+		clusterRoleName:        "cluster-admin",
 	},
 	model.UserPermissionDeveloper: {
 		clusterRoleBindingName: "cluster-developer-users",


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- cherry-picking cluster-admin role typo [fix](https://github.com/kyma-project/kyma/commit/4b0e6f770bc95709673c085eb685aa550af08fd1)