### PR TITLE
Improve check in svcat migration test

### DIFF
--- a/tests/fast-integration/skr-svcat-migration-test/skr-svcat-migration-test.js
+++ b/tests/fast-integration/skr-svcat-migration-test/skr-svcat-migration-test.js
@@ -114,6 +114,12 @@ describe('SKR SVCAT migration test', function() {
     await updateSKR(keb, kcp, gardener, instanceID, skr.shoot.name, null, updateTimeout, btpOperatorCreds, true);
   });
 
+  it('Should get Runtime Status after patch with BTP Operator Credentials', async function() {
+    const runtimeStatus = await kcp.getRuntimeStatusOperations(instanceID);
+    console.log(`\nRuntime status after patch: ${runtimeStatus}`);
+    await kcp.reconcileInformationLog(runtimeStatus);
+  });
+
   it('Should wait for btp-operator deployment availability', async function() {
     await waitForDeployment('sap-btp-operator-controller-manager', 'kyma-system', 10 * 60 * 1000); // 10 minutes
   });

--- a/tests/fast-integration/utils/index.js
+++ b/tests/fast-integration/utils/index.js
@@ -1811,4 +1811,5 @@ module.exports = {
   deleteEventingBackendK8sSecret,
   getTraceDAG,
   printStatusOfInClusterEventingInfrastructure,
+  getFunction,
 };


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Effort to make the svcat migration test a little more robust:
- there are actually 4 instances and bindings, not 3
```
 $ k get serviceinstances.servicecatalog.k8s.io --all-namespaces
NAMESPACE   NAME                          CLASS                                     PLAN          STATUS   AGE
default     hb-instbind-redis-1           ClusterServiceClass/redis                 micro         Ready    4m17s
default     svcat-auditlog-api-1          ClusterServiceClass/auditlog-api          default       Ready    4m18s
default     svcat-auditlog-management-1   ClusterServiceClass/auditlog-management   default       Ready    4m17s
default     svcat-html5-apps-repo-1       ClusterServiceClass/html5-apps-repo       app-runtime   Ready    4m17s
```
- checking function status before checking the pods as recommended in https://github.com/kyma-project/kyma/issues/13443

example of successful execution with pjtester:
https://status.build.kyma-project.io/log?container=test&id=1503999428573270016&job=wozniakjan_test_of_prowjob_skr-aws-svcat-migration-dev