### PR TITLE
Fix circular dependency between Eventing and commerce mock in the fast-integration tests

### DIFF
--- a/tests/fast-integration/eventing-test/common/common.js
+++ b/tests/fast-integration/eventing-test/common/common.js
@@ -1,0 +1,23 @@
+const fs = require('fs');
+const eventMeshSecretFilePath = process.env.EVENTMESH_SECRET_FILE || '';
+const eventMeshNamespace = getEventMeshNamespace();
+const natsBackend = 'nats';
+const bebBackend = 'beb';
+
+// returns the EventMesh namespace from the secret.
+function getEventMeshNamespace() {
+  try {
+    const eventMeshSecret = JSON.parse(fs.readFileSync(eventMeshSecretFilePath, {encoding: 'utf8'}));
+    return '/' + eventMeshSecret['namespace'];
+  } catch (e) {
+    console.error(e);
+    return undefined;
+  }
+}
+
+module.exports = {
+  eventMeshSecretFilePath,
+  eventMeshNamespace,
+  natsBackend,
+  bebBackend,
+};

--- a/tests/fast-integration/eventing-test/eventing-test-prep.js
+++ b/tests/fast-integration/eventing-test/eventing-test-prep.js
@@ -12,7 +12,6 @@ const {
   isSKR,
   backendK8sSecretName,
   backendK8sSecretNamespace,
-  eventMeshSecretFilePath,
   timeoutTime,
   slowTime,
   gardener,
@@ -20,6 +19,7 @@ const {
   shootName,
   cleanupTestingResources,
 } = require('./utils');
+const {eventMeshSecretFilePath} = require('./common/common');
 const {
   ensureCommerceMockLocalTestFixture,
   setEventMeshSourceNamespace,

--- a/tests/fast-integration/eventing-test/eventing-test.js
+++ b/tests/fast-integration/eventing-test/eventing-test.js
@@ -35,11 +35,9 @@ const {
   timeoutTime,
   slowTime,
   mockNamespace,
-  natsBackend,
-  bebBackend,
   isSKR,
-  eventMeshNamespace,
 } = require('./utils');
+const {bebBackend, natsBackend, eventMeshNamespace} = require('./common/common');
 
 describe('Eventing tests', function() {
   this.timeout(timeoutTime);

--- a/tests/fast-integration/eventing-test/utils.js
+++ b/tests/fast-integration/eventing-test/utils.js
@@ -12,7 +12,7 @@ const {
 
 const {DirectorClient, DirectorConfig, getAlreadyAssignedScenarios} = require('../compass');
 const {GardenerClient, GardenerConfig} = require('../gardener');
-const fs = require('fs');
+const {eventMeshSecretFilePath} = require('./common/common');
 const isSKR = process.env.KYMA_TYPE === 'SKR';
 const skipResourceCleanup = process.env.SKIP_CLEANUP || false;
 const suffix = getSuffix(isSKR);
@@ -22,13 +22,9 @@ const testNamespace = `test-${suffix}`;
 const mockNamespace = process.env.MOCK_NAMESPACE || 'mocks';
 const backendK8sSecretName = process.env.BACKEND_SECRET_NAME || 'eventing-backend';
 const backendK8sSecretNamespace = process.env.BACKEND_SECRET_NAMESPACE || 'default';
-const eventMeshSecretFilePath = process.env.EVENTMESH_SECRET_FILE || '';
 const DEBUG_MODE = process.env.DEBUG;
 const timeoutTime = 10 * 60 * 1000;
 const slowTime = 5000;
-const natsBackend = 'nats';
-const bebBackend = 'beb';
-const eventMeshNamespace = getEventMeshNamespace();
 
 // SKR related constants
 let gardener = null;
@@ -38,16 +34,6 @@ if (isSKR) {
   gardener = new GardenerClient(GardenerConfig.fromEnv()); // create gardener client
   director = new DirectorClient(DirectorConfig.fromEnv()); // director client for Compass
   shootName = getShootNameFromK8sServerUrl();
-}
-
-// reads the EventMesh namespace from the credentials file
-function getEventMeshNamespace() {
-  try {
-    const eventMeshSecret = JSON.parse(fs.readFileSync(eventMeshSecretFilePath, {encoding: 'utf8'}));
-    return '/' + eventMeshSecret['namespace'];
-  } catch (e) {
-    return undefined;
-  }
 }
 
 // cleans up all the test resources including the compass scenario
@@ -105,7 +91,6 @@ module.exports = {
   isSKR,
   backendK8sSecretName,
   backendK8sSecretNamespace,
-  eventMeshSecretFilePath,
   DEBUG_MODE,
   timeoutTime,
   slowTime,
@@ -114,8 +99,5 @@ module.exports = {
   shootName,
   suffix,
   cleanupTestingResources,
-  natsBackend,
-  bebBackend,
-  eventMeshNamespace,
   getRegisteredCompassScenarios,
 };

--- a/tests/fast-integration/test/fixtures/commerce-mock/index.js
+++ b/tests/fast-integration/test/fixtures/commerce-mock/index.js
@@ -60,7 +60,8 @@ const {
   OAuthToken,
   OAuthCredentials,
 } = require('../../../lib/oauth');
-const {bebBackend, eventMeshNamespace} = require('../../../eventing-test/utils');
+
+const {bebBackend, eventMeshNamespace} = require('../../../eventing-test/common/common');
 
 const commerceMockYaml = fs.readFileSync(
     path.join(__dirname, './commerce-mock.yaml'),


### PR DESCRIPTION
**Description**

Fix circular dependency between Eventing and commerce mock in the fast-integration tests.

**Examples**
- Sample run before fixing the circular dependency is [here](https://storage.googleapis.com/kyma-prow-logs/pr-logs/pull/kyma-project_kyma/13779/marcobebway_test_of_prowjob_pre-main-kyma-gardener-gcp-eventing/1513920647124750336/build-log.txt).
- Sample run after fixing the circular dependency is [here](https://storage.googleapis.com/kyma-prow-logs/pr-logs/pull/kyma-project_kyma/13972/pre-main-kyma-gardener-gcp-eventing/1514174122769256448/build-log.txt).