### PR TITLE
Reduce flakiness of getting started e2e tests

### DIFF
--- a/tests/fast-integration/test/fixtures/getting-started-guide/microservice.yaml
+++ b/tests/fast-integration/test/fixtures/getting-started-guide/microservice.yaml
@@ -20,7 +20,7 @@ spec:
     spec:
       containers:
         - name: orders-service
-          image: "eu.gcr.io/kyma-project/develop/orders-service:e8175c63"
+          image: "eu.gcr.io/kyma-project/orders-service:ff1444fb"
           imagePullPolicy: IfNotPresent
           resources:
             limits:


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Improve verification if redis is actually bound to the orders-service in the getting-started test case


**Related issue(s)**
Fixes https://github.com/kyma-project/kyma/issues/13872