### PR TITLE
Refine the App Conn tutorial on disabling TLS cert verification

### DIFF
--- a/docs/03-tutorials/00-application-connectivity/ac-11-disable-tls-certificate-verification.md
+++ b/docs/03-tutorials/00-application-connectivity/ac-11-disable-tls-certificate-verification.md
@@ -7,10 +7,10 @@ You can disable the [TLS certificate verification](../../01-overview/main-areas/
 >**NOTE:** By default, the TLS certificate verification is enabled when sending data and requests to every Application.
 Follow these steps to disable TLS certificate verification:
 
-1. Edit the `{APPLICATION_CR_NAME}` Application CR. Run:
+1. Edit the `{APP_NAME}` Application CR. Run:
 
    ```bash
-   kubectl edit application {APPLICATION_CR_NAME}
+   kubectl edit application {APP_NAME}
    ```
 
 2. Edit the Application by setting the **skipVerify** parameter to `true`.


### PR DESCRIPTION
**Description**

This PR introduces consistency with the remaining AC tutorials to the [Disable TLS certificate verification](https://github.com/kyma-project/kyma/blob/main/docs/03-tutorials/00-application-connectivity/ac-11-disable-tls-certificate-verification.md) tutorial

Changes proposed in this pull request:

- Rename the `{APPLICATION_CR_NAME}` placeholder to `{APP_NAME}` 

**Related issue(s)**
-
