### PR TITLE
Remove duplicate key from api-gateway deployment yaml

### DIFF
--- a/resources/api-gateway/templates/deployment.yaml
+++ b/resources/api-gateway/templates/deployment.yaml
@@ -59,9 +59,8 @@ spec:
           ports:
           - containerPort: {{ .Values.config.ports.metrics }}
             name: metrics
-          ports:
           - containerPort: {{ .Values.config.ports.healthProbe }}
-            name: health           
+            name: health
           livenessProbe:
             httpGet:
               port: health


### PR DESCRIPTION
**Description**

Key `ports` is defined two times, although kubernetes is kindly ignoring this and just takes one of the defined ports, but kyma deploy dry-runs when rendering manifests notices this and yaml libraries when parsing invalid yaml will fail.

**Related issue(s)**
* https://github.com/kyma-project/kyma/issues/13297