### PR TITLE
Report function pod status in fast-integration SVCAT migration test

### DIFF
--- a/tests/fast-integration/skr-svcat-migration-test/test-helpers.js
+++ b/tests/fast-integration/skr-svcat-migration-test/test-helpers.js
@@ -63,12 +63,10 @@ async function getFunctionPod(functionName) {
     }
     sleep(10000);
   }
-  if (res.body.items.length != 1) {
-    const podNames = res.body.items.map((p) => p.metadata.name);
-    const phases = res.body.items.map((p) => p.status.phase);
-    throw new Error(`Failed to find function ${functionName} pod in 5 minutes.
-    Expected 1 ${labelSelector} pod with phase "Running" but found ${res.body.items.length}, ${podNames}, ${phases}`);
-  }
+  const podNames = res.body.items.map((p) => p.metadata.name);
+  const phases = res.body.items.map((p) => p.status.phase);
+  throw new Error(`Failed to find function ${functionName} pod in 5 minutes.
+  Expected 1 ${labelSelector} pod with phase "Running" but found ${res.body.items.length}, ${podNames}, ${phases}`);
 }
 
 async function checkPodPresetEnvInjected() {


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

The redundant check for pod items length resulted in a suboptimal error message
```
  1) SKR SVCAT migration test
       Should check if pod presets injected secrets to functions containers:
     TypeError: Cannot read property 'metadata' of undefined
      at Object.checkPodPresetEnvInjected (skr-svcat-migration-test/test-helpers.js:80:32)
      at processTicksAndRejections (internal/process/task_queues.js:95:5)
      at async Context.<anonymous> (skr-svcat-migration-test/skr-svcat-migration-test.js:103:5)
```

This should now correctly report the status of the pod even if there is correctly one but not in `Running`.

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
