### PR TITLE
Skip rendering empty lines to fluent-bit ConfigMap

### DIFF
--- a/components/telemetry-operator/internal/fluentbit/config_builder.go
+++ b/components/telemetry-operator/internal/fluentbit/config_builder.go
@@ -20,7 +20,9 @@ func BuildConfigSection(header ConfigHeader, content string) string {
 	sb.WriteString(string(header))
 	sb.WriteByte('\n')
 	for _, line := range strings.Split(content, "\n") {
-		sb.WriteString("    " + line + "\n") // 4 indentations
+		if len(strings.TrimSpace(line)) > 0 { // Skip empty lines to do not break rendering in yaml output
+			sb.WriteString("    " + line + "\n") // 4 indentations
+		}
 	}
 	sb.WriteByte('\n')
 


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

LogPipelines with empty lines in a Fluent Bit section were rendered as 4 spaces into the Fluent Bit ConfigMap. This resulted into non-proper display of the ConfigMap when viewing with the kubectl yaml output. The PR skips empty lines to prevent the problem.

Changes proposed in this pull request:

- Skip rendering empty lines to fluent-bit ConfigMap