### PR TITLE
Upgrade nats from 2.6.4 to 2.7.4

### DIFF
--- a/resources/eventing/values.yaml
+++ b/resources/eventing/values.yaml
@@ -12,7 +12,7 @@ global:
       version: PR-13608
     nats:
       name: nats
-      version: 2.6.5-alpine
+      version: 2.7.4-alpine
       directory: external
     nats_config_reloader:
       name: natsio/nats-server-config-reloader


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- Use latest nats:2.7.4-alpine image

**Details**:
- See release notes here: https://github.com/nats-io/nats-server/releases
- See 2.7.4 tag on [Docker Hub](https://hub.docker.com/layers/nats/library/nats/2.7.4-alpine/images/sha256-ae7411548aaccfbe8c77b0f055c26ca31e0f446b32d5e0ac2057d071c679adab?context=explore)
- previous nats 2.6.5 was released on 19 Nov 2021

Related PR: https://github.com/kyma-project/test-infra/pull/5119

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
