### PR TITLE
EC bump nats and nats server

### DIFF
--- a/components/eventing-controller/go.mod
+++ b/components/eventing-controller/go.mod
@@ -10,11 +10,11 @@ require (
 	github.com/go-logr/zapr v1.2.3
 	github.com/kelseyhightower/envconfig v1.4.0
 	github.com/kyma-incubator/api-gateway v0.0.0-20220318061314-9fd030a8cbd1
-	github.com/kyma-project/kyma/common/logging v0.0.0-20220504115926-940176391e17
-	github.com/kyma-project/kyma/components/application-operator v0.0.0-20220504115926-940176391e17
+	github.com/kyma-project/kyma/common/logging v0.0.0-20220505104927-1bd0c8a0777d
+	github.com/kyma-project/kyma/components/application-operator v0.0.0-20220505104927-1bd0c8a0777d
 	github.com/mitchellh/hashstructure/v2 v2.0.2
-	github.com/nats-io/nats-server/v2 v2.8.1
-	github.com/nats-io/nats.go v1.14.0
+	github.com/nats-io/nats-server/v2 v2.8.2
+	github.com/nats-io/nats.go v1.15.0
 	github.com/onsi/ginkgo v1.16.5
 	github.com/onsi/gomega v1.19.0
 	github.com/pkg/errors v0.9.1

--- a/components/eventing-controller/go.sum
+++ b/components/eventing-controller/go.sum
@@ -578,8 +578,12 @@ github.com/kyma-incubator/api-gateway v0.0.0-20220318061314-9fd030a8cbd1 h1:HUlD
 github.com/kyma-incubator/api-gateway v0.0.0-20220318061314-9fd030a8cbd1/go.mod h1:2UUHTqQkCTzi+og/+EV6lPKxFAnKl36ogWCQOxDIVUg=
 github.com/kyma-project/kyma/common/logging v0.0.0-20220504115926-940176391e17 h1:uYHwL0nRURhiuDyhiV/9u/dIT97z4OiUV7lgx2bgbdk=
 github.com/kyma-project/kyma/common/logging v0.0.0-20220504115926-940176391e17/go.mod h1:7FWH0Lyls2xumj836aa+LVP8jhnJSv6wSlxC+2HAJ1s=
+github.com/kyma-project/kyma/common/logging v0.0.0-20220505104927-1bd0c8a0777d h1:wp2Q+sT3VFL6d3CCc5rfwdeNDG/6mJEtiX/+IySMOJo=
+github.com/kyma-project/kyma/common/logging v0.0.0-20220505104927-1bd0c8a0777d/go.mod h1:7FWH0Lyls2xumj836aa+LVP8jhnJSv6wSlxC+2HAJ1s=
 github.com/kyma-project/kyma/components/application-operator v0.0.0-20220504115926-940176391e17 h1:R3CFQyCbq+kqEyd5dWAk6qm6xF5mD30LQgsVzcSYP1E=
 github.com/kyma-project/kyma/components/application-operator v0.0.0-20220504115926-940176391e17/go.mod h1:9pe+mc3dOScffwfL6J24kQcU5CGZwGyl4zNm1YlRJbQ=
+github.com/kyma-project/kyma/components/application-operator v0.0.0-20220505104927-1bd0c8a0777d h1:MT/B8w0fVx8Vt6QVzocjI+454BiwAbTfb+QsuQOe8qc=
+github.com/kyma-project/kyma/components/application-operator v0.0.0-20220505104927-1bd0c8a0777d/go.mod h1:9pe+mc3dOScffwfL6J24kQcU5CGZwGyl4zNm1YlRJbQ=
 github.com/lann/builder v0.0.0-20180802200727-47ae307949d0/go.mod h1:dXGbAdH5GtBTC4WfIxhKZfyBF/HBFgRZSWwZ9g/He9o=
 github.com/lann/ps v0.0.0-20150810152359-62de8c46ede0/go.mod h1:vmVJ0l/dxyfGW6FmdpVm2joNMFikkuWg0EoCKLGUMNw=
 github.com/lib/pq v1.2.0/go.mod h1:5WUZQaWbwv1U+lTReE5YruASi9Al49XbQIvNi/34Woo=
@@ -673,10 +677,14 @@ github.com/nats-io/nats-server/v2 v2.1.2/go.mod h1:Afk+wRZqkMQs/p45uXdrVLuab3gwv
 github.com/nats-io/nats-server/v2 v2.3.4/go.mod h1:3mtbaN5GkCo/Z5T3nNj0I0/W1fPkKzLiDC6jjWJKp98=
 github.com/nats-io/nats-server/v2 v2.8.1 h1:WZ9m/d8rklkWo6opo3X927vXnuaE00VEEl5zXcpL6qw=
 github.com/nats-io/nats-server/v2 v2.8.1/go.mod h1:vIdpKz3OG+DCg4q/xVPdXHoztEyKDWRtykQ4N7hd7C4=
+github.com/nats-io/nats-server/v2 v2.8.2 h1:5m1VytMEbZx0YINvKY+X2gXdLNwP43uLXnFRwz8j8KE=
+github.com/nats-io/nats-server/v2 v2.8.2/go.mod h1:vIdpKz3OG+DCg4q/xVPdXHoztEyKDWRtykQ4N7hd7C4=
 github.com/nats-io/nats.go v1.9.1/go.mod h1:ZjDU1L/7fJ09jvUSRVBR2e7+RnLiiIQyqyzEE/Zbp4w=
 github.com/nats-io/nats.go v1.11.1-0.20210623165838-4b75fc59ae30/go.mod h1:BPko4oXsySz4aSWeFgOHLZs3G4Jq4ZAyE6/zMCxRT6w=
 github.com/nats-io/nats.go v1.14.0 h1:/QLCss4vQ6wvDpbqXucsVRDi13tFIR6kTdau+nXzKJw=
 github.com/nats-io/nats.go v1.14.0/go.mod h1:BPko4oXsySz4aSWeFgOHLZs3G4Jq4ZAyE6/zMCxRT6w=
+github.com/nats-io/nats.go v1.15.0 h1:3IXNBolWrwIUf2soxh6Rla8gPzYWEZQBUBK6RV21s+o=
+github.com/nats-io/nats.go v1.15.0/go.mod h1:BPko4oXsySz4aSWeFgOHLZs3G4Jq4ZAyE6/zMCxRT6w=
 github.com/nats-io/nkeys v0.1.0/go.mod h1:xpnFELMwJABBLVhffcfd1MZx6VsNRFpEugbxziKVo7w=
 github.com/nats-io/nkeys v0.1.3/go.mod h1:xpnFELMwJABBLVhffcfd1MZx6VsNRFpEugbxziKVo7w=
 github.com/nats-io/nkeys v0.2.0/go.mod h1:XdZpAbhgyyODYqjTawOnIOI7VlbKSarI9Gfy1tqEu/s=


### PR DESCRIPTION
This PR bumps the dependencies in `eventing controller` to avoid potential security issues.