### PR TITLE
Fast integration tests: Show reconciler information in log

### DIFF
--- a/tests/fast-integration/kcp/client.js
+++ b/tests/fast-integration/kcp/client.js
@@ -178,7 +178,7 @@ class KCPWrapper {
   async getReconciliationsInfo(schedulingID) {
     await this.login();
     const reconciliationsInfo = await this.reconciliations({parameter: 'info',
-      schedulingID: schedulingID, ops: true});
+      schedulingID: schedulingID});
 
     return JSON.stringify(reconciliationsInfo, null, '\t');
   }

--- a/tests/fast-integration/kcp/client.js
+++ b/tests/fast-integration/kcp/client.js
@@ -282,7 +282,7 @@ class KCPWrapper {
   async reconcileInformationLog(runtimeStatus) {
     const objRuntimeStatus = JSON.parse(runtimeStatus);
     // kcp reconciliations operations -c <shootName> -o json
-    const reconciliationsOperations = await kcp.getReconciliationsOperations(objRuntimeStatus.data[0].shootName);
+    const reconciliationsOperations = await this.getReconciliationsOperations(objRuntimeStatus.data[0].shootName);
 
     const objReconciliationsOperations = JSON.parse(reconciliationsOperations);
     console.log(`\nNumber of operations: ${objReconciliationsOperations.length}`);
@@ -293,8 +293,8 @@ class KCPWrapper {
 
     for (const i of lastObjReconciliationsOperations) {
       // kcp reconciliations info -i <scheduling-id> -o json
-      const getReconciliationsInfo = await kcp.getReconciliationsInfo(i.schedulingID);
-      console.log(`\nReconciliation info ${i.schedulingID}: ${getReconciliationsInfo}`);
+      const getReconciliationsInfo = await this.getReconciliationsInfo(i.schedulingID);
+      console.log(`\nReconciliation info: ${i.schedulingID}: ${getReconciliationsInfo}`);
     }
   }
 

--- a/tests/fast-integration/kcp/client.js
+++ b/tests/fast-integration/kcp/client.js
@@ -279,6 +279,26 @@ class KCPWrapper {
     }
   }
 
+  async reconcileInformationLog(runtimeStatus) {
+    const objRuntimeStatus = JSON.parse(runtimeStatus);
+    // kcp reconciliations operations -c <shootName> -o json
+    const reconciliationsOperations = await kcp.getReconciliationsOperations(objRuntimeStatus.data[0].shootName);
+
+    const objReconciliationsOperations = JSON.parse(reconciliationsOperations);
+    console.log(`\nNumber of operations: ${objReconciliationsOperations.length}`);
+
+    // using only last three operations
+    const lastObjReconciliationsOperations = objReconciliationsOperations.slice(objReconciliationsOperations.length - 3,
+        objReconciliationsOperations.length);
+
+    for (const i of lastObjReconciliationsOperations) {
+      // kcp reconciliations info -i <scheduling-id> -o json
+      const getReconciliationsInfo = await kcp.getReconciliationsInfo(i.schedulingID);
+      console.log(`\nReconciliation info ${i.schedulingID}: ${getReconciliationsInfo}`);
+    }
+  }
+
+
   async exec(args) {
     try {
       const defaultArgs = [

--- a/tests/fast-integration/kcp/client.js
+++ b/tests/fast-integration/kcp/client.js
@@ -107,7 +107,7 @@ class KCPWrapper {
       args = args.concat('--shoot', `${query.shootName}`);
     }
     if (query.schedulingID) {
-      args = args.concat('--scheduling-id', `${query.shootName}`);
+      args = args.concat('--scheduling-id', `${query.schedulingID}`);
     }
     const result = await this.exec(args);
     return JSON.parse(result);

--- a/tests/fast-integration/kcp/client.js
+++ b/tests/fast-integration/kcp/client.js
@@ -171,7 +171,7 @@ class KCPWrapper {
   async getReconciliationsOperations(shootName) {
     await this.login();
     const reconciliationsOperations = await this.reconciliations({parameter: 'operations',
-      shootName: shootName, ops: true});
+      shootName: shootName});
     return JSON.stringify(reconciliationsOperations, null, '\t');
   }
 

--- a/tests/fast-integration/kcp/client.js
+++ b/tests/fast-integration/kcp/client.js
@@ -168,6 +168,21 @@ class KCPWrapper {
     }
   };
 
+  async getReconciliationsOperations(shootName) {
+    await this.login();
+    const reconciliationsOperations = await this.reconciliations({parameter: 'operations',
+      shootName: shootName, ops: true});
+    return JSON.stringify(reconciliationsOperations, null, '\t');
+  }
+
+  async getReconciliationsInfo(schedulingID) {
+    await this.login();
+    const reconciliationsInfo = await this.reconciliations({parameter: 'info',
+      schedulingID: schedulingID, ops: true});
+
+    return JSON.stringify(reconciliationsInfo, null, '\t');
+  }
+
   async getRuntimeStatusOperations(instanceID) {
     await this.login();
     const runtimeStatus = await this.runtimes({instanceID: instanceID, ops: true});

--- a/tests/fast-integration/kcp/client.js
+++ b/tests/fast-integration/kcp/client.js
@@ -101,6 +101,18 @@ class KCPWrapper {
     return JSON.parse(result);
   }
 
+  async reconciliations(query) {
+    let args = ['reconciliations', `${query.parameter}`, '--output', 'json'];
+    if (query.shootName) {
+      args = args.concat('--shoot', `${query.shootName}`);
+    }
+    if (query.shootName) {
+      args = args.concat('--scheduling-id', `${query.shootName}`);
+    }
+    const result = await this.exec(args);
+    return JSON.parse(result);
+  }
+
   async login() {
     const args = ['login', '-u', `${this.username}`, '-p', `${this.password}`];
     return await this.exec(args);

--- a/tests/fast-integration/kcp/client.js
+++ b/tests/fast-integration/kcp/client.js
@@ -106,7 +106,7 @@ class KCPWrapper {
     if (query.shootName) {
       args = args.concat('--shoot', `${query.shootName}`);
     }
-    if (query.shootName) {
+    if (query.schedulingID) {
       args = args.concat('--scheduling-id', `${query.shootName}`);
     }
     const result = await this.exec(args);

--- a/tests/fast-integration/skr-test/skr-test.js
+++ b/tests/fast-integration/skr-test/skr-test.js
@@ -111,6 +111,24 @@ function oidcE2ETest() {
     it('Should get Runtime Status after updating admins', async function() {
       const runtimeStatus = await kcp.getRuntimeStatusOperations(this.options.instanceID);
       console.log(`\nRuntime status: ${runtimeStatus}`);
+
+      // kcp reconciliations operations -c <shootName> -o json
+      const objRuntimeStatus = JSON.parse(runtimeStatus);
+      const reconciliationsOperations = await kcp.getReconciliationsOperations(objRuntimeStatus.data[0].shootName);
+
+      // kcp reconciliations info -i <scheduling-id> -o json
+      const objReconciliationsOperations = JSON.parse(reconciliationsOperations);
+      console.log(`\nNumber of operations: ${objReconciliationsOperations.length}`);
+
+      // getting last three operations
+      const lastObjReconciliationsOperations = objReconciliationsOperations.slice(objReconciliationsOperations.length-3,
+          objReconciliationsOperations.length);
+
+      let i;
+      for (i of lastObjReconciliationsOperations) {
+        const getReconciliationsInfo = await kcp.getReconciliationsInfo(i.schedulingID);
+        console.log(`\nReconciliation info for operation ${i}: ${getReconciliationsInfo}`);
+      }
     });
 
     it('Assure only new cluster admins are configured', async function() {

--- a/tests/fast-integration/skr-test/skr-test.js
+++ b/tests/fast-integration/skr-test/skr-test.js
@@ -76,7 +76,7 @@ function oidcE2ETest() {
       let i;
       for (i of lastObjReconciliationsOperations) {
         const getReconciliationsInfo = await kcp.getReconciliationsInfo(i.schedulingID);
-        console.log(`\nReconciliation info for operation ${i}: ${getReconciliationsInfo}`);
+        console.log(`\nReconciliation info for operation ${i.schedulingID}: ${getReconciliationsInfo}`);
       }
     });
 

--- a/tests/fast-integration/skr-test/skr-test.js
+++ b/tests/fast-integration/skr-test/skr-test.js
@@ -60,24 +60,7 @@ function oidcE2ETest() {
     it('Should get Runtime Status after updating OIDC config', async function() {
       const runtimeStatus = await kcp.getRuntimeStatusOperations(this.options.instanceID);
       console.log(`\nRuntime status: ${runtimeStatus}`);
-
-      // kcp reconciliations operations -c <shootName> -o json
-      const objRuntimeStatus = JSON.parse(runtimeStatus);
-      const reconciliationsOperations = await kcp.getReconciliationsOperations(objRuntimeStatus.data[0].shootName);
-
-      // kcp reconciliations info -i <scheduling-id> -o json
-      const objReconciliationsOperations = JSON.parse(reconciliationsOperations);
-      console.log(`\nNumber of operations: ${objReconciliationsOperations.length}`);
-
-      // getting last three operations
-      const lastObjReconciliationsOperations = objReconciliationsOperations.slice(objReconciliationsOperations.length-3,
-          objReconciliationsOperations.length);
-
-      let i;
-      for (i of lastObjReconciliationsOperations) {
-        const getReconciliationsInfo = await kcp.getReconciliationsInfo(i.schedulingID);
-        console.log(`\nReconciliation info for operation ${i.schedulingID}: ${getReconciliationsInfo}`);
-      }
+      await kcp.reconcileInformationLog(runtimeStatus);
     });
 
     it('Assure updated OIDC config is applied on shoot cluster', async function() {
@@ -111,24 +94,7 @@ function oidcE2ETest() {
     it('Should get Runtime Status after updating admins', async function() {
       const runtimeStatus = await kcp.getRuntimeStatusOperations(this.options.instanceID);
       console.log(`\nRuntime status: ${runtimeStatus}`);
-
-      // kcp reconciliations operations -c <shootName> -o json
-      const objRuntimeStatus = JSON.parse(runtimeStatus);
-      const reconciliationsOperations = await kcp.getReconciliationsOperations(objRuntimeStatus.data[0].shootName);
-
-      // kcp reconciliations info -i <scheduling-id> -o json
-      const objReconciliationsOperations = JSON.parse(reconciliationsOperations);
-      console.log(`\nNumber of operations: ${objReconciliationsOperations.length}`);
-
-      // getting last three operations
-      const lastObjReconciliationsOperations = objReconciliationsOperations.slice(objReconciliationsOperations.length-3,
-          objReconciliationsOperations.length);
-
-      let i;
-      for (i of lastObjReconciliationsOperations) {
-        const getReconciliationsInfo = await kcp.getReconciliationsInfo(i.schedulingID);
-        console.log(`\nReconciliation info for operation ${i}: ${getReconciliationsInfo}`);
-      }
+      await kcp.reconcileInformationLog(runtimeStatus);
     });
 
     it('Assure only new cluster admins are configured', async function() {

--- a/tests/fast-integration/skr-test/skr-test.js
+++ b/tests/fast-integration/skr-test/skr-test.js
@@ -60,6 +60,24 @@ function oidcE2ETest() {
     it('Should get Runtime Status after updating OIDC config', async function() {
       const runtimeStatus = await kcp.getRuntimeStatusOperations(this.options.instanceID);
       console.log(`\nRuntime status: ${runtimeStatus}`);
+
+      // kcp reconciliations operations -c <shootName> -o json
+      const objRuntimeStatus = JSON.parse(runtimeStatus);
+      const reconciliationsOperations = await kcp.getReconciliationsOperations(objRuntimeStatus.data[0].shootName);
+
+      // kcp reconciliations info -i <scheduling-id> -o json
+      const objReconciliationsOperations = JSON.parse(reconciliationsOperations);
+      console.log(`\nNumber of operations: ${objReconciliationsOperations.length}`);
+
+      // getting last three operations
+      const lastObjReconciliationsOperations = objReconciliationsOperations.slice(objReconciliationsOperations.length-3,
+          objReconciliationsOperations.length);
+
+      let i;
+      for (i of lastObjReconciliationsOperations) {
+        const getReconciliationsInfo = await kcp.getReconciliationsInfo(i.schedulingID);
+        console.log(`\nReconciliation info for operation ${i}: ${getReconciliationsInfo}`);
+      }
     });
 
     it('Assure updated OIDC config is applied on shoot cluster', async function() {

--- a/tests/fast-integration/skr-test/test.js
+++ b/tests/fast-integration/skr-test/test.js
@@ -44,8 +44,7 @@ describe('Execute SKR test', function() {
       const lastObjReconciliationsOperations = objReconciliationsOperations.slice(objReconciliationsOperations.length-3,
           objReconciliationsOperations.length);
 
-      let i;
-      for (i of lastObjReconciliationsOperations) {
+      for (const i of lastObjReconciliationsOperations) {
         // kcp reconciliations info -i <scheduling-id> -o json
         const getReconciliationsInfo = await kcp.getReconciliationsInfo(i.schedulingID);
         console.log(`\nReconciliation info for operation ${i}: ${getReconciliationsInfo}`);

--- a/tests/fast-integration/skr-test/test.js
+++ b/tests/fast-integration/skr-test/test.js
@@ -32,24 +32,7 @@ describe('Execute SKR test', function() {
 
       const runtimeStatus = await kcp.getRuntimeStatusOperations(this.options.instanceID);
       console.log(`\nRuntime status after provisioning: ${runtimeStatus}`);
-
-      // kcp reconciliations operations -c <shootName> -o json
-      const objRuntimeStatus = JSON.parse(runtimeStatus);
-      const reconciliationsOperations = await kcp.getReconciliationsOperations(objRuntimeStatus.data[0].shootName);
-
-      const objReconciliationsOperations = JSON.parse(reconciliationsOperations);
-      console.log(`\nNumber of operations: ${objReconciliationsOperations.length}`);
-
-      // getting last three operations
-      const lastObjReconciliationsOperations = objReconciliationsOperations.slice(objReconciliationsOperations.length-3,
-          objReconciliationsOperations.length);
-
-      for (const i of lastObjReconciliationsOperations) {
-        // kcp reconciliations info -i <scheduling-id> -o json
-        const getReconciliationsInfo = await kcp.getReconciliationsInfo(i.schedulingID);
-        console.log(`\nReconciliation info for operation ${i}: ${getReconciliationsInfo}`);
-      }
-
+      await kcp.reconcileInformationLog(runtimeStatus);
       this.shoot = skr.shoot;
       await addScenarioInCompass(director, this.options.scenarioName);
       await assignRuntimeToScenario(director, this.shoot.compassID, this.options.scenarioName);

--- a/tests/fast-integration/skr-test/test.js
+++ b/tests/fast-integration/skr-test/test.js
@@ -33,7 +33,7 @@ describe('Execute SKR test', function() {
       const runtimeStatus = await kcp.getRuntimeStatusOperations(this.options.instanceID);
       console.log(`\nRuntime status after provisioning: ${runtimeStatus}`);
       await kcp.reconcileInformationLog(runtimeStatus);
-     
+
       this.shoot = skr.shoot;
       await addScenarioInCompass(director, this.options.scenarioName);
       await assignRuntimeToScenario(director, this.shoot.compassID, this.options.scenarioName);

--- a/tests/fast-integration/skr-test/test.js
+++ b/tests/fast-integration/skr-test/test.js
@@ -37,7 +37,6 @@ describe('Execute SKR test', function() {
       const objRuntimeStatus = JSON.parse(runtimeStatus);
       const reconciliationsOperations = await kcp.getReconciliationsOperations(objRuntimeStatus.data[0].shootName);
 
-      // kcp reconciliations info -i <scheduling-id> -o json
       const objReconciliationsOperations = JSON.parse(reconciliationsOperations);
       console.log(`\nNumber of operations: ${objReconciliationsOperations.length}`);
 
@@ -47,6 +46,7 @@ describe('Execute SKR test', function() {
 
       let i;
       for (i of lastObjReconciliationsOperations) {
+        // kcp reconciliations info -i <scheduling-id> -o json
         const getReconciliationsInfo = await kcp.getReconciliationsInfo(i.schedulingID);
         console.log(`\nReconciliation info for operation ${i}: ${getReconciliationsInfo}`);
       }

--- a/tests/fast-integration/skr-test/test.js
+++ b/tests/fast-integration/skr-test/test.js
@@ -33,6 +33,24 @@ describe('Execute SKR test', function() {
       const runtimeStatus = await kcp.getRuntimeStatusOperations(this.options.instanceID);
       console.log(`\nRuntime status after provisioning: ${runtimeStatus}`);
 
+      // kcp reconciliations operations -c <shootName> -o json
+      const objRuntimeStatus = JSON.parse(runtimeStatus);
+      const reconciliationsOperations = await kcp.getReconciliationsOperations(objRuntimeStatus.data[0].shootName);
+
+      // kcp reconciliations info -i <scheduling-id> -o json
+      const objReconciliationsOperations = JSON.parse(reconciliationsOperations);
+      console.log(`\nNumber of operations: ${objReconciliationsOperations.length}`);
+
+      // getting last three operations
+      const lastObjReconciliationsOperations = objReconciliationsOperations.slice(objReconciliationsOperations.length-3,
+          objReconciliationsOperations.length);
+
+      let i;
+      for (i of lastObjReconciliationsOperations) {
+        const getReconciliationsInfo = await kcp.getReconciliationsInfo(i.schedulingID);
+        console.log(`\nReconciliation info for operation ${i}: ${getReconciliationsInfo}`);
+      }
+
       this.shoot = skr.shoot;
       await addScenarioInCompass(director, this.options.scenarioName);
       await assignRuntimeToScenario(director, this.shoot.compassID, this.options.scenarioName);

--- a/tests/fast-integration/skr-test/test.js
+++ b/tests/fast-integration/skr-test/test.js
@@ -33,6 +33,7 @@ describe('Execute SKR test', function() {
       const runtimeStatus = await kcp.getRuntimeStatusOperations(this.options.instanceID);
       console.log(`\nRuntime status after provisioning: ${runtimeStatus}`);
       await kcp.reconcileInformationLog(runtimeStatus);
+     
       this.shoot = skr.shoot;
       await addScenarioInCompass(director, this.options.scenarioName);
       await assignRuntimeToScenario(director, this.shoot.compassID, this.options.scenarioName);


### PR DESCRIPTION
Changes proposed in this pull request:

"Improve fast-integration tests. When we get runtime status by kcp tool from KEB, please enhance that mechniasm and return status from reconciler by using kcp cli as well. That means I want to see runtime status from KEB and from reconciler  ( last operation , number of operations, info) every time after provisioning, deprovisioning, upgrade (kcp rc info -i {scheduling_id} -o json). 

Basically implementing these workflows and logging the results:

kcp reconciliations operations --shoot <shootName> -o json
kcp reconciliations info -i  <scheduling-id> -o json
