### PR TITLE
Subscriptions reconciliation should be requeued if subscription cannot be marked as ready

### DIFF
--- a/components/eventing-controller/controllers/subscription/nats/reconciler.go
+++ b/components/eventing-controller/controllers/subscription/nats/reconciler.go
@@ -225,21 +225,21 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 	// Check for valid sink
 	if err := r.sinkValidator(ctx, r, subscription); err != nil {
 		log.Errorw("sink URL validation failed", "error", err)
-		if err := r.syncSubscriptionStatus(ctx, subscription, false, false, err.Error()); err != nil {
-			return checkIsConflict(err)
+		if syncErr := r.syncSubscriptionStatus(ctx, subscription, false, false, err.Error()); err != nil {
+			return ctrl.Result{}, syncErr
 		}
-		// No point in reconciling as the sink is invalid
-		return ctrl.Result{}, nil
+		// No point in reconciling as the sink is invalid, return latest error to requeue the reconciliation request
+		return ctrl.Result{}, err
 	}
 
 	// Synchronize Kyma subscription to NATS backend
-	subscriptionStatusChanged, err := r.Backend.SyncSubscription(subscription, r.eventTypeCleaner)
-	if err != nil {
-		log.Errorw("sync subscription failed", "error", err)
-		if err := r.syncSubscriptionStatus(ctx, subscription, false, false, err.Error()); err != nil {
-			return checkIsConflict(err)
+	subscriptionStatusChanged, syncErr := r.Backend.SyncSubscription(subscription, r.eventTypeCleaner)
+	if syncErr != nil {
+		log.Errorw("sync subscription failed", "error", syncErr)
+		if err := r.syncSubscriptionStatus(ctx, subscription, false, false, syncErr.Error()); err != nil {
+			return ctrl.Result{}, err
 		}
-		return ctrl.Result{}, err
+		return ctrl.Result{}, syncErr
 	}
 	log.Debug("create NATS subscriptions succeeded")
 

--- a/resources/eventing/values.yaml
+++ b/resources/eventing/values.yaml
@@ -5,7 +5,7 @@ global:
   images:
     eventing_controller:
       name: eventing-controller
-      version: PR-13189
+      version: PR-13205
       pullPolicy: "IfNotPresent"
     publisher_proxy:
       name: event-publisher-proxy


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

See https://github.com/kyma-project/kyma/issues/13059#issuecomment-1023989101

Changes proposed in this pull request:

- In the NATS reconciler, return an error whenever we cannot set the subscription status to ready.

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->

This PR addresses https://github.com/kyma-project/kyma/issues/13059 for the NATS reconciler. If we agree on this way of addressing the issue, I'll create another PR for BEB.