### PR TITLE
Workaround for short expiry notice on gardener upgrade tests

### DIFF
--- a/tests/fast-integration/monitoring/prometheus.js
+++ b/tests/fast-integration/monitoring/prometheus.js
@@ -180,9 +180,9 @@ function shouldIgnoreTarget(target) {
 function shouldIgnoreAlert(alert) {
   // List of critical alerts we care about but which we have to ignore due to Workarounds
   const criticalAlertNamesToIgnore = [
-    // Sometimes the Gardener API Server has an expiring Cert Warning shortly before Rotation 
+    // Sometimes the Gardener API Server has an expiring Cert Warning shortly before Rotation
     // which causes the alert to fire as false positive
-    "K8sCertificateExpirationNotice",
+    'K8sCertificateExpirationNotice',
   ];
 
   // List of alerts that we don't care about and should be filtered
@@ -196,9 +196,7 @@ function shouldIgnoreAlert(alert) {
     'KubeMemoryOvercommit',
   ];
 
-  const ignoreCriticalAlert = criticalAlertNamesToIgnore.includes(
-    alert.labels.alertname,
-  );
+  const ignoreCriticalAlert = criticalAlertNamesToIgnore.includes(alert.labels.alertname);
 
   const ignoreAlert =
     alert.labels.severity !== 'critical' ||

--- a/tests/fast-integration/monitoring/prometheus.js
+++ b/tests/fast-integration/monitoring/prometheus.js
@@ -178,6 +178,13 @@ function shouldIgnoreTarget(target) {
 }
 
 function shouldIgnoreAlert(alert) {
+
+  // List of critical alerts we care about but which we have to ignore due to Workarounds
+  const criticalAlertNamesToIgnore = [
+    // Sometimes the Gardener API Server has an expiring Cert Warning shortly before Rotation which causes the alert to fire as false positive
+    "K8sCertificateExpirationNotice",
+  ];
+
   // List of alerts that we don't care about and should be filtered
   const alertNamesToIgnore = [
     // Watchdog is an alert meant to ensure functioning of the entire alerting pipeline
@@ -189,7 +196,15 @@ function shouldIgnoreAlert(alert) {
     'KubeMemoryOvercommit',
   ];
 
-  return alert.labels.severity !== 'critical' || alertNamesToIgnore.includes(alert.labels.alertname);
+  const ignoreCriticalAlert = criticalAlertNamesToIgnore.includes(
+    alert.labels.alertname
+  );
+
+  const ignoreAlert =
+    alert.labels.severity !== "critical" ||
+    alertNamesToIgnore.includes(alert.labels.alertname);
+
+  return ignoreCriticalAlert || ignoreAlert;
 }
 
 async function getServiceMonitors() {

--- a/tests/fast-integration/monitoring/prometheus.js
+++ b/tests/fast-integration/monitoring/prometheus.js
@@ -178,10 +178,10 @@ function shouldIgnoreTarget(target) {
 }
 
 function shouldIgnoreAlert(alert) {
-
   // List of critical alerts we care about but which we have to ignore due to Workarounds
   const criticalAlertNamesToIgnore = [
-    // Sometimes the Gardener API Server has an expiring Cert Warning shortly before Rotation which causes the alert to fire as false positive
+    // Sometimes the Gardener API Server has an expiring Cert Warning shortly before Rotation 
+    // which causes the alert to fire as false positive
     "K8sCertificateExpirationNotice",
   ];
 
@@ -197,11 +197,11 @@ function shouldIgnoreAlert(alert) {
   ];
 
   const ignoreCriticalAlert = criticalAlertNamesToIgnore.includes(
-    alert.labels.alertname
+    alert.labels.alertname,
   );
 
   const ignoreAlert =
-    alert.labels.severity !== "critical" ||
+    alert.labels.severity !== 'critical' ||
     alertNamesToIgnore.includes(alert.labels.alertname);
 
   return ignoreCriticalAlert || ignoreAlert;


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- Ignore certificate expiration to make pipelines run again
- Introduce Tech Debt until gardener improves the certificate rotation behavior to rotate ahead of time instead of waiting right until expiry
- ...

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->

- fix for https://github.com/kyma-project/kyma/issues/14104