### PR TITLE
Modify Loki labelMap

### DIFF
--- a/resources/logging/charts/fluent-bit/values.yaml
+++ b/resources/logging/charts/fluent-bit/values.yaml
@@ -245,16 +245,16 @@ config:
       config:
         loglevel: warn
         lineFormat: json
-        removeKeys: kubernetes, stream
+        removeKeys: stream
         labels: '{job="fluent-bit"}'
         labelMap:
           kubernetes:
             namespace_name: namespace
             labels:
               app: app
-              release: release
+              "app.kubernetes.io/component": component
+              "app.kubernetes.io/name": app
               "serverless.kyma-project.io/function-name": function
-              "serverless.kyma-project.io/uuid": functionUID
             host: node
             container_name: container
             pod_name: pod

--- a/resources/logging/charts/fluent-bit/values.yaml
+++ b/resources/logging/charts/fluent-bit/values.yaml
@@ -226,13 +226,37 @@ config:
       # Include Kubernetes resource labels in the extra metadata.
       labels: "On"
       # Include Kubernetes resource annotations in the extra metadata.
-      annotations: "Off"
+      annotations: "On"
     recordModifier:
       enabled: false
       match: "*"
       key: "myKey"
       value: "myValue"
-    additional: ""
+    additional: |
+      [FILTER]
+          Name                  modify
+          Match                 *
+          Copy                  kubernetes kubernetes2
+    
+      [FILTER]
+          Name                   nest
+          Match                  *
+          Operation              lift
+          Nested_under           kubernetes
+          Prefix_with            kubernetes_
+
+      [FILTER]
+          Name                   nest
+          Match                  *
+          Operation              nest
+          Nest_under             kubernetes
+          Remove_prefix          kubernetes_
+          Wildcard               kubernetes_labels
+          
+      [FILTER]
+          Name                  modify
+          Match                 *
+          Remove_wildcard       kubernetes_
   outputs:
     loki:
       enabled: true
@@ -245,10 +269,10 @@ config:
       config:
         loglevel: warn
         lineFormat: json
-        removeKeys: stream
+        removeKeys: stream,kubernetes2
         labels: '{job="fluent-bit"}'
         labelMap:
-          kubernetes:
+          kubernetes2:
             namespace_name: namespace
             labels:
               app: app

--- a/resources/logging/charts/fluent-bit/values.yaml
+++ b/resources/logging/charts/fluent-bit/values.yaml
@@ -232,31 +232,7 @@ config:
       match: "*"
       key: "myKey"
       value: "myValue"
-    additional: |
-      [FILTER]
-          Name                  modify
-          Match                 *
-          Copy                  kubernetes kubernetes2
-    
-      [FILTER]
-          Name                   nest
-          Match                  *
-          Operation              lift
-          Nested_under           kubernetes
-          Prefix_with            kubernetes_
-
-      [FILTER]
-          Name                   nest
-          Match                  *
-          Operation              nest
-          Nest_under             kubernetes
-          Remove_prefix          kubernetes_
-          Wildcard               kubernetes_labels
-          
-      [FILTER]
-          Name                  modify
-          Match                 *
-          Remove_wildcard       kubernetes_
+    additional: ""
   outputs:
     loki:
       enabled: true
@@ -269,10 +245,10 @@ config:
       config:
         loglevel: warn
         lineFormat: json
-        removeKeys: stream,kubernetes2
+        removeKeys: kubernetes, stream
         labels: '{job="fluent-bit"}'
         labelMap:
-          kubernetes2:
+          kubernetes:
             namespace_name: namespace
             labels:
               app: app

--- a/resources/logging/charts/fluent-bit/values.yaml
+++ b/resources/logging/charts/fluent-bit/values.yaml
@@ -226,7 +226,7 @@ config:
       # Include Kubernetes resource labels in the extra metadata.
       labels: "On"
       # Include Kubernetes resource annotations in the extra metadata.
-      annotations: "On"
+      annotations: "Off"
     recordModifier:
       enabled: false
       match: "*"


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

Modifications for Lokis's LabelMap:
- Add `app.kubernetes.io/name` and `app.kubernetes.io/component` labels, since they are currently commonly used.
- Both `app` and `app.kubernetes.io/name` labels are mapped into the `app` label, as usually only one of them is used. And even if there is a resource having both of these labels, you can still use Loki to search for any of the two values using the `app` label.
- Remove `release` label (fading away with helm2) and `functionUID` label (`function` label can be used instead for Loki queries).

**Related issue(s)**
#12536 
