### PR TITLE
Add links to the resources listed in the Migration Guide for Kyma 2.1

### DIFF
--- a/docs/migration-guide-2.0-2.1.md
+++ b/docs/migration-guide-2.0-2.1.md
@@ -3,4 +3,4 @@ title: Migration Guide 2.0-2.1
 ---
 
 Due to an upgrade of the monitoring stack, some obsolete resources must be deleted and some must be patched.
-When you upgrade from Kyma 2.0 to 2.1, either run the script `2.0-2.1-fix-upgraded-resources.sh` found in `/assets`, or perform the required steps from that script manually.
+When you upgrade from Kyma 2.0 to 2.1, either run the script [`2.0-2.1-fix-upgraded-resources.sh`](https://github.com/kyma-project/kyma/blob/release-2.1/docs/assets/2.0-2.1-fix-upgraded-resources.sh) found in [`/assets`](https://github.com/kyma-project/kyma/tree/release-2.1/docs/assets) or perform the required steps from that script manually.


### PR DESCRIPTION
**Description**

The [Migration Guide for Kyma 2.1](https://github.com/kyma-project/kyma/blob/release-2.1/docs/migration-guide-2.0-2.1.md) lists a [migration script](https://github.com/kyma-project/kyma/blob/release-2.1/docs/assets/2.0-2.1-fix-upgraded-resources.sh) and its [directory](https://github.com/kyma-project/kyma/blob/release-2.1/docs/assets), but they're not linked. 
When reading the Migration Guide via [Website](https://kyma-project.io/docs/kyma/2.1/migration-guide-2.0-2.1), it's a hassle to navigate to this directory without links. This PR adds the relevant links. 

Changes proposed in this pull request:

- Provide the link to the migration script and its directory in the Migration Guide

**Related issue(s)**
https://github.com/kyma-project/website/issues/837 
