### PR TITLE
Consistently use Kubebuilder tags in Eventing reconcilers

### DIFF
--- a/components/eventing-controller/controllers/subscription/beb/reconciler.go
+++ b/components/eventing-controller/controllers/subscription/beb/reconciler.go
@@ -92,10 +92,11 @@ func NewReconciler(ctx context.Context, client client.Client, logger *logger.Log
 
 // +kubebuilder:rbac:groups=eventing.kyma-project.io,resources=subscriptions,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=eventing.kyma-project.io,resources=subscriptions/status,verbs=get;update;patch
-// Generate required RBAC to emit kubernetes events in the controller
+// Generate required RBAC to emit kubernetes events in the controller.
 // +kubebuilder:rbac:groups="",resources=events,verbs=create;patch
 // +kubebuilder:rbac:groups=gateway.kyma-project.io,resources=apirules,verbs=get;list;watch;create;update;patch;delete
-// +kubebuilder:printcolumn:name="Ready",type=bool,JSONPath=`.status.Ready`
+// Generated required RBAC to list Applications (required by event type cleaner).
+// +kubebuilder:rbac:groups="applicationconnector.kyma-project.io",resources=applications,verbs=get;list;watch
 
 func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	// fetch current subscription object and ensure the object was not deleted in the meantime

--- a/components/eventing-controller/controllers/subscription/jetstream/reconciler.go
+++ b/components/eventing-controller/controllers/subscription/jetstream/reconciler.go
@@ -98,6 +98,13 @@ func (r *Reconciler) SetupUnmanaged(mgr ctrl.Manager) error {
 	return nil
 }
 
+// +kubebuilder:rbac:groups=eventing.kyma-project.io,resources=subscriptions,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=eventing.kyma-project.io,resources=subscriptions/status,verbs=get;update;patch
+// Generate required RBAC to emit kubernetes events in the controller.
+// +kubebuilder:rbac:groups="",resources=events,verbs=create;patch
+// Generated required RBAC to list Applications (required by event type cleaner).
+// +kubebuilder:rbac:groups="applicationconnector.kyma-project.io",resources=applications,verbs=get;list;watch
+
 func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	r.namedLogger().Debugw("received subscription reconciliation request", "namespace", req.Namespace, "name", req.Name)
 

--- a/components/eventing-controller/controllers/subscription/nats/reconciler.go
+++ b/components/eventing-controller/controllers/subscription/nats/reconciler.go
@@ -156,6 +156,15 @@ func (r *Reconciler) SetupUnmanaged(mgr ctrl.Manager) error {
 	return nil
 }
 
+// +kubebuilder:rbac:groups=eventing.kyma-project.io,resources=subscriptions,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=eventing.kyma-project.io,resources=subscriptions/status,verbs=get;update;patch
+// Generate required RBAC to emit kubernetes events in the controller.
+// +kubebuilder:rbac:groups="",resources=events,verbs=create;patch
+// Generate required RBAC to watch the NATS pods.
+// +kubebuilder:rbac:groups="",resources=pods,verbs=get;list;watch;delete
+// Generated required RBAC to list Applications (required by event type cleaner).
+// +kubebuilder:rbac:groups="applicationconnector.kyma-project.io",resources=applications,verbs=get;list;watch
+
 func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	if req.Name == natsFirstInstanceName && req.Namespace == natsNamespace {
 		r.namedLogger().Debugw("received watch request", "namespace", req.Namespace, "name", req.Name)

--- a/resources/eventing/charts/controller/templates/clusterrole.yaml
+++ b/resources/eventing/charts/controller/templates/clusterrole.yaml
@@ -105,9 +105,3 @@ rules:
   - patch
   - update
   - watch
-- apiGroups:
-  - nats.io
-  resources:
-  - natsclusters
-  verbs:
-  - get

--- a/resources/eventing/values.yaml
+++ b/resources/eventing/values.yaml
@@ -5,7 +5,7 @@ global:
   images:
     eventing_controller:
       name: eventing-controller
-      version: PR-12706
+      version: PR-13629
       pullPolicy: "IfNotPresent"
     publisher_proxy:
       name: event-publisher-proxy


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

* Consistently use Kubebuilder tags in Eventing reconcilers.
* Remove unused cluster role rule for `natsclusters`.
