### PR TITLE
Add upgrade timeout parameter

### DIFF
--- a/tests/fast-integration/kcp/client.js
+++ b/tests/fast-integration/kcp/client.js
@@ -123,7 +123,7 @@ class KCPWrapper {
     return await this.exec(args);
   }
 
-  async upgradeKyma(instanceID, kymaUpgradeVersion) {
+  async upgradeKyma(instanceID, kymaUpgradeVersion, upgradeTimeoutMin = 30) {
     const args = ['upgrade', 'kyma', `--version=${kymaUpgradeVersion}`, '--target', `instance-id=${instanceID}`];
     try {
       const res = await this.exec(args);
@@ -139,7 +139,7 @@ class KCPWrapper {
       debug(`OrchestrationID: ${orchestrationID}`);
 
       try {
-        const orchestrationStatus = await this.ensureOrchestrationSucceeded(orchestrationID);
+        const orchestrationStatus = await this.ensureOrchestrationSucceeded(orchestrationID, upgradeTimeoutMin);
         return orchestrationStatus;
       } catch (error) {
         debug(error);
@@ -254,7 +254,7 @@ class KCPWrapper {
     }
   };
 
-  async ensureOrchestrationSucceeded(orchenstrationID) {
+  async ensureOrchestrationSucceeded(orchenstrationID, upgradeTimeoutMin = 30) {
     // Decides whether to go to the next step of while or not based on
     // the orchestration result (0 = succeeded, 1 = failed, 2 = cancelled, 3 = pending/other)
     debug(`Waiting for Kyma Upgrade with OrchestrationID ${orchenstrationID} to succeed...`);
@@ -262,7 +262,7 @@ class KCPWrapper {
       const res = await wait(
           () => this.getOrchestrationStatus(orchenstrationID),
           (res) => res && res.state && (res.state === 'succeeded' || res.state === 'failed'),
-          1000*60*15, // 15 min
+          1000 * 60 * upgradeTimeoutMin, // 30 min
           1000 * 30, // 30 seconds
       );
 

--- a/tests/fast-integration/skr-aws-upgrade-integration/index.js
+++ b/tests/fast-integration/skr-aws-upgrade-integration/index.js
@@ -112,6 +112,7 @@ describe('SKR-Upgrade-test', function() {
 
   const provisioningTimeout = 1000 * 60 * 60; // 1h
   const deprovisioningTimeout = 1000 * 60 * 30; // 30m
+  const upgradeTimeoutMin = 30; // 30m
 
   let skr;
 
@@ -212,7 +213,7 @@ describe('SKR-Upgrade-test', function() {
   });
 
   it('Perform Upgrade', async function() {
-    await kcp.upgradeKyma(instanceID, kymaUpgradeVersion);
+    await kcp.upgradeKyma(instanceID, kymaUpgradeVersion, upgradeTimeoutMin);
     debug('Upgrade Done!');
   });
 


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- Add upgrade timeout as a parameter to `upgradeKyma` function
- Change the value of upgrade timeout to 30 min (also set as default)

`upgradeKyma` is also used in `skr-svcat-migration` test, but as the default value was set, everything should work as it was before.
