### PR TITLE
Add annotation to ignore pod state for auth-proxy deployments

### DIFF
--- a/resources/kiali/templates/kyma-additions/auth-proxy-deployment.yaml
+++ b/resources/kiali/templates/kyma-additions/auth-proxy-deployment.yaml
@@ -6,6 +6,8 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "kiali-server.labels" . | nindent 4 }}
+  annotations:
+    reconciler.kyma-project.io/ignore-pod-state: "true"
 spec:
   replicas: {{ .Values.authProxy.replicaCount }}
   selector:

--- a/resources/monitoring/charts/grafana/templates/kyma-additions/auth-proxy-deployment.yaml
+++ b/resources/monitoring/charts/grafana/templates/kyma-additions/auth-proxy-deployment.yaml
@@ -9,6 +9,8 @@ metadata:
     app.kubernetes.io/name: auth-proxy
     app.kubernetes.io/managed-by: {{ .Release.Service }}
     helm.sh/chart: {{ include "grafana.chart" . }}
+  annotations:
+    reconciler.kyma-project.io/ignore-pod-state: "true"
 spec:
   replicas: {{ .Values.kyma.authProxy.replicaCount }}
   selector:

--- a/resources/tracing/templates/kyma-additions/auth-proxy-deployment.yaml
+++ b/resources/tracing/templates/kyma-additions/auth-proxy-deployment.yaml
@@ -5,6 +5,8 @@ metadata:
   name: {{ include "jaeger-operator.fullname" . }}-auth-proxy
   labels:
 {{ include "jaeger-operator.labels" . | indent 4 }}
+  annotations:
+    reconciler.kyma-project.io/ignore-pod-state: "true"
 spec:
   replicas: {{ .Values.authProxy.replicaCount }}
   selector:


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

The the identity provider of the auth-proxy instances can be configured by a user-defined Secret. A faulty configuration can result in a crashing oauth2 proxy container. This PR adds an annotation to the related deployments so that a faulty identity provider configuration does not block a cluster reconciliation.
Changes proposed in this pull request:

- Add annotation to auth-proxy deployments to ignore pod state by the reconciler

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
See also https://github.com/kyma-incubator/reconciler/pull/805