### PR TITLE
Fix make target to run telemetry-operator locally

### DIFF
--- a/components/telemetry-operator/.gitignore
+++ b/components/telemetry-operator/.gitignore
@@ -23,3 +23,8 @@ testbin/*
 *.swp
 *.swo
 *~
+
+# Test certificates for webhook
+tls.crt
+tls.csr
+tls.key

--- a/components/telemetry-operator/Makefile
+++ b/components/telemetry-operator/Makefile
@@ -75,8 +75,18 @@ test-local: manifests-local generate-local fmt-local vet-local envtest
 build: generate fmt vet ## Build manager binary.
 	go build -o bin/manager main.go
 
-run-local: manifests-local generate-local fmt-local vet-local ## Run a controller from your host.
-	go run ./main.go --cm-name=telemetry-fluent-bit --sections-cm-name=telemetry-fluent-bit-sections --parser-cm-name=telemetry-fluent-bit-parsers --ds-name=telemetry-fluent-bit --env-secret=telemetry-fluent-bit-env --files-cm=telemetry-fluent-bit-files --fluent-bit-ns=kyma-system
+tls.key:
+	@openssl genrsa -out tls.key 4096
+
+tls.crt: tls.key
+	@openssl req -sha256 -new -key tls.key -out tls.csr -subj '/CN=localhost'
+	@openssl x509 -req -sha256 -days 3650 -in tls.csr -signkey tls.key -out tls.crt
+	@rm tls.csr
+
+gen-webhook-cert-local: tls.key tls.crt
+
+run-local: gen-webhook-cert-local manifests-local generate-local fmt-local vet-local ## Run a controller from your host.
+	go run ./main.go --cm-name=telemetry-fluent-bit --sections-cm-name=telemetry-fluent-bit-sections --parser-cm-name=telemetry-fluent-bit-parsers --ds-name=telemetry-fluent-bit --env-secret=telemetry-fluent-bit-env --files-cm=telemetry-fluent-bit-files --fluent-bit-ns=kyma-system --cert-dir=.
 
 ## Will be called from Prow-Pipeline; using targets from generic make file
 release: resolve generate verify build-image push-image

--- a/components/telemetry-operator/main.go
+++ b/components/telemetry-operator/main.go
@@ -58,6 +58,7 @@ var (
 	fluentBitPluginDirectory   string
 	logFormat                  string
 	logLevel                   string
+	certDir                    string
 )
 
 //nolint:gochecknoinits
@@ -94,6 +95,7 @@ func main() {
 	flag.StringVar(&fluentBitPluginDirectory, "fluent-bit-plugin-directory", "fluent-bit/lib", "Fluent Bit plugin directory")
 	flag.StringVar(&logFormat, "log-format", getEnvOrDefault("APP_LOG_FORMAT", "text"), "Log format (json or text)")
 	flag.StringVar(&logLevel, "log-level", getEnvOrDefault("APP_LOG_LEVEL", "debug"), "Log level (debug, info, warn, error, fatal)")
+	flag.StringVar(&certDir, "cert-dir", "/var/run/telemetry-webhook", "Webhook TLS certificate directory")
 	flag.Parse()
 
 	ctrLogger, err := logger.New(logFormat, logLevel)
@@ -120,7 +122,7 @@ func main() {
 		HealthProbeBindAddress: probeAddr,
 		LeaderElection:         enableLeaderElection,
 		LeaderElectionID:       "cdd7ef0b.kyma-project.io",
-		CertDir:                "/var/run/telemetry-webhook",
+		CertDir:                certDir,
 	})
 	if err != nil {
 		setupLog.Error(err, "Failed to start manager")

--- a/resources/telemetry/values.yaml
+++ b/resources/telemetry/values.yaml
@@ -4,7 +4,7 @@ global:
   images:
     telemetry_operator:
       name: "telemetry-operator"
-      version: "PR-14026"
+      version: "PR-14011"
     fluent_bit:
       name: "fluent-bit"
       version: "1.8.15-581a4014"


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Make `run-local` target working again with webhook

Changes proposed in this pull request:

- Make certificate directory for webhook configurable
- Generate test certificates for local execution in Makefile

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
See also #13836 