### PR TITLE
disable ingress metrics in kube-state-metrics

### DIFF
--- a/resources/monitoring/charts/kube-state-metrics/values.yaml
+++ b/resources/monitoring/charts/kube-state-metrics/values.yaml
@@ -169,7 +169,7 @@ collectors:
   - deployments
   - endpoints
   - horizontalpodautoscalers
-  - ingresses
+  # - ingresses # kube-state-metrics panics for badly configured ingress: https://github.com/kyma-project/kyma/issues/13768
   - jobs
   - limitranges
   - mutatingwebhookconfigurations


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- disable ingress resource in kube-state-metrics temporarily to not let it panic
- ...
- ...

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
https://github.com/kyma-project/kyma/issues/13768