### PR TITLE
Add the definition for `Application` to the Glossary

### DIFF
--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -8,6 +8,7 @@ Here's a list of the most commonly used terms that you may come across when brow
 
 | Term |  Description | Useful links |
 | ---- | ------------ | ------------ |
+| Application | An external solution connected to Kyma through Application Connector. <br> **CAUTION:** Do not confuse it with `application`, which is the term used for a microservice deployed on Kyma or in a general sense for software.  | [Application custom resource](./05-technical-reference/00-custom-resources/ac-01-application.md)      |
 | Credentials/Secrets | Sensitive data to call the service, connect to it, and authenticate it.  |       |
 | Custom resource | A custom resource (CR) allows you to extend the Kubernetes API to cover use cases that are not directly covered by core Kubernetes.  | [Kubernetes - Custom Resource](https://kubernetes.io/docs/concepts/extend-kubernetes/api-extension/custom-resources/) & [Custom resources provided by Kyma](./05-technical-reference/00-custom-resources)  |
 | Custom resource definition (CRD) | An object used to define a custom resource. | [CRDs of custom resources provided by Kyma](https://github.com/kyma-project/kyma/tree/main/installation/resources/crds)      |

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -8,7 +8,7 @@ Here's a list of the most commonly used terms that you may come across when brow
 
 | Term |  Description | Useful links |
 | ---- | ------------ | ------------ |
-| Application | An external solution connected to Kyma through Application Connector. <br> **CAUTION:** Do not confuse it with `application`, which is the term used for a microservice deployed on Kyma or in a general sense for software.  | [Application custom resource](./05-technical-reference/00-custom-resources/ac-01-application.md)      |
+| Application | An external solution connected to Kyma through Application Connector.   <br><br> **CAUTION:** <span style="color:red">Don't confuse it with `application`, which is the term used for a microservice deployed on Kyma or in a general sense for software.</span>  | [Application custom resource](./05-technical-reference/00-custom-resources/ac-01-application.md)      |
 | Credentials/Secrets | Sensitive data to call the service, connect to it, and authenticate it.  |       |
 | Custom resource | A custom resource (CR) allows you to extend the Kubernetes API to cover use cases that are not directly covered by core Kubernetes.  | [Kubernetes - Custom Resource](https://kubernetes.io/docs/concepts/extend-kubernetes/api-extension/custom-resources/) & [Custom resources provided by Kyma](./05-technical-reference/00-custom-resources)  |
 | Custom resource definition (CRD) | An object used to define a custom resource. | [CRDs of custom resources provided by Kyma](https://github.com/kyma-project/kyma/tree/main/installation/resources/crds)      |


### PR DESCRIPTION
**Description**

Kyma uses the term `Application` for an external solution connected to Kyma, but this is often confused with `application` (a microservice deployed in Kyma, or, in a more general sense, a piece of software).
This PR adds a clear definition of the term to the [Glossary](https://kyma-project.io/docs/kyma/latest/glossary/) to prevent confusion. 

Changes proposed in this pull request:

- Add the definition for `Application` to the Glossary. 
- Describe the difference between `Application` and `application`. 

**Related issue(s)**
#13637 
