### PR TITLE
Use commit hash for images tags for 2.1 release

### DIFF
--- a/resources/busola-migrator/values.yaml
+++ b/resources/busola-migrator/values.yaml
@@ -4,7 +4,7 @@ global:
   images:
     busola_migrator:
       name: "busola-migrator"
-      version: "PR-12963"
+      version: "708f6a87"
     k8s_tools:
       name: "k8s-tools"
       version: "20220318-b6a7453e"

--- a/resources/serverless/values.yaml
+++ b/resources/serverless/values.yaml
@@ -77,22 +77,22 @@ global:
       directory: "tpi"
     function_controller:
       name: "function-controller"
-      version: "PR-13548"
+      version: "a0a4ec40"
     function_webhook:
       name: "function-webhook"
-      version: "PR-13548"
+      version: "a0a4ec40"
     function_build_init:
       name: "function-build-init"
-      version: "PR-13548"
+      version: "a0a4ec40"
     function_runtime_nodejs12:
       name: "function-runtime-nodejs12"
-      version: "PR-13616"
+      version: "1ebd9636"
     function_runtime_nodejs14:
       name: "function-runtime-nodejs14"
-      version: "PR-13616"
+      version: "1ebd9636"
     function_runtime_python39:
       name: "function-runtime-python39"
-      version: "PR-13616"
+      version: "1ebd9636"
     kaniko_executor:
       name: "kaniko-executor"
       version: "1.7.0-6d270da8"
@@ -108,10 +108,10 @@ global:
   testImages:
     function_controller_test:
       name: "function-controller-test"
-      version: "PR-13214"
+      version: "708f6a87"
     git_server:
       name: "gitserver"
-      version: "PR-13313"
+      version: "708f6a87"
   highPriorityClassName: "kyma-system-priority"
 
 images:

--- a/tests/serverless-bench/fixtures/serverless-benchmark-job.yaml
+++ b/tests/serverless-bench/fixtures/serverless-benchmark-job.yaml
@@ -33,7 +33,7 @@ spec:
           value: "1m"
         - name: "SPAWN_RATE"
           value: "50"
-        image: eu.gcr.io/kyma-project/serverless-bench:PR-13358
+        image: eu.gcr.io/kyma-project/serverless-bench:708f6a87
         imagePullPolicy: Always
         name: serverless-benchmark
         resources: {}


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Use commit hash for serverless image tags
