### PR TITLE
Add LogPipeline status print column

### DIFF
--- a/components/telemetry-operator/api/v1alpha1/logpipeline_types.go
+++ b/components/telemetry-operator/api/v1alpha1/logpipeline_types.go
@@ -136,6 +136,7 @@ func filterOutCondition(conds []LogPipelineCondition, condType LogPipelineCondit
 //+kubebuilder:object:root=true
 //+kubebuilder:resource:scope=Cluster
 //+kubebuilder:subresource:status
+// +kubebuilder:printcolumn:name="Status",type=string,JSONPath=`.status.conditions[-1].type`
 
 // LogPipeline is the Schema for the logpipelines API
 type LogPipeline struct {

--- a/components/telemetry-operator/config/crd/bases/telemetry.kyma-project.io_logpipelines.yaml
+++ b/components/telemetry-operator/config/crd/bases/telemetry.kyma-project.io_logpipelines.yaml
@@ -16,7 +16,11 @@ spec:
     singular: logpipeline
   scope: Cluster
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - jsonPath: .status.conditions[-1].type
+      name: Status
+      type: string
+    name: v1alpha1
     schema:
       openAPIV3Schema:
         description: LogPipeline is the Schema for the logpipelines API

--- a/installation/resources/crds/telemetry/logpipelines.crd.yaml
+++ b/installation/resources/crds/telemetry/logpipelines.crd.yaml
@@ -16,7 +16,11 @@ spec:
     singular: logpipeline
   scope: Cluster
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - jsonPath: .status.conditions[-1].type
+      name: Status
+      type: string
+    name: v1alpha1
     schema:
       openAPIV3Schema:
         description: LogPipeline is the Schema for the logpipelines API


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

The LogPipeline CRD has a status sub-resource that contains a list of conditions that represent the daemon set state. This PR adds the most recent condition as a print column to be shown by `kubectl get logpipelines`.

Changes proposed in this pull request:

- Add LogPipeline condition as print column

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
