### PR TITLE
improved apiserver metrics relabeling to not drop all metrics

### DIFF
--- a/resources/monitoring/values.yaml
+++ b/resources/monitoring/values.yaml
@@ -926,8 +926,8 @@ kubeApiServer:
     ## ref: https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api.md#relabelconfig
     ##
     metricRelabelings:
-      - action: keep
-        regex: 'apiserver_request_duration_seconds_bucket;(0.1|0.5|1|5|30\+Inf)' # only keep 0.1, 0.5, 1, 5, 30 and +Inf buckets
+      - action: drop
+        regex: 'apiserver_request_duration_seconds_bucket;(0.05|0.15|0.2|0.25|0.3|0.35|0.4|0.45|0.6|0.7|0.8|0.9|1.25|1.5|1.75|2|2.5|3|3.5|4|4.5|6|7|8|9|10|15|20|25|40|50|60)' # only keep 0.1, 0.5, 1, 5, 30 and +Inf buckets
         sourceLabels: [__name__,le]
       - action: keep
         regex: ^(apiserver_audit_event_total|apiserver_audit_level_total|apiserver_audit_requests_rejected_total|apiserver_client_certificate_expiration_seconds_bucket|apiserver_registered_watchers|apiserver_request_total|apiserver_request_duration_seconds_bucket|apiserver_request_latencies_bucket|etcd_helper_cache_entry_total|etcd_helper_cache_hit_total|etcd_helper_cache_miss_total|etcd_request_cache_add_duration_seconds_bucket|etcd_request_cache_get_duration_seconds_bucket|go_goroutines|go_memstats_alloc_bytes|go_memstats_heap_alloc_bytes|go_memstats_heap_inuse_bytes|go_memstats_heap_sys_bytes|go_memstats_stack_inuse_bytes|kubernetes_build_info|process_cpu_seconds_total|process_max_fds|process_open_fds|process_resident_memory_bytes|process_start_time_seconds|process_virtual_memory_bytes|rest_client_request_latency_seconds_bucket|rest_client_requests_total|workqueue_adds_total|workqueue_depth|workqueue_queue_duration_seconds_bucket)$

--- a/tests/fast-integration/monitoring/prometheus.js
+++ b/tests/fast-integration/monitoring/prometheus.js
@@ -92,7 +92,7 @@ async function assertMetricsExist() {
 
     {'monitoring-apiserver': [
       {'apiserver_request_duration_seconds_bucket': [[]]},
-      {'etcd_disk_backend_commit_duration_seconds_bucket': [[]]}]},
+      {'apiserver_audit_event_total': [[]]}]},
 
     {'monitoring-kube-state-metrics': [
       {'kube_deployment_status_replicas_available': [['deployment', 'namespace']]},


### PR DESCRIPTION

<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- changed bucket drop relabeling so that from a "keep" to a "drop" expression
- fixed test case to verify audit log metric instead of wrong etcd metric sourced by helm-broker
- ...

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
Cherry-pick of https://github.com/kyma-project/kyma/pull/14088
Relates to https://github.com/kyma-project/kyma/issues/14087