### PR TITLE
Add custom plugins to LogPipeline validation

### DIFF
--- a/components/telemetry-operator/Dockerfile
+++ b/components/telemetry-operator/Dockerfile
@@ -19,7 +19,7 @@ COPY internal/ internal/
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -a -o manager main.go
 
 # Use the fluent-bit image because we need the fluent-bit binary
-FROM eu.gcr.io/kyma-project/tpi/fluent-bit:1.8.13-0ef8d26c
+FROM eu.gcr.io/kyma-project/tpi/fluent-bit:1.9.2-63880e48
 
 WORKDIR /
 COPY --from=builder /workspace/manager .

--- a/components/telemetry-operator/internal/fluentbit/config_validator_test.go
+++ b/components/telemetry-operator/internal/fluentbit/config_validator_test.go
@@ -1,13 +1,14 @@
 package fluentbit
 
 import (
+	"os"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 )
 
 func TestExtractError(t *testing.T) {
-
 	testCases := []struct {
 		name          string
 		output        string
@@ -41,4 +42,34 @@ func TestExtractError(t *testing.T) {
 			assert.Equal(t, tc.expectedError, err, "invalid error extracted")
 		})
 	}
+}
+
+func TestListPlugins(t *testing.T) {
+	plugins := []string{"flb-out_sequentialhttp.so", "out_grafana_loki.so"}
+	dir, err := os.MkdirTemp("", "plugins")
+	assert.NoError(t, err)
+
+	defer os.RemoveAll(dir)
+
+	for _, plugin := range plugins {
+		_, err := os.Create(dir + "/" + plugin)
+		assert.NoError(t, err)
+	}
+
+	// should be ignored
+	err = os.Mkdir(dir+"/test", 0777)
+	assert.NoError(t, err)
+
+	actual, err := listPlugins(dir)
+	assert.NoError(t, err)
+	assert.Equal(t, len(plugins), len(actual))
+
+	for _, found := range actual {
+		assert.True(t, strings.HasPrefix(found, dir))
+		file := strings.TrimPrefix(found, dir+"/")
+		assert.Contains(t, plugins, file)
+	}
+
+	_, err = listPlugins("/not/existing/dir")
+	assert.Error(t, err)
 }

--- a/components/telemetry-operator/main.go
+++ b/components/telemetry-operator/main.go
@@ -54,6 +54,8 @@ var (
 	fluentBitNs                string
 	fluentBitEnvSecret         string
 	fluentBitFilesConfigMap    string
+	fluentBitPath              string
+	fluentBitPluginDirectory   string
 	logFormat                  string
 	logLevel                   string
 )
@@ -88,6 +90,8 @@ func main() {
 	flag.StringVar(&fluentBitEnvSecret, "env-secret", "", "Secret for environment variables")
 	flag.StringVar(&fluentBitFilesConfigMap, "files-cm", "", "ConfigMap for referenced files")
 	flag.StringVar(&fluentBitNs, "fluent-bit-ns", "", "Fluent Bit namespace")
+	flag.StringVar(&fluentBitPath, "fluent-bit-path", "fluent-bit/bin/fluent-bit", "Fluent Bit binary path")
+	flag.StringVar(&fluentBitPluginDirectory, "fluent-bit-plugin-directory", "fluent-bit/lib", "Fluent Bit plugin directory")
 	flag.StringVar(&logFormat, "log-format", getEnvOrDefault("APP_LOG_FORMAT", "text"), "Log format (json or text)")
 	flag.StringVar(&logLevel, "log-level", getEnvOrDefault("APP_LOG_LEVEL", "debug"), "Log level (debug, info, warn, error, fatal)")
 	flag.Parse()
@@ -126,7 +130,7 @@ func main() {
 	logPipelineValidator := webhook.NewLogPipeLineValidator(mgr.GetClient(),
 		fluentBitConfigMap,
 		fluentBitNs,
-		fluentbit.NewConfigValidator(),
+		fluentbit.NewConfigValidator(fluentBitPath, fluentBitPluginDirectory),
 		fs.NewWrapper(),
 	)
 	mgr.GetWebhookServer().Register(

--- a/resources/telemetry/values.yaml
+++ b/resources/telemetry/values.yaml
@@ -4,7 +4,7 @@ global:
   images:
     telemetry_operator:
       name: "telemetry-operator"
-      version: "73ee7982"
+      version: "PR-14026"
     fluent_bit:
       name: "fluent-bit"
       version: "1.8.15-581a4014"


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Fluent Bit 1.9.x rejects configurations if unknown plugins are found. This PR adds all available custom plugins to the LogPipeline validation to make the telemetry-operator also working with Fluent Bit 1.9.x.

Changes proposed in this pull request:

- Consider custom Fluent Bit plugins in LogPipeline validation

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
See also #13806 