### PR TITLE
Docs: Functions referencing big GIT repositories cause FC crash

### DIFF
--- a/docs/03-tutorials/00-serverless/notka.md
+++ b/docs/03-tutorials/00-serverless/notka.md
@@ -1,0 +1,1 @@
+>**NOTE:** It is recommended to use small repositories to source your git functions. Using large multi-repos can cause problems.

--- a/docs/03-tutorials/00-serverless/notka.md
+++ b/docs/03-tutorials/00-serverless/notka.md
@@ -1,1 +1,0 @@
->**NOTE:** It is recommended to use small repositories to source your git functions. Using large multi-repos can cause problems.

--- a/docs/03-tutorials/00-serverless/svls-02-create-git-function.md
+++ b/docs/03-tutorials/00-serverless/svls-02-create-git-function.md
@@ -84,7 +84,7 @@ Follow these steps:
         secretName: # "git-creds-basic" or "git-creds-key"
     ```
    
-    >**NOTE:** It is recommended to use small repositories to source your git functions. Using large multi-repos can cause problems.
+    >**NOTE:** It is recommended to use small repositories to source your git functions. Using large multi-repos can cause problems with function controller stability as it may run out of CPU and i/o resources.
 
 4. Create a Function CR that specifies the Function's logic and points to the directory with code and dependencies in the given repository.
 

--- a/docs/03-tutorials/00-serverless/svls-02-create-git-function.md
+++ b/docs/03-tutorials/00-serverless/svls-02-create-git-function.md
@@ -83,6 +83,8 @@ Follow these steps:
         type: # "basic" or "key"
         secretName: # "git-creds-basic" or "git-creds-key"
     ```
+   
+    >**NOTE:** It is recommended to use small repositories to source your git functions. Using large multi-repos can cause problems.
 
 4. Create a Function CR that specifies the Function's logic and points to the directory with code and dependencies in the given repository.
 

--- a/docs/04-operation-guides/troubleshooting/svls-05-serverless-periodically-restarting.md
+++ b/docs/04-operation-guides/troubleshooting/svls-05-serverless-periodically-restarting.md
@@ -1,0 +1,17 @@
+---
+title: Serverless periodically restarting
+---
+
+
+## Symptom
+
+Serverless restarting every 10 minutes when checking for function changes.
+
+## Cause
+
+Git functions referencing large repositories cost a lot of resources to pull repositories and check for function changes. That causes serverless to restart.
+
+## Remedy
+
+Avoid using multi-repositories or large repositories to source your git functions. Using small or dedicated function repositories will decrease resources used and prevent serverless from restarting.
+

--- a/docs/04-operation-guides/troubleshooting/svls-05-serverless-periodically-restarting.md
+++ b/docs/04-operation-guides/troubleshooting/svls-05-serverless-periodically-restarting.md
@@ -5,13 +5,12 @@ title: Serverless periodically restarting
 
 ## Symptom
 
-Serverless restarting every 10 minutes when checking for function changes.
+Serverless restarting every 10 minutes when reconciling git-sourced functions.
 
 ## Cause
 
-Git functions referencing large repositories cost a lot of resources to pull repositories and check for function changes. That causes serverless to restart.
+Function controller is polling for changes in referenced git repositories. If you have a lot of git-sourced functions and they were deployed together in approximately the same time their git sources will be checked-out in a synchronised pulse (every 10 minutes). If you happen to reference large repositories (multi-repositories) there will be rhythmical high demand on cpu and I/O resources necessary to checkout repositories that may cause function controller to crash and restart.
 
 ## Remedy
 
-Avoid using multi-repositories or large repositories to source your git functions. Using small or dedicated function repositories will decrease resources used and prevent serverless from restarting.
-
+Avoid using multi-repositories or large repositories to source your git functions. Using small or dedicated function repositories will decrease cpu and I/O  resources used to checkout git sources and hence assure better stability of functions controller.

--- a/docs/04-operation-guides/troubleshooting/svls-05-serverless-periodically-restarting.md
+++ b/docs/04-operation-guides/troubleshooting/svls-05-serverless-periodically-restarting.md
@@ -5,12 +5,12 @@ title: Serverless periodically restarting
 
 ## Symptom
 
-Serverless restarting every 10 minutes when reconciling git-sourced functions.
+Serverless restarting every 10 minutes when reconciling git-sourced Functions.
 
 ## Cause
 
-Function controller is polling for changes in referenced git repositories. If you have a lot of git-sourced functions and they were deployed together in approximately the same time their git sources will be checked-out in a synchronised pulse (every 10 minutes). If you happen to reference large repositories (multi-repositories) there will be rhythmical high demand on cpu and I/O resources necessary to checkout repositories that may cause function controller to crash and restart.
+Function controller is polling for changes in referenced git repositories. If you have a lot of git-sourced Functions and they were deployed together at approximately the same time their git sources will be checked out in a synchronised pulse (every 10 minutes). If you happen to reference large repositories (multi-repositories), there will be rhythmical high demand on cpu and I/O resources necessary to checkout repositories. This may cause Function controller to crash and restart.
 
 ## Remedy
 
-Avoid using multi-repositories or large repositories to source your git functions. Using small or dedicated function repositories will decrease cpu and I/O  resources used to checkout git sources and hence assure better stability of functions controller.
+Avoid using multi-repositories or large repositories to source your git Functions. Using small, dedicated Function repositories will decreases the cpu and I/O  resources used to check out git sources, and hence improve the stability of Function controller.


### PR DESCRIPTION
**Description**
Added a troubleshooting guide informing users how to act when function controller periodically restarts.

**See also**
https://github.com/kyma-project/kyma/issues/13982