### PR TITLE
Fix Application connector  port names in services to comply with Isti…

### DIFF
--- a/resources/application-connector/charts/application-broker/templates/service.yaml
+++ b/resources/application-connector/charts/application-broker/templates/service.yaml
@@ -20,7 +20,7 @@ spec:
       port: {{ .Values.service.externalPort }}
       targetPort: {{ .Values.service.internalPort }}
       protocol: TCP
-    - name: status-port
+    - name: tcp-status-port
       port: 15020
       targetPort: 15020
       protocol: TCP

--- a/resources/application-connector/charts/application-operator/templates/service.yaml
+++ b/resources/application-connector/charts/application-operator/templates/service.yaml
@@ -17,6 +17,7 @@ spec:
     controller-tools.k8s.io: "1.0"
   ports:
   - port: 443
+    name: https-port
 ---
 apiVersion: v1
 kind: Service


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

We should follow [official Istio documentation about port naming convention](https://istio.io/latest/docs/reference/config/analysis/ist0118/). 

Istioctl analyze output:
```bash
Info [IST0118] (Service kyma-integration/application-broker) Port name status-port (port: 15020, targetPort: 15020) doesn't follow the naming convention of Istio port.
Info [IST0118] (Service kyma-integration/application-operator-service) Port name  (port: 443, targetPort: 443) doesn't follow the naming convention of Istio port.
```

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
See: 
- https://github.com/kyma-project/kyma/issues/11686
