### PR TITLE
Improve Eventing documentation for Event type cleanup

### DIFF
--- a/docs/05-technical-reference/00-custom-resources/evnt-01-subscription.md
+++ b/docs/05-technical-reference/00-custom-resources/evnt-01-subscription.md
@@ -11,7 +11,7 @@ The Subscription custom resource definition (CRD) is used to subscribe to events
 
 This sample Subscription resource subscribes to an event called `sap.kyma.custom.commerce.order.created.v1`.
 
-> **WARNING:** Non-alphanumeric characters `[^a-zA-Z0-9]+` are not allowed in event names under the **spec.filter.filters.eventType.value** property. If any are detected, Eventing will clean them up automatically. Read [Event names](../evnt-01-event-names.md#event-name-cleanup) for more information.
+> **WARNING:** Non-alphanumeric characters `[^a-zA-Z0-9]+` are not allowed in event names under the **spec.filter.filters.eventType.value** property. If any are detected, Eventing will remove them. Read [Event names](../evnt-01-event-names.md#event-name-cleanup) for more information.
 
 > **NOTE:** Both the subscriber and the Subscription should exist in the same Namespace.
 

--- a/docs/05-technical-reference/00-custom-resources/evnt-01-subscription.md
+++ b/docs/05-technical-reference/00-custom-resources/evnt-01-subscription.md
@@ -11,7 +11,7 @@ The Subscription custom resource definition (CRD) is used to subscribe to events
 
 This sample Subscription resource subscribes to an event called `sap.kyma.custom.commerce.order.created.v1`.
 
-> **WARNING:** Non-alphanumeric characters are not allowed in event names under the **spec.filter.filters.eventType.value** property. If any are detected, Eventing will clean them up automatically. Read [Event names](../evnt-01-event-names.md#event-name-cleanup) for more information.
+> **WARNING:** Non-alphanumeric characters `[^a-zA-Z0-9]+` are not allowed in event names under the **spec.filter.filters.eventType.value** property. If any are detected, Eventing will clean them up automatically. Read [Event names](../evnt-01-event-names.md#event-name-cleanup) for more information.
 
 > **NOTE:** Both the subscriber and the Subscription should exist in the same Namespace.
 
@@ -53,7 +53,7 @@ This table lists all the possible parameters of a given resource together with t
 | **spec.filter.filters.eventSource.value** | Yes | Must be set to `""` for the NATS backend. |
 | **spec.filter.filters.eventType.property** | Yes | Must be set to `type`. |
 | **spec.filter.filters.eventType.type** | No | Must be set to `exact`. |
-| **spec.filter.filters.eventType.value** | Yes | Name of the event being subscribed to, for example: `sap.kyma.custom.commerce.order.created.v1`. The name cannot contain any non-alphanumeric characters. Read [Event names](../evnt-01-event-names.md#event-name-cleanup) for more information. |
+| **spec.filter.filters.eventType.value** | Yes | Name of the event being subscribed to, for example: `sap.kyma.custom.commerce.order.created.v1`. The name cannot contain any non-alphanumeric characters `[^a-zA-Z0-9]+`. Read [Event names](../evnt-01-event-names.md#event-name-cleanup) for more information. |
 | **spec.protocol** | Yes | Must be set to `""`. |
 | **spec.protocolsettings** | Yes | Defines the Cloud Event protocol setting specification implementation. Must be set to `{}`. |
 | **spec.sink** | Yes | Specifies the HTTP endpoint where matching events should be sent to, for example: `test.test.svc.cluster.local`.  |

--- a/docs/05-technical-reference/evnt-01-event-names.md
+++ b/docs/05-technical-reference/evnt-01-event-names.md
@@ -31,8 +31,8 @@ If the event name contains more than two segments, Eventing combines them into t
 
 ### Non-alphanumeric characters
 
-If the Application name contains any non-alphanumeric character such as `-` or `_`, the underlying Eventing services use a clean name with alphanumeric characters only; for example, `system-prod` becomes `systemprod`.
+If the Application name contains any non-alphanumeric character `[^a-zA-Z0-9]+`, the underlying Eventing services use a clean name with alphanumeric characters only `[a-zA-Z0-9]+`; for example, `system-prod` becomes `systemprod`.
 
 This could lead to a naming collision. For example, both `system-prod` and `systemprod` become `systemprod`. While this won't result in an error, it can cause Kyma to not work as expected.
 
-A solution for this is to provide an `application-type` label (with alphanumeric characters only), which is then used by the Eventing services instead of the Application name. If the `application-type` label also contains `-` or `_`, the underlying Eventing services clean it and use the cleaned label.
+A solution for this is to provide an `application-type` label (with alphanumeric characters only), which is then used by the Eventing services instead of the Application name. If the `application-type` label also contains any non-alphanumeric character, the underlying Eventing services clean it and use the cleaned label.


### PR DESCRIPTION
**Description**

As a follow-up to https://github.com/kyma-project/kyma/pull/13608, this PR improves the Eventing documentation for Event type cleanup by defining what does alphanumeric characters mean in the context of Eventing.