### PR TITLE
Putting back code for execing in pod in tests

### DIFF
--- a/tests/fast-integration/utils/index.js
+++ b/tests/fast-integration/utils/index.js
@@ -4,6 +4,7 @@ const net = require('net');
 const fs = require('fs');
 const {join} = require('path');
 const {expect} = require('chai');
+const execa = require('execa');
 
 const kc = new k8s.KubeConfig();
 let k8sDynamicApi;
@@ -705,6 +706,7 @@ function waitForJob(name, namespace = 'default', timeout = 900000, success = 1) 
 async function kubectlExecInPod(pod, container, cmd, namespace = 'default') {
   const execCmd = ['exec', pod, '-c', container, '-n', namespace, '--', ...cmd];
   try {
+    await execa(`kubectl`, execCmd);
   } catch (error) {
     if (error.stdout === undefined) {
       throw error;


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**
https://github.com/kyma-project/kyma/pull/12895 appears to have removed any effective code from `kubectlExecInPod()` for our fast-integration tests making it a try-catch block without doing nothing else. Putting the code back in.

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
https://github.com/kyma-project/kyma/pull/12895#discussion_r849500344 