### PR TITLE
Remove Migration Guide for Kyma 2.1

### DIFF
--- a/docs/migration-guide-2.0-2.1.md
+++ b/docs/migration-guide-2.0-2.1.md
@@ -1,6 +1,0 @@
----
-title: Migration Guide 2.0-2.1
----
-
-Due to an upgrade of the monitoring stack, some obsolete resources must be deleted and some must be patched.
-When you upgrade from Kyma 2.0 to 2.1, either run the script [`2.0-2.1-fix-upgraded-resources.sh`](https://github.com/kyma-project/kyma/blob/release-2.1/docs/assets/2.0-2.1-fix-upgraded-resources.sh) found in [`/assets`](https://github.com/kyma-project/kyma/tree/release-2.1/docs/assets) or perform the required steps from that script manually.


### PR DESCRIPTION
**Description**

This PR removes the Migration Guide for Kyma 2.1 from `main` after the [release of Kyma 2.1](https://kyma-project.io/blog/2022/3/25/release-notes-21/), which happened 25th March 2022.

**Related issue(s)**
Resolves #13807 