### PR TITLE
Clear subscription status in JetStream reconciler

### DIFF
--- a/components/eventing-controller/cmd/eventing-controller/main.go
+++ b/components/eventing-controller/cmd/eventing-controller/main.go
@@ -42,19 +42,32 @@ func main() {
 	// Set controller core logger.
 	ctrl.SetLogger(zapr.NewLogger(ctrLogger.WithContext().Desugar()))
 
-	// Add schemes.
+	// Instantiate and initialize all the subscription managers.
+	restCfg := ctrl.GetConfigOrDie()
 	scheme := runtime.NewScheme()
-	if err := beb.AddToScheme(scheme); err != nil {
-		setupLogger.Error(err, "start manager failed")
-		os.Exit(1)
+
+	var natsSubMgr subscriptionmanager.Manager
+	if opts.EnableJetStreamBackend {
+		natsSubMgr = jetstream.NewSubscriptionManager(restCfg, opts.MetricsAddr, opts.MaxReconnects, opts.ReconnectWait, ctrLogger)
+		if err := jetstream.AddToScheme(scheme); err != nil {
+			setupLogger.Error(err, "start manager failed")
+			os.Exit(1)
+		}
+	} else {
+		natsSubMgr = nats.NewSubscriptionManager(restCfg, opts.MetricsAddr, opts.MaxReconnects, opts.ReconnectWait, ctrLogger)
+		if err := nats.AddToScheme(scheme); err != nil {
+			setupLogger.Error(err, "start manager failed")
+			os.Exit(1)
+		}
 	}
-	if err := nats.AddToScheme(scheme); err != nil {
+
+	bebSubMgr := beb.NewSubscriptionManager(restCfg, opts.MetricsAddr, opts.ReconcilePeriod, ctrLogger)
+	if err := beb.AddToScheme(scheme); err != nil {
 		setupLogger.Error(err, "start manager failed")
 		os.Exit(1)
 	}
 
 	// Init the manager.
-	restCfg := ctrl.GetConfigOrDie()
 	mgr, err := ctrl.NewManager(restCfg, ctrl.Options{
 		Scheme:                 scheme,
 		MetricsBindAddress:     opts.MetricsAddr,
@@ -67,19 +80,11 @@ func main() {
 		os.Exit(1)
 	}
 
-	// Instantiate and initialize all the subscription managers.
-	var natsSubMgr subscriptionmanager.Manager
-	if opts.EnableJetStreamBackend {
-		natsSubMgr = jetstream.NewSubscriptionManager(restCfg, opts.MetricsAddr, opts.MaxReconnects, opts.ReconnectWait, ctrLogger)
-	} else {
-		natsSubMgr = nats.NewSubscriptionManager(restCfg, opts.MetricsAddr, opts.MaxReconnects, opts.ReconnectWait, ctrLogger)
-	}
 	if err := natsSubMgr.Init(mgr); err != nil {
 		setupLogger.Error(err, "initialize NATS subscription manager failed")
 		os.Exit(1)
 	}
 
-	bebSubMgr := beb.NewSubscriptionManager(restCfg, opts.MetricsAddr, opts.ReconcilePeriod, ctrLogger)
 	if err := bebSubMgr.Init(mgr); err != nil {
 		setupLogger.Error(err, "initialize BEB subscription manager failed")
 		os.Exit(1)

--- a/components/eventing-controller/controllers/subscription/jetstream/reconciler.go
+++ b/components/eventing-controller/controllers/subscription/jetstream/reconciler.go
@@ -4,6 +4,10 @@ import (
 	"context"
 	"os"
 
+	"github.com/kyma-project/kyma/components/eventing-controller/controllers/events"
+	"github.com/kyma-project/kyma/components/eventing-controller/utils"
+	"github.com/pkg/errors"
+
 	"github.com/kyma-project/kyma/components/eventing-controller/pkg/env"
 
 	eventingv1alpha1 "github.com/kyma-project/kyma/components/eventing-controller/api/v1alpha1"
@@ -70,9 +74,36 @@ func (r *Reconciler) SetupUnmanaged(mgr ctrl.Manager) error {
 	return nil
 }
 
-func (r *Reconciler) Reconcile(_ context.Context, req ctrl.Request) (ctrl.Result, error) {
-	r.namedLogger().Errorf("cannot reconcile subscription %s (not implemented)", req)
+func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	r.namedLogger().Debugw("received subscription reconciliation request", "namespace", req.Namespace, "name", req.Name)
+
+	actualSubscription := &eventingv1alpha1.Subscription{}
+	// Ensure the object was not deleted in the meantime
+	err := r.Client.Get(ctx, req.NamespacedName, actualSubscription)
+	if err != nil {
+		return ctrl.Result{}, client.IgnoreNotFound(err)
+	}
+
+	desiredSubscription := actualSubscription.DeepCopy()
+	log := utils.LoggerWithSubscription(r.namedLogger(), desiredSubscription)
+
+	// Mark subscription as not ready, since we have not implemented the reconciliation logic.
+	desiredSubscription.Status = eventingv1alpha1.SubscriptionStatus{}
+	if err := r.syncSubscriptionStatus(ctx, desiredSubscription); err != nil {
+		return ctrl.Result{}, err
+	}
+
+	log.Error("cannot reconcile JetStream subscription (not implemented)")
 	return ctrl.Result{}, nil
+}
+
+func (r *Reconciler) syncSubscriptionStatus(ctx context.Context, sub *eventingv1alpha1.Subscription) error {
+	if err := r.Client.Status().Update(ctx, sub); err != nil {
+		events.Warn(r.recorder, sub, events.ReasonUpdateFailed, "Update Subscription status failed %s", sub.Name)
+		return errors.Wrapf(err, "update subscription status failed")
+	}
+	events.Normal(r.recorder, sub, events.ReasonUpdate, "Update Subscription status succeeded %s", sub.Name)
+	return nil
 }
 
 func (r *Reconciler) namedLogger() *zap.SugaredLogger {

--- a/components/eventing-controller/pkg/subscriptionmanager/jetstream/jetstream.go
+++ b/components/eventing-controller/pkg/subscriptionmanager/jetstream/jetstream.go
@@ -5,6 +5,10 @@ import (
 	"fmt"
 	"time"
 
+	eventingv1alpha1 "github.com/kyma-project/kyma/components/eventing-controller/api/v1alpha1"
+	"k8s.io/apimachinery/pkg/runtime"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+
 	"k8s.io/client-go/rest"
 
 	"github.com/kyma-project/kyma/components/eventing-controller/controllers/subscription/jetstream"
@@ -19,6 +23,17 @@ import (
 const (
 	subscriptionManagerName = "jetstream-subscription-manager"
 )
+
+// AddToScheme adds all types of clientset and eventing into the given scheme.
+func AddToScheme(scheme *runtime.Scheme) error {
+	if err := clientgoscheme.AddToScheme(scheme); err != nil {
+		return err
+	}
+	if err := eventingv1alpha1.AddToScheme(scheme); err != nil {
+		return err
+	}
+	return nil
+}
 
 type SubscriptionManager struct {
 	cancel      context.CancelFunc
@@ -60,7 +75,7 @@ func (sm *SubscriptionManager) Start(_ env.DefaultSubscriptionConfig, _ subscrip
 		sm.mgr.GetEventRecorderFor("eventing-controller-jetstream"),
 		sm.envCfg,
 	)
-	// TODO(PS): this could be refactored (also in other backends), so that the backend is created here and passed to
+	// TODO: this could be refactored (also in other backends), so that the backend is created here and passed to
 	//  the reconciler, not the other way around.
 	sm.backend = jetStreamReconciler.Backend
 	if err := jetStreamReconciler.SetupUnmanaged(sm.mgr); err != nil {

--- a/resources/eventing/values.yaml
+++ b/resources/eventing/values.yaml
@@ -5,7 +5,7 @@ global:
   images:
     eventing_controller:
       name: eventing-controller
-      version: PR-13352
+      version: PR-13394
       pullPolicy: "IfNotPresent"
     publisher_proxy:
       name: event-publisher-proxy


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

While testing https://github.com/kyma-project/kyma/issues/13316, I found out that the "empty" JetStream reconciler (done in https://github.com/kyma-project/kyma/issues/13251) should at lease make sure subscription status is cleared, as otherwise, during an upgrade with feature flag enabled, the subscription would still be reported as ready. 

Marking the subscription as not ready makes the tests fail quicker, and it is clear why the test fails (i.e. the subscription is not ready).
