### PR TITLE
Rename telemetry-operator install-local make target

### DIFF
--- a/components/telemetry-operator/Makefile
+++ b/components/telemetry-operator/Makefile
@@ -96,10 +96,10 @@ release: resolve generate verify build-image push-image
 
 ##@ Deployment
 
-install-local: manifests-local ## Install CRDs into the K8s cluster specified in ~/.kube/config.
+install-crds-local: manifests-local ## Install CRDs into the K8s cluster specified in ~/.kube/config.
 	kustomize build config/crd | kubectl apply -f -
 
-uninstall-local: manifests-local ## Uninstall CRDs from the K8s cluster specified in ~/.kube/config.
+uninstall-crds-local: manifests-local ## Uninstall CRDs from the K8s cluster specified in ~/.kube/config.
 	kustomize build config/crd | kubectl delete -f -
 
 ENVTEST = $(PROJECT_DIR)/bin/setup-envtest

--- a/components/telemetry-operator/README.md
+++ b/components/telemetry-operator/README.md
@@ -106,13 +106,13 @@ make copy-crds-local
 - Install CRDs to cluster in current kubeconfig context
 
 ```bash
-make install-local
+make install-crds-local
 ```
 
 - Uninstall CRDs to cluster in current kubeconfig context
 
 ```bash
-make uninstall-local
+make uninstall-crds-local
 ```
 
 - Run the operator locally (uses current kubeconfig context)


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

The naming of the install-local and uninstall-local targets might raise wrong expectations about its behaviour. This PR renames the targets to point out that only the CRDs are installed.

Changes proposed in this pull request:

- Rename install-local and uninstall-local make targets to install-crds-local and uninstall-crds-local