### PR TITLE
reduce apiserver metrics footprint

### DIFF
--- a/resources/monitoring/values.yaml
+++ b/resources/monitoring/values.yaml
@@ -42,7 +42,7 @@ defaultRules:
     kubeApiserverAvailability: true
     kubeApiserverBurnrate: false
     kubeApiserverHistogram: false
-    kubeApiserverSlos: true
+    kubeApiserverSlos: false
     kubelet: true
     kubeProxy: true
     kubePrometheusGeneral: true
@@ -926,6 +926,9 @@ kubeApiServer:
     ## ref: https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api.md#relabelconfig
     ##
     metricRelabelings:
+      - action: keep
+        regex: 'apiserver_request_duration_seconds_bucket;(0.1|0.4|0.7|1|5|\+Inf)' # only keep 0.1, 0.4, 0.7, 1, 5 and +Inf buckets
+        sourceLabels: [__name__,le]
       - action: keep
         regex: ^(apiserver_audit_event_total|apiserver_audit_level_total|apiserver_audit_requests_rejected_total|apiserver_client_certificate_expiration_seconds_bucket|apiserver_registered_watchers|apiserver_request_total|apiserver_request_duration_seconds_bucket|apiserver_request_latencies_bucket|etcd_helper_cache_entry_total|etcd_helper_cache_hit_total|etcd_helper_cache_miss_total|etcd_request_cache_add_duration_seconds_bucket|etcd_request_cache_get_duration_seconds_bucket|go_goroutines|go_memstats_alloc_bytes|go_memstats_heap_alloc_bytes|go_memstats_heap_inuse_bytes|go_memstats_heap_sys_bytes|go_memstats_stack_inuse_bytes|kubernetes_build_info|process_cpu_seconds_total|process_max_fds|process_open_fds|process_resident_memory_bytes|process_start_time_seconds|process_virtual_memory_bytes|rest_client_request_latency_seconds_bucket|rest_client_requests_total|workqueue_adds_total|workqueue_depth|workqueue_queue_duration_seconds_bucket)$
         sourceLabels: [__name__]


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- disable apiserver slo metrics
- reduce amount of buckets for `apiserver_request_duration_seconds_bucket` metric. Preferred to allowlisting 6 fixed buckets instead of denylisting all other buckets with an ugly regex (e.g. `'apiserver_request_duration_seconds_bucket;(0\.[0235689].*|[0-9]\.[1-9]?5.*|[2-4|6-9]|[1-6][05])`)

**Related issue(s)**
Relates to #13386 
