### PR TITLE
Replace port forwarding with calling API server proxy

### DIFF
--- a/tests/fast-integration/monitoring/client.js
+++ b/tests/fast-integration/monitoring/client.js
@@ -13,11 +13,15 @@ const {
 const SECOND = 1000;
 const jaegerPort = 16686;
 
+function base64Decode(str) {
+  return Buffer.from(str, 'base64').toString();
+}
+
 function prometheusGet(path) {
   let httpsAgent;
   let headers;
   const token = kc.getCurrentUser().token;
-  const caCrt = Buffer.from(kc.getCurrentCluster().caData, 'base64').toString();
+  const caCrt = base64Decode(kc.getCurrentCluster().caData, 'base64');
   if (token) {
     httpsAgent = new https.Agent({
       rejectUnauthorized: false,
@@ -25,10 +29,19 @@ function prometheusGet(path) {
       timeout: 10000,
     });
     headers = {'Authorization': `Bearer ${token}`};
+  } else {
+    httpsAgent = new https.Agent({
+      rejectUnauthorized: false,
+      ca: caCrt,
+      cert: base64Decode(kc.getCurrentUser().certData),
+      key: base64Decode(kc.getCurrentUser().keyData),
+      timeout: 10000,
+    });
+    headers = {'Authorization': `Bearer ${token}`};
   }
 
   const server = kc.getCurrentCluster().server;
-  const prometheusProxyUrl = 'api/v1/namespaces/kyma-system/services/monitoring-prometheus:http-web/proxy';
+  const prometheusProxyUrl = 'api/v1/namespaces/kyma-system/services/monitoring-prometheus:9090/proxy';
   const url = `${server}/${prometheusProxyUrl}${path}`;
 
   return retryPromise(() => axios.get(url, {httpsAgent: httpsAgent, headers: headers}), 5);

--- a/tests/fast-integration/monitoring/client.js
+++ b/tests/fast-integration/monitoring/client.js
@@ -2,6 +2,7 @@ const axios = require('axios');
 const https = require('https');
 
 const {
+  kc,
   kubectlPortForward,
   retryPromise,
   convertAxiosError,
@@ -10,29 +11,33 @@ const {
 } = require('../utils');
 
 const SECOND = 1000;
-const prometheusPort = 9090;
 const jaegerPort = 16686;
 
-function prometheusPortForward() {
-  return kubectlPortForward('kyma-system', 'prometheus-monitoring-prometheus-0', prometheusPort);
-}
-
-async function getPrometheusUIStatus() {
-  const path = '/graph';
-  const url = `http://localhost:${prometheusPort}${path}`;
-  try {
-    const responseBody = await retryPromise(() => axios.get(url, {timeout: 10000}), 5);
-    return responseBody.status;
-  } catch (err) {
-    throw convertAxiosError(err, 'cannot get prometheus UI status');
+function prometheusGet(path) {
+  let httpsAgent;
+  let headers;
+  const token = kc.getCurrentUser().token;
+  const caCrt = Buffer.from(kc.getCurrentCluster().caData, 'base64').toString();
+  if (token) {
+    httpsAgent = new https.Agent({
+      rejectUnauthorized: false,
+      ca: caCrt,
+      timeout: 10000,
+    });
+    headers = {'Authorization': `Bearer ${token}`};
   }
+
+  const server = kc.getCurrentCluster().server;
+  const prometheusProxyUrl = 'api/v1/namespaces/kyma-system/services/monitoring-prometheus:http-web/proxy';
+  const url = `${server}/${prometheusProxyUrl}${path}`;
+
+  return retryPromise(() => axios.get(url, {httpsAgent: httpsAgent, headers: headers}), 5);
 }
 
 async function getPrometheusActiveTargets() {
   const path = '/api/v1/targets?state=active';
-  const url = `http://localhost:${prometheusPort}${path}`;
   try {
-    const responseBody = await retryPromise(() => axios.get(url, {timeout: 10000}), 5);
+    const responseBody = await prometheusGet(path);
     return responseBody.data.data.activeTargets;
   } catch (err) {
     throw convertAxiosError(err, 'cannot get prometheus targets');
@@ -41,9 +46,8 @@ async function getPrometheusActiveTargets() {
 
 async function getPrometheusAlerts() {
   const path = '/api/v1/alerts';
-  const url = `http://localhost:${prometheusPort}${path}`;
   try {
-    const responseBody = await retryPromise(() => axios.get(url, {timeout: 10000}), 5);
+    const responseBody = await prometheusGet(path);
     return responseBody.data.data.alerts;
   } catch (err) {
     throw convertAxiosError(err, 'cannot get prometheus alerts');
@@ -52,9 +56,8 @@ async function getPrometheusAlerts() {
 
 async function getPrometheusRuleGroups() {
   const path = '/api/v1/rules';
-  const url = `http://localhost:${prometheusPort}${path}`;
   try {
-    const responseBody = await retryPromise(() => axios.get(url, {timeout: 10000}), 5);
+    const responseBody = await prometheusGet(path);
     return responseBody.data.data.groups;
   } catch (err) {
     throw convertAxiosError(err, 'cannot get prometheus rules');
@@ -63,9 +66,8 @@ async function getPrometheusRuleGroups() {
 
 async function queryPrometheus(query) {
   const path = `/api/v1/query?query=${encodeURIComponent(query)}`;
-  const url = `http://localhost:${prometheusPort}${path}`;
   try {
-    const responseBody = await retryPromise(() => axios.get(url, {timeout: 10000}), 5);
+    const responseBody = await prometheusGet(path);
     return responseBody.data.data.result;
   } catch (err) {
     throw convertAxiosError(err, 'cannot query prometheus');
@@ -145,8 +147,6 @@ async function getJaegerTrace(traceId) {
 }
 
 module.exports = {
-  prometheusPortForward,
-  getPrometheusUIStatus,
   getPrometheusActiveTargets,
   getPrometheusAlerts,
   getPrometheusRuleGroups,

--- a/tests/fast-integration/monitoring/index.js
+++ b/tests/fast-integration/monitoring/index.js
@@ -1,7 +1,6 @@
 const prometheus = require('./prometheus');
 const grafana = require('./grafana');
 const {getEnvOrDefault} = require('../utils');
-const {prometheusPortForward} = require('./client');
 
 function monitoringTests() {
   if (getEnvOrDefault('KYMA_MAJOR_UPGRADE', 'false') === 'true') {
@@ -13,22 +12,8 @@ function monitoringTests() {
     this.timeout(5 * 60 * 1000); // 5 min
     this.slow(5 * 1000);
 
-    let cancelPortForward;
-
-    before(async () => {
-      cancelPortForward = prometheusPortForward();
-    });
-
-    after(async () => {
-      cancelPortForward();
-    });
-
     it('Prometheus pods should be ready', async () => {
       await prometheus.assertPodsExist();
-    });
-
-    it('Prometheus UI should be reachable', async () => {
-      await prometheus.assertPrometheusUIIsReachable();
     });
 
     it('Prometheus targets should be healthy', async () => {

--- a/tests/fast-integration/monitoring/prometheus.js
+++ b/tests/fast-integration/monitoring/prometheus.js
@@ -8,7 +8,6 @@ const {
 } = require('../utils');
 
 const {
-  getPrometheusUIStatus,
   getPrometheusActiveTargets,
   getPrometheusAlerts,
   queryPrometheus,
@@ -24,11 +23,6 @@ async function assertPodsExist() {
       'kube-state-metrics',
       namespace,
   );
-}
-
-async function assertPrometheusUIIsReachable() {
-  const status = await getPrometheusUIStatus();
-  assert.equal(status, 200, 'Prometheus UI is not reachable');
 }
 
 async function assertAllTargetsAreHealthy() {
@@ -320,7 +314,6 @@ async function retry(getList, maxRetries = 20, interval = 5 * 1000) {
 
 module.exports = {
   assertPodsExist,
-  assertPrometheusUIIsReachable,
   assertAllTargetsAreHealthy,
   assertNoCriticalAlertsExist,
   assertScrapePoolTargetsExist,

--- a/tests/fast-integration/utils/index.js
+++ b/tests/fast-integration/utils/index.js
@@ -1831,4 +1831,5 @@ module.exports = {
   getTraceDAG,
   printStatusOfInClusterEventingInfrastructure,
   getFunction,
+  kc,
 };


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Previously we used port-forwarding to access Kyma services, which are not exposed by default, in fast integration tests. However, it seems to be not stable and sometimes the connection hangs. In order to circumvent this issue it was decided to call the API server proxy: https://kubernetes.io/docs/tasks/access-application-cluster/access-cluster-services/#manually-constructing-apiserver-proxy-urls.

Changes proposed in this pull request:

- Replace port-forwarding with API server proxy in monitoring tests

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
Fixes #13375