### PR TITLE
Unify the usages of EVENT_TYPE_PREFIX and LEGACY_EVENT_TYPE_PREFIX

### DIFF
--- a/components/event-publisher-proxy/cmd/event-publisher-proxy/nats/nats.go
+++ b/components/event-publisher-proxy/cmd/event-publisher-proxy/nats/nats.go
@@ -115,7 +115,7 @@ func (c *Commander) Start() error {
 	c.logger.Info("Informers are synced successfully")
 
 	// configure event type cleaner
-	eventTypeCleaner := eventtype.NewCleaner(c.envCfg.LegacyEventTypePrefix, applicationLister, c.logger)
+	eventTypeCleaner := eventtype.NewCleaner(c.envCfg.EventTypePrefix, applicationLister, c.logger)
 
 	// start handler which blocks until it receives a shutdown signal
 	if err := nats.NewHandler(messageReceiver, &messageSenderToNats, c.envCfg.RequestTimeout, legacyTransformer, c.opts,

--- a/components/event-publisher-proxy/config/event-publisher-nats/200-deployment.yaml
+++ b/components/event-publisher-proxy/config/event-publisher-nats/200-deployment.yaml
@@ -35,7 +35,7 @@ spec:
               value: 5s
             - name: LEGACY_NAMESPACE
               value: kyma
-            - name: LEGACY_EVENT_TYPE_PREFIX
+            - name: EVENT_TYPE_PREFIX
               value: sap.kyma.custom
           image: ko://github.com/kyma-project/kyma/components/event-publisher-proxy/cmd/event-publisher-proxy
           imagePullPolicy: IfNotPresent

--- a/components/event-publisher-proxy/pkg/env/nats_config.go
+++ b/components/event-publisher-proxy/pkg/env/nats_config.go
@@ -19,9 +19,9 @@ type NatsConfig struct {
 
 	// Legacy Namespace is used as the event source for legacy events
 	LegacyNamespace string `envconfig:"LEGACY_NAMESPACE" default:"kyma"`
-	// LegacyEventTypePrefix is the prefix of each event as per the eventing specification, used for legacy events
-	// It follows the eventType format: <LegacyEventTypePrefix>.<appName>.<event-name>.<version>
-	LegacyEventTypePrefix string `envconfig:"LEGACY_EVENT_TYPE_PREFIX" default:"kyma"`
+	// EventTypePrefix is the prefix of each event as per the eventing specification
+	// It follows the eventType format: <eventTypePrefix>.<appName>.<event-name>.<version>
+	EventTypePrefix string `envconfig:"EVENT_TYPE_PREFIX" default:"kyma"`
 
 	// JetStream-specific configs
 	JSStreamName          string `envconfig:"JS_STREAM_NAME" default:"kyma"`
@@ -32,7 +32,7 @@ type NatsConfig struct {
 func (c *NatsConfig) ToConfig() *BebConfig {
 	cfg := &BebConfig{
 		BEBNamespace:    c.LegacyNamespace,
-		EventTypePrefix: c.LegacyEventTypePrefix,
+		EventTypePrefix: c.EventTypePrefix,
 	}
 	return cfg
 }

--- a/components/event-publisher-proxy/pkg/handler/nats/mock/mock.go
+++ b/components/event-publisher-proxy/pkg/handler/nats/mock/mock.go
@@ -155,7 +155,7 @@ func WithEventTypePrefix(eventTypePrefix string) NatsHandlerMockOpt {
 // WithSubscription returns NatsHandlerMockOpt which sets the subscribed.Processor for the given NatsHandlerMock.
 func WithSubscription(scheme *runtime.Scheme, subscription *eventingv1alpha1.Subscription) NatsHandlerMockOpt {
 	return func(m *NatsHandlerMock) {
-		m.natsConfig.LegacyEventTypePrefix = m.eventTypePrefix
+		m.natsConfig.EventTypePrefix = m.eventTypePrefix
 		dynamicTestClient := dynamicfake.NewSimpleDynamicClient(scheme, subscription)
 		dFilteredSharedInfFactory := dynamicinformer.NewFilteredDynamicSharedInformerFactory(dynamicTestClient, 10*time.Second, v1.NamespaceAll, nil)
 		genericInf := dFilteredSharedInfFactory.ForResource(subscribed.GVR)
@@ -191,9 +191,9 @@ func WithJetstream(jsEnabled bool) NatsHandlerMockOpt {
 
 func newNatsConfig(port int) *env.NatsConfig {
 	return &env.NatsConfig{
-		Port:                  port,
-		LegacyNamespace:       testingutils.MessagingNamespace,
-		LegacyEventTypePrefix: testingutils.MessagingEventTypePrefix,
-		JSStreamName:          testingutils.StreamName,
+		Port:            port,
+		LegacyNamespace: testingutils.MessagingNamespace,
+		EventTypePrefix: testingutils.MessagingEventTypePrefix,
+		JSStreamName:    testingutils.StreamName,
 	}
 }

--- a/components/eventing-controller/README.md
+++ b/components/eventing-controller/README.md
@@ -56,7 +56,7 @@ This section explains how to use the Eventing Controller. It expects the followi
 | `PUBLISHER_LIMITS_MEMORY`         | The memory limits of the Event Publisher Proxy.                                                |
 | **For NATS**                      |                                                                                                |
 | `NATS_URL`                        | The URL for the NATS server.                                                                   |
-| `EVENT_TYPE_PREFIX`               | The Event Type Prefix for the NATS backend.                                                    |
+| `EVENT_TYPE_PREFIX`               | The event type prefix for the NATS backend.                                                    |
 | `MAX_IDLE_CONNS`                  | The maximum number of idle connections for the HTTP transport of the NATS backend.             |
 | `MAX_CONNS_PER_HOST`              | The maximum connections per host for the HTTP transport of the NATS backend.                   |
 | `MAX_IDLE_CONNS_PER_HOST`         | The maximum idle connections per host for the HTTP transport of the NATS backend.              |
@@ -183,7 +183,7 @@ kubectl port-forward -n kyma-system svc/eventing-nats 4222
 |--------------------------|----------------------------------------------------|----------|-----------------------------|
 | `KUBECONFIG`             | Path to a local kubeconfig file.                   | yes      | ~/.kube/config              |
 | `NATS_URL`               | URL of the NATS server.                            | no       | nats.nats.svc.cluster.local |
-| `EVENT_TYPE_PREFIX`      | Path to a local kubeconfig file.                   | yes      | sap.kyma.custom             |
+| `EVENT_TYPE_PREFIX`      | The Event Type Prefix for the NATS backend.        | yes      | sap.kyma.custom             |
 | `WEBHOOK_TOKEN_ENDPOINT` | The Kyma public endpoint to provide Access Tokens. | yes      | WEBHOOK_TOKEN_ENDPOINT      |
 | `DOMAIN`                 | Domain.                                            | yes      | example.com                 |
 

--- a/components/eventing-controller/README.md
+++ b/components/eventing-controller/README.md
@@ -183,7 +183,7 @@ kubectl port-forward -n kyma-system svc/eventing-nats 4222
 |--------------------------|----------------------------------------------------|----------|-----------------------------|
 | `KUBECONFIG`             | Path to a local kubeconfig file.                   | yes      | ~/.kube/config              |
 | `NATS_URL`               | URL of the NATS server.                            | no       | nats.nats.svc.cluster.local |
-| `EVENT_TYPE_PREFIX`      | The Event Type Prefix for the NATS backend.        | yes      | sap.kyma.custom             |
+| `EVENT_TYPE_PREFIX`      | The event type prefix for the NATS backend.        | yes      | sap.kyma.custom             |
 | `WEBHOOK_TOKEN_ENDPOINT` | The Kyma public endpoint to provide Access Tokens. | yes      | WEBHOOK_TOKEN_ENDPOINT      |
 | `DOMAIN`                 | Domain.                                            | yes      | example.com                 |
 

--- a/components/eventing-controller/pkg/deployment/publisher_deployment.go
+++ b/components/eventing-controller/pkg/deployment/publisher_deployment.go
@@ -308,17 +308,6 @@ func getNATSEnvVars(natsConfig env.NatsConfig, publisherConfig env.PublisherConf
 		{Name: "REQUEST_TIMEOUT", Value: publisherConfig.RequestTimeout},
 		{Name: "LEGACY_NAMESPACE", Value: "kyma"},
 		{
-			Name: "LEGACY_EVENT_TYPE_PREFIX",
-			ValueFrom: &v1.EnvVarSource{
-				ConfigMapKeyRef: &v1.ConfigMapKeySelector{
-					LocalObjectReference: v1.LocalObjectReference{
-						Name: configMapName,
-					},
-					Key: configMapKeyEventTypePrefix,
-				},
-			},
-		},
-		{
 			Name: "EVENT_TYPE_PREFIX",
 			ValueFrom: &v1.EnvVarSource{
 				ConfigMapKeyRef: &v1.ConfigMapKeySelector{

--- a/resources/eventing/values.yaml
+++ b/resources/eventing/values.yaml
@@ -5,11 +5,11 @@ global:
   images:
     eventing_controller:
       name: eventing-controller
-      version: 91da5162
+      version: PR-13329
       pullPolicy: "IfNotPresent"
     publisher_proxy:
       name: event-publisher-proxy
-      version: a60a0f36
+      version: PR-13329
     nats:
       name: nats
       version: 2.7.4-alpine-2022-04-05


### PR DESCRIPTION
**Description**
Remove the usage of LEGACY_EVENT_TYPE_PREFIX, so that BEB and NATS event prefix config are set similarly.


**Related issue(s)**
Fixes https://github.com/kyma-project/kyma/issues/12238
