### PR TITLE
Add JetStream retention policy workqueue option for stream storage

### DIFF
--- a/components/eventing-controller/pkg/handlers/jetstream.go
+++ b/components/eventing-controller/pkg/handlers/jetstream.go
@@ -377,7 +377,7 @@ func (js *JetStream) getDefaultSubscriptionOptions(consumerName string, subConfi
 		nats.AckExplicit(),
 		nats.IdleHeartbeat(idleHeartBeatDuration),
 		nats.EnableFlowControl(),
-		nats.DeliverNew(),
+		nats.DeliverAll(),
 		nats.MaxAckPending(subConfig.MaxInFlightMessages),
 		nats.MaxDeliver(jsConsumerMaxRedeliver),
 		nats.AckWait(jsConsumerAcKWait),

--- a/resources/eventing/values.yaml
+++ b/resources/eventing/values.yaml
@@ -5,7 +5,7 @@ global:
   images:
     eventing_controller:
       name: eventing-controller
-      version: PR-13884
+      version: PR-13890
       pullPolicy: "IfNotPresent"
     publisher_proxy:
       name: event-publisher-proxy


### PR DESCRIPTION
####  Description

Add the JetStream retention policy workqueue option for the stream storage.

#### Notes

- The retention policy defined in the Eventing charts is not changed.