### PR TITLE
Prepare k3d upgrade: wait for connector-service to be ready for commerce mock

### DIFF
--- a/tests/fast-integration/test/fixtures/commerce-mock/index.js
+++ b/tests/fast-integration/test/fixtures/commerce-mock/index.js
@@ -693,6 +693,7 @@ async function ensureCommerceMockLocalTestFixture(mockNamespace,
       mockNamespace,
       targetNamespace,
     withCentralApplicationConnectivity ? prepareFunction('central-app-gateway') : prepareFunction());
+  await waitForPodWithLabel('app.kubernetes.io/name', 'connector-service', 'kyma-integration');
   await retryPromise(() => connectMockLocal(mockHost, targetNamespace), 10, 30000);
   await retryPromise(() => registerAllApis(mockHost), 10, 30000);
 

--- a/tests/fast-integration/test/fixtures/commerce-mock/index.js
+++ b/tests/fast-integration/test/fixtures/commerce-mock/index.js
@@ -23,6 +23,7 @@ const {
   waitForDeployment,
   waitForTokenRequest,
   waitForFunction,
+  waitForPodWithLabel,
   waitForSubscription,
   deleteAllK8sResources,
   genRandom,


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- When running integration tests on a newer k3d version, there appear timing issues and increased flakiness in the commerce-mock scenario
- Waiting for connector-service to be ready should improve that 

**Related issue(s)**
* Prerequisite for: https://github.com/kyma-project/test-infra/pull/5262
* https://github.com/kyma-project/kyma/issues/13700
