### PR TITLE
change default time picker to 1h for istio dashboards

### DIFF
--- a/resources/istio-resources/files/dashboards/control-plane.json
+++ b/resources/istio-resources/files/dashboards/control-plane.json
@@ -1714,7 +1714,7 @@
     ]
   },
   "time": {
-    "from": "now-5m",
+    "from": "now-1h",
     "to": "now"
   },
   "timepicker": {

--- a/resources/istio-resources/files/dashboards/mesh.json
+++ b/resources/istio-resources/files/dashboards/mesh.json
@@ -1709,7 +1709,7 @@
     ]
   },
   "time": {
-    "from": "now-5m",
+    "from": "now-1h",
     "to": "now"
   },
   "timepicker": {

--- a/resources/istio-resources/files/dashboards/performance.json
+++ b/resources/istio-resources/files/dashboards/performance.json
@@ -1279,7 +1279,7 @@
     "list": []
   },
   "time": {
-    "from": "now-5m",
+    "from": "now-1h",
     "to": "now"
   },
   "timepicker": {

--- a/resources/istio-resources/files/dashboards/service.json
+++ b/resources/istio-resources/files/dashboards/service.json
@@ -2959,7 +2959,7 @@
     ]
   },
   "time": {
-    "from": "now-5m",
+    "from": "now-1h",
     "to": "now"
   },
   "timepicker": {

--- a/resources/istio-resources/files/dashboards/workload.json
+++ b/resources/istio-resources/files/dashboards/workload.json
@@ -2641,7 +2641,7 @@
     ]
   },
   "time": {
-    "from": "now-5m",
+    "from": "now-1h",
     "to": "now"
   },
   "timepicker": {


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**
All dashboards are using 1h timerange by default. It is annoying that istio dashboards are different here.

Changes proposed in this pull request:

- change default time picker to 1h for istio dashboards
- ...
- ...

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
