### PR TITLE
Made apiserver rules optional

### DIFF
--- a/resources/monitoring/templates/prometheus/rules-1.14/kube-apiserver-burnrate.rules.yaml
+++ b/resources/monitoring/templates/prometheus/rules-1.14/kube-apiserver-burnrate.rules.yaml
@@ -1,10 +1,13 @@
 {{- /*
+  Customization: make the dashboard rules optional via the values
+*/ -}}
+{{- /*
 Generated from 'kube-apiserver-burnrate.rules' group from https://raw.githubusercontent.com/prometheus-operator/kube-prometheus/main/manifests/kubernetesControlPlane-prometheusRule.yaml
 Do not change in-place! In order to change this file first read following link:
 https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-prometheus-stack/hack
 */ -}}
 {{- $kubeTargetVersion := default .Capabilities.KubeVersion.GitVersion .Values.kubeTargetVersionOverride }}
-{{- if and (semverCompare ">=1.14.0-0" $kubeTargetVersion) (semverCompare "<9.9.9-9" $kubeTargetVersion) .Values.defaultRules.create }}
+{{- if and (semverCompare ">=1.14.0-0" $kubeTargetVersion) (semverCompare "<9.9.9-9" $kubeTargetVersion) .Values.defaultRules.create .Values.kubeApiServer.enabled .Values.defaultRules.rules.kubeApiserverBurnrate }}
 apiVersion: monitoring.coreos.com/v1
 kind: PrometheusRule
 metadata:

--- a/resources/monitoring/templates/prometheus/rules-1.14/kube-apiserver-histogram.rules.yaml
+++ b/resources/monitoring/templates/prometheus/rules-1.14/kube-apiserver-histogram.rules.yaml
@@ -1,10 +1,13 @@
 {{- /*
+    Customization: make the dashboard rules optional via the values
+*/ -}}
+{{- /*
 Generated from 'kube-apiserver-histogram.rules' group from https://raw.githubusercontent.com/prometheus-operator/kube-prometheus/main/manifests/kubernetesControlPlane-prometheusRule.yaml
 Do not change in-place! In order to change this file first read following link:
 https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-prometheus-stack/hack
 */ -}}
 {{- $kubeTargetVersion := default .Capabilities.KubeVersion.GitVersion .Values.kubeTargetVersionOverride }}
-{{- if and (semverCompare ">=1.14.0-0" $kubeTargetVersion) (semverCompare "<9.9.9-9" $kubeTargetVersion) .Values.defaultRules.create }}
+{{- if and (semverCompare ">=1.14.0-0" $kubeTargetVersion) (semverCompare "<9.9.9-9" $kubeTargetVersion) .Values.defaultRules.create .Values.kubeApiServer.enabled .Values.defaultRules.rules.kubeApiserverHistogram }}
 apiVersion: monitoring.coreos.com/v1
 kind: PrometheusRule
 metadata:

--- a/resources/monitoring/values.yaml
+++ b/resources/monitoring/values.yaml
@@ -40,6 +40,8 @@ defaultRules:
     k8s: true
     kubeApiserver: true
     kubeApiserverAvailability: true
+    kubeApiserverBurnrate: false
+    kubeApiserverHistogram: false
     kubeApiserverSlos: true
     kubelet: true
     kubeProxy: true


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- Introduce customization to make `apiserver-histogram` and `apiserver-burndown` rules optional. The new rules were introduced in https://github.com/kyma-project/kyma/issues/11567 and are duplicates of the `apiserver` rules, which breaks Prometheus

**Related issue(s)**
https://github.com/kyma-project/kyma/issues/13336
