### PR TITLE
Use default namespace in eventing documentation

### DIFF
--- a/docs/03-tutorials/00-eventing/evnt-02-setup-in-cluster-eventing.md
+++ b/docs/03-tutorials/00-eventing/evnt-02-setup-in-cluster-eventing.md
@@ -11,7 +11,7 @@ apiVersion: eventing.kyma-project.io/v1alpha1
 kind: Subscription
 metadata:
   name: mysub
-  namespace: mynamespace
+  namespace: default
 spec:
   filter:
     filters:
@@ -23,7 +23,7 @@ spec:
         property: type
         type: exact
         value: sap.kyma.custom.nonexistingapp.order.created.v1
-  sink: http://myservice.mynamespace.svc.cluster.local
+  sink: http://myservice.default.svc.cluster.local
 ```
 
 2. On the publisher side, include the exact same Application name in the `type` field, like in the following example:


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- Use default namespace in eventing documentation

**Reasoning**: default namespace exists by default in a kubernetes cluster. Therefore the sample can simply be used without first creating a namespace (`mynamespace` previously).