### PR TITLE
Fix telemetry-operator ServiceMonitor

### DIFF
--- a/resources/telemetry/charts/operator/templates/servicemonitor.yaml
+++ b/resources/telemetry/charts/operator/templates/servicemonitor.yaml
@@ -8,6 +8,7 @@ metadata:
 spec:
   endpoints:
     - path: {{ .Values.serviceMonitor.endpoints.path }}
+      port: {{ .Values.serviceMonitor.endpoints.port }}
       metricRelabelings:
         {{- toYaml .Values.serviceMonitor.endpoints.metricRelabelings | nindent 8 }}
   selector:


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

After adding the webhook, the ServiceMonitor was scraping both, the webhook and metrics Service.

Changes proposed in this pull request:

- Limit telemetry-operator ServiceMonitor to metrics service

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
See also #11831, #13597