### PR TITLE
Bring back removed feature flag in NATS chart

### DIFF
--- a/resources/eventing/charts/nats/templates/statefulset.yaml
+++ b/resources/eventing/charts/nats/templates/statefulset.yaml
@@ -62,7 +62,7 @@ spec:
       - name: pid
         emptyDir: {}
 
-      {{- if and (eq .Values.global.jetstream.storage "file") .Values.nats.jetstream.fileStorage.existingClaim }}
+      {{- if and .Values.global.jetstream.enabled (eq .Values.global.jetstream.storage "file") .Values.nats.jetstream.fileStorage.existingClaim }}
       # Persistent volume for jetstream running with file storage option
       - name: {{ include "nats.fullname" . }}-js-pvc
         persistentVolumeClaim:
@@ -165,7 +165,7 @@ spec:
             mountPath: /etc/nats-config
           - name: pid
             mountPath: /var/run/nats
-          {{- if eq .Values.global.jetstream.storage "file" }}
+          {{- if and .Values.global.jetstream.enabled (eq .Values.global.jetstream.storage "file") }}
           - name: {{ include "nats.fullname" . }}-js-pvc
             mountPath: {{ .Values.nats.jetstream.fileStorage.storageDirectory }}
           {{- end }}
@@ -200,7 +200,7 @@ spec:
               - "nats-server -sl=ldm=/var/run/nats/nats.pid && /bin/sleep {{ .Values.nats.terminationGracePeriodSeconds }}"
 
   volumeClaimTemplates:
-  {{- if and (eq .Values.global.jetstream.storage "file") (not .Values.nats.jetstream.fileStorage.existingClaim) }}
+  {{- if and .Values.global.jetstream.enabled (eq .Values.global.jetstream.storage "file") (not .Values.nats.jetstream.fileStorage.existingClaim) }}
   #####################################
   #                                   #
   #  Jetstream New Persistent Volume  #


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Persistent options should not be rendered in the NATS Helm chart when the JetStream feature flag is off. It seems that the conditionals introduced [here](https://github.com/kyma-project/kyma/pull/13636/files#diff-5df5dc6df34a19043716db179776ac00c6948d680d500283375efff76d943a66) don't take the feature flag into account.

<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
