### PR TITLE
Consistent sink validation in BEB and NATS

### DIFF
--- a/components/eventing-controller/controllers/subscription/beb/reconciler_test.go
+++ b/components/eventing-controller/controllers/subscription/beb/reconciler_test.go
@@ -224,7 +224,8 @@ var _ = Describe("Subscription Reconciliation Tests", func() {
 			givenSubscription := reconcilertesting.NewSubscription(subscriptionName, namespaceName,
 				reconcilertesting.WithOrderCreatedFilter(),
 				reconcilertesting.WithWebhookAuthForBEB(),
-				reconcilertesting.WithInvalidSink(),
+				// The following sink is invalid because it is missing a scheme.
+				reconcilertesting.WithSinkMissingScheme(subscriberSvc.Namespace, subscriberSvc.Name),
 			)
 			ensureSubscriptionCreated(ctx, givenSubscription)
 

--- a/components/eventing-controller/controllers/subscription/beb/reconciler_test.go
+++ b/components/eventing-controller/controllers/subscription/beb/reconciler_test.go
@@ -11,6 +11,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/kyma-project/kyma/components/eventing-controller/pkg/handlers/sink"
+
 	"github.com/kyma-project/kyma/components/eventing-controller/pkg/handlers/eventtype"
 
 	bebreconciler "github.com/kyma-project/kyma/components/eventing-controller/controllers/subscription/beb"
@@ -1405,8 +1407,10 @@ var _ = BeforeSuite(func(done Done) {
 	nameMapper = handlers.NewBEBSubscriptionNameMapper(domain, handlers.MaxBEBSubscriptionNameLength)
 	bebHandler := handlers.NewBEB(credentials, nameMapper, defaultLogger)
 
+	recorder := k8sManager.GetEventRecorderFor("eventing-controller")
+	sinkValidator := sink.NewValidator(context.Background(), k8sManager.GetClient(), recorder, defaultLogger)
 	err = bebreconciler.NewReconciler(context.Background(), k8sManager.GetClient(), defaultLogger,
-		k8sManager.GetEventRecorderFor("eventing-controller"), envConf, cleaner, bebHandler, credentials, nameMapper).SetupUnmanaged(k8sManager)
+		recorder, envConf, cleaner, bebHandler, credentials, nameMapper, sinkValidator).SetupUnmanaged(k8sManager)
 	Expect(err).ToNot(HaveOccurred())
 
 	go func() {

--- a/components/eventing-controller/controllers/subscription/jetstream/reconciler_test.go
+++ b/components/eventing-controller/controllers/subscription/jetstream/reconciler_test.go
@@ -132,7 +132,7 @@ func TestCreateSubscription(t *testing.T) {
 			},
 			want: utils.Want{
 				K8sSubscription: []gomegatypes.GomegaMatcher{
-					reconcilertesting.HaveCondition(utils.ConditionInvalidSink("sink URL scheme should be 'http' or 'https'")),
+					reconcilertesting.HaveCondition(utils.ConditionInvalidSink(sink.MissingSchemeErrMsg)),
 				},
 				K8sEvents: []v1.Event{utils.EventInvalidSink("Sink URL scheme should be HTTP or HTTPS: invalid")},
 			},

--- a/components/eventing-controller/controllers/subscription/nats/reconciler_test.go
+++ b/components/eventing-controller/controllers/subscription/nats/reconciler_test.go
@@ -132,7 +132,7 @@ func TestCreateSubscription(t *testing.T) {
 			},
 			want: utils.Want{
 				K8sSubscription: []gomegatypes.GomegaMatcher{
-					reconcilertesting.HaveCondition(utils.ConditionInvalidSink("sink URL scheme should be 'http' or 'https'")),
+					reconcilertesting.HaveCondition(utils.ConditionInvalidSink(sink.MissingSchemeErrMsg)),
 				},
 				K8sEvents: []v1.Event{utils.EventInvalidSink("Sink URL scheme should be HTTP or HTTPS: invalid")},
 			},

--- a/components/eventing-controller/pkg/handlers/sink/validator.go
+++ b/components/eventing-controller/pkg/handlers/sink/validator.go
@@ -16,7 +16,10 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-const clusterLocalURLSuffix = "svc.cluster.local"
+const (
+	clusterLocalURLSuffix = "svc.cluster.local"
+	MissingSchemeErrMsg   = "sink URL scheme should be 'http' or 'https'"
+)
 
 type Validator interface {
 	Validate(subscription *v1alpha1.Subscription) error
@@ -39,7 +42,7 @@ func NewValidator(ctx context.Context, client client.Client, recorder record.Eve
 func (s defaultSinkValidator) Validate(subscription *v1alpha1.Subscription) error {
 	if !isValidScheme(subscription.Spec.Sink) {
 		events.Warn(s.recorder, subscription, events.ReasonValidationFailed, "Sink URL scheme should be HTTP or HTTPS: %s", subscription.Spec.Sink)
-		return fmt.Errorf("sink URL scheme should be 'http' or 'https'")
+		return fmt.Errorf(MissingSchemeErrMsg)
 	}
 
 	sURL, err := url.ParseRequestURI(subscription.Spec.Sink)

--- a/components/eventing-controller/pkg/handlers/sink/validator_test.go
+++ b/components/eventing-controller/pkg/handlers/sink/validator_test.go
@@ -36,7 +36,7 @@ func TestSinkValidator(t *testing.T) {
 		{
 			name:                  "With invalid scheme",
 			givenSubscriptionSink: "invalid Sink",
-			wantErrString:         "sink URL scheme should be 'http' or 'https'",
+			wantErrString:         MissingSchemeErrMsg,
 		},
 		{
 			name:                  "With invalid URL",
@@ -73,6 +73,11 @@ func TestSinkValidator(t *testing.T) {
 			givenSubscriptionSink: "https://eventing-nats.test.svc.cluster.local:8080",
 			givenSvcNameToCreate:  "test", // wrong name
 			wantErrString:         "sink is not valid cluster local svc, failed with error",
+		},
+		{
+			name:                  "With correct format but missing scheme",
+			givenSubscriptionSink: "eventing-nats.test.svc.cluster.local:8080",
+			wantErrString:         MissingSchemeErrMsg,
 		},
 		{
 			name:                  "With no existing svc in the cluster, service has the wrong name",

--- a/components/eventing-controller/testing/test_helpers.go
+++ b/components/eventing-controller/testing/test_helpers.go
@@ -374,9 +374,8 @@ func WithOrderCreatedFilter() SubscriptionOpt {
 	return WithFilter(EventSource, OrderCreatedEventType)
 }
 
-func WithInvalidSink() SubscriptionOpt {
-	return WithSinkURL("invalid")
-
+func WithSinkMissingScheme(svcNamespace, svcName string) SubscriptionOpt {
+	return WithSinkURL(fmt.Sprintf("%s.%s.svc.cluster.local", svcName, svcNamespace))
 }
 
 // WithValidSink is a SubscriptionOpt for creating a subscription with a valid sink that itself gets created from

--- a/resources/eventing/values.yaml
+++ b/resources/eventing/values.yaml
@@ -5,7 +5,7 @@ global:
   images:
     eventing_controller:
       name: eventing-controller
-      version: PR-12706
+      version: PR-13689
       pullPolicy: "IfNotPresent"
     publisher_proxy:
       name: event-publisher-proxy


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- Reuse sink validator instead of the duplicate code. The existing code in BEB which was doing sink validation would issue a "skippable" error when the scheme was missing from the sink.

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
Closes #13354 