### PR TITLE
Fix `make test` for eventing-controller and event-publisher-proxy

### DIFF
--- a/components/event-publisher-proxy/Makefile
+++ b/components/event-publisher-proxy/Makefile
@@ -1,5 +1,6 @@
 APP_NAME = event-publisher-proxy
 APP_PATH = components/$(APP_NAME)
+BUILDPACK = eu.gcr.io/kyma-project/test-infra/buildpack-golang-kubebuilder2:v20210601-24c60b5a
 SCRIPTS_DIR = $(realpath $(shell pwd)/../..)/common/makefiles
 
 # fail on lint issues

--- a/components/event-publisher-proxy/Makefile
+++ b/components/event-publisher-proxy/Makefile
@@ -1,6 +1,6 @@
 APP_NAME = event-publisher-proxy
 APP_PATH = components/$(APP_NAME)
-BUILDPACK = eu.gcr.io/kyma-project/test-infra/buildpack-golang-kubebuilder2:v20210601-24c60b5a
+BUILDPACK = eu.gcr.io/kyma-project/test-infra/buildpack-golang:v20220407-4da6c929
 SCRIPTS_DIR = $(realpath $(shell pwd)/../..)/common/makefiles
 
 # fail on lint issues

--- a/components/eventing-controller/Makefile
+++ b/components/eventing-controller/Makefile
@@ -1,6 +1,6 @@
 APP_NAME = eventing-controller
 APP_PATH = components/$(APP_NAME)
-BUILDPACK = eu.gcr.io/kyma-project/test-infra/buildpack-golang-kubebuilder2:v20210601-24c60b5a
+BUILDPACK = eu.gcr.io/kyma-project/test-infra/buildpack-golang:v20220407-4da6c929
 SCRIPTS_DIR = $(realpath $(shell pwd)/../..)/common/makefiles
 
 override ENTRYPOINT = cmd/eventing-controller/main.go
@@ -59,7 +59,7 @@ set-up-local-env:
     export WEBHOOK_TOKEN_ENDPOINT ?= "https://oauth2.${DOMAIN}/oauth2/token"
 
 ENVTEST_ASSETS_DIR=$(PROJECT_DIR)/testbin/$(shell uname)
-test-local: copy-external-crds go-test; ## Run tests.
+test-local: go-test; ## Run tests.
 
 setup-envtest:
 	mkdir -p ${ENVTEST_ASSETS_DIR}
@@ -79,6 +79,7 @@ eventing-controller: gomod-vendor-local ## Build the binary
         $(GOBUILD_FLAGS) \
         $(PKG)/$(ENTRYPOINT)
 
+test: copy-external-crds ## It will also run overridden `test` target from generic makefile after `copy-external-crds`
 
 ##@ Release
 
@@ -127,3 +128,5 @@ resolve_clean:
 
 licenses_clean:
 	rm -rf licenses
+
+


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- Add missing BUILDPACK image name to event-publisher-proxy makefile.
- Remove `copy-external-crds` from `test-local` make target because it cannot be done inside a docker container.
- Added `copy-external-crds` to `test` make target.

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
- https://github.com/kyma-project/kyma/issues/13568