### PR TITLE
support additional linters per component

### DIFF
--- a/common/makefiles/generic-make-go.mk
+++ b/common/makefiles/generic-make-go.mk
@@ -15,6 +15,7 @@ VERIFY_IGNORE := /vendor\|/automock
 # enable failing builds by specifying the following in the components makefile
 # override IGNORE_LINTING_ISSUES =
 IGNORE_LINTING_ISSUES := -
+ADDITIONAL_LINTERS :=
 
 # Other variables
 # LOCAL_DIR in a local path to scripts folder
@@ -193,7 +194,7 @@ vet-local:
 # Forcing build failing:
 # override IGNORE_LINTING_ISSUES = 
 lint: ## Run various linters
-	$(IGNORE_LINTING_ISSUES)SKIP_VERIFY="true" ../../hack/verify-lint.sh $(COMPONENT_DIR) 
+	$(IGNORE_LINTING_ISSUES)SKIP_VERIFY="true" ADDITIONAL_LINTERS=$(ADDITIONAL_LINTERS) ../../hack/verify-lint.sh $(COMPONENT_DIR) 
 
 generate-local: ## Run code generation
 	go generate ./...

--- a/hack/verify-lint.sh
+++ b/hack/verify-lint.sh
@@ -10,6 +10,8 @@ readonly ROOT_PATH="${1:-$( cd "${CURRENT_DIR}/.." && pwd )}" # first argument o
 readonly TMP_DIR=$(mktemp -d)
 readonly GOLANGCI_LINT_VERSION="v1.38.0"
 
+ADDITIONAL_LINTERS=${ADDITIONAL_LINTERS:-}
+
 source "${CURRENT_DIR}/utilities.sh" || { echo 'Cannot load CI utilities.'; exit 1; }
 
 cleanup() {
@@ -55,6 +57,7 @@ golangci::run_checks() {
     structcheck typecheck unused varcheck \
     # additional lints
     golint gofmt misspell gochecknoinits unparam scopelint gosec
+    ${ADDITIONAL_LINTERS}
   )
 
   echo "Checks: ${LINTS[*]}"


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- Support per component additional linters by configuring:
```override ADDITIONAL_LINTERS=golanci_linter (eg. gocognit)```
in a components Makefile

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
