### PR TITLE
Apply latest security patches for serverless runtimes

### DIFF
--- a/components/function-runtimes/nodejs12/Dockerfile
+++ b/components/function-runtimes/nodejs12/Dockerfile
@@ -26,7 +26,7 @@
 # We use this code to manually use newest alpine and nodejs.
 # Use official build when it will be available.
 
-FROM alpine:3.15.0
+FROM alpine:3.15.1
 
 ENV NODE_VERSION 12.22.10
 

--- a/components/function-runtimes/nodejs12/Dockerfile
+++ b/components/function-runtimes/nodejs12/Dockerfile
@@ -26,9 +26,9 @@
 # We use this code to manually use newest alpine and nodejs.
 # Use official build when it will be available.
 
-FROM alpine:3.14.2
+FROM alpine:3.15.0
 
-ENV NODE_VERSION 12.22.6
+ENV NODE_VERSION 12.22.10
 
 SHELL ["/bin/ash", "-o", "pipefail", "-c"]
 
@@ -44,7 +44,7 @@ RUN addgroup -g 1000 node \
       && case "${alpineArch##*-}" in \
         x86_64) \
           ARCH='x64' \
-          CHECKSUM="0ce2b97ecbbd84f1a5ed13278ed6845d93c6454d8550730b247a990438dba322" \
+          CHECKSUM="ec1e2f0c33a495002ffb1647159d8e17643e2f229c0f4fe2c1be33398f56b5f4" \
           ;; \
         *) ;; \
       esac \

--- a/components/function-runtimes/nodejs14/Dockerfile
+++ b/components/function-runtimes/nodejs14/Dockerfile
@@ -26,9 +26,9 @@
 # We use this code to manually use newest alpine and nodejs.
 # Use official build when it will be available.
 
-FROM alpine:3.14.2
+FROM alpine:3.15.0
 
-ENV NODE_VERSION 14.17.6
+ENV NODE_VERSION 14.19.0
 
 SHELL ["/bin/ash", "-o", "pipefail", "-c"]
 
@@ -44,7 +44,7 @@ RUN addgroup -g 1000 node \
       && case "${alpineArch##*-}" in \
         x86_64) \
           ARCH='x64' \
-          CHECKSUM="d9292c9fa9b4439f0d681110802d03750d34cc95a8b37a06314e5a228de827e7" \
+          CHECKSUM="8d5e638d88b62de2f147dee812a5d74e4860a20468eb7ff32c41a02b58e2aebf" \
           ;; \
         *) ;; \
       esac \

--- a/components/function-runtimes/nodejs14/Dockerfile
+++ b/components/function-runtimes/nodejs14/Dockerfile
@@ -26,7 +26,7 @@
 # We use this code to manually use newest alpine and nodejs.
 # Use official build when it will be available.
 
-FROM alpine:3.15.0
+FROM alpine:3.15.1
 
 ENV NODE_VERSION 14.19.0
 

--- a/components/function-runtimes/python39/Dockerfile
+++ b/components/function-runtimes/python39/Dockerfile
@@ -7,7 +7,7 @@
 # We use this code to manually use newest alpine and nodejs.
 # Use official build when it will be available.
 
-FROM alpine:3.14.2
+FROM alpine:3.15.0
 
 SHELL ["/bin/ash", "-o", "pipefail", "-c"]
 

--- a/components/function-runtimes/python39/Dockerfile
+++ b/components/function-runtimes/python39/Dockerfile
@@ -7,7 +7,7 @@
 # We use this code to manually use newest alpine and nodejs.
 # Use official build when it will be available.
 
-FROM alpine:3.15.0
+FROM alpine:3.15.1
 
 SHELL ["/bin/ash", "-o", "pipefail", "-c"]
 

--- a/resources/serverless/values.yaml
+++ b/resources/serverless/values.yaml
@@ -92,7 +92,7 @@ global:
       version: "PR-13616"
     function_runtime_python39:
       name: "function-runtime-python39"
-      version: "PR-13348"
+      version: "PR-13616"
     kaniko_executor:
       name: "kaniko-executor"
       version: "1.7.0-6d270da8"

--- a/resources/serverless/values.yaml
+++ b/resources/serverless/values.yaml
@@ -86,10 +86,10 @@ global:
       version: "PR-13548"
     function_runtime_nodejs12:
       name: "function-runtime-nodejs12"
-      version: "PR-13348"
+      version: "PR-13616"
     function_runtime_nodejs14:
       name: "function-runtime-nodejs14"
-      version: "PR-13348"
+      version: "PR-13616"
     function_runtime_python39:
       name: "function-runtime-python39"
       version: "PR-13348"


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Include latest security patches in node runtimes to address CVE-2021-44531 and CVE-2022-21824
- Use latest alpine patch to address expat vulnerabilities

