### PR TITLE
Update NodeJS12 and NodeJS14

### DIFF
--- a/components/function-runtimes/nodejs12/Dockerfile
+++ b/components/function-runtimes/nodejs12/Dockerfile
@@ -28,7 +28,7 @@
 
 FROM alpine:3.14.2
 
-ENV NODE_VERSION 12.22.6
+ENV NODE_VERSION 12.22.9
 
 SHELL ["/bin/ash", "-o", "pipefail", "-c"]
 

--- a/components/function-runtimes/nodejs12/Dockerfile
+++ b/components/function-runtimes/nodejs12/Dockerfile
@@ -26,9 +26,9 @@
 # We use this code to manually use newest alpine and nodejs.
 # Use official build when it will be available.
 
-FROM alpine:3.14.2
+FROM alpine:3.15
 
-ENV NODE_VERSION 12.22.9
+ENV NODE_VERSION 12.22.7
 
 SHELL ["/bin/ash", "-o", "pipefail", "-c"]
 

--- a/components/function-runtimes/nodejs14/Dockerfile
+++ b/components/function-runtimes/nodejs14/Dockerfile
@@ -28,7 +28,7 @@
 
 FROM alpine:3.14.2
 
-ENV NODE_VERSION 14.17.6
+ENV NODE_VERSION 14.18.3
 
 SHELL ["/bin/ash", "-o", "pipefail", "-c"]
 

--- a/components/function-runtimes/nodejs14/Dockerfile
+++ b/components/function-runtimes/nodejs14/Dockerfile
@@ -26,7 +26,7 @@
 # We use this code to manually use newest alpine and nodejs.
 # Use official build when it will be available.
 
-FROM alpine:3.14.2
+FROM alpine:3.15
 
 ENV NODE_VERSION 14.18.3
 

--- a/resources/serverless/values.yaml
+++ b/resources/serverless/values.yaml
@@ -77,13 +77,13 @@ global:
       directory: "tpi"
     function_controller:
       name: "function-controller"
-      version: "PR-13548"
+      version: "PR-13589"
     function_webhook:
       name: "function-webhook"
-      version: "PR-13548"
+      version: "PR-13589"
     function_build_init:
       name: "function-build-init"
-      version: "PR-13548"
+      version: "PR-13589"
     function_runtime_nodejs12:
       name: "function-runtime-nodejs12"
       version: "PR-13589"
@@ -92,7 +92,7 @@ global:
       version: "PR-13589"
     function_runtime_python39:
       name: "function-runtime-python39"
-      version: "PR-13348"
+      version: "PR-13589"
     kaniko_executor:
       name: "kaniko-executor"
       version: "1.7.0-6d270da8"

--- a/resources/serverless/values.yaml
+++ b/resources/serverless/values.yaml
@@ -86,10 +86,10 @@ global:
       version: "PR-13548"
     function_runtime_nodejs12:
       name: "function-runtime-nodejs12"
-      version: "PR-13348"
+      version: "PR-13589"
     function_runtime_nodejs14:
       name: "function-runtime-nodejs14"
-      version: "PR-13348"
+      version: "PR-13589"
     function_runtime_python39:
       name: "function-runtime-python39"
       version: "PR-13348"


### PR DESCRIPTION
**Description**
Bump to fix [CVE-2021-44533](https://nvd.nist.gov/vuln/detail/CVE-2021-44533) and [CVE-2021-44532](https://nvd.nist.gov/vuln/detail/CVE-2021-44532)