### PR TITLE
Update docs for the Event name format

### DIFF
--- a/docs/05-technical-reference/evnt-01-event-names.md
+++ b/docs/05-technical-reference/evnt-01-event-names.md
@@ -18,8 +18,7 @@ The event type is composed of the following components:
 
 For publishers, the event type takes this sample form:
 - `order.created` or `Account.Root.Created` for legacy events coming from the `commerce` application
-- `sap.kyma.custom.commerce.order.created.v1` or `sap.kyma.custom.commerce.AccountRoot.Created.v1` for Cloud Events
-
+- `sap.kyma.custom.commerce.order.created.v1` or `sap.kyma.custom.commerce.Account.Root.Created.v1` for Cloud Events
 
 ## Event name cleanup
 


### PR DESCRIPTION
**Description**

As a follow-up to https://github.com/kyma-project/kyma/pull/13608, CloudEvent publishers can publish events with the same event type used inside Kyma subscriptions.

This PR updates the Eventing documentation to reflect that change.