### PR TITLE
Add missing telemetry-operator integration to fluent-bit

### DIFF
--- a/components/telemetry-operator/config/samples/telemetry_v1alpha1_logpipeline_loki.yaml
+++ b/components/telemetry-operator/config/samples/telemetry_v1alpha1_logpipeline_loki.yaml
@@ -1,0 +1,50 @@
+apiVersion: telemetry.kyma-project.io/v1alpha1
+kind: LogPipeline
+metadata:
+  name: loki
+spec:
+  parsers: [ ]
+  multilineParsers:
+    - content: |
+        # Example to parse multiline exceptions in Kyma node.js functions
+        Name          multiline-kyma-js-function
+        Type          regex
+        Flush_timeout 1000
+        Rule      "start_state"   "/^Function failed to execute.*/"  "cont"
+        Rule      "cont"          "/^\s+at.*/"                       "cont"
+  filters:
+    - content: |
+        name                  multiline
+        match                 *
+        multiline.key_content log
+        multiline.parser      multiline-kyma-js-function
+  outputs:
+    - content: |
+        Name               grafana-loki
+        Alias              loki-output
+        Match              kube.*
+        Url                http://logging-loki:3100/loki/api/v1/push
+        Labels             {job="telemetry-fluent-bit"}
+        RemoveKeys         kubernetes, stream
+        LineFormat         json
+        LogLevel           warn
+        LabelMapPath       /files/labelmap.json
+  files:
+    - name: labelmap.json
+      content: |
+        {
+          "kubernetes": {
+            "container_name": "container",
+            "host": "node",
+            "labels": {
+              "app": "app",
+              "app.kubernetes.io/component": "component",
+              "app.kubernetes.io/name": "app",
+              "serverless.kyma-project.io/function-name": "function"
+            },
+            "namespace_name": "namespace",
+            "pod_name": "pod"
+          },
+          "stream": "stream"
+        }
+  secretRefs: [ ]

--- a/resources/logging/charts/loki/templates/kyma-additions/authorizationpolicy.yaml
+++ b/resources/logging/charts/loki/templates/kyma-additions/authorizationpolicy.yaml
@@ -27,6 +27,7 @@ spec:
     - source:
         principals:
         - "cluster.local/ns/kyma-system/sa/logging-fluent-bit"
+        - "cluster.local/ns/kyma-system/sa/telemetry-fluent-bit"
     to:
     - operation:
         paths: ["/loki/api/v1/push"]

--- a/resources/telemetry/charts/fluent-bit/values.yaml
+++ b/resources/telemetry/charts/fluent-bit/values.yaml
@@ -126,7 +126,10 @@ priorityClassName: ""
 
 env: []
 
-envFrom: []
+envFrom:
+  - secretRef:
+      name: telemetry-fluent-bit-env
+      optional: true
 
 extraContainers: []
 #   - name: do-something
@@ -142,9 +145,15 @@ extraPorts: []
 volumes:
   mountMachineIdFile: false
 
-extraVolumes: []
+extraVolumes:
+  - name: dynamic-files
+    configMap:
+      name: telemetry-fluent-bit-files
+      optional: true
 
-extraVolumeMounts: []
+extraVolumeMounts:
+  - name: dynamic-files
+    mountPath: /files
 
 updateStrategy: {}
 #   type: RollingUpdate
@@ -168,7 +177,6 @@ config:
   service: |
     [SERVICE]
         Daemon Off
-        Flush 1
         Log_Level {{ .Values.logLevel }}
         Parsers_File parsers.conf
         Parsers_File custom_parsers.conf

--- a/resources/telemetry/values.yaml
+++ b/resources/telemetry/values.yaml
@@ -4,7 +4,7 @@ global:
   images:
     telemetry_operator:
       name: "telemetry-operator"
-      version: "PR-13331"
+      version: "PR-13550"
     fluent_bit:
       name: "fluent-bit"
       version: "1.8.12-780c4842"


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Add missing pieces to connect telemetry-fluent-bit with Loki

Changes proposed in this pull request:

- Consume ConfigMaps and Secrets that are created by telemetry-operator in fluent-bit
- Add missing AuthorizationPolicy to Loki for telemetry-fluent-bit pods
- Add LogPipeline example for Loki

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
