### PR TITLE
Add missing fn reference to svcat migration test

### DIFF
--- a/tests/fast-integration/skr-svcat-migration-test/test-helpers.js
+++ b/tests/fast-integration/skr-svcat-migration-test/test-helpers.js
@@ -74,6 +74,7 @@ async function getFunctionPod(functionName) {
   }
   const podNames = res.body.items.map((p) => p.metadata.name);
   const phases = res.body.items.map((p) => p.status.phase);
+  const fn = await getFunction(functionName, 'default');
   throw new Error(`Failed to find function ${functionName} pod in 5 minutes.
   Expected 1 ${labelSelector} pod with phase "Running" but found ${res.body.items.length}, ${podNames}, ${phases}\n
   function status: ${JSON.stringify(fn.status)}`);


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

when functions misbehave, the status is not printed

```
  1) SKR SVCAT migration test
       Should check if pod presets injected secrets to functions containers:
     ReferenceError: fn is not defined
      at getFunctionPod (skr-svcat-migration-test/test-helpers.js:79:37)
      at runMicrotasks (<anonymous>)
      at processTicksAndRejections (internal/process/task_queues.js:95:5)
      at async Object.checkPodPresetEnvInjected (skr-svcat-migration-test/test-helpers.js:86:17)
      at async Context.<anonymous> (skr-svcat-migration-test/skr-svcat-migration-test.js:102:5)
```


**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
https://github.com/kyma-project/kyma/pull/13628/