### PR TITLE
Add missing method to CORS for release 1.24

### DIFF
--- a/resources/api-gateway/values.yaml
+++ b/resources/api-gateway/values.yaml
@@ -59,6 +59,7 @@ config:
       - "POST"
       - "PUT"
       - "DELETE"
+      - "PATCH"
     allowHeaders: # "*" is not yet supported by all browsers
       - "Authorization"
       - "Content-Type"


### PR DESCRIPTION
**Description**
Adding missing PATCH method to CORS in api-gsateway

**Related issues:**
Fixes #11126 in release 1.24