### PR TITLE
bump github.com/nats-io/nats-server/v2 from 2.8.0 to 2.8.1 in EC

### DIFF
--- a/components/eventing-controller/go.mod
+++ b/components/eventing-controller/go.mod
@@ -10,10 +10,10 @@ require (
 	github.com/go-logr/zapr v1.2.3
 	github.com/kelseyhightower/envconfig v1.4.0
 	github.com/kyma-incubator/api-gateway v0.0.0-20220318061314-9fd030a8cbd1
-	github.com/kyma-project/kyma/common/logging v0.0.0-20220421142140-496cc7687d1f
-	github.com/kyma-project/kyma/components/application-operator v0.0.0-20220421142140-496cc7687d1f
+	github.com/kyma-project/kyma/common/logging v0.0.0-20220422083339-385009e35e7b
+	github.com/kyma-project/kyma/components/application-operator v0.0.0-20220422083339-385009e35e7b
 	github.com/mitchellh/hashstructure/v2 v2.0.2
-	github.com/nats-io/nats-server/v2 v2.8.0
+	github.com/nats-io/nats-server/v2 v2.8.1
 	github.com/nats-io/nats.go v1.14.0
 	github.com/onsi/ginkgo v1.16.5
 	github.com/onsi/gomega v1.19.0

--- a/components/eventing-controller/go.sum
+++ b/components/eventing-controller/go.sum
@@ -567,10 +567,10 @@ github.com/kubernetes-sigs/go-open-service-broker-client v0.0.0-20200527163240-4
 github.com/kubernetes-sigs/service-catalog v0.3.1/go.mod h1:MUAf+rdT06kiNpLXRAIqtPHC3Kgkw63YziVj1VMu3HM=
 github.com/kyma-incubator/api-gateway v0.0.0-20220318061314-9fd030a8cbd1 h1:HUlDBauoIaryCAvnpsjRz6z62WFkGxt+ar/Lais0jf0=
 github.com/kyma-incubator/api-gateway v0.0.0-20220318061314-9fd030a8cbd1/go.mod h1:2UUHTqQkCTzi+og/+EV6lPKxFAnKl36ogWCQOxDIVUg=
-github.com/kyma-project/kyma/common/logging v0.0.0-20220421142140-496cc7687d1f h1:PRxpJ3TA7eDUz/bM0kEpQqxHOnUJOOn+6Mi67Iq+ZBo=
-github.com/kyma-project/kyma/common/logging v0.0.0-20220421142140-496cc7687d1f/go.mod h1:7FWH0Lyls2xumj836aa+LVP8jhnJSv6wSlxC+2HAJ1s=
-github.com/kyma-project/kyma/components/application-operator v0.0.0-20220421142140-496cc7687d1f h1:1iTd9vgPQt9Cv3wkhtgUzgkyJLiDaJ2pxTeNT8pETks=
-github.com/kyma-project/kyma/components/application-operator v0.0.0-20220421142140-496cc7687d1f/go.mod h1:9pe+mc3dOScffwfL6J24kQcU5CGZwGyl4zNm1YlRJbQ=
+github.com/kyma-project/kyma/common/logging v0.0.0-20220422083339-385009e35e7b h1:iqukURkD3Bbm94EFPoCInh5mFu1SKVcXOiM1wSkHi0I=
+github.com/kyma-project/kyma/common/logging v0.0.0-20220422083339-385009e35e7b/go.mod h1:7FWH0Lyls2xumj836aa+LVP8jhnJSv6wSlxC+2HAJ1s=
+github.com/kyma-project/kyma/components/application-operator v0.0.0-20220422083339-385009e35e7b h1:cE+ne+Oka54ntb5v+Tw0BlWFgbih8J5Ymjd8UopYqds=
+github.com/kyma-project/kyma/components/application-operator v0.0.0-20220422083339-385009e35e7b/go.mod h1:9pe+mc3dOScffwfL6J24kQcU5CGZwGyl4zNm1YlRJbQ=
 github.com/lann/builder v0.0.0-20180802200727-47ae307949d0/go.mod h1:dXGbAdH5GtBTC4WfIxhKZfyBF/HBFgRZSWwZ9g/He9o=
 github.com/lann/ps v0.0.0-20150810152359-62de8c46ede0/go.mod h1:vmVJ0l/dxyfGW6FmdpVm2joNMFikkuWg0EoCKLGUMNw=
 github.com/lib/pq v1.2.0/go.mod h1:5WUZQaWbwv1U+lTReE5YruASi9Al49XbQIvNi/34Woo=
@@ -660,8 +660,8 @@ github.com/nats-io/jwt/v2 v2.2.1-0.20220330180145-442af02fd36a h1:lem6QCvxR0Y28g
 github.com/nats-io/jwt/v2 v2.2.1-0.20220330180145-442af02fd36a/go.mod h1:0tqz9Hlu6bCBFLWAASKhE5vUA4c24L9KPUUgvwumE/k=
 github.com/nats-io/nats-server/v2 v2.1.2/go.mod h1:Afk+wRZqkMQs/p45uXdrVLuab3gwv3Z8C4HTBu8GD/k=
 github.com/nats-io/nats-server/v2 v2.3.4/go.mod h1:3mtbaN5GkCo/Z5T3nNj0I0/W1fPkKzLiDC6jjWJKp98=
-github.com/nats-io/nats-server/v2 v2.8.0 h1:9cX87APzxnmVhr+Oiv1t41eGrDaRDG2ffuu/e+gGwaQ=
-github.com/nats-io/nats-server/v2 v2.8.0/go.mod h1:5vic7C58BFEVltiZhs7Kq81q2WcEPhJPsmNv1FOrdv0=
+github.com/nats-io/nats-server/v2 v2.8.1 h1:WZ9m/d8rklkWo6opo3X927vXnuaE00VEEl5zXcpL6qw=
+github.com/nats-io/nats-server/v2 v2.8.1/go.mod h1:vIdpKz3OG+DCg4q/xVPdXHoztEyKDWRtykQ4N7hd7C4=
 github.com/nats-io/nats.go v1.9.1/go.mod h1:ZjDU1L/7fJ09jvUSRVBR2e7+RnLiiIQyqyzEE/Zbp4w=
 github.com/nats-io/nats.go v1.11.1-0.20210623165838-4b75fc59ae30/go.mod h1:BPko4oXsySz4aSWeFgOHLZs3G4Jq4ZAyE6/zMCxRT6w=
 github.com/nats-io/nats.go v1.14.0 h1:/QLCss4vQ6wvDpbqXucsVRDi13tFIR6kTdau+nXzKJw=

--- a/resources/eventing/values.yaml
+++ b/resources/eventing/values.yaml
@@ -5,7 +5,7 @@ global:
   images:
     eventing_controller:
       name: eventing-controller
-      version: PR-14016
+      version: PR-14069
       pullPolicy: "IfNotPresent"
     publisher_proxy:
       name: event-publisher-proxy


### PR DESCRIPTION
This is a replacement for the dependabot PR that misses the image bump: https://github.com/kyma-project/kyma/pull/14065

This PR bumps [github.com/nats-io/nats-server/v2](https://github.com/nats-io/nats-server) from 2.8.0 to 2.8.1.