### PR TITLE
bump docker build image to go 1.18.1 in EPP

### DIFF
--- a/components/event-publisher-proxy/cmd/event-publisher-proxy/Dockerfile
+++ b/components/event-publisher-proxy/cmd/event-publisher-proxy/Dockerfile
@@ -1,4 +1,4 @@
-FROM eu.gcr.io/kyma-project/external/golang:1.18.0-alpine3.15 as builder
+FROM eu.gcr.io/kyma-project/external/golang:1.18.1-alpine3.15 as builder
 
 ARG DOCK_PKG_DIR=/go/src/github.com/kyma-project/kyma/components/event-publisher-proxy
 

--- a/resources/eventing/values.yaml
+++ b/resources/eventing/values.yaml
@@ -9,7 +9,7 @@ global:
       pullPolicy: "IfNotPresent"
     publisher_proxy:
       name: event-publisher-proxy
-      version: PR-13883
+      version: PR-14010
     nats:
       name: nats
       version: 2.7.4-alpine-2022-04-05


### PR DESCRIPTION
This PR updates the Dockerfile to use `golang:1.18.1-alpine3.15` for building the actual EPP image. This prevents possible security vulnerabilities in golang before version `1.18.1`.