### PR TITLE
Fix Tracing port names in services to comply with Istio convention

### DIFF
--- a/resources/tracing/templates/kyma-additions/metrics-service.yaml
+++ b/resources/tracing/templates/kyma-additions/metrics-service.yaml
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/name: {{ include "jaeger-operator.fullname" . }}-jaeger-metrics
 spec:
   ports:
-  - name: http-metrics
+  - name: http-jaeger-metrics
     port: 14269
     protocol: TCP
     targetPort: 14269

--- a/resources/tracing/templates/kyma-additions/metrics-service.yaml
+++ b/resources/tracing/templates/kyma-additions/metrics-service.yaml
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/name: {{ include "jaeger-operator.fullname" . }}-jaeger-metrics
 spec:
   ports:
-  - name: tcp-metrics
+  - name: http-metrics
     port: 14269
     protocol: TCP
     targetPort: 14269

--- a/resources/tracing/templates/kyma-additions/metrics-service.yaml
+++ b/resources/tracing/templates/kyma-additions/metrics-service.yaml
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/name: {{ include "jaeger-operator.fullname" . }}-jaeger-metrics
 spec:
   ports:
-  - name: metrics
+  - name: tcp-metrics
     port: 14269
     protocol: TCP
     targetPort: 14269

--- a/resources/tracing/templates/kyma-additions/metrics-servicemonitor.yaml
+++ b/resources/tracing/templates/kyma-additions/metrics-servicemonitor.yaml
@@ -7,7 +7,7 @@ metadata:
     prometheus: monitoring
 spec:
   endpoints:
-  - port: metrics
+  - port: http-jaeger-operator-metrics
     scheme: https
     tlsConfig:
       caFile: /etc/prometheus/secrets/istio.default/root-cert.pem
@@ -29,7 +29,7 @@ metadata:
     prometheus: monitoring
 spec:
   endpoints:
-  - port: metrics
+  - port: http-jaeger-metrics
     scheme: https
     tlsConfig:
       caFile: /etc/prometheus/secrets/istio.default/root-cert.pem

--- a/resources/tracing/templates/kyma-additions/zipkin-service.yaml
+++ b/resources/tracing/templates/kyma-additions/zipkin-service.yaml
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/component: zipkin 
 spec:
   ports:
-  - name: tcp-jaeger-collector-zipkin
+  - name: http-jaeger-collector-zipkin
     port: {{ .Values.jaeger.kyma.zipkinPort }}
     targetPort: {{ .Values.jaeger.kyma.zipkinPort }}
     protocol: TCP

--- a/resources/tracing/templates/kyma-additions/zipkin-service.yaml
+++ b/resources/tracing/templates/kyma-additions/zipkin-service.yaml
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/component: zipkin 
 spec:
   ports:
-  - name: jaeger-collector-zipkin
+  - name: tcp-jaeger-collector-zipkin
     port: {{ .Values.jaeger.kyma.zipkinPort }}
     targetPort: {{ .Values.jaeger.kyma.zipkinPort }}
     protocol: TCP

--- a/resources/tracing/templates/service.yaml
+++ b/resources/tracing/templates/service.yaml
@@ -6,7 +6,7 @@ metadata:
 {{ include "jaeger-operator.labels" . | indent 4 }}
 spec:
   ports:
-  - name: tcp-metrics
+  - name: http-jaeger-operator-metrics
     port: 8383
     protocol: TCP
     targetPort: 8383

--- a/resources/tracing/templates/service.yaml
+++ b/resources/tracing/templates/service.yaml
@@ -6,7 +6,7 @@ metadata:
 {{ include "jaeger-operator.labels" . | indent 4 }}
 spec:
   ports:
-  - name: metrics
+  - name: tcp-metrics
     port: 8383
     protocol: TCP
     targetPort: 8383


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

We should follow [official Istio documentation about port naming convention](https://istio.io/latest/docs/reference/config/analysis/ist0118/). After editing both services there is a similar spec which indicates that the used protocol is TCP.

```yaml
...
spec:
  ...
  ports:
  - name: tcp-metrics
    port: 8383
    protocol: TCP
    targetPort: 8383
  ...
```

Changes proposed in this pull request:

- fix port names in `tracing-jaeger-operator` service to include protocol prefix
- fix port names in `tracing-jaeger-metrics` service to include protocol prefix
- fix port names in `zipkin` service to include protocol prefix
- get rid of the following errors:

```bash
Info [IST0118] (Service tracing-jaeger-operator.kyma-system) Port name metrics (port: 8383, targetPort: 8383) doesn't follow the naming convention of Istio port.
Info [IST0118] (Service tracing-jaeger-metrics.kyma-system) Port name metrics (port: 14269, targetPort: 14269) doesn't follow the naming convention of Istio port.
Info [IST0118] (Service zipkin.kyma-system) Port name jaeger-collector-zipkin (port: 9411, targetPort: 9411) doesn't follow the naming convention of Istio port.
```

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
See: https://github.com/kyma-project/kyma/issues/11686
