### PR TITLE
configurable option for fluent-bit tail inotify_watcher setting

### DIFF
--- a/resources/logging/charts/fluent-bit/templates/configmap.yaml
+++ b/resources/logging/charts/fluent-bit/templates/configmap.yaml
@@ -76,6 +76,7 @@ data:
         multiline.parser  {{ .Values.config.inputs.tail.multilineParser }}
         {{- end }}
         Read_from_Head    {{ .Values.config.inputs.tail.readFromHead }}
+        Inotify_Watcher   {{ .Values.config.inputs.tail.inotifyWatcher }}
         
 {{- end }}
 

--- a/resources/logging/charts/fluent-bit/values.yaml
+++ b/resources/logging/charts/fluent-bit/values.yaml
@@ -196,6 +196,8 @@ config:
       parserFirstline:
       # For new discovered files on start (without a database offset/position), read the content from the head of the file, not tail.
       readFromHead: "Off"
+      # Set to false to use file stat watcher instead of inotify.
+      inotifyWatcher: "true"
       # Specify one or Multiline Parser definition to apply to the content.
       multilineParser: docker, cri
       exclude:


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- added option to configure the inotifer_watcher setting in tail plugin of fluent bit
- ...
- ...

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
