### PR TITLE
Fix port names in services to comply with Istio co…

### DIFF
--- a/resources/cluster-essentials/charts/pod-preset/templates/webhook/service.yaml
+++ b/resources/cluster-essentials/charts/pod-preset/templates/webhook/service.yaml
@@ -11,6 +11,7 @@ metadata:
 spec:
   ports:
   - port: 443
+    name: https-port
     protocol: TCP
     targetPort: 8443
   selector:

--- a/resources/rafter/charts/controller-manager/values.yaml
+++ b/resources/rafter/charts/controller-manager/values.yaml
@@ -114,7 +114,7 @@ metrics:
     type: ClusterIP
     port:
       name: http-metrics
-      internal: metrics
+      internal: http-metrics
       external: 8080
       protocol: TCP
     labels: {}

--- a/resources/rafter/charts/controller-manager/values.yaml
+++ b/resources/rafter/charts/controller-manager/values.yaml
@@ -113,7 +113,7 @@ metrics:
     name:
     type: ClusterIP
     port:
-      name: metrics
+      name: http-controller-metrics
       internal: metrics
       external: 8080
       protocol: TCP

--- a/resources/rafter/charts/controller-manager/values.yaml
+++ b/resources/rafter/charts/controller-manager/values.yaml
@@ -113,7 +113,7 @@ metrics:
     name:
     type: ClusterIP
     port:
-      name: http-controller-metrics
+      name: http-metrics
       internal: metrics
       external: 8080
       protocol: TCP

--- a/resources/service-catalog/charts/catalog/templates/webhook-service.yaml
+++ b/resources/service-catalog/charts/catalog/templates/webhook-service.yaml
@@ -17,7 +17,7 @@ spec:
   selector:
     app: {{ template "fullname" . }}-webhook
   ports:
-  - name: healthz
+  - name: http-healthz
     port: 8081
     protocol: TCP
     targetPort: 8081


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

We should follow [official Istio documentation about port naming convention](https://istio.io/latest/docs/reference/config/analysis/ist0118/). 

Istioctl analyze output:
```bash
Info [IST0118] (Service kyma-system/cluster-essentials-pod-preset-webhook) Port name  (port: 443, targetPort: 8443) doesn't follow the naming convention of Istio port.
Info [IST0118] (Service kyma-system/rafter-controller-manager) Port name metrics (port: 8080, targetPort: metrics) doesn't follow the naming convention of Istio port.
Info [IST0118] (Service kyma-system/service-catalog-catalog-webhook) Port name healthz (port: 8081, targetPort: 8081) doesn't follow the naming convention of Istio port.
```

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
See: 
- https://github.com/kyma-project/kyma/issues/11686
