### PR TITLE
Switch from go-get to go-install and bump linter version

### DIFF
--- a/components/eventing-controller/Makefile
+++ b/components/eventing-controller/Makefile
@@ -92,9 +92,9 @@ undeploy: ## Undeploy controller from the K8s cluster specified in ~/.kube/confi
 	kustomize build config/default | kubectl delete -f -
 
 CONTROLLER_GEN = $(PROJECT_DIR)/bin/$(shell uname)/controller-gen
-ARCH := $(shell uname)
+OS := $(shell uname)
 controller-gen-local: ## Download controller-gen locally if necessary.
-	GOBIN=$(PROJECT_DIR)/bin/$(ARCH) go install sigs.k8s.io/controller-tools/cmd/controller-gen@v0.4.1
+	GOBIN=$(PROJECT_DIR)/bin/$(OS) go install sigs.k8s.io/controller-tools/cmd/controller-gen@v0.4.1
 
 path-to-referenced-charts:
 	@echo "resources/eventing"

--- a/components/eventing-controller/Makefile
+++ b/components/eventing-controller/Makefile
@@ -92,8 +92,9 @@ undeploy: ## Undeploy controller from the K8s cluster specified in ~/.kube/confi
 	kustomize build config/default | kubectl delete -f -
 
 CONTROLLER_GEN = $(PROJECT_DIR)/bin/$(shell uname)/controller-gen
+ARCH := $(shell uname)
 controller-gen-local: ## Download controller-gen locally if necessary.
-	$(call go-get-tool,$(CONTROLLER_GEN),sigs.k8s.io/controller-tools/cmd/controller-gen@v0.4.1)
+	GOBIN=$(PROJECT_DIR)/bin/$(ARCH) go install sigs.k8s.io/controller-tools/cmd/controller-gen@v0.4.1
 
 path-to-referenced-charts:
 	@echo "resources/eventing"
@@ -113,20 +114,6 @@ copy-external-crds: ## copy external CRDs to config/crd/external
 	mkdir -p config/crd/external
 	cp ../../installation/resources/crds/api-gateway/apirules.gateway.crd.yaml config/crd/external/apirules-gateway-kyma-project-io.yaml
 	cp ../../installation/resources/crds/application-connector/applications.applicationconnector.crd.yaml config/crd/external/applications-applicationconnector-kyma-project-io.yaml
-
-# go-get-tool will 'go get' any package $2 and install it to $1.
-ARCH := $(shell uname)
-define go-get-tool
-@[ -f $(1) ] || { \
-set -e ;\
-TMP_DIR=$$(mktemp -d) ;\
-cd $$TMP_DIR ;\
-go mod init tmp ;\
-echo "Downloading $(2)" ;\
-GOBIN=$(PROJECT_DIR)/bin/$(ARCH) go get $(2) ;\
-rm -rf $$TMP_DIR ;\
-}
-endef
 
 $(eval $(call buildpack-cp-ro,resolve))
 $(eval $(call buildpack-mount,mod-verify))

--- a/components/eventing-controller/pkg/handlers/nats_test.go
+++ b/components/eventing-controller/pkg/handlers/nats_test.go
@@ -55,7 +55,7 @@ func TestConvertMsgToCE(t *testing.T) {
 				Sub:     nil,
 			},
 			expectedCloudEvent: cev2event.New(cev2event.CloudEventsVersionV1),
-			expectedErr:        errors.New("id: MUST be a non-empty string\n"), //nolint:golint
+			expectedErr:        errors.New("id: MUST be a non-empty string\n"), //nolint:revive
 		},
 	}
 	for _, tc := range testCases {

--- a/hack/verify-lint.sh
+++ b/hack/verify-lint.sh
@@ -56,7 +56,7 @@ golangci::run_checks() {
     deadcode errcheck gosimple govet ineffassign staticcheck \
     structcheck typecheck unused varcheck \
     # additional lints
-    golint gofmt misspell gochecknoinits unparam scopelint gosec
+    revive gofmt misspell gochecknoinits unparam exportloopref gosec
     ${ADDITIONAL_LINTERS}
   )
 

--- a/hack/verify-lint.sh
+++ b/hack/verify-lint.sh
@@ -8,7 +8,7 @@ set -E         # needs to be set if we want the ERR trap
 readonly CURRENT_DIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
 readonly ROOT_PATH="${1:-$( cd "${CURRENT_DIR}/.." && pwd )}" # first argument or root of the project
 readonly TMP_DIR=$(mktemp -d)
-readonly GOLANGCI_LINT_VERSION="v1.38.0"
+readonly GOLANGCI_LINT_VERSION="v1.45.2"
 
 ADDITIONAL_LINTERS=${ADDITIONAL_LINTERS:-}
 


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- Remove deprecated `go get` and use `go install` instead
- Bump golangci-lint to 1.45.2 as go1.18 is supported from v1.45.0.

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
