### PR TITLE
fix iteration

### DIFF
--- a/components/eventing-controller/controllers/subscription/nats/reconciler_test.go
+++ b/components/eventing-controller/controllers/subscription/nats/reconciler_test.go
@@ -296,7 +296,8 @@ func TestCreateSubscription(t *testing.T) {
 		},
 	}
 
-	for _, tc := range testCases {
+	for _, testCase := range testCases {
+		tc := testCase
 		t.Run(tc.name, func(t *testing.T) {
 			subscription := createSubscription(ens, tc.givenSubscriptionOpts...)
 			testSubscriptionOnK8s(ens, subscription, tc.want.k8sSubscription...)
@@ -492,7 +493,8 @@ func TestChangeSubscription(t *testing.T) {
 		},
 	}
 
-	for _, tc := range testCases {
+	for _, testCase := range testCases {
+		tc := testCase
 		t.Run(tc.name, func(t *testing.T) {
 			// given
 			subscription := createSubscription(ens, tc.givenSubscriptionOpts...)

--- a/resources/eventing/values.yaml
+++ b/resources/eventing/values.yaml
@@ -5,7 +5,7 @@ global:
   images:
     eventing_controller:
       name: eventing-controller
-      version: PR-13558
+      version: PR-13593
       pullPolicy: "IfNotPresent"
     publisher_proxy:
       name: event-publisher-proxy


### PR DESCRIPTION
when iterating over the test cases while executing the tests async, the value of the local test case would get overwritten by following iterations.

this pr fixes this by creating a local copy of the iteration value to prevent overwriting. 