### PR TITLE
Refactor reconciler test functions

### DIFF
--- a/components/eventing-controller/controllers/subscription/nats/unit_test.go
+++ b/components/eventing-controller/controllers/subscription/nats/unit_test.go
@@ -1,14 +1,15 @@
 // This file contains unit tests for the NATS subscription reconciler.
-// It uses the testing.T and gomega testing libraries to perform the assertions.
+// It uses the testing.T and stretchr/testify libraries to perform assertions.
 // TestEnvironment struct mocks the required resources.
 package nats
 
 import (
 	"context"
-	"path/filepath"
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/require"
 
 	kymalogger "github.com/kyma-project/kyma/common/logging/logger"
 	eventingv1alpha1 "github.com/kyma-project/kyma/components/eventing-controller/api/v1alpha1"
@@ -17,53 +18,49 @@ import (
 	"github.com/kyma-project/kyma/components/eventing-controller/pkg/handlers/eventtype"
 	"github.com/kyma-project/kyma/components/eventing-controller/pkg/handlers/mocks"
 	controllertesting "github.com/kyma-project/kyma/components/eventing-controller/testing"
-	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/tools/record"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
-	"sigs.k8s.io/controller-runtime/pkg/envtest"
-
-	"k8s.io/apimachinery/pkg/types"
 )
 
-const namespaceName = "test"
-
-var (
-	defaultSubsConfig = env.DefaultSubscriptionConfig{MaxInFlightMessages: 1, DispatcherRetryPeriod: time.Second, DispatcherMaxRetries: 1}
-	testEnv           *envtest.Environment
+const (
+	subscriptionName = "testSubscription"
+	namespaceName    = "test"
 )
+
+var defaultSubsConfig = env.DefaultSubscriptionConfig{MaxInFlightMessages: 1, DispatcherRetryPeriod: time.Second, DispatcherMaxRetries: 1}
 
 func Test_handleSubscriptionDeletion(t *testing.T) {
-	g := NewGomegaWithT(t)
 	testEnvironment := setupTestEnvironment(t)
 	ctx, r, mockedBackend := testEnvironment.Context, testEnvironment.Reconciler, testEnvironment.Backend
 
 	testCases := []struct {
-		name               string
-		givenFinalizers    []string
-		expectedDeleteCall bool
-		expectedFinalizers []string
+		name            string
+		givenFinalizers []string
+		wantDeleteCall  bool
+		wantFinalizers  []string
 	}{
 		{
-			name:               "With no finalizers the NATS subscription should not be deleted",
-			givenFinalizers:    []string{},
-			expectedDeleteCall: false,
-			expectedFinalizers: []string{},
+			name:            "With no finalizers the NATS subscription should not be deleted",
+			givenFinalizers: []string{},
+			wantDeleteCall:  false,
+			wantFinalizers:  []string{},
 		},
 		{
-			name:               "With eventing finalizer the NATS subscription should be deleted and the finalizer should be cleared",
-			givenFinalizers:    []string{Finalizer},
-			expectedDeleteCall: true,
-			expectedFinalizers: []string{},
+			name:            "With eventing finalizer the NATS subscription should be deleted and the finalizer should be cleared",
+			givenFinalizers: []string{Finalizer},
+			wantDeleteCall:  true,
+			wantFinalizers:  []string{},
 		},
 		{
-			name:               "With wrong finalizer the NATS subscription should not be deleted",
-			givenFinalizers:    []string{"eventing2.kyma-project.io"},
-			expectedDeleteCall: false,
-			expectedFinalizers: []string{"eventing2.kyma-project.io"},
+			name:            "With wrong finalizer the NATS subscription should not be deleted",
+			givenFinalizers: []string{"eventing2.kyma-project.io"},
+			wantDeleteCall:  false,
+			wantFinalizers:  []string{"eventing2.kyma-project.io"},
 		},
 	}
 
@@ -71,39 +68,40 @@ func Test_handleSubscriptionDeletion(t *testing.T) {
 		testCase := tC
 		t.Run(testCase.name, func(t *testing.T) {
 			// given
-			subscription := NewSubscription(WithFinalizers(testCase.givenFinalizers))
+			subscription := NewTestSubscription(
+				controllertesting.WithFinalizers(testCase.givenFinalizers),
+			)
 			err := r.Client.Create(testEnvironment.Context, subscription)
-			g.Expect(err).Should(BeNil())
+			require.NoError(t, err)
 
 			mockedBackend.On("DeleteSubscription", subscription).Return(nil)
 
 			// when
 			err = r.handleSubscriptionDeletion(ctx, subscription, r.namedLogger())
-			g.Expect(err).Should(BeNil())
+			require.NoError(t, err)
 
 			// then
-			if testCase.expectedDeleteCall {
+			if testCase.wantDeleteCall {
 				mockedBackend.AssertCalled(t, "DeleteSubscription", subscription)
 			} else {
 				mockedBackend.AssertNotCalled(t, "DeleteSubscription", subscription)
 			}
 
-			ensureFinalizerMatch(g, subscription, testCase.expectedFinalizers)
+			ensureFinalizerMatch(t, subscription, testCase.wantFinalizers)
 
 			// check the changes were made on the kubernetes server
 			fetchedSub, err := fetchTestSubscription(ctx, r)
-			g.Expect(err).Should(BeNil())
-			ensureFinalizerMatch(g, &fetchedSub, testCase.expectedFinalizers)
+			require.NoError(t, err)
+			ensureFinalizerMatch(t, &fetchedSub, testCase.wantFinalizers)
 
 			// clean up
 			err = r.Client.Delete(ctx, subscription)
-			g.Expect(err).Should(BeNil())
+			require.NoError(t, err)
 		})
 	}
 }
 
 func Test_syncSubscriptionStatus(t *testing.T) {
-	g := NewGomegaWithT(t)
 	testEnvironment := setupTestEnvironment(t)
 	ctx, r := testEnvironment.Context, testEnvironment.Reconciler
 
@@ -116,78 +114,78 @@ func Test_syncSubscriptionStatus(t *testing.T) {
 		corev1.ConditionTrue, message)
 
 	testCases := []struct {
-		name               string
-		givenSub           *eventingv1alpha1.Subscription
-		givenNatsSubReady  bool
-		givenForceStatus   bool
-		expectedConditions []eventingv1alpha1.Condition
-		expectedStatus     bool
+		name              string
+		givenSub          *eventingv1alpha1.Subscription
+		givenNatsSubReady bool
+		givenForceStatus  bool
+		wantConditions    []eventingv1alpha1.Condition
+		wantStatus        bool
 	}{
 		{
 			name: "Subscription with no conditions should stay not ready with false condition",
-			givenSub: NewSubscription(
-				WithConditions([]eventingv1alpha1.Condition{}),
-				WithStatus(true),
+			givenSub: NewTestSubscription(
+				controllertesting.WithConditions([]eventingv1alpha1.Condition{}),
+				controllertesting.WithStatus(true),
 			),
-			givenNatsSubReady:  false,
-			givenForceStatus:   false,
-			expectedConditions: []eventingv1alpha1.Condition{falseNatsSubActiveCondition},
-			expectedStatus:     false,
+			givenNatsSubReady: false,
+			givenForceStatus:  false,
+			wantConditions:    []eventingv1alpha1.Condition{falseNatsSubActiveCondition},
+			wantStatus:        false,
 		},
 		{
 			name: "Subscription with false ready condition should stay not ready with false condition",
-			givenSub: NewSubscription(
-				WithConditions([]eventingv1alpha1.Condition{falseNatsSubActiveCondition}),
-				WithStatus(false),
+			givenSub: NewTestSubscription(
+				controllertesting.WithConditions([]eventingv1alpha1.Condition{falseNatsSubActiveCondition}),
+				controllertesting.WithStatus(false),
 			),
-			givenNatsSubReady:  false,
-			givenForceStatus:   false,
-			expectedConditions: []eventingv1alpha1.Condition{falseNatsSubActiveCondition},
-			expectedStatus:     false,
+			givenNatsSubReady: false,
+			givenForceStatus:  false,
+			wantConditions:    []eventingv1alpha1.Condition{falseNatsSubActiveCondition},
+			wantStatus:        false,
 		},
 		{
 			name: "Subscription should become ready because of isNatsSubReady flag",
-			givenSub: NewSubscription(
-				WithConditions([]eventingv1alpha1.Condition{falseNatsSubActiveCondition}),
-				WithStatus(false),
+			givenSub: NewTestSubscription(
+				controllertesting.WithConditions([]eventingv1alpha1.Condition{falseNatsSubActiveCondition}),
+				controllertesting.WithStatus(false),
 			),
-			givenNatsSubReady:  true, // isNatsSubReady
-			givenForceStatus:   false,
-			expectedConditions: []eventingv1alpha1.Condition{trueNatsSubActiveCondition},
-			expectedStatus:     true,
+			givenNatsSubReady: true, // isNatsSubReady
+			givenForceStatus:  false,
+			wantConditions:    []eventingv1alpha1.Condition{trueNatsSubActiveCondition},
+			wantStatus:        true,
 		},
 		{
 			name: "Subscription should stay with ready condition and status",
-			givenSub: NewSubscription(
-				WithConditions([]eventingv1alpha1.Condition{trueNatsSubActiveCondition}),
-				WithStatus(true),
+			givenSub: NewTestSubscription(
+				controllertesting.WithConditions([]eventingv1alpha1.Condition{trueNatsSubActiveCondition}),
+				controllertesting.WithStatus(true),
 			),
-			givenNatsSubReady:  true,
-			givenForceStatus:   false,
-			expectedConditions: []eventingv1alpha1.Condition{trueNatsSubActiveCondition},
-			expectedStatus:     true,
+			givenNatsSubReady: true,
+			givenForceStatus:  false,
+			wantConditions:    []eventingv1alpha1.Condition{trueNatsSubActiveCondition},
+			wantStatus:        true,
 		},
 		{
 			name: "Subscription should become not ready because of false isNatsSubReady flag",
-			givenSub: NewSubscription(
-				WithConditions([]eventingv1alpha1.Condition{trueNatsSubActiveCondition}),
-				WithStatus(true),
+			givenSub: NewTestSubscription(
+				controllertesting.WithConditions([]eventingv1alpha1.Condition{trueNatsSubActiveCondition}),
+				controllertesting.WithStatus(true),
 			),
-			givenNatsSubReady:  false, // isNatsSubReady
-			givenForceStatus:   false,
-			expectedConditions: []eventingv1alpha1.Condition{falseNatsSubActiveCondition},
-			expectedStatus:     false,
+			givenNatsSubReady: false, // isNatsSubReady
+			givenForceStatus:  false,
+			wantConditions:    []eventingv1alpha1.Condition{falseNatsSubActiveCondition},
+			wantStatus:        false,
 		},
 		{
 			name: "Subscription should stay with the same condition, but still updated because of the forceUpdateStatus flag",
-			givenSub: NewSubscription(
-				WithConditions([]eventingv1alpha1.Condition{trueNatsSubActiveCondition}),
-				WithStatus(true),
+			givenSub: NewTestSubscription(
+				controllertesting.WithConditions([]eventingv1alpha1.Condition{trueNatsSubActiveCondition}),
+				controllertesting.WithStatus(true),
 			),
-			givenNatsSubReady:  true,
-			givenForceStatus:   true,
-			expectedConditions: []eventingv1alpha1.Condition{trueNatsSubActiveCondition},
-			expectedStatus:     true,
+			givenNatsSubReady: true,
+			givenForceStatus:  true,
+			wantConditions:    []eventingv1alpha1.Condition{trueNatsSubActiveCondition},
+			wantStatus:        true,
 		},
 	}
 	for _, tC := range testCases {
@@ -196,29 +194,28 @@ func Test_syncSubscriptionStatus(t *testing.T) {
 			// given
 			sub := testCase.givenSub
 			err := r.Client.Create(ctx, sub)
-			g.Expect(err).Should(BeNil())
+			require.NoError(t, err)
 
 			// when
 			err = r.syncSubscriptionStatus(ctx, sub, testCase.givenNatsSubReady, testCase.givenForceStatus, message)
-			g.Expect(err).To(BeNil())
+			require.NoError(t, err)
 
 			// then
-			ensureSubscriptionMatchesConditionsAndStatus(g, *sub, testCase.expectedConditions, testCase.expectedStatus)
+			ensureSubscriptionMatchesConditionsAndStatus(t, *sub, testCase.wantConditions, testCase.wantStatus)
 
 			// fetch the sub also from k8s server in order to check whether changes were done both in-memory and on k8s server
 			fetchedSub, err := fetchTestSubscription(ctx, r)
-			g.Expect(err).Should(BeNil())
-			ensureSubscriptionMatchesConditionsAndStatus(g, fetchedSub, testCase.expectedConditions, testCase.expectedStatus)
+			require.NoError(t, err)
+			ensureSubscriptionMatchesConditionsAndStatus(t, fetchedSub, testCase.wantConditions, testCase.wantStatus)
 
 			// clean up
 			err = r.Client.Delete(ctx, sub)
-			g.Expect(err).To(BeNil())
+			require.NoError(t, err)
 		})
 	}
 }
 
 func Test_defaultSinkValidator(t *testing.T) {
-	g := NewGomegaWithT(t)
 	testEnvironment := setupTestEnvironment(t)
 	ctx, r, log := testEnvironment.Context, testEnvironment.Reconciler, testEnvironment.Logger
 
@@ -226,64 +223,64 @@ func Test_defaultSinkValidator(t *testing.T) {
 		name                  string
 		givenSubscriptionSink string
 		givenSvcNameToCreate  string
-		expectedErrString     string
+		wantErrString         string
 	}{
 		{
 			name:                  "With invalid scheme",
 			givenSubscriptionSink: "invalid Sink",
-			expectedErrString:     "sink URL scheme should be 'http' or 'https'",
+			wantErrString:         "sink URL scheme should be 'http' or 'https'",
 		},
 		{
 			name:                  "With invalid URL",
 			givenSubscriptionSink: "http://invalid Sink",
-			expectedErrString:     "not able to parse sink url with error",
+			wantErrString:         "not able to parse sink url with error",
 		},
 		{
 			name:                  "With invalid suffix",
 			givenSubscriptionSink: "https://svc2.test.local",
-			expectedErrString:     "sink does not contain suffix",
+			wantErrString:         "sink does not contain suffix",
 		},
 		{
 			name:                  "With invalid suffix and port",
 			givenSubscriptionSink: "https://svc2.test.local:8080",
-			expectedErrString:     "sink does not contain suffix",
+			wantErrString:         "sink does not contain suffix",
 		},
 		{
 			name:                  "With invalid number of subdomains",
 			givenSubscriptionSink: "https://svc.cluster.local:8080", // right suffix but 3 subdomains
-			expectedErrString:     "sink should contain 5 sub-domains",
+			wantErrString:         "sink should contain 5 sub-domains",
 		},
 		{
 			name:                  "With different namespaces in subscription and sink name",
 			givenSubscriptionSink: "https://eventing-nats.kyma-system.svc.cluster.local:8080", // sub is in test ns
-			expectedErrString:     "namespace of subscription: test and the namespace of subscriber: kyma-system are different",
+			wantErrString:         "namespace of subscription: test and the namespace of subscriber: kyma-system are different",
 		},
 		{
 			name:                  "With no existing svc in the cluster",
 			givenSubscriptionSink: "https://eventing-nats.test.svc.cluster.local:8080",
-			expectedErrString:     "sink is not valid cluster local svc, failed with error",
+			wantErrString:         "sink is not valid cluster local svc, failed with error",
 		},
 		{
 			name:                  "With no existing svc in the cluster, service has the wrong name",
 			givenSubscriptionSink: "https://eventing-nats.test.svc.cluster.local:8080",
 			givenSvcNameToCreate:  "test", // wrong name
-			expectedErrString:     "sink is not valid cluster local svc, failed with error",
+			wantErrString:         "sink is not valid cluster local svc, failed with error",
 		},
 		{
 			name:                  "With no existing svc in the cluster, service has the wrong name",
 			givenSubscriptionSink: "https://eventing-nats.test.svc.cluster.local:8080",
 			givenSvcNameToCreate:  "eventing-nats",
-			expectedErrString:     "",
+			wantErrString:         "",
 		},
 	}
 	for _, tC := range testCases {
 		testCase := tC
 		t.Run(testCase.name, func(t *testing.T) {
 			// given
-			sub := NewSubscription(
-				WithConditions([]eventingv1alpha1.Condition{}),
-				WithStatus(true),
-				WithSink(testCase.givenSubscriptionSink),
+			sub := NewTestSubscription(
+				controllertesting.WithConditions([]eventingv1alpha1.Condition{}),
+				controllertesting.WithStatus(true),
+				controllertesting.WithSink(testCase.givenSubscriptionSink),
 			)
 
 			// create the service if required for test
@@ -296,7 +293,7 @@ func Test_defaultSinkValidator(t *testing.T) {
 				}
 
 				err := r.Client.Create(ctx, svc)
-				g.Expect(err).To(BeNil())
+				require.NoError(t, err)
 			}
 
 			// when
@@ -306,68 +303,67 @@ func Test_defaultSinkValidator(t *testing.T) {
 
 			// then
 			// given error should match expected error
-			if testCase.expectedErrString == "" {
-				g.Expect(err).To(BeNil())
+			if testCase.wantErrString == "" {
+				require.NoError(t, err)
 			} else {
-				substringResult := strings.Contains(err.Error(), testCase.expectedErrString)
-				g.Expect(substringResult).Should(BeTrue())
+				substringResult := strings.Contains(err.Error(), testCase.wantErrString)
+				require.True(t, substringResult)
 			}
 		})
 	}
 }
 
 func Test_syncInitialStatus(t *testing.T) {
-	g := NewGomegaWithT(t)
 	testEnvironment := setupTestEnvironment(t)
 	r := testEnvironment.Reconciler
 
-	expectedSubConfig := eventingv1alpha1.MergeSubsConfigs(nil, &defaultSubsConfig)
+	wantSubConfig := eventingv1alpha1.MergeSubsConfigs(nil, &defaultSubsConfig)
 	newSubsConfig := env.DefaultSubscriptionConfig{MaxInFlightMessages: 5}
 	updatedSubConfig := eventingv1alpha1.MergeSubsConfigs(nil, &newSubsConfig)
 
 	testCases := []struct {
-		name              string
-		givenSub          *eventingv1alpha1.Subscription
-		expectedSubStatus eventingv1alpha1.SubscriptionStatus
-		wantStatus        bool
+		name          string
+		givenSub      *eventingv1alpha1.Subscription
+		wantSubStatus eventingv1alpha1.SubscriptionStatus
+		wantStatus    bool
 	}{
 		{
 			name: "A new Subscription must be updated with cleanEventTypes and config and return true",
-			givenSub: NewSubscription(
-				WithStatus(false),
+			givenSub: NewTestSubscription(
+				controllertesting.WithStatus(false),
 				controllertesting.WithFilter("", controllertesting.OrderCreatedEventType),
 			),
-			expectedSubStatus: eventingv1alpha1.SubscriptionStatus{
+			wantSubStatus: eventingv1alpha1.SubscriptionStatus{
 				Ready:           false,
 				CleanEventTypes: []string{controllertesting.OrderCreatedEventType},
-				Config:          expectedSubConfig,
+				Config:          wantSubConfig,
 			},
 			wantStatus: true,
 		},
 		{
 			name: "A subscription with the same cleanEventTypes and config must return false",
-			givenSub: NewSubscription(
-				WithStatus(true),
+			givenSub: NewTestSubscription(
+				controllertesting.WithStatus(true),
 				controllertesting.WithFilter("", controllertesting.OrderCreatedEventType),
 				controllertesting.WithStatusCleanEventTypes([]string{controllertesting.OrderCreatedEventType}),
 				controllertesting.WithStatusConfig(defaultSubsConfig),
 			),
-			expectedSubStatus: eventingv1alpha1.SubscriptionStatus{
+			wantSubStatus: eventingv1alpha1.SubscriptionStatus{
 				Ready:           true,
 				CleanEventTypes: []string{controllertesting.OrderCreatedEventType},
-				Config:          expectedSubConfig,
+				Config:          wantSubConfig,
 			},
 			wantStatus: false,
 		},
 		{
 			name: "A subscription with the same cleanEventTypes and new config must return true",
-			givenSub: NewSubscription(
-				WithStatus(true),
+			givenSub: NewTestSubscription(
+				controllertesting.WithStatus(true),
 				controllertesting.WithFilter("", controllertesting.OrderCreatedEventType),
 				controllertesting.WithStatusCleanEventTypes([]string{controllertesting.OrderCreatedEventType}),
 				controllertesting.WithSpecConfig(newSubsConfig),
 			),
-			expectedSubStatus: eventingv1alpha1.SubscriptionStatus{
+			wantSubStatus: eventingv1alpha1.SubscriptionStatus{
 				Ready:           true,
 				CleanEventTypes: []string{controllertesting.OrderCreatedEventType},
 				Config:          updatedSubConfig,
@@ -376,16 +372,16 @@ func Test_syncInitialStatus(t *testing.T) {
 		},
 		{
 			name: "A subscription with changed cleanEventTypes and the same config must return true",
-			givenSub: NewSubscription(
-				WithStatus(true),
+			givenSub: NewTestSubscription(
+				controllertesting.WithStatus(true),
 				controllertesting.WithFilter("", controllertesting.OrderCreatedEventTypeNotClean),
 				controllertesting.WithStatusCleanEventTypes([]string{controllertesting.OrderCreatedEventType}),
 				controllertesting.WithStatusConfig(defaultSubsConfig),
 			),
-			expectedSubStatus: eventingv1alpha1.SubscriptionStatus{
+			wantSubStatus: eventingv1alpha1.SubscriptionStatus{
 				Ready:           true,
 				CleanEventTypes: []string{controllertesting.OrderCreatedEventTypeNotClean},
-				Config:          expectedSubConfig,
+				Config:          wantSubConfig,
 			},
 			wantStatus: true,
 		},
@@ -398,18 +394,18 @@ func Test_syncInitialStatus(t *testing.T) {
 
 			// when
 			gotStatus, err := r.syncInitialStatus(sub, r.namedLogger())
-			g.Expect(err).To(BeNil())
+			require.NoError(t, err)
 
 			// then
-			g.Expect(sub.Status.CleanEventTypes).To(Equal(testCase.expectedSubStatus.CleanEventTypes))
-			g.Expect(sub.Status.Config).To(Equal(testCase.expectedSubStatus.Config))
-			g.Expect(sub.Status.Ready).To(Equal(testCase.expectedSubStatus.Ready))
-			g.Expect(gotStatus).To(Equal(testCase.wantStatus))
+			require.Equal(t, testCase.wantSubStatus.CleanEventTypes, sub.Status.CleanEventTypes)
+			require.Equal(t, testCase.wantSubStatus.Config, sub.Status.Config)
+			require.Equal(t, testCase.wantSubStatus.Ready, sub.Status.Ready)
+			require.Equal(t, gotStatus, testCase.wantStatus)
 		})
 	}
 }
 
-// helper function and structs
+// helper functions and structs
 
 // TestEnvironment provides mocked resources for tests.
 type TestEnvironment struct {
@@ -423,10 +419,9 @@ type TestEnvironment struct {
 
 // setupTestEnvironment is a TestEnvironment constructor
 func setupTestEnvironment(t *testing.T) *TestEnvironment {
-	g := NewGomegaWithT(t)
 	mockedBackend := &mocks.NatsBackend{}
 	ctx := context.Background()
-	fakeClient := createFakeClient(g)
+	fakeClient := createFakeClient(t)
 	recorder := &record.FakeRecorder{}
 
 	defaultLogger, err := logger.New(string(kymalogger.JSON), string(kymalogger.INFO))
@@ -457,76 +452,39 @@ func setupTestEnvironment(t *testing.T) *TestEnvironment {
 	}
 }
 
-func createFakeClient(g *GomegaWithT) client.WithWatch {
-	testEnv = &envtest.Environment{
-		CRDDirectoryPaths: []string{
-			filepath.Join("../../", "config", "crd", "bases"),
-			filepath.Join("../../", "config", "crd", "external"),
-		},
-	}
+func createFakeClient(t *testing.T) client.WithWatch {
 	err := eventingv1alpha1.AddToScheme(scheme.Scheme)
-	g.Expect(err).Should(BeNil())
+	require.NoError(t, err)
 	return fake.NewClientBuilder().WithScheme(scheme.Scheme).Build()
 }
 
-func NewSubscription(options ...func(subscription *eventingv1alpha1.Subscription)) *eventingv1alpha1.Subscription {
-	sub := &eventingv1alpha1.Subscription{
-		ObjectMeta: v1.ObjectMeta{
-			Name:      "test",
-			Namespace: namespaceName,
-		},
-	}
-	for _, o := range options {
-		o(sub)
-	}
-	return sub
-}
-
-type SubscriptionOpt func(subscription *eventingv1alpha1.Subscription)
-
-func WithSink(sink string) SubscriptionOpt {
-	return func(sub *eventingv1alpha1.Subscription) {
-		sub.Spec.Sink = sink
-	}
-}
-func WithConditions(conditions []eventingv1alpha1.Condition) SubscriptionOpt {
-	return func(sub *eventingv1alpha1.Subscription) {
-		sub.Status.Conditions = conditions
-	}
-}
-func WithStatus(status bool) SubscriptionOpt {
-	return func(sub *eventingv1alpha1.Subscription) {
-		sub.Status.Ready = status
-	}
-}
-func WithFinalizers(finalizers []string) SubscriptionOpt {
-	return func(sub *eventingv1alpha1.Subscription) {
-		sub.ObjectMeta.Finalizers = finalizers
-	}
+// NewTestSubscription creates a test subscription
+func NewTestSubscription(opts ...controllertesting.SubscriptionOpt) *eventingv1alpha1.Subscription {
+	return controllertesting.NewSubscription(subscriptionName, namespaceName, opts...)
 }
 
 func fetchTestSubscription(ctx context.Context, r *Reconciler) (eventingv1alpha1.Subscription, error) {
 	var fetchedSub eventingv1alpha1.Subscription
 	err := r.Client.Get(ctx, types.NamespacedName{
-		Name:      "test",
+		Name:      subscriptionName,
 		Namespace: namespaceName,
 	}, &fetchedSub)
 	return fetchedSub, err
 }
 
-func ensureFinalizerMatch(g *GomegaWithT, subscription *eventingv1alpha1.Subscription, expectedFinalizers []string) {
-	if len(expectedFinalizers) == 0 {
-		g.Expect(subscription.ObjectMeta.Finalizers).Should(BeEmpty())
+func ensureFinalizerMatch(t *testing.T, subscription *eventingv1alpha1.Subscription, wantFinalizers []string) {
+	if len(wantFinalizers) == 0 {
+		require.Empty(t, subscription.ObjectMeta.Finalizers)
 	} else {
-		g.Expect(subscription.ObjectMeta.Finalizers).Should(Equal(expectedFinalizers))
+		require.Equal(t, wantFinalizers, subscription.ObjectMeta.Finalizers)
 	}
 }
 
-func ensureSubscriptionMatchesConditionsAndStatus(g *GomegaWithT, subscription eventingv1alpha1.Subscription, expectedConditions []eventingv1alpha1.Condition, expectedStatus bool) {
-	g.Expect(len(expectedConditions)).Should(Equal(len(subscription.Status.Conditions)))
-	for i := range expectedConditions {
-		comparisonResult := equalsConditionsIgnoringTime(expectedConditions[i], subscription.Status.Conditions[i])
-		g.Expect(comparisonResult).To(BeTrue())
+func ensureSubscriptionMatchesConditionsAndStatus(t *testing.T, subscription eventingv1alpha1.Subscription, wantConditions []eventingv1alpha1.Condition, wantStatus bool) {
+	require.Equal(t, len(wantConditions), len(subscription.Status.Conditions))
+	for i := range wantConditions {
+		comparisonResult := equalsConditionsIgnoringTime(wantConditions[i], subscription.Status.Conditions[i])
+		require.True(t, comparisonResult)
 	}
-	g.Expect(expectedStatus).Should(Equal(subscription.Status.Ready))
+	require.Equal(t, wantStatus, subscription.Status.Ready)
 }

--- a/components/eventing-controller/testing/test_helpers.go
+++ b/components/eventing-controller/testing/test_helpers.go
@@ -153,22 +153,6 @@ func MarkReady(r *apigatewayv1alpha1.APIRule) {
 	}
 }
 
-type SubscriptionOpt func(subscription *eventingv1alpha1.Subscription)
-
-func NewSubscription(name, namespace string, opts ...SubscriptionOpt) *eventingv1alpha1.Subscription {
-	newSub := &eventingv1alpha1.Subscription{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      name,
-			Namespace: namespace,
-		},
-		Spec: eventingv1alpha1.SubscriptionSpec{},
-	}
-	for _, o := range opts {
-		o(newSub)
-	}
-	return newSub
-}
-
 type ProtoOpt func(p *eventingv1alpha1.ProtocolSettings)
 
 func NewProtocolSettings(opts ...ProtoOpt) *eventingv1alpha1.ProtocolSettings {
@@ -213,6 +197,22 @@ func WithDefaultWebhookAuth() ProtoOpt {
 	}
 }
 
+type SubscriptionOpt func(subscription *eventingv1alpha1.Subscription)
+
+func NewSubscription(name, namespace string, opts ...SubscriptionOpt) *eventingv1alpha1.Subscription {
+	newSub := &eventingv1alpha1.Subscription{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+		Spec: eventingv1alpha1.SubscriptionSpec{},
+	}
+	for _, o := range opts {
+		o(newSub)
+	}
+	return newSub
+}
+
 func NewBEBSubscription(name, contentMode string, webhookURL string, events types.Events, webhookAuth *types.WebhookAuth) *types.Subscription {
 	return &types.Subscription{
 		Name:            name,
@@ -240,6 +240,27 @@ func WithFakeSubscriptionStatus() SubscriptionOpt {
 				Message: "foo-message",
 			},
 		}
+	}
+}
+
+func WithSink(sink string) SubscriptionOpt {
+	return func(sub *eventingv1alpha1.Subscription) {
+		sub.Spec.Sink = sink
+	}
+}
+func WithConditions(conditions []eventingv1alpha1.Condition) SubscriptionOpt {
+	return func(sub *eventingv1alpha1.Subscription) {
+		sub.Status.Conditions = conditions
+	}
+}
+func WithStatus(status bool) SubscriptionOpt {
+	return func(sub *eventingv1alpha1.Subscription) {
+		sub.Status.Ready = status
+	}
+}
+func WithFinalizers(finalizers []string) SubscriptionOpt {
+	return func(sub *eventingv1alpha1.Subscription) {
+		sub.ObjectMeta.Finalizers = finalizers
 	}
 }
 


### PR DESCRIPTION
**Description**

Currently we have two very similar `NewSubscription` constructors in our `components/eventing-controller/testing/test_helpers.go` and `components/eventing-controller/controllers/subscription/nats/unit_test.go` files. Also with have configuration options for Subscription in both nats and test_helpers files. 

The idea or this PR is to refactor them in order to make the code more readable and structured. 

Changes proposed in this pull request:

- move configuration options for Subscription into one place
- change the nats-reconciler specific subscription constructor for usage of an already existing code

