### PR TITLE
Make cleanEventTypes reflect the right state of the subscription

### DIFF
--- a/components/eventing-controller/controllers/subscription/beb/reconciler.go
+++ b/components/eventing-controller/controllers/subscription/beb/reconciler.go
@@ -117,13 +117,13 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 	// instantiate a return object
 	result := ctrl.Result{}
 
-	// sync the initial Subscription status
-	r.syncInitialStatus(subscription)
-
 	// handle deletion of the subscription
 	if isInDeletion(subscription) {
 		return r.handleDeleteSubscription(ctx, subscription, log)
 	}
+
+	// sync the initial Subscription status
+	r.syncInitialStatus(subscription)
 
 	// sync Finalizers, ensure the finalizer is set
 	if err := r.syncFinalizer(subscription, log); err != nil {

--- a/components/eventing-controller/controllers/subscription/jetstream/reconciler.go
+++ b/components/eventing-controller/controllers/subscription/jetstream/reconciler.go
@@ -248,6 +248,10 @@ func (r *Reconciler) syncInitialStatus(subscription *eventingv1alpha1.Subscripti
 	cleanedSubjects, err := handlers.GetCleanSubjects(subscription, r.eventTypeCleaner)
 	if err != nil {
 		log.Errorw("getting clean subjects failed", "error", err)
+		if len(subscription.Status.CleanEventTypes) != 0 {
+			subscription.Status.CleanEventTypes = nil
+			return true, err
+		}
 		return false, err
 	}
 	if !reflect.DeepEqual(subscription.Status.CleanEventTypes, cleanedSubjects) {

--- a/components/eventing-controller/controllers/subscription/jetstream/reconciler_test.go
+++ b/components/eventing-controller/controllers/subscription/jetstream/reconciler_test.go
@@ -445,7 +445,7 @@ func TestChangeSubscription(t *testing.T) {
 			},
 			wantBefore: utils.Want{
 				K8sSubscription: []gomegatypes.GomegaMatcher{
-					reconcilertesting.HaveCleanEventTypes(nil),
+					reconcilertesting.HaveCleanEventTypesEmpty(),
 					reconcilertesting.HaveCondition(reconcilertesting.DefaultReadyCondition()),
 					reconcilertesting.HaveSubsConfiguration(utils.ConfigDefault(ens.DefaultSubscriptionConfig.MaxInFlightMessages)),
 					reconcilertesting.HaveSubscriptionReady(),
@@ -465,6 +465,34 @@ func TestChangeSubscription(t *testing.T) {
 					reconcilertesting.HaveCleanEventTypes([]string{reconcilertesting.OrderCreatedEventType}),
 					gomega.Not(reconcilertesting.HaveCondition(reconcilertesting.MultipleDefaultConditions()[0])),
 					gomega.Not(reconcilertesting.HaveCondition(reconcilertesting.MultipleDefaultConditions()[1])),
+				},
+			},
+		},
+		{
+			name: "CleanEventTypes; update valid filter to a filter with an invalid prefix",
+			givenSubscriptionOpts: []reconcilertesting.SubscriptionOpt{
+				reconcilertesting.WithFilter(reconcilertesting.EventSource, utils.NewCleanEventType("0")),
+				reconcilertesting.WithWebhookForNATS(),
+				reconcilertesting.WithSinkURLFromSvc(ens.SubscriberSvc),
+			},
+			wantBefore: utils.Want{
+				K8sSubscription: []gomegatypes.GomegaMatcher{
+					reconcilertesting.HaveCondition(reconcilertesting.DefaultReadyCondition()),
+					reconcilertesting.HaveCleanEventTypes([]string{
+						utils.NewCleanEventType("0"),
+					}),
+				},
+			},
+			changeSubscription: func(subscription *eventingv1alpha1.Subscription) {
+				// change the filter  to the event type
+				for _, f := range subscription.Spec.Filter.Filters {
+					f.EventType.Value = fmt.Sprintf("invalid%s", f.EventType.Value)
+				}
+			},
+			wantAfter: utils.Want{
+				K8sSubscription: []gomegatypes.GomegaMatcher{
+					reconcilertesting.HaveConditionInvalidPrefix(),
+					reconcilertesting.HaveCleanEventTypesEmpty(),
 				},
 			},
 		},

--- a/components/eventing-controller/controllers/subscription/nats/reconciler.go
+++ b/components/eventing-controller/controllers/subscription/nats/reconciler.go
@@ -246,6 +246,10 @@ func (r *Reconciler) syncInitialStatus(subscription *eventingv1alpha1.Subscripti
 	cleanEventTypes, err := handlers.GetCleanSubjects(subscription, r.eventTypeCleaner)
 	if err != nil {
 		log.Errorw("get clean subject failed", "error", err)
+		if len(subscription.Status.CleanEventTypes) != 0 {
+			subscription.Status.CleanEventTypes = nil
+			return true, err
+		}
 		return false, err
 	}
 	if !reflect.DeepEqual(subscription.Status.CleanEventTypes, cleanEventTypes) {

--- a/components/eventing-controller/pkg/handlers/beb.go
+++ b/components/eventing-controller/pkg/handlers/beb.go
@@ -124,6 +124,8 @@ func (b *BEB) SyncSubscription(subscription *eventingv1alpha1.Subscription, clea
 	var bebSubscription *types.Subscription
 	// check the hash values for ev2 and EMS
 	if newEv2Hash != subscription.Status.Ev2hash {
+		// reset the cleanEventTypes
+		subscription.Status.CleanEventTypes = nil
 		// delete & create a new EMS subscription
 		var newEMSHash int64
 		bebSubscription, newEMSHash, err = b.deleteCreateAndHashSubscription(sEv2, cleaner, log)
@@ -157,6 +159,8 @@ func (b *BEB) SyncSubscription(subscription *eventingv1alpha1.Subscription, clea
 			return false, err
 		}
 		if newEmsHash != subscription.Status.Emshash {
+			// reset the cleanEventTypes
+			subscription.Status.CleanEventTypes = nil
 			// delete & create a new EMS subscription
 			bebSubscription, newEmsHash, err = b.deleteCreateAndHashSubscription(sEv2, cleaner, log)
 			if err != nil {

--- a/components/eventing-controller/pkg/handlers/nats.go
+++ b/components/eventing-controller/pkg/handlers/nats.go
@@ -119,7 +119,7 @@ func GetCleanSubjects(sub *eventingv1alpha1.Subscription, cleaner eventtype.Clea
 	if sub.Spec.Filter != nil {
 		uniqueFilters, err := sub.Spec.Filter.Deduplicate()
 		if err != nil {
-			return []string{}, errors.Wrap(err, "deduplicate subscription filters failed")
+			return nil, errors.Wrap(err, "deduplicate subscription filters failed")
 		}
 		filters = uniqueFilters.Filters
 	}
@@ -128,7 +128,7 @@ func GetCleanSubjects(sub *eventingv1alpha1.Subscription, cleaner eventtype.Clea
 	for _, filter := range filters {
 		subject, err := getCleanSubject(filter, cleaner)
 		if err != nil {
-			return []string{}, err
+			return nil, err
 		}
 		cleanSubjects = append(cleanSubjects, subject)
 	}

--- a/components/eventing-controller/testing/matchers.go
+++ b/components/eventing-controller/testing/matchers.go
@@ -199,12 +199,29 @@ func HaveConditionBadSubject() gomegatypes.GomegaMatcher {
 	return HaveCondition(condition)
 }
 
+func HaveConditionInvalidPrefix() gomegatypes.GomegaMatcher {
+	condition := eventingv1alpha1.MakeCondition(
+		eventingv1alpha1.ConditionSubscriptionActive,
+		eventingv1alpha1.ConditionReasonNATSSubscriptionNotActive,
+		corev1.ConditionFalse, "prefix not found",
+	)
+	return HaveCondition(condition)
+}
+
 func HaveCleanEventTypes(cleanEventTypes []string) gomegatypes.GomegaMatcher {
 	return WithTransform(
 		func(s *eventingv1alpha1.Subscription) []string {
 			return s.Status.CleanEventTypes
 		},
 		Equal(cleanEventTypes))
+}
+
+func HaveCleanEventTypesEmpty() gomegatypes.GomegaMatcher {
+	return WithTransform(
+		func(s *eventingv1alpha1.Subscription) []string {
+			return s.Status.CleanEventTypes
+		},
+		BeEmpty())
 }
 
 func HaveEvent(event corev1.Event) gomegatypes.GomegaMatcher {

--- a/resources/eventing/values.yaml
+++ b/resources/eventing/values.yaml
@@ -5,7 +5,7 @@ global:
   images:
     eventing_controller:
       name: eventing-controller
-      version: PR-14241
+      version: PR-14209
       pullPolicy: "IfNotPresent"
     publisher_proxy:
       name: event-publisher-proxy


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- CleanEventTypes should be empty if there is an error in cleaning the subjects

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
https://github.com/kyma-project/kyma/issues/14154