### PR TITLE
Make JetStream consumer deliver policy configurable

### DIFF
--- a/components/eventing-controller/README.md
+++ b/components/eventing-controller/README.md
@@ -71,6 +71,7 @@ This section explains how to use the Eventing Controller. It expects the followi
 |  `JS_STREAM_MAX_MSGS`             | The maximum number of messages in the stream. Used only when storage policy is set to `limits`. |
 |  `JS_STREAM_MAX_BYTES`            | The maximum size of the stream in bytes. Used only when storage policy is set to `limits`.     |
 |  `JS_STREAM_SUBJECT_PREFIX`       | The prefix for the JetStream subjects filter. Used only when `EVENT_TYPE_PREFIX` is empty.     |
+|  `JS_CONSUMER_DELIVER_POLICY`     | The policy to deliver events to consumers from the stream. Supported values are: `all`, `last`, `last_per_subject` and `new`. See https://docs.nats.io/nats-concepts/jetstream/consumers#deliverpolicy-optstartseq-optstarttime. |
 | **For BEB**                       |                                                                                                |
 | `TOKEN_ENDPOINT`                  | The Authentication Server Endpoint to provide Access Tokens.                                   |
 | `WEBHOOK_ACTIVATION_TIMEOUT`      | The timeout duration used for webhook activation to acquire Access Tokens for Kyma.            |

--- a/components/eventing-controller/README.md
+++ b/components/eventing-controller/README.md
@@ -71,7 +71,7 @@ This section explains how to use the Eventing Controller. It expects the followi
 |  `JS_STREAM_MAX_MSGS`             | The maximum number of messages in the stream. Used only when storage policy is set to `limits`. |
 |  `JS_STREAM_MAX_BYTES`            | The maximum size of the stream in bytes. Used only when storage policy is set to `limits`.     |
 |  `JS_STREAM_SUBJECT_PREFIX`       | The prefix for the JetStream subjects filter. Used only when `EVENT_TYPE_PREFIX` is empty.     |
-|  `JS_CONSUMER_DELIVER_POLICY`     | The policy to deliver events to consumers from the stream. Supported values are: `all`, `last`, `last_per_subject` and `new`. See https://docs.nats.io/nats-concepts/jetstream/consumers#deliverpolicy-optstartseq-optstarttime. |
+|  `JS_CONSUMER_DELIVER_POLICY`     | The policy to deliver events to consumers from the stream. Supported values are: `all`, `last`, `last_per_subject`, and `new`. See https://docs.nats.io/nats-concepts/jetstream/consumers#deliverpolicy-optstartseq-optstarttime. |
 | **For BEB**                       |                                                                                                |
 | `TOKEN_ENDPOINT`                  | The Authentication Server Endpoint to provide Access Tokens.                                   |
 | `WEBHOOK_ACTIVATION_TIMEOUT`      | The timeout duration used for webhook activation to acquire Access Tokens for Kyma.            |

