### PR TITLE
Adjust auth-proxy memory reservation and limit

### DIFF
--- a/resources/kiali/values.yaml
+++ b/resources/kiali/values.yaml
@@ -54,10 +54,10 @@ authProxy:
   resources:
     limits:
       cpu: 50m
-      memory: 20Mi
+      memory: 100Mi
     requests:
       cpu: 10m
-      memory: 5Mi
+      memory: 15Mi
 
 # 'fullnameOverride' is deprecated. Use 'deployment.instance_name' instead.
 # This is only supported for backward compatibility and will be removed in a future version.

--- a/resources/monitoring/charts/grafana/values.yaml
+++ b/resources/monitoring/charts/grafana/values.yaml
@@ -804,10 +804,10 @@ kyma:
     resources:
       limits:
         cpu: 50m
-        memory: 20Mi
+        memory: 100Mi
       requests:
         cpu: 10m
-        memory: 5Mi
+        memory: 15Mi
 
 global:
   kymaRuntime:

--- a/resources/tracing/values.yaml
+++ b/resources/tracing/values.yaml
@@ -148,7 +148,7 @@ authProxy:
   resources:
     limits:
       cpu: 50m
-      memory: 20Mi
+      memory: 100Mi
     requests:
       cpu: 10m
-      memory: 5Mi
+      memory: 15Mi


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Adjust auth-proxy memory reservation and limit

Changes proposed in this pull request:

- Increase the auth-proxy pod memory reservation to 15 MiB and limit to 100 MiB to prevent the pods being OOM killed

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
Fixes #13095