### PR TITLE
Make EmsSubscriptionStatus a pointer type

### DIFF
--- a/components/eventing-controller/api/v1alpha1/subscription_types.go
+++ b/components/eventing-controller/api/v1alpha1/subscription_types.go
@@ -210,7 +210,7 @@ type SubscriptionStatus struct {
 
 	// EmsSubscriptionStatus defines the status of Subscription in BEB
 	// +optional
-	EmsSubscriptionStatus EmsSubscriptionStatus `json:"emsSubscriptionStatus,omitempty"`
+	EmsSubscriptionStatus *EmsSubscriptionStatus `json:"emsSubscriptionStatus,omitempty"`
 
 	// Config defines the configurations that have been applied to the eventing backend when creating this subscription
 	// +optional

--- a/components/eventing-controller/api/v1alpha1/zz_generated.deepcopy.go
+++ b/components/eventing-controller/api/v1alpha1/zz_generated.deepcopy.go
@@ -361,7 +361,11 @@ func (in *SubscriptionStatus) DeepCopyInto(out *SubscriptionStatus) {
 		*out = make([]string, len(*in))
 		copy(*out, *in)
 	}
-	out.EmsSubscriptionStatus = in.EmsSubscriptionStatus
+	if in.EmsSubscriptionStatus != nil {
+		in, out := &in.EmsSubscriptionStatus, &out.EmsSubscriptionStatus
+		*out = new(EmsSubscriptionStatus)
+		**out = **in
+	}
 	if in.Config != nil {
 		in, out := &in.Config, &out.Config
 		*out = new(SubscriptionConfig)

--- a/components/eventing-controller/controllers/subscription/beb/reconciler_internal_test.go
+++ b/components/eventing-controller/controllers/subscription/beb/reconciler_internal_test.go
@@ -393,6 +393,7 @@ func Test_syncConditionSubscriptionActive(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			// given
 			subscription := tc.givenSubscription
+			subscription.Status.EmsSubscriptionStatus = &eventingv1alpha1.EmsSubscriptionStatus{}
 			log := utils.LoggerWithSubscription(r.namedLogger(), subscription)
 
 			// when
@@ -436,7 +437,7 @@ func Test_syncConditionWebhookCallStatus(t *testing.T) {
 					},
 				}
 				// set EmsSubscriptionStatus
-				subscription.Status.EmsSubscriptionStatus = eventingv1alpha1.EmsSubscriptionStatus{
+				subscription.Status.EmsSubscriptionStatus = &eventingv1alpha1.EmsSubscriptionStatus{
 					LastSuccessfulDelivery:   "invalid",
 					LastFailedDelivery:       "invalid",
 					LastFailedDeliveryReason: "",
@@ -474,7 +475,7 @@ func Test_syncConditionWebhookCallStatus(t *testing.T) {
 				}
 				// set EmsSubscriptionStatus
 				// LastFailedDelivery is latest
-				subscription.Status.EmsSubscriptionStatus = eventingv1alpha1.EmsSubscriptionStatus{
+				subscription.Status.EmsSubscriptionStatus = &eventingv1alpha1.EmsSubscriptionStatus{
 					LastSuccessfulDelivery:   time.Now().Format(time.RFC3339),
 					LastFailedDelivery:       time.Now().Add(1 * time.Hour).Format(time.RFC3339),
 					LastFailedDeliveryReason: "abc",
@@ -512,7 +513,7 @@ func Test_syncConditionWebhookCallStatus(t *testing.T) {
 				}
 				// set EmsSubscriptionStatus
 				// LastSuccessfulDelivery is latest
-				subscription.Status.EmsSubscriptionStatus = eventingv1alpha1.EmsSubscriptionStatus{
+				subscription.Status.EmsSubscriptionStatus = &eventingv1alpha1.EmsSubscriptionStatus{
 					LastSuccessfulDelivery:   time.Now().Add(1 * time.Hour).Format(time.RFC3339),
 					LastFailedDelivery:       time.Now().Format(time.RFC3339),
 					LastFailedDeliveryReason: "",
@@ -569,7 +570,7 @@ func Test_checkStatusActive(t *testing.T) {
 			subscription: func() *eventingv1alpha1.Subscription {
 				subscription := reconcilertesting.NewSubscription("some-name", "some-namespace")
 				subscription.Status.InitializeConditions()
-				subscription.Status.EmsSubscriptionStatus = eventingv1alpha1.EmsSubscriptionStatus{
+				subscription.Status.EmsSubscriptionStatus = &eventingv1alpha1.EmsSubscriptionStatus{
 					SubscriptionStatus: string(types.SubscriptionStatusActive),
 				}
 				return subscription
@@ -583,7 +584,7 @@ func Test_checkStatusActive(t *testing.T) {
 				subscription := reconcilertesting.NewSubscription("some-name", "some-namespace")
 				subscription.Status.InitializeConditions()
 				subscription.Status.FailedActivation = currentTime.Format(time.RFC3339)
-				subscription.Status.EmsSubscriptionStatus = eventingv1alpha1.EmsSubscriptionStatus{
+				subscription.Status.EmsSubscriptionStatus = &eventingv1alpha1.EmsSubscriptionStatus{
 					SubscriptionStatus: string(types.SubscriptionStatusActive),
 				}
 				return subscription
@@ -596,7 +597,7 @@ func Test_checkStatusActive(t *testing.T) {
 			subscription: func() *eventingv1alpha1.Subscription {
 				subscription := reconcilertesting.NewSubscription("some-name", "some-namespace")
 				subscription.Status.InitializeConditions()
-				subscription.Status.EmsSubscriptionStatus = eventingv1alpha1.EmsSubscriptionStatus{
+				subscription.Status.EmsSubscriptionStatus = &eventingv1alpha1.EmsSubscriptionStatus{
 					SubscriptionStatus: string(types.SubscriptionStatusPaused),
 				}
 				return subscription
@@ -610,7 +611,7 @@ func Test_checkStatusActive(t *testing.T) {
 				subscription := reconcilertesting.NewSubscription("some-name", "some-namespace")
 				subscription.Status.InitializeConditions()
 				subscription.Status.FailedActivation = currentTime.Format(time.RFC3339)
-				subscription.Status.EmsSubscriptionStatus = eventingv1alpha1.EmsSubscriptionStatus{
+				subscription.Status.EmsSubscriptionStatus = &eventingv1alpha1.EmsSubscriptionStatus{
 					SubscriptionStatus: string(types.SubscriptionStatusPaused),
 				}
 				return subscription
@@ -624,7 +625,7 @@ func Test_checkStatusActive(t *testing.T) {
 				subscription := reconcilertesting.NewSubscription("some-name", "some-namespace")
 				subscription.Status.InitializeConditions()
 				subscription.Status.FailedActivation = currentTime.Add(time.Minute * -1).Format(time.RFC3339)
-				subscription.Status.EmsSubscriptionStatus = eventingv1alpha1.EmsSubscriptionStatus{
+				subscription.Status.EmsSubscriptionStatus = &eventingv1alpha1.EmsSubscriptionStatus{
 					SubscriptionStatus: string(types.SubscriptionStatusPaused),
 				}
 				return subscription
@@ -661,7 +662,7 @@ func Test_checkLastFailedDelivery(t *testing.T) {
 			givenSubscription: func() *eventingv1alpha1.Subscription {
 				subscription := reconcilertesting.NewSubscription("some-name", "some-namespace")
 				// set EmsSubscriptionStatus
-				subscription.Status.EmsSubscriptionStatus = eventingv1alpha1.EmsSubscriptionStatus{
+				subscription.Status.EmsSubscriptionStatus = &eventingv1alpha1.EmsSubscriptionStatus{
 					LastSuccessfulDelivery:   "",
 					LastFailedDelivery:       "",
 					LastFailedDeliveryReason: "",
@@ -676,7 +677,7 @@ func Test_checkLastFailedDelivery(t *testing.T) {
 			givenSubscription: func() *eventingv1alpha1.Subscription {
 				subscription := reconcilertesting.NewSubscription("some-name", "some-namespace")
 				// set EmsSubscriptionStatus
-				subscription.Status.EmsSubscriptionStatus = eventingv1alpha1.EmsSubscriptionStatus{
+				subscription.Status.EmsSubscriptionStatus = &eventingv1alpha1.EmsSubscriptionStatus{
 					LastSuccessfulDelivery:   "",
 					LastFailedDelivery:       "invalid",
 					LastFailedDeliveryReason: "",
@@ -691,7 +692,7 @@ func Test_checkLastFailedDelivery(t *testing.T) {
 			givenSubscription: func() *eventingv1alpha1.Subscription {
 				subscription := reconcilertesting.NewSubscription("some-name", "some-namespace")
 				// set EmsSubscriptionStatus
-				subscription.Status.EmsSubscriptionStatus = eventingv1alpha1.EmsSubscriptionStatus{
+				subscription.Status.EmsSubscriptionStatus = &eventingv1alpha1.EmsSubscriptionStatus{
 					LastSuccessfulDelivery:   "invalid",
 					LastFailedDelivery:       time.Now().Format(time.RFC3339),
 					LastFailedDeliveryReason: "",
@@ -706,7 +707,7 @@ func Test_checkLastFailedDelivery(t *testing.T) {
 			givenSubscription: func() *eventingv1alpha1.Subscription {
 				subscription := reconcilertesting.NewSubscription("some-name", "some-namespace")
 				// set EmsSubscriptionStatus
-				subscription.Status.EmsSubscriptionStatus = eventingv1alpha1.EmsSubscriptionStatus{
+				subscription.Status.EmsSubscriptionStatus = &eventingv1alpha1.EmsSubscriptionStatus{
 					LastSuccessfulDelivery:   time.Now().Format(time.RFC3339),
 					LastFailedDelivery:       time.Now().Add(1 * time.Hour).Format(time.RFC3339),
 					LastFailedDeliveryReason: "",
@@ -721,7 +722,7 @@ func Test_checkLastFailedDelivery(t *testing.T) {
 			givenSubscription: func() *eventingv1alpha1.Subscription {
 				subscription := reconcilertesting.NewSubscription("some-name", "some-namespace")
 				// set EmsSubscriptionStatus
-				subscription.Status.EmsSubscriptionStatus = eventingv1alpha1.EmsSubscriptionStatus{
+				subscription.Status.EmsSubscriptionStatus = &eventingv1alpha1.EmsSubscriptionStatus{
 					LastSuccessfulDelivery:   time.Now().Add(1 * time.Hour).Format(time.RFC3339),
 					LastFailedDelivery:       time.Now().Format(time.RFC3339),
 					LastFailedDeliveryReason: "",

--- a/components/eventing-controller/pkg/handlers/beb.go
+++ b/components/eventing-controller/pkg/handlers/beb.go
@@ -263,6 +263,9 @@ func cleanEventTypes(subscription *types.Subscription, cleaner eventtype.Cleaner
 // setEmsSubscriptionStatus sets the status of bebSubscription in ev2Subscription
 func (b *BEB) setEmsSubscriptionStatus(subscription *eventingv1alpha1.Subscription, bebSubscription *types.Subscription) bool {
 	var statusChanged = false
+	if subscription.Status.EmsSubscriptionStatus == nil {
+		subscription.Status.EmsSubscriptionStatus = &eventingv1alpha1.EmsSubscriptionStatus{}
+	}
 	if subscription.Status.EmsSubscriptionStatus.SubscriptionStatus != string(bebSubscription.SubscriptionStatus) {
 		subscription.Status.EmsSubscriptionStatus.SubscriptionStatus = string(bebSubscription.SubscriptionStatus)
 		statusChanged = true

--- a/resources/eventing/values.yaml
+++ b/resources/eventing/values.yaml
@@ -5,7 +5,7 @@ global:
   images:
     eventing_controller:
       name: eventing-controller
-      version: PR-14090
+      version: PR-14146
       pullPolicy: "IfNotPresent"
     publisher_proxy:
       name: event-publisher-proxy


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

Made EmsSubscriptionStatus a pointer type in the Subscription Status, so that `omitempty` works when the object is empty.
A kyma subscription that uses the NATS backend, does not need to have EmsSubscriptionStatus field in the status. 

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
