### PR TITLE
Add env to Nats StatefulSet to distinguish if jetstream is enabled

### DIFF
--- a/resources/eventing/charts/nats/templates/statefulset.yaml
+++ b/resources/eventing/charts/nats/templates/statefulset.yaml
@@ -131,6 +131,10 @@ spec:
           value: {{ include "nats.clusterAdvertise" . }}
 
         {{- if .Values.global.features.enableJetStream }}
+        - name: JS_ENABLED
+          value: "true"
+        {{- end }}
+        {{- if .Values.global.features.enableJetStream }}
         {{- with .Values.nats.jetstream.encryption }}
         {{- with .secret }}
         - name: JS_KEY


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- add env var to nats container for reconciler to be able to recongnize that whether the jetstream chart changes were applied to the nats stateful set or not 
- there is a reconciler PR, which depends on this change: https://github.com/kyma-incubator/reconciler/pull/864

**Related issue(s)**
https://github.com/kyma-project/kyma/issues/13321

