### PR TITLE
Fix UID collision for telemetry-operator Grafana dashboard

### DIFF
--- a/resources/telemetry/charts/operator/templates/dashboard-configmap.yaml
+++ b/resources/telemetry/charts/operator/templates/dashboard-configmap.yaml
@@ -1253,6 +1253,6 @@ data:
       },
       "timezone": "",
       "title":   "Kyma / Telemetry / Operator",
-      "uid": "mSTqzBFZka",
+      "uid": "mSTqzBFZkb",
       "version": 2
     }


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

The telemetry-operator dashboard was cloned from the rafter controller dashboard, but the UID was not changed. This caused occasionally switching to another dashboard when reloading Grafana.

Changes proposed in this pull request:

- Fix UID collision for telemetry-operator Grafana dashboard

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
See also #11823 