### PR TITLE
Fix Ory port names in services to comply with Istio convention

### DIFF
--- a/resources/ory/charts/hydra/charts/hydra-maester/templates/service-metrics.yaml
+++ b/resources/ory/charts/hydra/charts/hydra-maester/templates/service-metrics.yaml
@@ -7,7 +7,7 @@ metadata:
   name: {{ include "hydra-maester.fullname" . }}-metrics
 spec:
   ports:
-  - name: metrics
+  - name: http-metrics
     port: {{ .Values.port.metrics }}
   selector:
     app.kubernetes.io/instance: {{ .Release.Name }}

--- a/resources/ory/charts/hydra/templates/service-admin.yaml
+++ b/resources/ory/charts/hydra/templates/service-admin.yaml
@@ -20,7 +20,7 @@ spec:
     - port: 15020
       targetPort: 15020
       protocol: TCP
-      name: status-port
+      name: tcp-status-port
   selector:
     app.kubernetes.io/name: {{ include "hydra.name" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}

--- a/resources/ory/charts/oathkeeper/templates/service-metrics.yaml
+++ b/resources/ory/charts/oathkeeper/templates/service-metrics.yaml
@@ -9,7 +9,7 @@ metadata:
   name: {{ include "oathkeeper.fullname" . }}-maester-metrics
 spec:
   ports:
-  - name: metrics
+  - name: http-metrics
     port: {{ .Values.sidecar.port.metrics }}
   selector:
     app.kubernetes.io/instance: {{ .Release.Name }}

--- a/resources/ory/charts/oathkeeper/templates/service-proxy.yaml
+++ b/resources/ory/charts/oathkeeper/templates/service-proxy.yaml
@@ -22,7 +22,7 @@ spec:
       targetPort: http-proxy
       protocol: TCP
       name: http
-    - name: status-port
+    - name: tcp-status-port
       port: 15020
       targetPort: 15020
       protocol: TCP

--- a/resources/ory/templates/monitoring-hydra.yaml
+++ b/resources/ory/templates/monitoring-hydra.yaml
@@ -11,7 +11,7 @@ metadata:
   name: {{ include "ory.fullname" . }}-hydra-maester
 spec:
   endpoints:
-  - port: metrics
+  - port: http-metrics
     scheme: http
     metricRelabelings:
     - sourceLabels: [ __name__ ]

--- a/resources/ory/templates/monitoring-oathkeeper.yaml
+++ b/resources/ory/templates/monitoring-oathkeeper.yaml
@@ -11,7 +11,7 @@ metadata:
   name: {{ include "ory.fullname" . }}-oathkeeper-maester
 spec:
   endpoints:
-  - port: metrics
+  - port: http-metrics
     scheme: http
     metricRelabelings:
     - sourceLabels: [ __name__ ]


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

We should follow [official Istio documentation about port naming convention](https://istio.io/latest/docs/reference/config/analysis/ist0118/). 

Istioctl analyze output:
```bash
Info [IST0118] (Service kyma-system/ory-hydra-admin) Port name status-port (port: 15020, targetPort: 15020) doesn't follow the naming convention of Istio port.
Info [IST0118] (Service kyma-system/ory-hydra-maester-metrics) Port name metrics (port: 8080, targetPort: 8080) doesn't follow the naming convention of Istio port.
Info [IST0118] (Service kyma-system/ory-oathkeeper-maester-metrics) Port name metrics (port: 8080, targetPort: 8080) doesn't follow the naming convention of Istio port.
Info [IST0118] (Service kyma-system/ory-oathkeeper-proxy) Port name status-port (port: 15020, targetPort: 15020) doesn't follow the naming convention of Istio port.
```

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
See: 
- https://github.com/kyma-project/kyma/issues/11686
