### PR TITLE
Fix cleanup of BTP resources in fast-integration tests

### DIFF
--- a/tests/fast-integration/skr-svcat-migration-test/deploy-sample-resources.js
+++ b/tests/fast-integration/skr-svcat-migration-test/deploy-sample-resources.js
@@ -256,8 +256,9 @@ async function deploy() {
     await waitForClusterServiceBroker('sm-html5-apps-repo', 5 * 60 * 1000);
     await waitForClusterServiceBroker('sm-auditlog-management', 5 * 60 * 1000);
   } catch (e) {
-    let csb = await listResources(`/apis/servicecatalog.k8s.io/v1beta1/clusterservicebrokers`);
-    throw new Error(`Cluster service brokers failed to be available in 5 minutes ${JSON.stringify(e)}:\n${JSON.stringify(csb)}`)
+    const csb = await listResources(`/apis/servicecatalog.k8s.io/v1beta1/clusterservicebrokers`);
+    msg = 'Cluster service brokers failed to be available in 5 minutes';
+    throw new Error(`${msg} ${JSON.stringify(e)}:\n${JSON.stringify(csb)}`);
   }
 
   times.push(installRedisExample());

--- a/tests/fast-integration/skr-svcat-migration-test/deploy-sample-resources.js
+++ b/tests/fast-integration/skr-svcat-migration-test/deploy-sample-resources.js
@@ -250,10 +250,15 @@ async function deploy() {
   await waitForPodWithLabel('app', 'service-catalog-catalog-webhook', 'kyma-system');
   await waitForPodWithLabel('app', 'service-broker-proxy-k8s', 'kyma-system');
 
-  await waitForClusterServiceBroker('helm-broker', 5 * 60 * 1000);
-  await waitForClusterServiceBroker('sm-auditlog-api', 5 * 60 * 1000);
-  await waitForClusterServiceBroker('sm-html5-apps-repo', 5 * 60 * 1000);
-  await waitForClusterServiceBroker('sm-auditlog-management', 5 * 60 * 1000);
+  try {
+    await waitForClusterServiceBroker('helm-broker', 5 * 60 * 1000);
+    await waitForClusterServiceBroker('sm-auditlog-api', 5 * 60 * 1000);
+    await waitForClusterServiceBroker('sm-html5-apps-repo', 5 * 60 * 1000);
+    await waitForClusterServiceBroker('sm-auditlog-management', 5 * 60 * 1000);
+  } catch (e) {
+    let csb = await listResources(`/apis/servicecatalog.k8s.io/v1beta1/clusterservicebrokers`);
+    throw new Error(`Cluster service brokers failed to be available in 5 minutes ${JSON.stringify(e)}:\n${JSON.stringify(csb)}`)
+  }
 
   times.push(installRedisExample());
   times.push(installAuditlogExample());

--- a/tests/fast-integration/skr-svcat-migration-test/test-helpers.js
+++ b/tests/fast-integration/skr-svcat-migration-test/test-helpers.js
@@ -8,7 +8,7 @@ const {
   listPods,
   deleteK8sPod,
   sleep,
-  deleteAllK8sResources,
+  deleteK8sObjects,
   listResources,
 } = require('../utils');
 
@@ -313,20 +313,20 @@ async function deleteBTPResources() {
   const instances = 'serviceinstances';
   const bindings = 'servicebindings';
   const keepFinalizers = true;
-  await deleteAllK8sResources(`/apis/${group}/${version}/${instances}`, {}, 10, 1000, keepFinalizers);
-  await deleteAllK8sResources(`/apis/${group}/${version}/${bindings}`, {}, 10, 1000, keepFinalizers);
 
   let needsPoll = [];
   for (let i = 0; i < 90; i++) { // 15 minutes
     needsPoll = [];
-    const k8sInstances = listResources(`/apis/${group}/${version}/${instances}`);
-    if (k8sInstances > 1) {
-      needsPoll.push(k8sInstances);
-    }
-    const k8sBindings = listResources(`/apis/${group}/${version}/${bindings}`);
-    if (k8sBindings > 1) {
+    let k8sBindings = await listResources(`/apis/${group}/${version}/${bindings}`);
+    if (k8sBindings.length > 0) {
       needsPoll.push(k8sBindings);
     }
+    await deleteK8sObjects(k8sBindings);
+    let k8sInstances = await listResources(`/apis/${group}/${version}/${instances}`);
+    if (k8sInstances.length > 0) {
+      needsPoll.push(k8sInstances);
+    }
+    await deleteK8sObjects(k8sInstances);
     if (needsPoll.length != 0) {
       await sleep(10000); // 10 seconds
     } else {

--- a/tests/fast-integration/skr-svcat-migration-test/test-helpers.js
+++ b/tests/fast-integration/skr-svcat-migration-test/test-helpers.js
@@ -312,17 +312,16 @@ async function deleteBTPResources() {
   const version = 'v1alpha1';
   const instances = 'serviceinstances';
   const bindings = 'servicebindings';
-  const keepFinalizers = true;
 
   let needsPoll = [];
   for (let i = 0; i < 90; i++) { // 15 minutes
     needsPoll = [];
-    let k8sBindings = await listResources(`/apis/${group}/${version}/${bindings}`);
+    const k8sBindings = await listResources(`/apis/${group}/${version}/${bindings}`);
     if (k8sBindings.length > 0) {
       needsPoll.push(k8sBindings);
     }
     await deleteK8sObjects(k8sBindings);
-    let k8sInstances = await listResources(`/apis/${group}/${version}/${instances}`);
+    const k8sInstances = await listResources(`/apis/${group}/${version}/${instances}`);
     if (k8sInstances.length > 0) {
       needsPoll.push(k8sInstances);
     }

--- a/tests/fast-integration/utils/index.js
+++ b/tests/fast-integration/utils/index.js
@@ -961,12 +961,13 @@ function ignore404(e) {
 
 // NOTE: this works only for those where resource == lowercase plural kind
 async function deleteK8sObjects(objects) {
-  console.log(`deleting ${objects.length} objects`)
-  for (let o of objects) {
+  console.log(`deleting ${objects.length} objects`);
+  for (const o of objects) {
+    const path = `${o.apiVersion}/namespaces/${o.metadata.namespace}/${o.kind.toLowerCase()}s/${o.metadata.name}`;
     await k8sDynamicApi.requestPromise({
-      url: `${k8sDynamicApi.basePath}/apis/${o.apiVersion}/namespaces/${o.metadata.namespace}/${o.kind.toLowerCase()}s/${o.metadata.name}`,
-      method: "DELETE",
-    })
+      url: `${k8sDynamicApi.basePath}/apis/${path}`,
+      method: 'DELETE',
+    });
   }
 }
 

--- a/tests/fast-integration/utils/index.js
+++ b/tests/fast-integration/utils/index.js
@@ -963,7 +963,6 @@ function ignore404(e) {
 async function deleteK8sObjects(objects) {
   console.log(`deleting ${objects.length} objects`)
   for (let o of objects) {
-    console.log(`deleting ${path}`)
     await k8sDynamicApi.requestPromise({
       url: `${k8sDynamicApi.basePath}/apis/${o.apiVersion}/namespaces/${o.metadata.namespace}/${o.kind.toLowerCase()}s/${o.metadata.name}`,
       method: "DELETE",

--- a/tests/fast-integration/utils/index.js
+++ b/tests/fast-integration/utils/index.js
@@ -959,6 +959,18 @@ function ignore404(e) {
   throw e;
 }
 
+// NOTE: this works only for those where resource == lowercase plural kind
+async function deleteK8sObjects(objects) {
+  console.log(`deleting ${objects.length} objects`)
+  for (let o of objects) {
+    console.log(`deleting ${path}`)
+    await k8sDynamicApi.requestPromise({
+      url: `${k8sDynamicApi.basePath}/apis/${o.apiVersion}/namespaces/${o.metadata.namespace}/${o.kind.toLowerCase()}s/${o.metadata.name}`,
+      method: "DELETE",
+    })
+  }
+}
+
 // NOTE: this no longer works, it relies on kube-api sending `selfLink` but the field has been deprecated
 async function deleteAllK8sResources(
     path,
@@ -1768,6 +1780,7 @@ module.exports = {
   printContainerLogs,
   kubectlExecInPod,
   deleteK8sResource,
+  deleteK8sObjects,
   deleteK8sPod,
   listPods,
   switchEventingBackend,


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**
The generic function `deleteAllK8sResources` appears to no longer be working because it relies on `selfLink` which has been deprecated kubernetes/kubernetes#94397. Adding much-simplified replacement for resource cleanup in form of `deleteK8sObjects()` taking a list of objects instead.

Also adding better logging when `ClusterServiceBroker` fails to be ready in time.

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
https://github.com/kyma-project/kyma/issues/12843, https://github.com/kyma-project/kyma/pull/12705