### PR TITLE
Exclude cert expiration alert in monitoring tests

### DIFF
--- a/tests/fast-integration/monitoring/prometheus.js
+++ b/tests/fast-integration/monitoring/prometheus.js
@@ -156,12 +156,14 @@ function shouldIgnoreAlert(alert) {
     'Watchdog',
     // Scrape limits can be exceeded on long-running clusters and can be ignored
     'ScrapeLimitForTargetExceeded',
-    // Overcommitting resources is fine for e2e test scenarios
+    // Resource overcommitment is fine for e2e test scenarios
     'KubeCPUOvercommit',
     'KubeMemoryOvercommit',
+    // API server certificates are auto-renewed
+    'K8sCertificateExpirationNotice'
   ];
 
-  return alert.labels.severity == 'critical' || alertNamesToIgnore.includes(alert.labels.alertname);
+  return alert.labels.severity != 'critical' || alertNamesToIgnore.includes(alert.labels.alertname);
 }
 
 async function getServiceMonitors() {

--- a/tests/fast-integration/monitoring/prometheus.js
+++ b/tests/fast-integration/monitoring/prometheus.js
@@ -160,7 +160,7 @@ function shouldIgnoreAlert(alert) {
     'KubeCPUOvercommit',
     'KubeMemoryOvercommit',
     // API server certificates are auto-renewed
-    'K8sCertificateExpirationNotice'
+    'K8sCertificateExpirationNotice',
   ];
 
   return alert.labels.severity != 'critical' || alertNamesToIgnore.includes(alert.labels.alertname);


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- Fix a bug resulting in only non-critical alert taken into account (should be vice versa)
- Ignore `K8sCertificateExpirationNotice` alert in tests

**Related issue(s)**
Fixes #13253
