### PR TITLE
Change the commerce-mock version used in fast integration tests

### DIFF
--- a/tests/fast-integration/test/fixtures/commerce-mock/commerce-mock.yaml
+++ b/tests/fast-integration/test/fixtures/commerce-mock/commerce-mock.yaml
@@ -19,7 +19,7 @@ spec:
         app: commerce-mock
     spec:
       containers:
-        - image: ghcr.io/sap-samples/xf-application-mocks/commerce-mock-lite:0.7.0
+        - image: ghcr.io/sap-samples/xf-application-mocks/commerce-mock-lite:0.7.1
           imagePullPolicy: Always
           name: mock
           ports:


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- change the commerce-mock version from 0.7.0 to 0.7.1


**Related issue(s)**
See the issue - #13563 
