### PR TITLE
Add additional info about deprovisioning and KEB operation state in fast-integration tests

### DIFF
--- a/tests/fast-integration/kyma-environment-broker/helpers.js
+++ b/tests/fast-integration/kyma-environment-broker/helpers.js
@@ -55,7 +55,7 @@ async function deprovisionSKR(keb, kcp, instanceID, timeout, ensureSuccess=true)
   expect(resp).to.have.property("operation");
 
   const operationID = resp.operation;
-  debug(`Operation ID ${operationID}`);
+  console.log(`Deprovision SKR - operation ID ${operationID}`);
 
   if (ensureSuccess) {
     await ensureOperationSucceeded(keb, kcp, instanceID, operationID, timeout);
@@ -92,11 +92,13 @@ async function ensureOperationSucceeded(keb, kcp, instanceID, operationID, timeo
     throw(`${err}\nRuntime status: ${runtimeStatus}`)
   });
 
-  debug("KEB operation:", res);
   if(res.state !== "succeeded") {
     let runtimeStatus = await kcp.getRuntimeStatusOperations(instanceID)
     throw(`operation didn't succeed in time: ${JSON.stringify(res, null, `\t`)}\nRuntime status: ${runtimeStatus}`);
   }
+
+  console.log(`Operation ${res.operation} finished with state ${res.state}`);
+
   return res;
 }
 


### PR DESCRIPTION


<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**
Adding additional logging to make sure that deprovisioning started for SKR in fast-integration test.

Changes proposed in this pull request:

- Added `console.log` when deprovisioning starts and when operation succeeds.

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
