### PR TITLE
Grafana function dashboard broken

### DIFF
--- a/resources/monitoring/charts/kube-state-metrics/values.yaml
+++ b/resources/monitoring/charts/kube-state-metrics/values.yaml
@@ -148,6 +148,7 @@ metricDenylist: []
 metricLabelsAllowlist:
   # - namespaces=[k8s-label-1,k8s-label-n]
   - pods=[kyma-project.io/component,kyma-project.io/dashboard]
+  - services=[serverless.kyma-project.io/function-name]
 
 # Comma-separated list of Kubernetes annotations keys that will be used in the resource'
 # labels metric. By default the metric contains only name and namespace labels.


### PR DESCRIPTION
The selectors in the grafana serverless dashboard are not working anymore. The kube_services_label metric does not collect the serverless labels anymore (since last major upgrade)

<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- added labels to the kube-static-metrics white list
- ...
- ...

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
