### PR TITLE
2.0 update golang version for eventing

### DIFF
--- a/components/event-publisher-proxy/cmd/event-publisher-proxy/Dockerfile
+++ b/components/event-publisher-proxy/cmd/event-publisher-proxy/Dockerfile
@@ -1,4 +1,4 @@
-FROM eu.gcr.io/kyma-project/test-infra/buildpack-golang:v20211223-df98b255 as builder
+FROM eu.gcr.io/kyma-project/external/golang:1.17.8-alpine3.15 as builder
 
 ARG DOCK_PKG_DIR=/go/src/github.com/kyma-project/kyma/components/event-publisher-proxy
 

--- a/components/eventing-controller/Dockerfile
+++ b/components/eventing-controller/Dockerfile
@@ -1,5 +1,5 @@
 # Build the controller binary
-FROM eu.gcr.io/kyma-project/test-infra/buildpack-golang:v20211223-df98b255 as builder
+FROM eu.gcr.io/kyma-project/external/golang:1.17.8-alpine3.15 as builder
 ARG DOCK_PKG_DIR=/go/src/github.com/kyma-project/kyma/components/eventing-controller
 WORKDIR $DOCK_PKG_DIR
 


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Update golang version for Eventing components to have the fix for **CVE-2022-24921**.