--- a/components/eventing-controller/pkg/env/nats_config.go
+++ b/components/eventing-controller/pkg/env/nats_config.go
@@ -48,6 +48,17 @@ type NatsConfig struct {
 	// Prefix for the JetStream stream subjects filter.
 	// It will be overridden by non-empty EventTypePrefix.
 	JSStreamSubjectPrefix string `envconfig:"JS_STREAM_SUBJECT_PREFIX" required:"true"`
+
+	// Deliver policy determines for a consumer where in the stream it wants to start receiving messages
+	// (more info https://docs.nats.io/nats-concepts/jetstream/consumers#deliverpolicy-optstartseq-optstarttime):
+	// - all: The consumer will start receiving from the earliest available message.
+	// - last: When first consuming messages, the consumer will start receiving messages with the last message
+	//   added to the stream, so the very last message in the stream when the server realizes the consumer is ready.
+	// - last_per_subject: When first consuming messages, start with the latest one for each filtered subject
+	//   currently in the stream.
+	// - new: When first consuming messages, the consumer will only start receiving messages that were created
+	//   after the consumer was created.
+	JSConsumerDeliverPolicy string `envconfig:"JS_CONSUMER_DELIVER_POLICY" default:"new"`
 }
 
 func GetNatsConfig(maxReconnects int, reconnectWait time.Duration) NatsConfig {

--- a/components/eventing-controller/pkg/env/nats_config.go
+++ b/components/eventing-controller/pkg/env/nats_config.go
@@ -49,14 +49,13 @@ type NatsConfig struct {
 	// It will be overridden by non-empty EventTypePrefix.
 	JSStreamSubjectPrefix string `envconfig:"JS_STREAM_SUBJECT_PREFIX" required:"true"`
 
-	// Deliver policy determines for a consumer where in the stream it wants to start receiving messages
+	// Deliver Policy determines for a consumer where in the stream it starts receiving messages
 	// (more info https://docs.nats.io/nats-concepts/jetstream/consumers#deliverpolicy-optstartseq-optstarttime):
-	// - all: The consumer will start receiving from the earliest available message.
-	// - last: When first consuming messages, the consumer will start receiving messages with the last message
-	//   added to the stream, so the very last message in the stream when the server realizes the consumer is ready.
+	// - all: The consumer starts receiving from the earliest available message.
+	// - last: When first consuming messages, the consumer starts receiving messages with the latest message.
 	// - last_per_subject: When first consuming messages, start with the latest one for each filtered subject
 	//   currently in the stream.
-	// - new: When first consuming messages, the consumer will only start receiving messages that were created
+	// - new: When first consuming messages, the consumer starts receiving messages that were created
 	//   after the consumer was created.
 	JSConsumerDeliverPolicy string `envconfig:"JS_CONSUMER_DELIVER_POLICY" default:"new"`
 }

--- a/components/eventing-controller/pkg/handlers/jetstream.go
+++ b/components/eventing-controller/pkg/handlers/jetstream.go
@@ -377,7 +377,7 @@ func (js *JetStream) getDefaultSubscriptionOptions(consumerName string, subConfi
 		nats.AckExplicit(),
 		nats.IdleHeartbeat(idleHeartBeatDuration),
 		nats.EnableFlowControl(),
-		nats.DeliverNew(),
+		toJetStreamConsumerDeliverPolicyOptOrDefault(js.config.JSConsumerDeliverPolicy),
 		nats.MaxAckPending(subConfig.MaxInFlightMessages),
 		nats.MaxDeliver(jsConsumerMaxRedeliver),
 		nats.AckWait(jsConsumerAcKWait),

--- a/components/eventing-controller/pkg/handlers/jetstream_util.go
+++ b/components/eventing-controller/pkg/handlers/jetstream_util.go
@@ -12,6 +12,11 @@ const (
 
 	JetStreamRetentionPolicyLimits   = "limits"
 	JetStreamRetentionPolicyInterest = "interest"
+
+	JetStreamConsumerDeliverPolicyAll            = "all"
+	JetStreamConsumerDeliverPolicyLast           = "last"
+	JetStreamConsumerDeliverPolicyLastPerSubject = "last_per_subject"
+	JetStreamConsumerDeliverPolicyNew            = "new"
 )
 
 func toJetStreamStorageType(s string) (nats.StorageType, error) {
@@ -32,4 +37,21 @@ func toJetStreamRetentionPolicy(s string) (nats.RetentionPolicy, error) {
 		return nats.InterestPolicy, nil
 	}
 	return nats.LimitsPolicy, fmt.Errorf("invalid stream retention policy %q", s)
+}
+
+// toJetStreamConsumerDeliverPolicyOpt returns a nats.DeliverPolicy opt based on the given deliver policy string value.
+// It returns "DeliverNew" as the default nats.DeliverPolicy opt, if the given deliver policy value is not supported.
+// Supported deliver policy values are ("all", "last", "last_per_subject" and "new").
+func toJetStreamConsumerDeliverPolicyOptOrDefault(deliverPolicy string) nats.SubOpt {
+	switch deliverPolicy {
+	case JetStreamConsumerDeliverPolicyAll:
+		return nats.DeliverAll()
+	case JetStreamConsumerDeliverPolicyLast:
+		return nats.DeliverLast()
+	case JetStreamConsumerDeliverPolicyLastPerSubject:
+		return nats.DeliverLastPerSubject()
+	case JetStreamConsumerDeliverPolicyNew:
+		return nats.DeliverNew()
+	}
+	return nats.DeliverNew()
 }

--- a/resources/eventing/charts/controller/templates/deployment.yaml
+++ b/resources/eventing/charts/controller/templates/deployment.yaml
@@ -70,6 +70,8 @@ spec:
             value: {{ .Values.global.jetstream.storage | quote }}
           - name: JS_STREAM_RETENTION_POLICY
             value: {{ .Values.jetstream.retentionPolicy | quote }}
+          - name: JS_CONSUMER_DELIVER_POLICY
+            value: {{ .Values.jetstream.consumerDeliverPolicy | quote }}
           - name: JS_STREAM_MAX_MSGS
             value: {{ .Values.jetstream.maxMessages | quote }}
           - name: JS_STREAM_MAX_BYTES

--- a/resources/eventing/charts/controller/values.yaml
+++ b/resources/eventing/charts/controller/values.yaml
@@ -80,20 +80,18 @@ jetstream:
   streamName: sap
   # Subject prefix for the JetStream stream when eventTypePrefix is not provided.
   subjectPrefix: kyma
-  # Retention policy determines when messages should be deleted from the stream:
+  # Retention policy determines when messages are deleted from the stream:
   # (more info https://docs.nats.io/using-nats/developer/develop_jetstream/model_deep_dive#stream-limits-retention-and-policy):
-  # - interest: when all known observables have acknowledged a message it can be removed.
-  # - limits: messages are retained until any given limit is reached. This can be configured via maxMessages and maxBytes.
+  # - interest: When all known observables have acknowledged a message, it can be removed.
+  # - limits: Retain messages until any given limit is reached. Configure limits with maxMessages and maxBytes.
   retentionPolicy: interest
-  # Consumer deliver policy determines from where in the stream a consumer should start receiving messages
+  # Consumer Deliver Policy determines from where in the stream a consumer starts receiving messages
   # (more info https://docs.nats.io/nats-concepts/jetstream/consumers#deliverpolicy-optstartseq-optstarttime):
-  # - all: The consumer will start receiving from the earliest available message.
-  # - last: When first consuming messages, the consumer will start receiving messages with the last message
-  #   added to the stream, so the very last message in the stream when the server realizes the consumer is ready.
+  # - all: The consumer starts receiving from the earliest available message.
+  # - last: When first consuming messages, the consumer starts receiving messages with the latest message.
   # - last_per_subject: When first consuming messages, start with the latest one for each filtered subject
   #   currently in the stream.
-  # - new: When first consuming messages, the consumer will only start receiving messages that were created
-  #   after the consumer was created.
+  # - new: When first consuming messages, the consumer starts receiving messages that were created
   consumerDeliverPolicy: new
   maxMessages: -1 # no limit
   maxBytes: -1

--- a/resources/eventing/charts/controller/values.yaml
+++ b/resources/eventing/charts/controller/values.yaml
@@ -80,9 +80,20 @@ jetstream:
   streamName: sap
   # Subject prefix for the JetStream stream when eventTypePrefix is not provided.
   subjectPrefix: kyma
-  # When should events be deleted from the stream:
-  # interest: when all known observables have acknowledged a message it can be removed.
-  # limits: messages are retained until any given limit is reached. This can be configured via maxMessages and maxBytes.
+  # Retention policy determines when messages should be deleted from the stream:
+  # (more info https://docs.nats.io/using-nats/developer/develop_jetstream/model_deep_dive#stream-limits-retention-and-policy):
+  # - interest: when all known observables have acknowledged a message it can be removed.
+  # - limits: messages are retained until any given limit is reached. This can be configured via maxMessages and maxBytes.
   retentionPolicy: interest
+  # Consumer deliver policy determines from where in the stream a consumer should start receiving messages
+  # (more info https://docs.nats.io/nats-concepts/jetstream/consumers#deliverpolicy-optstartseq-optstarttime):
+  # - all: The consumer will start receiving from the earliest available message.
+  # - last: When first consuming messages, the consumer will start receiving messages with the last message
+  #   added to the stream, so the very last message in the stream when the server realizes the consumer is ready.
+  # - last_per_subject: When first consuming messages, start with the latest one for each filtered subject
+  #   currently in the stream.
+  # - new: When first consuming messages, the consumer will only start receiving messages that were created
+  #   after the consumer was created.
+  consumerDeliverPolicy: new
   maxMessages: -1 # no limit
   maxBytes: -1

--- a/resources/eventing/profile-evaluation.yaml
+++ b/resources/eventing/profile-evaluation.yaml
@@ -5,6 +5,7 @@ global:
 controller:
   jetstream:
     retentionPolicy: interest
+    consumerDeliverPolicy: new
     maxMessages: -1
     maxBytes: -1
   resources:

--- a/resources/eventing/profile-production.yaml
+++ b/resources/eventing/profile-production.yaml
@@ -5,6 +5,7 @@ global:
 controller:
   jetstream:
     retentionPolicy: limits
+    consumerDeliverPolicy: new
     maxMessages: -1
     maxBytes: -1
   resources:

--- a/resources/eventing/values.yaml
+++ b/resources/eventing/values.yaml
@@ -5,7 +5,7 @@ global:
   images:
     eventing_controller:
       name: eventing-controller
-      version: PR-13841
+      version: PR-13947
       pullPolicy: "IfNotPresent"
     publisher_proxy:
       name: event-publisher-proxy


### PR DESCRIPTION
**Description**

Make JetStream consumer deliver policy configurable as per JetStream [docs](https://docs.nats.io/nats-concepts/jetstream/consumers#deliverpolicy-optstartseq-optstarttime).

**Note**

The deliver policy is set to "new" in the Eventing charts.