### PR TITLE
Adjust default refresh time and time picker for istio dashboards back to kyma defaults

### DIFF
--- a/resources/istio-resources/files/dashboards/control-plane.json
+++ b/resources/istio-resources/files/dashboards/control-plane.json
@@ -1687,7 +1687,7 @@
       }
     }
   ],
-  "refresh": "5s",
+  "refresh": 10s",
   "schemaVersion": 18,
   "style": "dark",
   "templating": {

--- a/resources/istio-resources/files/dashboards/control-plane.json
+++ b/resources/istio-resources/files/dashboards/control-plane.json
@@ -1687,7 +1687,7 @@
       }
     }
   ],
-  "refresh": 10s",
+  "refresh": "10s",
   "schemaVersion": 18,
   "style": "dark",
   "templating": {

--- a/resources/istio-resources/files/dashboards/control-plane.json
+++ b/resources/istio-resources/files/dashboards/control-plane.json
@@ -1714,7 +1714,7 @@
     ]
   },
   "time": {
-    "from": "now-5m",
+    "from": "now-1h",
     "to": "now"
   },
   "timepicker": {

--- a/resources/istio-resources/files/dashboards/mesh.json
+++ b/resources/istio-resources/files/dashboards/mesh.json
@@ -1709,7 +1709,7 @@
     ]
   },
   "time": {
-    "from": "now-5m",
+    "from": "now-1h",
     "to": "now"
   },
   "timepicker": {

--- a/resources/istio-resources/files/dashboards/mesh.json
+++ b/resources/istio-resources/files/dashboards/mesh.json
@@ -1682,7 +1682,7 @@
       }
     }
   ],
-  "refresh": "5s",
+  "refresh": "10s",
   "schemaVersion": 18,
   "style": "dark",
   "templating": {

--- a/resources/istio-resources/files/dashboards/performance.json
+++ b/resources/istio-resources/files/dashboards/performance.json
@@ -1279,7 +1279,7 @@
     "list": []
   },
   "time": {
-    "from": "now-5m",
+    "from": "now-1h",
     "to": "now"
   },
   "timepicker": {

--- a/resources/istio-resources/files/dashboards/service.json
+++ b/resources/istio-resources/files/dashboards/service.json
@@ -2796,7 +2796,7 @@
       "type": "row"
     }
   ],
-  "refresh": "1m",
+  "refresh": "10s",
   "schemaVersion": 26,
   "style": "dark",
   "templating": {

--- a/resources/istio-resources/files/dashboards/service.json
+++ b/resources/istio-resources/files/dashboards/service.json
@@ -2959,7 +2959,7 @@
     ]
   },
   "time": {
-    "from": "now-5m",
+    "from": "now-1h",
     "to": "now"
   },
   "timepicker": {

--- a/resources/istio-resources/files/dashboards/workload.json
+++ b/resources/istio-resources/files/dashboards/workload.json
@@ -2478,7 +2478,7 @@
       "type": "row"
     }
   ],
-  "refresh": "1m",
+  "refresh": "10s",
   "schemaVersion": 26,
   "style": "dark",
   "templating": {

--- a/resources/istio-resources/files/dashboards/workload.json
+++ b/resources/istio-resources/files/dashboards/workload.json
@@ -2641,7 +2641,7 @@
     ]
   },
   "time": {
-    "from": "now-5m",
+    "from": "now-1h",
     "to": "now"
   },
   "timepicker": {


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- change default refresh time to 10s for istio dashboards
- change default time picker to 1h for istio dashboards
- ...

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
https://github.com/kyma-project/kyma/pull/13706
https://github.com/kyma-project/kyma/pull/13664
https://github.com/kyma-project/kyma/pull/13713