### PR TITLE
Remove flaky testDispatcherWithMultipleSubscribers

### DIFF
--- a/components/eventing-controller/controllers/subscription/nats/reconciler_test.go
+++ b/components/eventing-controller/controllers/subscription/nats/reconciler_test.go
@@ -3,10 +3,7 @@ package nats
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"log"
-	"net/http"
-	"net/http/httptest"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -70,10 +67,6 @@ var (
 		testCleanEventTypes,
 		testUpdateSubscriptionStatus,
 		testNATSUnavailabilityReflectedInSubscriptionStatus,
-	}
-
-	dispatcherTestCases = []testCase{
-		testDispatcherWithMultipleSubscribers,
 	}
 )
 
@@ -625,98 +618,6 @@ func testCreateSubscriptionWithEmptyEventType(id int, eventTypePrefix, _, _ stri
 	})
 }
 
-func testDispatcherWithMultipleSubscribers(id int, eventTypePrefix, natsSubjectToPublish, eventTypeToSubscribe string) bool {
-	return When("Sending Events through Dispatcher for multiple subscribers", func() {
-		It("Should receive events in subscribers", func() {
-			ctx := context.Background()
-
-			// Start reconciler with empty checkSink function
-			cancel = startReconciler(eventTypePrefix, func(ctx context.Context, r *Reconciler, subscription *eventingv1alpha1.Subscription) error {
-				return nil
-			}, natsURL)
-			defer cancel()
-
-			subName1 := fmt.Sprintf(subscriptionNameFormat, id)
-			subName2 := fmt.Sprintf("subb-%d", id)
-
-			publishToSubjects := []string{
-				fmt.Sprintf("%s0", natsSubjectToPublish),
-				fmt.Sprintf("%s1", natsSubjectToPublish),
-			}
-
-			subscribeToEventTypes := []string{
-				fmt.Sprintf("%s0", eventTypeToSubscribe),
-				fmt.Sprintf("%s1", eventTypeToSubscribe),
-			}
-
-			// create subscribers
-			subChan1 := make(chan []byte)
-			url1, shutdown := newSubscriber(subChan1)
-			defer shutdown()
-
-			subChan2 := make(chan []byte)
-			url2, shutdown2 := newSubscriber(subChan2)
-			defer shutdown2()
-
-			// create subscription
-			subscription1 := reconcilertesting.NewSubscription(subName1, namespaceName, reconcilertesting.WithFilter(reconcilertesting.EventSource, subscribeToEventTypes[0]), reconcilertesting.WithWebhookForNats)
-			subscription2 := reconcilertesting.NewSubscription(subName2, namespaceName, reconcilertesting.WithFilter(reconcilertesting.EventSource, subscribeToEventTypes[1]), reconcilertesting.WithWebhookForNats)
-
-			// assign sink URL
-			subscription1.Spec.Sink = url1
-			subscription2.Spec.Sink = url2
-
-			// ensure subscription is created
-			ensureSubscriptionCreated(ctx, subscription1)
-			ensureSubscriptionCreated(ctx, subscription2)
-
-			// retrieve subscription and check whether it is ready
-			getSubscription(ctx, subscription1).Should(And(
-				reconcilertesting.HaveSubscriptionName(subName1),
-				reconcilertesting.HaveCondition(eventingv1alpha1.MakeCondition(
-					eventingv1alpha1.ConditionSubscriptionActive,
-					eventingv1alpha1.ConditionReasonNATSSubscriptionActive,
-					v1.ConditionTrue, "")),
-				reconcilertesting.HaveSubsConfiguration(&eventingv1alpha1.SubscriptionConfig{
-					MaxInFlightMessages: defaultSubsConfig.MaxInFlightMessages,
-				}),
-			))
-
-			getSubscription(ctx, subscription2).Should(And(
-				reconcilertesting.HaveSubscriptionName(subName2),
-				reconcilertesting.HaveCondition(eventingv1alpha1.MakeCondition(
-					eventingv1alpha1.ConditionSubscriptionActive,
-					eventingv1alpha1.ConditionReasonNATSSubscriptionActive,
-					v1.ConditionTrue, "")),
-				reconcilertesting.HaveSubsConfiguration(&eventingv1alpha1.SubscriptionConfig{
-					MaxInFlightMessages: defaultSubsConfig.MaxInFlightMessages,
-				}),
-			))
-
-			// establish connection with NATS
-			connection, err := connectToNats(natsURL)
-			Expect(err).ShouldNot(HaveOccurred())
-
-			// publish events to nats
-			err = connection.Publish(publishToSubjects[0], []byte(reconcilertesting.StructuredCloudEvent))
-			Expect(err).ShouldNot(HaveOccurred())
-
-			err = connection.Publish(publishToSubjects[1], []byte(reconcilertesting.StructuredCloudEventUpdated))
-			Expect(err).ShouldNot(HaveOccurred())
-
-			// make sure that the subscriber received the message
-			sent := fmt.Sprintf(`"%s"`, reconcilertesting.EventData)
-			Eventually(func() ([]byte, error) {
-				return getFromChanOrTimeout(subChan1, smallPollingInterval)
-			}, timeout, pollingInterval).Should(WithTransform(bytesStringer, Equal(sent)))
-
-			Eventually(func() ([]byte, error) {
-				return getFromChanOrTimeout(subChan2, smallPollingInterval)
-			}, timeout, pollingInterval).Should(WithTransform(bytesStringer, Equal(sent)))
-		})
-	})
-}
-
 var (
 	_ = Describe("NATS Subscription reconciler tests with non-empty eventTypePrefix", testExecutor(reconcilertesting.EventTypePrefix, reconcilertesting.OrderCreatedEventType, reconcilertesting.OrderCreatedEventTypeNotClean))
 	_ = Describe("NATS Subscription reconciler tests with empty eventTypePrefix", testExecutor(reconcilertesting.EventTypePrefixEmpty, reconcilertesting.OrderCreatedEventTypePrefixEmpty, reconcilertesting.OrderCreatedEventTypeNotCleanPrefixEmpty))
@@ -726,11 +627,6 @@ func testExecutor(eventTypePrefix, natsSubjectToPublish, eventTypeToSubscribe st
 	return func() {
 
 		for _, tc := range reconcilerTestCases {
-			tc(testID, eventTypePrefix, natsSubjectToPublish, eventTypeToSubscribe)
-			testID++
-		}
-
-		for _, tc := range dispatcherTestCases {
 			tc(testID, eventTypePrefix, natsSubjectToPublish, eventTypeToSubscribe)
 			testID++
 		}
@@ -748,42 +644,6 @@ func getK8sEvents(eventList *v1.EventList, namespace string) AsyncAssertion {
 		}
 		return *eventList
 	}, smallTimeout, smallPollingInterval)
-}
-
-func newSubscriber(result chan []byte) (string, func()) {
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		body, err := ioutil.ReadAll(r.Body)
-		if err != nil {
-			w.WriteHeader(http.StatusBadRequest)
-			return
-		}
-		result <- body
-	}))
-	return server.URL, server.Close
-}
-
-func connectToNats(natsURL string) (*nats.Conn, error) {
-	connection, err := nats.Connect(natsURL, nats.RetryOnFailedConnect(true), nats.MaxReconnects(3), nats.ReconnectWait(time.Second))
-	if err != nil {
-		return nil, err
-	}
-	if connection.Status() != nats.CONNECTED {
-		return nil, err
-	}
-	return connection, nil
-}
-
-func getFromChanOrTimeout(ch <-chan []byte, t time.Duration) ([]byte, error) {
-	select {
-	case received := <-ch:
-		return received, nil
-	case <-time.After(t):
-		return nil, fmt.Errorf("timed out waiting for a message")
-	}
-}
-
-func bytesStringer(bs []byte) string {
-	return string(bs)
 }
 
 func ensureSubscriptionCreated(ctx context.Context, subscription *eventingv1alpha1.Subscription) {


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

In the NATS reconciler tests, we have recently added `testDispatcherWithMultipleSubscribers`. Currently, the test is flaky (see attached issue). I have tried debugging the test, with no success! On a second thought, the test is not really adding any value, IMO. As far as the NATS reconciler logic is concerned, the test is checking basic subscription reconciliation functionality, which is checked in other tests already. However, it also mixes it with testing dispatching/delivery logic, which is unrelated here. That part is already tested in the NATS handler unit tests, and the whole end-to-end flow is tested in fast-integration tests. So no need to mix it here. It only makes the whole ginko/envtest test suite more complicated.

**Related issue(s)**

Closes https://github.com/kyma-project/kyma/issues/13173
