### PR TITLE
Adding the missing Cloud Event attribute

### DIFF
--- a/components/function-runtimes/nodejs12/kubeless/kubeless_rt/lib/ce.js
+++ b/components/function-runtimes/nodejs12/kubeless/kubeless_rt/lib/ce.js
@@ -54,7 +54,7 @@ function publishCloudEvent(data) {
 }
 
 function resolvedatatype(data){
-    switch(typeof(data)) {
+    switch(typeof data) {
         case 'object':
             return 'application/json'
         case 'string':

--- a/components/function-runtimes/nodejs12/kubeless/kubeless_rt/lib/ce.js
+++ b/components/function-runtimes/nodejs12/kubeless/kubeless_rt/lib/ce.js
@@ -53,6 +53,15 @@ function publishCloudEvent(data) {
     });
 }
 
+function resolvedatatype(data){
+    switch(typeof(data)) {
+        case 'object':
+            return 'application/json'
+        case 'string':
+            return 'text/plain'
+    }
+}
+
 function buildResponseCloudEvent(req, id, type, data) {
     return {
         'type': type,
@@ -61,6 +70,7 @@ function buildResponseCloudEvent(req, id, type, data) {
         'specversion': req.get('ce-specversion'),
         'id': id,
         'data': data,
+        'datacontenttype': resolvedatatype(data),
     };
 }
 

--- a/components/function-runtimes/nodejs14/kubeless/kubeless_rt/lib/ce.js
+++ b/components/function-runtimes/nodejs14/kubeless/kubeless_rt/lib/ce.js
@@ -54,7 +54,7 @@ function publishCloudEvent(data) {
 }
 
 function resolvedatatype(data){
-    switch(typeof(data)) {
+    switch(typeof data) {
         case 'object':
             return 'application/json'
         case 'string':

--- a/components/function-runtimes/nodejs14/kubeless/kubeless_rt/lib/ce.js
+++ b/components/function-runtimes/nodejs14/kubeless/kubeless_rt/lib/ce.js
@@ -53,6 +53,15 @@ function publishCloudEvent(data) {
     });
 }
 
+function resolvedatatype(data){
+    switch(typeof(data)) {
+        case 'object':
+            return 'application/json'
+        case 'string':
+            return 'text/plain'
+    }
+}
+
 function buildResponseCloudEvent(req, id, type, data) {
     return {
         'type': type,
@@ -61,6 +70,7 @@ function buildResponseCloudEvent(req, id, type, data) {
         'specversion': req.get('ce-specversion'),
         'id': id,
         'data': data,
+        'datacontenttype': resolvedatatype(data),
     };
 }
 

--- a/components/function-runtimes/python39/kubeless/kubeless.py
+++ b/components/function-runtimes/python39/kubeless/kubeless.py
@@ -116,6 +116,13 @@ class Event:
             headers = {"Content-Type": "application/cloudevents+json"}
             )
     
+    def resolvedatatype(event_data):
+        match type(event_data)
+            case 'dict':
+                return 'application/json'
+            case 'str':
+                return 'text/plain'
+
     def buildResponseCloudEvent(self, event_id, event_type, event_data):
         return {
             'type': event_type,
@@ -124,6 +131,7 @@ class Event:
             'specversion': self.ceHeaders['ce-specversion'],
             'id': event_id,
             'data': event_data
+            'datacontenttype': resolvedatatype(data),
         }
 
 


### PR DESCRIPTION
**Description**
Setting the `datacontenttype` attribute to the correct value prevents json payloads from getting stringified.

**Related issue(s)**
See also #13182 