### PR TITLE
Update the Application Gateway docs to say `X-forwarded-*` headers are proxied, not removed

### DIFF
--- a/docs/05-technical-reference/00-architecture/ac-03-application-gateway.md
+++ b/docs/05-technical-reference/00-architecture/ac-03-application-gateway.md
@@ -17,18 +17,4 @@ which are either unsecured or secured with various security mechanisms and prote
 4. Application Gateway gets a CSRF token from the endpoint exposed by the upstream service. This step is optional and is valid only for the API which was registered with a CSRF token turned on.
 5. Application Gateway calls the target API.
 
-## Caching
-
-To ensure optimal performance, Application Gateway caches the OAuth tokens and CSRF tokens it obtains. If the service doesn't find valid tokens for the call it makes, it gets new tokens from the OAuth server and the CSRF token endpoint.
-Additionally, the service caches ReverseProxy objects used to proxy the requests to the underlying URL.
-
-## Handling of headers
-
-Application Gateway proxies the following headers while making calls to the registered Applications:
-
-- `X-Forwarded-Proto`
-- `X-Forwarded-For`
-- `X-Forwarded-Host`
-- `X-Forwarded-Client-Cert`
-
-In addition, the `User-Agent` header is set to an empty value not specified in the call, which prevents setting the default value.
+To learn more, read about the [Application Gateway details](../ac-01-application-gateway-details.md). 

--- a/docs/05-technical-reference/00-architecture/ac-03-application-gateway.md
+++ b/docs/05-technical-reference/00-architecture/ac-03-application-gateway.md
@@ -24,7 +24,7 @@ Additionally, the service caches ReverseProxy objects used to proxy the requests
 
 ## Handling of headers
 
-Application Gateway removes the following headers while making calls to the registered Applications:
+Application Gateway proxies the following headers while making calls to the registered Applications:
 
 - `X-Forwarded-Proto`
 - `X-Forwarded-For`

--- a/docs/05-technical-reference/ac-01-application-gateway-details.md
+++ b/docs/05-technical-reference/ac-01-application-gateway-details.md
@@ -63,7 +63,7 @@ Additionally, the service caches ReverseProxy objects used to proxy requests to 
 
 ## Handling of headers
 
-Application Gateway removes the following headers while making calls to the registered Applications:
+Application Gateway proxies the following headers while making calls to the registered Applications:
 
 - `X-Forwarded-Proto`
 - `X-Forwarded-For`


### PR DESCRIPTION
**Description**

The Application Gateway code has recently been changed so that the `X-Forwarded-*` headers are no longer removed, but proxied. This PR updates the documentation to reflect these changes. 

Changes proposed in this pull request:

- Update the [Application Gateway docs](https://kyma-project.io/docs/kyma/latest/05-technical-reference/ac-01-application-gateway-details/) to say `X-forwarded-*` headers are proxied, not removed
- Remove the duplicated section in [Application Gateway docs](https://kyma-project.io/docs/kyma/latest/05-technical-reference/00-architecture/ac-03-application-gateway/) and replace it with a link to [App Gateway details](https://kyma-project.io/docs/kyma/latest/05-technical-reference/ac-01-application-gateway-details/)

**Related PR**
#13171 

**Related issue**
#12190 
