### PR TITLE
Fix Fluent Bit config indentation from LogPipeline

### DIFF
--- a/components/telemetry-operator/internal/fluentbit/config_builder.go
+++ b/components/telemetry-operator/internal/fluentbit/config_builder.go
@@ -21,7 +21,7 @@ func BuildConfigSection(header ConfigHeader, content string) string {
 	sb.WriteByte('\n')
 	for _, line := range strings.Split(content, "\n") {
 		if len(strings.TrimSpace(line)) > 0 { // Skip empty lines to do not break rendering in yaml output
-			sb.WriteString("    " + line + "\n") // 4 indentations
+			sb.WriteString("    " + strings.TrimSpace(line) + "\n") // 4 indentations
 		}
 	}
 	sb.WriteByte('\n')

--- a/components/telemetry-operator/internal/fluentbit/config_builder_test.go
+++ b/components/telemetry-operator/internal/fluentbit/config_builder_test.go
@@ -18,3 +18,16 @@ func TestBuildSection(t *testing.T) {
 
 	assert.Equal(t, expected, actual, "Fluent Bit Config Build is invalid")
 }
+
+func TestBuildSectionWithWrongIndentation(t *testing.T) {
+	expected := `[PARSER]
+    Name   dummy_test
+    Format   regex
+    Regex   ^(?<INT>[^ ]+) (?<FLOAT>[^ ]+) (?<BOOL>[^ ]+) (?<STRING>.+)$
+
+`
+	content := "Name   dummy_test   \n  Format   regex\nRegex   ^(?<INT>[^ ]+) (?<FLOAT>[^ ]+) (?<BOOL>[^ ]+) (?<STRING>.+)$"
+	actual := BuildConfigSection(ParserConfigHeader, content)
+
+	assert.Equal(t, expected, actual, "Fluent Bit config indentation has not been fixed")
+}


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Fluent Bit requires all values in a configuration section to be properly indented to work correctly. The --dry-run, which is used by the telemetry-operator's webhook, does not reliably detect wrong indentations anymore with Fluent Bit 1.9. This change trims all leading and tailing whitespaces from the provided configuration section in the LogPipeline before writing to the ConfigMap.

Changes proposed in this pull request:

- Trim leading and tailing whitespaces from Fluent Bit configuration sections

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
See also #13146