### PR TITLE
Add a workspace prefix to the AC dockerfiles

### DIFF
--- a/components/application-connectivity-certs-setup-job/Dockerfile
+++ b/components/application-connectivity-certs-setup-job/Dockerfile
@@ -22,4 +22,4 @@ COPY --from=builder /go/src/github.com/kyma-project/kyma/components/application-
 COPY --from=builder /etc_passwd /etc/passwd
 USER 1000
 
-CMD ["/appconnectivitycertssetupjob"]
+CMD ["/app/appconnectivitycertssetupjob"]

--- a/components/application-connectivity-validator/Dockerfile
+++ b/components/application-connectivity-validator/Dockerfile
@@ -22,4 +22,4 @@ COPY --from=builder /app/licenses /app/licenses
 COPY --from=builder /etc_passwd /etc/passwd
 USER nobody
 
-CMD ["/applicationconnectivityvalidator"]
+CMD ["/app/applicationconnectivityvalidator"]

--- a/components/application-gateway/Dockerfile
+++ b/components/application-gateway/Dockerfile
@@ -26,4 +26,4 @@ COPY --from=builder /app/licenses /app/licenses
 COPY --from=builder /etc_passwd /etc/passwd
 USER nobody
 
-CMD ["/applicationgateway"]
+CMD ["/app/applicationgateway"]

--- a/components/application-operator/Dockerfile
+++ b/components/application-operator/Dockerfile
@@ -24,4 +24,4 @@ COPY --from=builder /app/licenses /app/licenses
 COPY --from=builder /etc_passwd /etc/passwd
 USER nobody
 
-CMD ["/manager"]
+CMD ["/app/manager"]

--- a/components/application-operator/charts/application/templates/deployment.yaml
+++ b/components/application-operator/charts/application/templates/deployment.yaml
@@ -35,7 +35,7 @@ spec:
         image: {{ .Values.global.applicationGatewayImage }}
         imagePullPolicy: {{ .Values.deployment.image.pullPolicy }}
         args:
-          - "/applicationgateway"
+          - "/app/applicationgateway"
           - "--proxyPort={{ .Values.deployment.args.proxyPort }}"
           - "--externalAPIPort={{ .Values.deployment.args.externalAPIPort }}"
           - "--application={{ .Release.Name }}"

--- a/components/application-operator/charts/gateway/templates/deployment.yaml
+++ b/components/application-operator/charts/gateway/templates/deployment.yaml
@@ -35,7 +35,7 @@ spec:
         image: {{ .Values.global.applicationGatewayImage }}
         imagePullPolicy: {{ .Values.deployment.image.pullPolicy }}
         args:
-          - "/applicationgateway"
+          - "/app/applicationgateway"
           - "--proxyPort={{ .Values.deployment.args.proxyPort }}"
           - "--externalAPIPort={{ .Values.deployment.args.externalAPIPort }}"
           - "--application={{ .Release.Name }}"

--- a/components/application-registry/Dockerfile
+++ b/components/application-registry/Dockerfile
@@ -27,4 +27,4 @@ COPY --from=builder /app/licenses /app/licenses
 COPY --from=builder /etc_passwd /etc/passwd
 USER nobody
 
-CMD ["/applicationregistry"]
+CMD ["/app/applicationregistry"]

--- a/resources/application-connector/charts/application-operator/templates/controller.yaml
+++ b/resources/application-connector/charts/application-operator/templates/controller.yaml
@@ -53,7 +53,7 @@ spec:
           timeoutSeconds: {{ .Values.controller.readinessProbe.timeoutSeconds }}
           periodSeconds: {{ .Values.controller.readinessProbe.periodSeconds }}
         args:
-        - "/manager"
+        - "/app/manager"
         - "--appName={{ .Values.controller.args.appName }}"
         - "--domainName={{ .Values.global.domainName }}"
         - "--namespace={{ .Values.global.integrationNamespace }}"

--- a/resources/application-connector/charts/application-registry/templates/deployment.yaml
+++ b/resources/application-connector/charts/application-registry/templates/deployment.yaml
@@ -47,7 +47,7 @@ spec:
             cpu: {{ .Values.deployment.resources.requests.cpu }}
             memory: {{ .Values.deployment.resources.requests.memory }}
         args:
-          - "/applicationregistry"
+          - "/app/applicationregistry"
           - "--proxyPort={{ .Values.deployment.args.proxyPort }}"
           - "--externalAPIPort={{ .Values.deployment.args.externalAPIPort }}"
           - "--uploadServiceURL={{ .Values.deployment.args.uploadServiceURL }}"

--- a/resources/application-connector/templates/certs-setup-job.yaml
+++ b/resources/application-connector/templates/certs-setup-job.yaml
@@ -30,7 +30,7 @@ spec:
       - name: {{ .Chart.Name }}-certs-setup-job
         image: "{{ include "imageurl" (dict "reg" .Values.global.containerRegistry "img" .Values.global.images.application_connectivity_certs_setup_job) }}"
         args:
-          - "/appconnectivitycertssetupjob"
+          - "/app/appconnectivitycertssetupjob"
           - "--connectorCertificateSecret={{ .Values.application_connectivity_certs_setup_job.secrets.connectorCertificateSecret.namespace }}/{{ .Values.application_connectivity_certs_setup_job.secrets.connectorCertificateSecret.name }}"
           - "--caCertificateSecret={{ .Values.application_connectivity_certs_setup_job.secrets.caCertificateSecret.namespace }}/{{ .Values.application_connectivity_certs_setup_job.secrets.caCertificateSecret.name }}"
           - "--caCertificate={{ .Values.global.applicationConnectorCa }}"

--- a/resources/application-connector/values.yaml
+++ b/resources/application-connector/values.yaml
@@ -42,19 +42,19 @@ global:
       version: "c8a2ae16"
     application_connectivity_certs_setup_job:
       name: "application-connectivity-certs-setup-job"
-      version: "PR-13076"
+      version: "PR-13170"
     application_connectivity_validator:
       name: "application-connectivity-validator"
-      version: "PR-13076"
+      version: "PR-13170"
     application_gateway:
       name: "application-gateway"
-      version: "PR-13076"
+      version: "PR-13170"
     application_operator:
       name: "application-operator"
-      version: "PR-13076"
+      version: "PR-13170"
     application_registry:
       name: "application-registry"
-      version: "PR-13076"
+      version: "PR-13170"
     central_application_connectivity_validator:
       name: "central-application-connectivity-validator"
       version: "PR-13076"


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- Fix problems introduced in https://github.com/kyma-project/kyma/pull/12867
- Add a workspace prefix to the Application Connector dockerfiles and container args

The bug wasn't discovered by the CI, because there were no image bumps and no integration job was run. The bug causes Application Connector installation failures ([example](https://status.build.kyma-project.io/view/gs/kyma-prow-logs/pr-logs/pull/kyma-project_kyma/12257/pre-main-kyma-integration-k3d/1485918996703219712)). Here is a description from Application Operator running on such a failing cluster:
```
$ kubectl -n kyma-integration describe po application-operator-0

...
  Warning  Failed     25m (x5 over 26m)     kubelet            Error: failed to start container "application-operator": Error response from daemon: OCI runtime create failed: container_linux.go:367: starting container process caused: exec: "/manager": stat /manager: no such file or directory: unknown
...
```