### PR TITLE
Remove warning about istio installation on macs with m1 SoC

### DIFF
--- a/docs/04-operation-guides/operations/02-install-kyma.md
+++ b/docs/04-operation-guides/operations/02-install-kyma.md
@@ -16,8 +16,6 @@ Meet the prerequisites, provision a k3d cluster, and use the `deploy` command to
 
 ## Provision and install
 
-> **CAUTION:** Installation on a local k3d cluster does not work on Apple M1 SoC due to Istio installation error. 
-
 You can either use an out-of-the-box k3d cluster or choose any other cluster provider. To quickly provision a k3d cluster, run:
 
   ```bash


### PR DESCRIPTION
After bumping istio to version 1.13.x installation on m1 SoC is fixed