### PR TITLE
removed failing resource from the clean step and added the right resource to delete

### DIFF
--- a/tests/fast-integration/test/fixtures/commerce-mock/index.js
+++ b/tests/fast-integration/test/fixtures/commerce-mock/index.js
@@ -667,6 +667,7 @@ function getResourcePaths(namespace) {
     `/apis/apps/v1/namespaces/${namespace}/deployments`,
     `/api/v1/namespaces/${namespace}/services`,
     `/apis/applicationconnector.kyma-project.io/v1alpha1/namespaces/${namespace}/applicationmappings`,
+    `/apis/applicationconnector.kyma-project.io/v1alpha1/namespaces/${namespace}/applications`,
   ];
 }
 
@@ -675,20 +676,6 @@ async function cleanMockTestFixture(mockNamespace, targetNamespace, wait = true)
     getResourcePaths(targetNamespace)
   )) {
     await deleteAllK8sResources(path);
-  }
-
-  try {
-    debug("Deleting applicationconnector.kyma-project.io/v1alpha1")
-    await k8sDynamicApi.delete({
-      apiVersion: "applicationconnector.kyma-project.io/v1alpha1",
-      kind: "Application",
-      metadata: {
-        name: "commerce",
-      },
-    });
-  }
-  catch (err) {
-    ignore404(err)
   }
 
   debug('Deleting test namespaces');


### PR DESCRIPTION

**Description**

Changes proposed in this pull request:

- removed failing resource from the clean step
- added the right resource to delete

**Related issue(s)**
**Link to the job**
https://status.build.kyma-project.io/?job=skr-kyma-to-kyma2-upgrade-aws-dev
**Link to the latest logs**
https://storage.googleapis.com/kyma-prow-logs/logs/skr-kyma-to-kyma2-upgrade-aws-dev/1483752926949150720/build-log.txt

**troubleshooting**
I have tried to delete the CR using Kubectl while the job was running.

```
#app.yml
apiVersion: applicationconnector.kyma-project.io/v1alpha1
kind: Application
metadata:
  name: commerce
#output
❯ k delete -f app.yml
Error from server (NotFound): error when deleting "app.yml": applications.applicationconnector.kyma-project.io "commerce" not found
```
So I tried to get all CRs and look for it:
```
❯ k get app -n test
NAME          AGE
mp-app-iw4u   4m35s

❯ k get app -o yaml
apiVersion: v1
items:
- apiVersion: applicationconnector.kyma-project.io/v1alpha1
  kind: Application
  metadata:
    creationTimestamp: "2022-01-19T12:32:48Z"
    finalizers:
    - finalizer.applicationconnector.kyma-project.io
    generation: 4
    labels:
      applicationconnector.kyma-project.io/managed-by: compass-runtime-agent
    name: mp-app-iw4u
```
This CR defined in the `/kyma/tests/fast-integration/test/fixtures/commerce-mock/application.yaml` file is declared in line 86 of commerce-mock/index.js `const applicationObjs = k8s.loadAllYaml(applicationMockYaml);` and only applied in the `ensureCommerceMockLocalTestFixture()` method declared in line 557 of the same script. Which is not included in the `tests/fast-integration/skr-kyma-to-kyma2-upgrade/index.js` but which have similar name with `ensureCommerceMockWithCompassTestFixture()` which is executed in the test-suite. That is why my proposed fix is removing the deletion step from `cleanMockTestFixture()` and adding the `/apis/applicationconnector.kyma-project.io/v1alpha1/namespaces/${namespace}/applications` resource path to be deleted.