### PR TITLE
Create JetStream consumers with the recommended name length

### DIFF
--- a/components/eventing-controller/controllers/subscription/jetstream/reconciler_test.go
+++ b/components/eventing-controller/controllers/subscription/jetstream/reconciler_test.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"log"
 	"path/filepath"
-	"strings"
 	"testing"
 	"time"
 
@@ -627,9 +626,9 @@ func getSubscriptionFromJetStream(ens *jetStreamTestEnsemble, subscription *even
 
 	return g.Expect(func() *nats.Subscription {
 		subscriptions := ens.jetStreamBackend.GetAllSubscriptions()
-		jsSubkey := ens.jetStreamBackend.GenerateJsSubKey(subject, subscription)
+		subscriptionSubject := handlers.NewSubscriptionSubjectIdentifier(subscription, subject)
 		for key, sub := range subscriptions {
-			if strings.EqualFold(key, jsSubkey) {
+			if key.ConsumerName() == subscriptionSubject.ConsumerName() {
 				return sub
 			}
 		}

--- a/components/eventing-controller/pkg/handlers/jetstream.go
+++ b/components/eventing-controller/pkg/handlers/jetstream.go
@@ -2,6 +2,8 @@ package handlers
 
 import (
 	"context"
+	"crypto/md5" // #nosec
+	"encoding/hex"
 	"fmt"
 	"net/http"
 	"strings"
@@ -10,16 +12,15 @@ import (
 
 	cev2 "github.com/cloudevents/sdk-go/v2"
 	cev2protocol "github.com/cloudevents/sdk-go/v2/protocol"
-	"github.com/kyma-project/kyma/components/eventing-controller/pkg/tracing"
-	"github.com/kyma-project/kyma/components/eventing-controller/utils"
-	"k8s.io/apimachinery/pkg/types"
+	"github.com/nats-io/nats.go"
+	"github.com/pkg/errors"
+	"go.uber.org/zap"
 
 	eventingv1alpha1 "github.com/kyma-project/kyma/components/eventing-controller/api/v1alpha1"
 	"github.com/kyma-project/kyma/components/eventing-controller/logger"
 	"github.com/kyma-project/kyma/components/eventing-controller/pkg/env"
-	"github.com/nats-io/nats.go"
-	"github.com/pkg/errors"
-	"go.uber.org/zap"
+	"github.com/kyma-project/kyma/components/eventing-controller/pkg/tracing"
+	"github.com/kyma-project/kyma/components/eventing-controller/utils"
 )
 
 var _ JetStreamBackend = &JetStream{}
@@ -29,6 +30,7 @@ const (
 	idleHeartBeatDuration  = 1 * time.Minute
 	jsConsumerMaxRedeliver = 100
 	jsConsumerAcKWait      = 30 * time.Second
+	separator              = "/"
 )
 
 type JetStreamBackend interface {
@@ -45,12 +47,49 @@ type JetStreamBackend interface {
 	GetJetStreamSubjects(subjects []string) []string
 }
 
+// SubscriptionSubjectIdentifier is used to uniquely identify a Subscription subject.
+// It should be used only with JetStream backend.
+type SubscriptionSubjectIdentifier struct {
+	consumerName, namespacedName string
+}
+
+// NewSubscriptionSubjectIdentifier returns a new SubscriptionSubjectIdentifier instance.
+func NewSubscriptionSubjectIdentifier(subscription *eventingv1alpha1.Subscription, subject string) SubscriptionSubjectIdentifier {
+	cn := computeConsumerName(subscription, subject) // compute the consumer name once
+	nn := computeNamespacedName(subscription)        // compute the namespaced name once
+	return SubscriptionSubjectIdentifier{consumerName: cn, namespacedName: nn}
+}
+
+// ConsumerName returns the JetStream consumer name.
+func (s SubscriptionSubjectIdentifier) ConsumerName() string {
+	return s.consumerName
+}
+
+// NamespacedName returns the Kubernetes namespaced name.
+func (s SubscriptionSubjectIdentifier) NamespacedName() string {
+	return s.namespacedName
+}
+
+// computeConsumerName returns JetStream consumer name of the given subscription and subject.
+// It uses the crypto/md5 lib to return a string of 32 characters as recommended by the JetStream
+// documentation https://docs.nats.io/running-a-nats-service/nats_admin/jetstream_admin/naming.
+func computeConsumerName(subscription *eventingv1alpha1.Subscription, subject string) string {
+	cn := subscription.Namespace + separator + subscription.Name + separator + subject
+	h := md5.Sum([]byte(cn)) // #nosec
+	return hex.EncodeToString(h[:])
+}
+
+// computeNamespacedName returns Kubernetes namespaced name of the given subscription.
+func computeNamespacedName(subscription *eventingv1alpha1.Subscription) string {
+	return subscription.Namespace + separator + subscription.Name
+}
+
 type JetStream struct {
 	config        env.NatsConfig
 	conn          *nats.Conn
 	jsCtx         nats.JetStreamContext
 	client        cev2.Client
-	subscriptions map[string]*nats.Subscription
+	subscriptions map[SubscriptionSubjectIdentifier]*nats.Subscription
 	sinks         sync.Map
 	// connClosedHandler gets called by the NATS server when conn is closed and retry attempts are exhausted.
 	connClosedHandler ConnClosedHandler
@@ -61,7 +100,7 @@ func NewJetStream(config env.NatsConfig, logger *logger.Logger) *JetStream {
 	return &JetStream{
 		config:        config,
 		logger:        logger,
-		subscriptions: make(map[string]*nats.Subscription),
+		subscriptions: make(map[SubscriptionSubjectIdentifier]*nats.Subscription),
 	}
 }
 
@@ -111,9 +150,7 @@ func (js *JetStream) SyncSubscription(subscription *eventingv1alpha1.Subscriptio
 	// which is not anymore in this subscription filters (i.e. cleanSubjects).
 	// e.g. when filters are modified.
 	for key, jsSub := range js.subscriptions {
-		if isRelated, err := js.isJsSubAssociatedWithKymaSub(key, subscription); err != nil {
-			return err
-		} else if !isRelated {
+		if !js.isJsSubAssociatedWithKymaSub(key, subscription) {
 			continue
 		}
 		// Delete the subscription if it is no longer valid
@@ -131,7 +168,7 @@ func (js *JetStream) SyncSubscription(subscription *eventingv1alpha1.Subscriptio
 		if err != nil {
 			if err == nats.ErrConsumerNotFound {
 				log.Infow("Deleting invalid Consumer!")
-				if err := js.deleteConsumerFromJetStream(key, log); err != nil {
+				if err := js.deleteConsumerFromJetStream(key.ConsumerName(), log); err != nil {
 					return err
 				}
 				delete(js.subscriptions, key)
@@ -146,7 +183,7 @@ func (js *JetStream) SyncSubscription(subscription *eventingv1alpha1.Subscriptio
 			}
 			log.Infow(
 				"deleted JetStream subscription because it was deleted from subscription filters",
-				"subscriptionKey", key,
+				"subscriptionSubject", key,
 				"jetStreamSubject", jsSub.Subject,
 			)
 		}
@@ -159,7 +196,7 @@ func (js *JetStream) SyncSubscription(subscription *eventingv1alpha1.Subscriptio
 
 	callback := js.getCallback(subKeyPrefix)
 	for _, subject := range subscription.Status.CleanEventTypes {
-		jsSubKey := js.GenerateJsSubKey(subject, subscription)
+		jsSubKey := NewSubscriptionSubjectIdentifier(subscription, subject)
 
 		// check if the subscription already exists and if it is valid.
 		if existingNatsSub, ok := js.subscriptions[jsSubKey]; ok {
@@ -178,7 +215,7 @@ func (js *JetStream) SyncSubscription(subscription *eventingv1alpha1.Subscriptio
 		jsSubscription, err := js.jsCtx.Subscribe(
 			subject,
 			asyncCallback,
-			js.getDefaultSubscriptionOptions(jsSubKey, subscription.Status.Config)...,
+			js.getDefaultSubscriptionOptions(jsSubKey.ConsumerName(), subscription.Status.Config)...,
 		)
 		if err != nil {
 			log.Errorw("failed to subscribe on JetStream", "subject", subject, "error", err)
@@ -197,20 +234,19 @@ func (js *JetStream) DeleteSubscription(subscription *eventingv1alpha1.Subscript
 	// loop over the global list of subscriptions
 	// and delete any related JetStream subscription
 	for key, jsSub := range js.subscriptions {
-		if isRelated, err := js.isJsSubAssociatedWithKymaSub(key, subscription); err != nil {
+		if !js.isJsSubAssociatedWithKymaSub(key, subscription) {
+			continue
+		}
+		if err := js.deleteSubscriptionFromJetStream(jsSub, key, log); err != nil {
 			return err
-		} else if isRelated {
-			if err = js.deleteSubscriptionFromJetStream(jsSub, key, log); err != nil {
-				return err
-			}
 		}
 	}
 
 	// cleanup consumers on nats-server
 	// in-case data in js.subscriptions[] was lost due to handler restart
 	for _, subject := range subscription.Status.CleanEventTypes {
-		jsSubKey := js.GenerateJsSubKey(subject, subscription)
-		if err := js.deleteConsumerFromJetStream(jsSubKey, log); err != nil {
+		jsSubKey := NewSubscriptionSubjectIdentifier(subscription, subject)
+		if err := js.deleteConsumerFromJetStream(jsSubKey.ConsumerName(), log); err != nil {
 			return err
 		}
 	}
@@ -384,19 +420,14 @@ func (js *JetStream) getCallback(subKeyPrefix string) nats.MsgHandler {
 	}
 }
 
-// isJsSubAssociatedWithKymaSub checks if the JetStream subscription is associated / related to Kyma subscription or not.
-func (js *JetStream) isJsSubAssociatedWithKymaSub(jsSubKey string, subscription *eventingv1alpha1.Subscription) (bool, error) {
-	// extract out namespacedName of subscription from key
-	namespacedName, err := createJSSubscriptionNamespacedName(jsSubKey)
-	if err != nil {
-		return false, err
-	}
-	// check if the namespacedName matches the target subscription
-	return createKeyPrefix(subscription) == namespacedName.String(), nil
+// isJsSubAssociatedWithKymaSub returns true if the given SubscriptionSubjectIdentifier and Kyma subscription
+// have the same namespaced name, otherwise returns false.
+func (js *JetStream) isJsSubAssociatedWithKymaSub(jsSubKey SubscriptionSubjectIdentifier, subscription *eventingv1alpha1.Subscription) bool {
+	return createKeyPrefix(subscription) == jsSubKey.NamespacedName()
 }
 
 // deleteSubscriptionFromJS deletes subscription from JetStream and from in-memory db.
-func (js *JetStream) deleteSubscriptionFromJetStream(jsSub *nats.Subscription, jsSubKey string, log *zap.SugaredLogger) error {
+func (js *JetStream) deleteSubscriptionFromJetStream(jsSub *nats.Subscription, jsSubKey SubscriptionSubjectIdentifier, log *zap.SugaredLogger) error {
 	// unsubscribe call to JetStream is async hence checking the status of the connection is important
 	if err := js.checkJetStreamConnection(log); err != nil {
 		return err
@@ -410,13 +441,13 @@ func (js *JetStream) deleteSubscriptionFromJetStream(jsSub *nats.Subscription, j
 		}
 	} else {
 		// if JS sub is not valid, then we need to delete the consumer on JetStream
-		if err := js.deleteConsumerFromJetStream(jsSubKey, log); err != nil {
+		if err := js.deleteConsumerFromJetStream(jsSubKey.ConsumerName(), log); err != nil {
 			return err
 		}
 	}
 
 	delete(js.subscriptions, jsSubKey)
-	log.Debugw("unsubscribe from JetStream succeeded", "subscriptionKey", jsSubKey)
+	log.Debugw("unsubscribe from JetStream succeeded", "subscriptionSubject", jsSubKey)
 
 	return nil
 }
@@ -435,11 +466,6 @@ func (js *JetStream) deleteConsumerFromJetStream(name string, log *zap.SugaredLo
 	}
 
 	return nil
-}
-
-// GenerateJsSubKey generates an encoded unique key for JetStream subscription.
-func (js *JetStream) GenerateJsSubKey(subject string, subscription *eventingv1alpha1.Subscription) string {
-	return encodeString(fmt.Sprintf("%s/%s", createKeyPrefix(subscription), subject))
 }
 
 // GetJetStreamSubjects returns a list of subjects appended with prefix if needed
@@ -462,21 +488,9 @@ func (js *JetStream) checkJetStreamConnection(log *zap.SugaredLogger) error {
 	return nil
 }
 
-func createJSSubscriptionNamespacedName(jsSubKey string) (types.NamespacedName, error) {
-	consumer, err := decodeString(jsSubKey)
-	if err != nil {
-		return types.NamespacedName{}, err
-	}
-	nsn := types.NamespacedName{}
-	nnValues := strings.Split(consumer, string(types.Separator))
-	nsn.Namespace = nnValues[0]
-	nsn.Name = nnValues[1]
-	return nsn, nil
-}
-
 // GetAllSubscriptions returns the map which contains details of all subscriptions and consumers.
 // Use this only for testing purposes.
-func (js *JetStream) GetAllSubscriptions() map[string]*nats.Subscription {
+func (js *JetStream) GetAllSubscriptions() map[SubscriptionSubjectIdentifier]*nats.Subscription {
 	return js.subscriptions
 }
 

--- a/components/eventing-controller/pkg/handlers/jetstream_test.go
+++ b/components/eventing-controller/pkg/handlers/jetstream_test.go
@@ -1203,8 +1203,8 @@ func setupTestEnvironment(t *testing.T) *TestEnvironment {
 	}
 }
 
-// TestSubscriptionSubjectEqual checks the equality of two SubscriptionSubject instances and their consumer names.
-func TestSubscriptionSubjectEqual(t *testing.T) {
+// TestSubscriptionSubjectIdentifierEqual checks the equality of two SubscriptionSubjectIdentifier instances and their consumer names.
+func TestSubscriptionSubjectIdentifierEqual(t *testing.T) {
 	t.Parallel()
 	testCases := []struct {
 		name             string
@@ -1301,9 +1301,9 @@ func TestSubscriptionSubjectEqual(t *testing.T) {
 	}
 }
 
-// TestSubscriptionSubjectConsumerNameLength checks that the consumer name length is equal to the recommended
-// length by JetStream https://docs.nats.io/running-a-nats-service/nats_admin/jetstream_admin/naming.
-func TestSubscriptionSubjectConsumerNameLength(t *testing.T) {
+// TestSubscriptionSubjectIdentifierConsumerNameLength checks that the SubscriptionSubjectIdentifier consumer name
+// length is equal to the recommended length by JetStream.
+func TestSubscriptionSubjectIdentifierConsumerNameLength(t *testing.T) {
 	t.Parallel()
 	testCases := []struct {
 		name                   string
@@ -1336,8 +1336,8 @@ func TestSubscriptionSubjectConsumerNameLength(t *testing.T) {
 	}
 }
 
-// TestSubscriptionSubjectNamespacedName checks the syntax of the SubscriptionSubject namespaced name.
-func TestSubscriptionSubjectNamespacedName(t *testing.T) {
+// TestSubscriptionSubjectIdentifierNamespacedName checks the syntax of the SubscriptionSubjectIdentifier namespaced name.
+func TestSubscriptionSubjectIdentifierNamespacedName(t *testing.T) {
 	t.Parallel()
 	testCases := []struct {
 		name               string

--- a/components/eventing-controller/pkg/handlers/jetstream_test.go
+++ b/components/eventing-controller/pkg/handlers/jetstream_test.go
@@ -3,8 +3,14 @@ package handlers
 import (
 	"errors"
 	"fmt"
+	"reflect"
 	"testing"
 	"time"
+
+	"github.com/nats-io/nats-server/v2/server"
+	"github.com/nats-io/nats.go"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	kymalogger "github.com/kyma-project/kyma/common/logging/logger"
 	eventingv1alpha1 "github.com/kyma-project/kyma/components/eventing-controller/api/v1alpha1"
@@ -12,14 +18,15 @@ import (
 	"github.com/kyma-project/kyma/components/eventing-controller/pkg/env"
 	"github.com/kyma-project/kyma/components/eventing-controller/pkg/handlers/eventtype"
 	evtesting "github.com/kyma-project/kyma/components/eventing-controller/testing"
-	"github.com/nats-io/nats-server/v2/server"
-	"github.com/nats-io/nats.go"
-	"github.com/stretchr/testify/require"
 )
 
 const (
 	defaultStreamName    = "kyma"
 	defaultMaxReconnects = 10
+
+	// maxJetStreamConsumerNameLength is the maximum preferred length for the JetStream consumer names
+	// as per https://docs.nats.io/running-a-nats-service/nats_admin/jetstream_admin/naming
+	maxJetStreamConsumerNameLength = 32
 )
 
 type jetStreamClient struct {
@@ -193,10 +200,11 @@ func TestJetStreamSubAfterSync_NoChange(t *testing.T) {
 	// by comparing the metadata of nats subscription
 	require.Len(t, jsBackend.subscriptions, 1)
 	jsSubject := jsBackend.GetJsSubjectToSubscribe(subject)
-	jsSubKey := jsBackend.GenerateJsSubKey(jsSubject, sub)
+	jsSubKey := NewSubscriptionSubjectIdentifier(sub, jsSubject)
 	jsSub := jsBackend.subscriptions[jsSubKey]
 	require.NotNil(t, jsSub)
 	require.True(t, jsSub.IsValid())
+
 	// check the metadata, if they are now same then it means that NATS subscription
 	// were not re-created by SyncSubscription method
 	subMsgLimit, subBytesLimit, err := jsSub.PendingLimits()
@@ -283,10 +291,11 @@ func TestJetStreamSubAfterSync_SinkChange(t *testing.T) {
 	// by comparing the metadata of nats subscription
 	require.Len(t, jsBackend.subscriptions, 1)
 	jsSubject := jsBackend.GetJsSubjectToSubscribe(subject)
-	jsSubKey := jsBackend.GenerateJsSubKey(jsSubject, sub)
+	jsSubKey := NewSubscriptionSubjectIdentifier(sub, jsSubject)
 	jsSub := jsBackend.subscriptions[jsSubKey]
 	require.NotNil(t, jsSub)
 	require.True(t, jsSub.IsValid())
+
 	// check the metadata, if they are now same then it means that NATS subscription
 	// were not re-created by SyncSubscription method
 	subMsgLimit, subBytesLimit, err := jsSub.PendingLimits()
@@ -298,6 +307,7 @@ func TestJetStreamSubAfterSync_SinkChange(t *testing.T) {
 	data = fmt.Sprintf("data-%s", time.Now().Format(time.RFC850))
 	expectedDataInStore = fmt.Sprintf("\"%s\"", data)
 	require.NoError(t, SendEventToJetStream(jsBackend, data))
+
 	// Old sink should not have received the event, the new sink should have
 	require.Error(t, subscriber1.CheckEvent(expectedDataInStore))
 	require.NoError(t, subscriber2.CheckEvent(expectedDataInStore))
@@ -375,11 +385,11 @@ func TestJetStreamSubAfterSync_FiltersChange(t *testing.T) {
 	// because the subscriptions should have being re-created for new subject
 	require.Len(t, jsBackend.subscriptions, 1)
 	jsSubject := jsBackend.GetJsSubjectToSubscribe(newSubject)
-	jsSubKey := jsBackend.GenerateJsSubKey(jsSubject, sub)
-
+	jsSubKey := NewSubscriptionSubjectIdentifier(sub, jsSubject)
 	jsSub := jsBackend.subscriptions[jsSubKey]
 	require.NotNil(t, jsSub)
 	require.True(t, jsSub.IsValid())
+
 	// check the metadata, if they are NOT same then it means that NATS subscription
 	// were re-created by SyncSubscription method
 	subMsgLimit, subBytesLimit, err := jsSub.PendingLimits()
@@ -468,11 +478,11 @@ func TestJetStreamSubAfterSync_FilterAdded(t *testing.T) {
 	require.Len(t, jsBackend.subscriptions, 2)
 	// Verify that the nats subscriptions for first subject was not re-created
 	jsSubject := jsBackend.GetJsSubjectToSubscribe(firstSubject)
-	jsSubKey := jsBackend.GenerateJsSubKey(jsSubject, sub)
-
+	jsSubKey := NewSubscriptionSubjectIdentifier(sub, jsSubject)
 	jsSub := jsBackend.subscriptions[jsSubKey]
 	require.NotNil(t, jsSub)
 	require.True(t, jsSub.IsValid())
+
 	// check the metadata, if they are now same then it means that NATS subscription
 	// were not re-created by SyncSubscription method
 	subMsgLimit, subBytesLimit, err := jsSub.PendingLimits()
@@ -568,11 +578,11 @@ func TestJetStreamSubAfterSync_FilterRemoved(t *testing.T) {
 	require.Len(t, jsBackend.subscriptions, 1)
 	// Verify that the nats subscriptions for first subject was not re-created
 	jsSubject := jsBackend.GetJsSubjectToSubscribe(firstSubject)
-	jsSubKey := jsBackend.GenerateJsSubKey(jsSubject, sub)
-
+	jsSubKey := NewSubscriptionSubjectIdentifier(sub, jsSubject)
 	jsSub := jsBackend.subscriptions[jsSubKey]
 	require.NotNil(t, jsSub)
 	require.True(t, jsSub.IsValid())
+
 	// check the metadata, if they are now same then it means that NATS subscription
 	// were not re-created by SyncSubscription method
 	subMsgLimit, subBytesLimit, err := jsSub.PendingLimits()
@@ -678,11 +688,11 @@ func TestJetStreamSubAfterSync_MultipleSubs(t *testing.T) {
 	// check if the NATS subscription are NOT the same after sync for subscription 1
 	// because the subscriptions should have being re-created for new subject
 	jsSubject := jsBackend.GetJsSubjectToSubscribe(newSubject)
-	jsSubKey := jsBackend.GenerateJsSubKey(jsSubject, sub)
-
+	jsSubKey := NewSubscriptionSubjectIdentifier(sub, jsSubject)
 	jsSub := jsBackend.subscriptions[jsSubKey]
 	require.NotNil(t, jsSub)
 	require.True(t, jsSub.IsValid())
+
 	// check the metadata, if they are now same then it means that NATS subscription
 	// were not re-created by SyncSubscription method
 	subMsgLimit, subBytesLimit, err := jsSub.PendingLimits()
@@ -699,11 +709,11 @@ func TestJetStreamSubAfterSync_MultipleSubs(t *testing.T) {
 	// because the subscriptions should NOT have being re-created as
 	// subscription 2 was not modified
 	jsSubject = jsBackend.GetJsSubjectToSubscribe(cleanSubjectSub2)
-	jsSubKey = jsBackend.GenerateJsSubKey(jsSubject, sub2)
-
+	jsSubKey = NewSubscriptionSubjectIdentifier(sub2, jsSubject)
 	jsSub = jsBackend.subscriptions[jsSubKey]
 	require.NotNil(t, jsSub)
 	require.True(t, jsSub.IsValid())
+
 	// check the metadata, if they are now same then it means that NATS subscription
 	// were not re-created by SyncSubscription method
 	subMsgLimit, subBytesLimit, err = jsSub.PendingLimits()
@@ -725,20 +735,16 @@ func TestJetStream_isJsSubAssociatedWithKymaSub(t *testing.T) {
 	// create subscription 1 and its JetStream subscription
 	cleanSubject1 := "subOne"
 	sub1 := evtesting.NewSubscription(cleanSubject1, "foo", evtesting.WithNotCleanFilter())
-	jsSub1Key := jsBackend.GenerateJsSubKey(
-		jsBackend.GetJsSubjectToSubscribe(cleanSubject1),
-		sub1)
+	jsSub1Key := NewSubscriptionSubjectIdentifier(sub1, cleanSubject1)
 
 	// create subscription 2 and its JetStream subscription
 	cleanSubject2 := "subOneTwo"
 	sub2 := evtesting.NewSubscription(cleanSubject2, "foo", evtesting.WithNotCleanFilter())
-	jsSub2Key := jsBackend.GenerateJsSubKey(
-		jsBackend.GetJsSubjectToSubscribe(cleanSubject2),
-		sub2)
+	jsSub2Key := NewSubscriptionSubjectIdentifier(sub2, cleanSubject2)
 
 	testCases := []struct {
 		name            string
-		givenJSSubKey   string
+		givenJSSubKey   SubscriptionSubjectIdentifier
 		givenKymaSubKey *eventingv1alpha1.Subscription
 		wantResult      bool
 	}{
@@ -771,11 +777,8 @@ func TestJetStream_isJsSubAssociatedWithKymaSub(t *testing.T) {
 	for _, tC := range testCases {
 		testCase := tC
 		t.Run(testCase.name, func(t *testing.T) {
-			gotResult, err := jsBackend.isJsSubAssociatedWithKymaSub(
-				tC.givenJSSubKey,
-				tC.givenKymaSubKey)
-			require.Equal(t, gotResult, tC.wantResult)
-			require.NoError(t, err)
+			gotResult := jsBackend.isJsSubAssociatedWithKymaSub(tC.givenJSSubKey, tC.givenKymaSubKey)
+			require.Equal(t, tC.wantResult, gotResult)
 		})
 	}
 }
@@ -914,8 +917,8 @@ func TestJSSubscriptionWithMaxInFlightChange(t *testing.T) {
 
 	// then
 	require.Eventually(t, func() bool {
-		consumerName := jsBackend.GenerateJsSubKey(sub.Status.CleanEventTypes[0], sub)
 		// fetch consumer info from JetStream
+		consumerName := NewSubscriptionSubjectIdentifier(sub, sub.Status.CleanEventTypes[0]).ConsumerName()
 		consumerInfo, err := jsBackend.jsCtx.ConsumerInfo(jsBackend.config.JSStreamName, consumerName)
 		require.NoError(t, err)
 
@@ -1197,5 +1200,172 @@ func setupTestEnvironment(t *testing.T) *TestEnvironment {
 		natsConfig: natsConfig,
 		cleaner:    cleaner,
 		natsPort:   natsPort,
+	}
+}
+
+// TestSubscriptionSubjectEqual checks the equality of two SubscriptionSubject instances and their consumer names.
+func TestSubscriptionSubjectEqual(t *testing.T) {
+	t.Parallel()
+	testCases := []struct {
+		name             string
+		givenIdentifier1 SubscriptionSubjectIdentifier
+		givenIdentifier2 SubscriptionSubjectIdentifier
+		wantEqual        bool
+	}{
+		// instances are equal
+		{
+			name: "should be equal if the two instances are identical",
+			givenIdentifier1: NewSubscriptionSubjectIdentifier(
+				evtesting.NewSubscription("sub-1", "ns-1"),
+				"prefix.app.event.operation.v1",
+			),
+			givenIdentifier2: NewSubscriptionSubjectIdentifier(
+				evtesting.NewSubscription("sub-1", "ns-1"),
+				"prefix.app.event.operation.v1",
+			),
+			wantEqual: true,
+		},
+		// instances are not equal
+		{
+			name: "should not be equal if only name is different",
+			givenIdentifier1: NewSubscriptionSubjectIdentifier(
+				evtesting.NewSubscription("sub-1", "ns-1"),
+				"prefix.app.event.operation.v1",
+			),
+			givenIdentifier2: NewSubscriptionSubjectIdentifier(
+				evtesting.NewSubscription("sub-2", "ns-1"),
+				"prefix.app.event.operation.v1",
+			),
+			wantEqual: false,
+		},
+		{
+			name: "should not be equal if only namespace is different",
+			givenIdentifier1: NewSubscriptionSubjectIdentifier(
+				evtesting.NewSubscription("sub-1", "ns-1"),
+				"prefix.app.event.operation.v1",
+			),
+			givenIdentifier2: NewSubscriptionSubjectIdentifier(
+				evtesting.NewSubscription("sub-1", "ns-2"),
+				"prefix.app.event.operation.v1",
+			),
+			wantEqual: false,
+		},
+		{
+			name: "should not be equal if only subject is different",
+			givenIdentifier1: NewSubscriptionSubjectIdentifier(
+				evtesting.NewSubscription("sub-1", "ns-1"),
+				"prefix.app.event.operation.v1",
+			),
+			givenIdentifier2: NewSubscriptionSubjectIdentifier(
+				evtesting.NewSubscription("sub-1", "ns-1"),
+				"prefix.app.event.operation.v2",
+			),
+			wantEqual: false,
+		},
+		// possible naming collisions
+		{
+			name: "should not be equal if subject is the same but name and namespace are swapped",
+			givenIdentifier1: NewSubscriptionSubjectIdentifier(
+				evtesting.NewSubscription("sub-1", "ns-1"),
+				"prefix.app.event.operation.v1",
+			),
+			givenIdentifier2: NewSubscriptionSubjectIdentifier(
+				evtesting.NewSubscription("ns-1", "sub-1"),
+				"prefix.app.event.operation.v1",
+			),
+			wantEqual: false,
+		},
+		{
+			name: "should not be equal if subject is the same but name and namespace are only equal if joined together",
+			givenIdentifier1: NewSubscriptionSubjectIdentifier(
+				evtesting.NewSubscription("sub-1", "ns-1"), // evaluates to "sub-1ns-1" when joined
+				"prefix.app.event.operation.v1",
+			),
+			givenIdentifier2: NewSubscriptionSubjectIdentifier(
+				evtesting.NewSubscription("sub-1n", "s-1"), // evaluates to "sub-1ns-1" when joined
+				"prefix.app.event.operation.v1",
+			),
+			wantEqual: false,
+		},
+	}
+	for _, tc := range testCases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			gotInstanceEqual := reflect.DeepEqual(tc.givenIdentifier1, tc.givenIdentifier2)
+			assert.Equal(t, tc.wantEqual, gotInstanceEqual)
+
+			gotConsumerNameEqual := tc.givenIdentifier1.ConsumerName() == tc.givenIdentifier2.ConsumerName()
+			assert.Equal(t, tc.wantEqual, gotConsumerNameEqual)
+		})
+	}
+}
+
+// TestSubscriptionSubjectConsumerNameLength checks that the consumer name length is equal to the recommended
+// length by JetStream https://docs.nats.io/running-a-nats-service/nats_admin/jetstream_admin/naming.
+func TestSubscriptionSubjectConsumerNameLength(t *testing.T) {
+	t.Parallel()
+	testCases := []struct {
+		name                   string
+		givenIdentifier        SubscriptionSubjectIdentifier
+		wantConsumerNameLength int
+	}{
+		{
+			name: "short string values",
+			givenIdentifier: NewSubscriptionSubjectIdentifier(
+				evtesting.NewSubscription("sub", "ns"),
+				"app.event.operation.v1",
+			),
+			wantConsumerNameLength: maxJetStreamConsumerNameLength,
+		},
+		{
+			name: "long string values",
+			givenIdentifier: NewSubscriptionSubjectIdentifier(
+				evtesting.NewSubscription("some-test-subscription", "some-test-namespace"),
+				"some.test.prefix.some-test-application.some-test-event-name.some-test-operation.some-test-version",
+			),
+			wantConsumerNameLength: maxJetStreamConsumerNameLength,
+		},
+	}
+	for _, tc := range testCases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tc.wantConsumerNameLength, len(tc.givenIdentifier.ConsumerName()))
+		})
+	}
+}
+
+// TestSubscriptionSubjectNamespacedName checks the syntax of the SubscriptionSubject namespaced name.
+func TestSubscriptionSubjectNamespacedName(t *testing.T) {
+	t.Parallel()
+	testCases := []struct {
+		name               string
+		givenIdentifier    SubscriptionSubjectIdentifier
+		wantNamespacedName string
+	}{
+		{
+			name: "short name and namespace values",
+			givenIdentifier: NewSubscriptionSubjectIdentifier(
+				evtesting.NewSubscription("sub", "ns"),
+				"app.event.operation.v1",
+			),
+			wantNamespacedName: "ns/sub",
+		},
+		{
+			name: "long name and namespace values",
+			givenIdentifier: NewSubscriptionSubjectIdentifier(
+				evtesting.NewSubscription("some-test-subscription", "some-test-namespace"),
+				"app.event.operation.v1",
+			),
+			wantNamespacedName: "some-test-namespace/some-test-subscription",
+		},
+	}
+	for _, tc := range testCases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tc.wantNamespacedName, tc.givenIdentifier.NamespacedName())
+		})
 	}
 }

--- a/components/eventing-controller/pkg/handlers/utils.go
+++ b/components/eventing-controller/pkg/handlers/utils.go
@@ -4,7 +4,6 @@ package handlers
 import (
 	"context"
 	"crypto/sha1"
-	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"math/rand"
@@ -12,17 +11,16 @@ import (
 	"strings"
 	"time"
 
-	"github.com/mitchellh/hashstructure/v2"
-	"github.com/pkg/errors"
-
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	k8sruntime "k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/dynamic"
 
-	apigatewayv1alpha1 "github.com/kyma-incubator/api-gateway/api/v1alpha1"
+	"github.com/mitchellh/hashstructure/v2"
+	"github.com/pkg/errors"
 
+	apigatewayv1alpha1 "github.com/kyma-incubator/api-gateway/api/v1alpha1"
 	eventingv1alpha1 "github.com/kyma-project/kyma/components/eventing-controller/api/v1alpha1"
 	"github.com/kyma-project/kyma/components/eventing-controller/pkg/ems/api/events/types"
 )
@@ -58,18 +56,6 @@ func (m *bebSubscriptionNameMapper) MapSubscriptionName(sub *eventingv1alpha1.Su
 func hashSubscriptionFullName(domainName, namespace, name string) string {
 	hash := sha1.Sum([]byte(domainName + namespace + name))
 	return fmt.Sprintf("%x", hash)
-}
-
-func encodeString(value string) string {
-	return base64.StdEncoding.EncodeToString([]byte(value))
-}
-
-func decodeString(value string) (string, error) {
-	data, err := base64.StdEncoding.DecodeString(value)
-	if err != nil {
-		return "", err
-	}
-	return string(data), nil
 }
 
 // produces a name+hash which is not longer than maxLength. If necessary, shortens name, not the hash.

--- a/resources/eventing/values.yaml
+++ b/resources/eventing/values.yaml
@@ -5,7 +5,7 @@ global:
   images:
     eventing_controller:
       name: eventing-controller
-      version: PR-13703
+      version: PR-13744
       pullPolicy: "IfNotPresent"
     publisher_proxy:
       name: event-publisher-proxy


### PR DESCRIPTION
**Description**

Create JetStream consumers with the recommended name length mentioned [here](https://docs.nats.io/running-a-nats-service/nats_admin/jetstream_admin/naming).

**Related issue(s)**

- https://github.com/kyma-project/kyma/issues/13546