### PR TITLE
Make slack FIRING alert only contains Firing alerts instead of both Firing and Resolved

### DIFF
--- a/resources/monitoring/values.yaml
+++ b/resources/monitoring/values.yaml
@@ -278,7 +278,7 @@ alertmanager:
        icon_emoji: ":ghost:"
        title: '{{`{{ template "__subject" . }}`}} ({{ .Values.global.domainName }})'
        title_link: 'https://console.{{ .Values.global.domainName }}'
-       text: '{{`{{ range .Alerts }}`}}<!channel>{{`{{- "\n" -}}`}}{{`{{ .Annotations.description }}`}}{{`{{- "\n" -}}`}}{{`{{ end }}`}}'
+       text: '{{`{{ range .Alerts.Firing }}`}}<!channel>{{`{{- "\n" -}}`}}{{`{{ .Annotations.description }}`}}{{`{{- "\n" -}}`}}{{`{{ end }}`}}'
    {{- end }}
    templates:
    - '/etc/alertmanager/config/*.tmpl'


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- Make slack alert FIRING notification only contains Firing alerts instead of including both Firing and Resolved alets.


**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
Current slack firing alert contains both Firing and Resolved alerts which cause confusion.
