### PR TITLE
Hardcode the JS stream prefix 

### DIFF
--- a/components/event-publisher-proxy/pkg/env/nats_config.go
+++ b/components/event-publisher-proxy/pkg/env/nats_config.go
@@ -8,6 +8,8 @@ import (
 // compile time check
 var _ fmt.Stringer = &NatsConfig{}
 
+const JetstreamSubjectPrefix = "kyma"
+
 // NatsConfig represents the environment config for the Event Publisher to NATS.
 type NatsConfig struct {
 	Port                 int           `envconfig:"INGRESS_PORT" default:"8080"`
@@ -24,8 +26,7 @@ type NatsConfig struct {
 	EventTypePrefix string `envconfig:"EVENT_TYPE_PREFIX" default:"kyma"`
 
 	// JetStream-specific configs
-	JSStreamName          string `envconfig:"JS_STREAM_NAME" default:"kyma"`
-	JSStreamSubjectPrefix string `envconfig:"JS_STREAM_SUBJECT_PREFIX" required:"true"`
+	JSStreamName string `envconfig:"JS_STREAM_NAME" default:"kyma"`
 }
 
 // ToConfig converts to a default BEB BebConfig

--- a/components/event-publisher-proxy/pkg/sender/jetstream.go
+++ b/components/event-publisher-proxy/pkg/sender/jetstream.go
@@ -108,5 +108,5 @@ func (s *JetstreamMessageSender) eventToNatsMsg(event *event.Event) (*nats.Msg, 
 
 // getJsSubjectToPublish appends stream name to subject if needed.
 func (s *JetstreamMessageSender) getJsSubjectToPublish(subject string) string {
-	return fmt.Sprintf("%s.%s", s.envCfg.JSStreamSubjectPrefix, subject)
+	return fmt.Sprintf("%s.%s", env.JetstreamSubjectPrefix, subject)
 }

--- a/components/event-publisher-proxy/pkg/sender/jetstream.go
+++ b/components/event-publisher-proxy/pkg/sender/jetstream.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
-	"strings"
 
 	"github.com/cloudevents/sdk-go/v2/event"
 	"github.com/kyma-project/kyma/components/event-publisher-proxy/internal"
@@ -109,8 +108,5 @@ func (s *JetstreamMessageSender) eventToNatsMsg(event *event.Event) (*nats.Msg, 
 
 // getJsSubjectToPublish appends stream name to subject if needed.
 func (s *JetstreamMessageSender) getJsSubjectToPublish(subject string) string {
-	if strings.HasPrefix(subject, s.envCfg.JSStreamSubjectPrefix) {
-		return subject
-	}
 	return fmt.Sprintf("%s.%s", s.envCfg.JSStreamSubjectPrefix, subject)
 }

--- a/components/event-publisher-proxy/pkg/sender/jetstream_test.go
+++ b/components/event-publisher-proxy/pkg/sender/jetstream_test.go
@@ -65,7 +65,7 @@ func TestJetstreamMessageSender(t *testing.T) {
 			}()
 
 			if tc.givenStream {
-				addStream(t, connection, getStreamConfig(testEnv.Config))
+				addStream(t, connection, getStreamConfig())
 			}
 
 			ce := createCloudEvent(t)
@@ -132,7 +132,7 @@ func TestStreamExists(t *testing.T) {
 			}()
 
 			if tc.givenStream {
-				addStream(t, connection, getStreamConfig(testEnv.Config))
+				addStream(t, connection, getStreamConfig())
 			}
 
 			// close the connection to provoke the error
@@ -206,10 +206,10 @@ func createCloudEvent(t *testing.T) *event.Event {
 }
 
 // getStreamConfig inits a testing stream config.
-func getStreamConfig(config *env.NatsConfig) *nats.StreamConfig {
+func getStreamConfig() *nats.StreamConfig {
 	return &nats.StreamConfig{
 		Name:      testingutils.StreamName,
-		Subjects:  []string{fmt.Sprintf("%s.>", config.JSStreamSubjectPrefix)},
+		Subjects:  []string{fmt.Sprintf("%s.>", env.JetstreamSubjectPrefix)},
 		Storage:   nats.MemoryStorage,
 		Retention: nats.InterestPolicy,
 	}
@@ -225,9 +225,8 @@ func addStream(t *testing.T, connection *nats.Conn, config *nats.StreamConfig) {
 
 func CreateNatsJsConfig(url string) *env.NatsConfig {
 	return &env.NatsConfig{
-		JSStreamName:          testingutils.StreamName,
-		JSStreamSubjectPrefix: testingutils.JSStreamPrefix,
-		URL:                   url,
-		ReconnectWait:         time.Second,
+		JSStreamName:  testingutils.StreamName,
+		URL:           url,
+		ReconnectWait: time.Second,
 	}
 }

--- a/components/event-publisher-proxy/testing/fixtures.go
+++ b/components/event-publisher-proxy/testing/fixtures.go
@@ -14,6 +14,7 @@ const (
 
 	MessagingNamespace            = "/messaging.namespace"
 	MessagingEventTypePrefix      = "prefix"
+	JSStreamPrefix                = "sap.kyma.custom"
 	MessagingEventTypePrefixEmpty = ""
 
 	EventID      = "8945ec08-256b-11eb-9928-acde48001122"

--- a/components/eventing-controller/README.md
+++ b/components/eventing-controller/README.md
@@ -70,7 +70,6 @@ This section explains how to use the Eventing Controller. It expects the followi
 |  `JS_STREAM_RETENTION_POLICY`     | The policy to delete events from the stream: `limits` or `interest`. See https://docs.nats.io/using-nats/developer/develop_jetstream/model_deep_dive#stream-limits-retention-and-policy. |
 |  `JS_STREAM_MAX_MSGS`             | The maximum number of messages in the stream. Used only when storage policy is set to `limits`. |
 |  `JS_STREAM_MAX_BYTES`            | The maximum size of the stream in bytes. Used only when storage policy is set to `limits`.     |
-|  `JS_STREAM_SUBJECT_PREFIX`       | The prefix for the JetStream subjects filter. Used only when `EVENT_TYPE_PREFIX` is empty.     |
 |  `JS_CONSUMER_DELIVER_POLICY`     | The policy to deliver events to consumers from the stream. Supported values are: `all`, `last`, `last_per_subject`, and `new`. See https://docs.nats.io/nats-concepts/jetstream/consumers#deliverpolicy-optstartseq-optstarttime. |
 | **For BEB**                       |                                                                                                |
 | `TOKEN_ENDPOINT`                  | The Authentication Server Endpoint to provide Access Tokens.                                   |

--- a/components/eventing-controller/controllers/backend/reconciler.go
+++ b/components/eventing-controller/controllers/backend/reconciler.go
@@ -424,7 +424,7 @@ func (r *Reconciler) emitConditionEvent(backend *eventingv1alpha1.EventingBacken
 func (r *Reconciler) isPublisherDeploymentReady(publisher *appsv1.Deployment) bool {
 	result := *publisher.Spec.Replicas == publisher.Status.ReadyReplicas
 	if !result {
-		r.namedLogger().Errorf("Publisher Deployment not ready: expected replicas: %d, got: %d", *publisher.Spec.Replicas, publisher.Status.ReadyReplicas)
+		r.namedLogger().Debugf("Publisher Deployment not ready: expected replicas: %d, got: %d", *publisher.Spec.Replicas, publisher.Status.ReadyReplicas)
 	}
 	return result
 }

--- a/components/eventing-controller/controllers/backend/reconciler_test.go
+++ b/components/eventing-controller/controllers/backend/reconciler_test.go
@@ -148,9 +148,8 @@ var _ = BeforeSuite(func(done Done) {
 	var err error
 	// populate with required env variables
 	natsConfig := env.NatsConfig{
-		EventTypePrefix:       reconcilertesting.EventTypePrefix,
-		JSStreamName:          reconcilertesting.JSStreamName,
-		JSStreamSubjectPrefix: reconcilertesting.JSStreamSubjectPrefix,
+		EventTypePrefix: reconcilertesting.EventTypePrefix,
+		JSStreamName:    reconcilertesting.JSStreamName,
 	}
 
 	defaultLogger, err = logger.New(string(kymalogger.JSON), string(kymalogger.INFO))

--- a/components/eventing-controller/controllers/subscription/jetstream/reconciler_test.go
+++ b/components/eventing-controller/controllers/subscription/jetstream/reconciler_test.go
@@ -8,10 +8,9 @@ import (
 	"testing"
 	"time"
 
-	utils "github.com/kyma-project/kyma/components/eventing-controller/controllers/subscription/testing"
-
-	natstesting "github.com/kyma-project/kyma/components/eventing-controller/testing/nats"
 	"github.com/nats-io/nats.go"
+
+	utils "github.com/kyma-project/kyma/components/eventing-controller/controllers/subscription/testing"
 
 	kymalogger "github.com/kyma-project/kyma/common/logging/logger"
 	eventingv1alpha1 "github.com/kyma-project/kyma/components/eventing-controller/api/v1alpha1"
@@ -23,6 +22,7 @@ import (
 	"github.com/kyma-project/kyma/components/eventing-controller/pkg/handlers/eventtype"
 	"github.com/kyma-project/kyma/components/eventing-controller/pkg/handlers/sink"
 	reconcilertesting "github.com/kyma-project/kyma/components/eventing-controller/testing"
+	natstesting "github.com/kyma-project/kyma/components/eventing-controller/testing/nats"
 	natsserver "github.com/nats-io/nats-server/v2/server"
 	"github.com/onsi/gomega"
 	gomegatypes "github.com/onsi/gomega/types"
@@ -560,7 +560,7 @@ func TestEmptyEventTypePrefix(t *testing.T) {
 }
 
 func testSubscriptionOnNATS(ens *jetStreamTestEnsemble, subscription *eventingv1alpha1.Subscription, subject string, expectations ...gomegatypes.GomegaMatcher) {
-	getSubscriptionFromJetStream(ens, subscription, ens.jetStreamBackend.GetJestreamSubject(subject)).Should(gomega.And(expectations...))
+	getSubscriptionFromJetStream(ens, subscription, ens.jetStreamBackend.GetJetstreamSubject(subject)).Should(gomega.And(expectations...))
 }
 
 func testDeletion(ens *jetStreamTestEnsemble, subscription *eventingv1alpha1.Subscription, subject string) {

--- a/components/eventing-controller/controllers/subscription/jetstream/reconciler_test.go
+++ b/components/eventing-controller/controllers/subscription/jetstream/reconciler_test.go
@@ -549,7 +549,7 @@ func TestEmptyEventTypePrefix(t *testing.T) {
 	expectedNatsSubscription := []gomegatypes.GomegaMatcher{
 		natstesting.BeExistingSubscription(),
 		natstesting.BeValidSubscription(),
-		natstesting.BeJetStreamSubscriptionWithSubject(fmt.Sprintf("%s.%s", reconcilertesting.JSStreamSubjectPrefix, reconcilertesting.OrderCreatedEventTypePrefixEmpty)),
+		natstesting.BeJetStreamSubscriptionWithSubject(reconcilertesting.OrderCreatedEventTypePrefixEmpty),
 	}
 
 	testSubscriptionOnNATS(ens, subscription, reconcilertesting.OrderCreatedEventTypePrefixEmpty, expectedNatsSubscription...)
@@ -560,7 +560,7 @@ func TestEmptyEventTypePrefix(t *testing.T) {
 }
 
 func testSubscriptionOnNATS(ens *jetStreamTestEnsemble, subscription *eventingv1alpha1.Subscription, subject string, expectations ...gomegatypes.GomegaMatcher) {
-	getSubscriptionFromJetStream(ens, subscription, subject).Should(gomega.And(expectations...))
+	getSubscriptionFromJetStream(ens, subscription, ens.jetStreamBackend.GetJestreamSubject(subject)).Should(gomega.And(expectations...))
 }
 
 func testDeletion(ens *jetStreamTestEnsemble, subscription *eventingv1alpha1.Subscription, subject string) {
@@ -636,7 +636,6 @@ func startReconciler(eventTypePrefix string, ens *jetStreamTestEnsemble) *jetStr
 		ReconnectWait:           time.Second,
 		EventTypePrefix:         eventTypePrefix,
 		JSStreamName:            reconcilertesting.JSStreamName,
-		JSStreamSubjectPrefix:   reconcilertesting.JSStreamSubjectPrefix,
 		JSStreamStorageType:     "memory",
 		JSStreamMaxBytes:        -1,
 		JSStreamMaxMessages:     -1,

--- a/components/eventing-controller/pkg/deployment/publisher_deployment.go
+++ b/components/eventing-controller/pkg/deployment/publisher_deployment.go
@@ -319,10 +319,10 @@ func getNATSEnvVars(natsConfig env.NatsConfig, publisherConfig env.PublisherConf
 				},
 			},
 		},
-		// jetstream-specific config
+		// Jetstream-specific config
 		{Name: "ENABLE_JETSTREAM_BACKEND", Value: strconv.FormatBool(natsConfig.EnableJetStreamBackend)},
 		{Name: "JS_STREAM_NAME", Value: natsConfig.JSStreamName},
-		{Name: "JS_STREAM_SUBJECT_PREFIX", Value: natsConfig.JSStreamSubjectPrefix},
+		{Name: "JS_STREAM_SUBJECT_PREFIX", Value: env.JetstreamSubjectPrefix},
 	}
 }
 

--- a/components/eventing-controller/pkg/deployment/publisher_deployment.go
+++ b/components/eventing-controller/pkg/deployment/publisher_deployment.go
@@ -322,7 +322,6 @@ func getNATSEnvVars(natsConfig env.NatsConfig, publisherConfig env.PublisherConf
 		// Jetstream-specific config
 		{Name: "ENABLE_JETSTREAM_BACKEND", Value: strconv.FormatBool(natsConfig.EnableJetStreamBackend)},
 		{Name: "JS_STREAM_NAME", Value: natsConfig.JSStreamName},
-		{Name: "JS_STREAM_SUBJECT_PREFIX", Value: env.JetstreamSubjectPrefix},
 	}
 }
 

--- a/components/eventing-controller/pkg/deployment/publisher_deployment_test.go
+++ b/components/eventing-controller/pkg/deployment/publisher_deployment_test.go
@@ -99,7 +99,6 @@ func Test_GetNATSEnvVars(t *testing.T) {
 				"REQUEST_TIMEOUT":          "10s",
 				"ENABLE_JETSTREAM_BACKEND": "true",
 				"JS_STREAM_NAME":           "",
-				"JS_STREAM_SUBJECT_PREFIX": env.JetstreamSubjectPrefix,
 			},
 		},
 		{
@@ -111,10 +110,8 @@ func Test_GetNATSEnvVars(t *testing.T) {
 			},
 			givenNatsConfig: env.NatsConfig{},
 			wantEnvs: map[string]string{
-				"REQUEST_TIMEOUT":          "10s",
-				"JS_STREAM_NAME":           "",
-				"JS_STREAM_SUBJECT_PREFIX": env.JetstreamSubjectPrefix,
-				"ENABLE_JETSTREAM_BACKEND": "false",
+				"REQUEST_TIMEOUT": "10s",
+				"JS_STREAM_NAME":  "",
 			},
 		},
 		{
@@ -129,7 +126,6 @@ func Test_GetNATSEnvVars(t *testing.T) {
 			wantEnvs: map[string]string{
 				"REQUEST_TIMEOUT":          "10s",
 				"JS_STREAM_NAME":           "kyma",
-				"JS_STREAM_SUBJECT_PREFIX": env.JetstreamSubjectPrefix,
 				"ENABLE_JETSTREAM_BACKEND": "true",
 			},
 		},

--- a/components/eventing-controller/pkg/deployment/publisher_deployment_test.go
+++ b/components/eventing-controller/pkg/deployment/publisher_deployment_test.go
@@ -53,7 +53,6 @@ func TestNewDeployment(t *testing.T) {
 				natsConfig = env.NatsConfig{
 					EnableJetStreamBackend: true,
 					JSStreamName:           "kyma",
-					JSStreamSubjectPrefix:  "subjectPrefix",
 				}
 				deployment = NewNATSPublisherDeployment(natsConfig, publisherConfig)
 			case "BEB":
@@ -100,7 +99,7 @@ func Test_GetNATSEnvVars(t *testing.T) {
 				"REQUEST_TIMEOUT":          "10s",
 				"ENABLE_JETSTREAM_BACKEND": "true",
 				"JS_STREAM_NAME":           "",
-				"JS_STREAM_SUBJECT_PREFIX": "",
+				"JS_STREAM_SUBJECT_PREFIX": env.JetstreamSubjectPrefix,
 			},
 		},
 		{
@@ -114,7 +113,7 @@ func Test_GetNATSEnvVars(t *testing.T) {
 			wantEnvs: map[string]string{
 				"REQUEST_TIMEOUT":          "10s",
 				"JS_STREAM_NAME":           "",
-				"JS_STREAM_SUBJECT_PREFIX": "",
+				"JS_STREAM_SUBJECT_PREFIX": env.JetstreamSubjectPrefix,
 				"ENABLE_JETSTREAM_BACKEND": "false",
 			},
 		},
@@ -126,12 +125,11 @@ func Test_GetNATSEnvVars(t *testing.T) {
 			givenNatsConfig: env.NatsConfig{
 				EnableJetStreamBackend: true,
 				JSStreamName:           "kyma",
-				JSStreamSubjectPrefix:  "subjectPrefix",
 			},
 			wantEnvs: map[string]string{
 				"REQUEST_TIMEOUT":          "10s",
 				"JS_STREAM_NAME":           "kyma",
-				"JS_STREAM_SUBJECT_PREFIX": "subjectPrefix",
+				"JS_STREAM_SUBJECT_PREFIX": env.JetstreamSubjectPrefix,
 				"ENABLE_JETSTREAM_BACKEND": "true",
 			},
 		},

--- a/components/eventing-controller/pkg/env/nats_config.go
+++ b/components/eventing-controller/pkg/env/nats_config.go
@@ -7,7 +7,7 @@ import (
 	"github.com/kelseyhightower/envconfig"
 )
 
-const JetstreamSubjectPrefix = "sap.kyma.custom"
+const JetstreamSubjectPrefix = "kyma"
 
 // NatsConfig represents the environment config for the Eventing Controller with Nats.
 type NatsConfig struct {

--- a/components/eventing-controller/pkg/env/nats_config.go
+++ b/components/eventing-controller/pkg/env/nats_config.go
@@ -2,17 +2,12 @@ package env
 
 import (
 	"log"
-	"regexp"
 	"time"
 
 	"github.com/kelseyhightower/envconfig"
 )
 
-var (
-	// invalidSubjectPrefixCharacters used to match and replace non-alphanumeric characters in the subject-prefix
-	// as per JetStream spec https://docs.nats.io/running-a-nats-service/nats_admin/jetstream_admin/naming.
-	invalidSubjectPrefixCharacters = regexp.MustCompile("[^a-zA-Z0-9.]")
-)
+const JetstreamSubjectPrefix = "sap.kyma.custom"
 
 // NatsConfig represents the environment config for the Eventing Controller with Nats.
 type NatsConfig struct {
@@ -44,11 +39,6 @@ type NatsConfig struct {
 	JSStreamRetentionPolicy string `envconfig:"JS_STREAM_RETENTION_POLICY" default:"interest"`
 	JSStreamMaxMessages     int64  `envconfig:"JS_STREAM_MAX_MSGS" default:"-1"`
 	JSStreamMaxBytes        int64  `envconfig:"JS_STREAM_MAX_BYTES" default:"-1"`
-
-	// Prefix for the JetStream stream subjects filter.
-	// It will be overridden by non-empty EventTypePrefix.
-	JSStreamSubjectPrefix string `envconfig:"JS_STREAM_SUBJECT_PREFIX" required:"true"`
-
 	// Deliver Policy determines for a consumer where in the stream it starts receiving messages
 	// (more info https://docs.nats.io/nats-concepts/jetstream/consumers#deliverpolicy-optstartseq-optstarttime):
 	// - all: The consumer starts receiving from the earliest available message.
@@ -68,14 +58,5 @@ func GetNatsConfig(maxReconnects int, reconnectWait time.Duration) NatsConfig {
 	if err := envconfig.Process("", &cfg); err != nil {
 		log.Fatalf("Invalid configuration: %v", err)
 	}
-
-	// set stream subjects prefix for JetStream
-	if len(cfg.EventTypePrefix) > 0 {
-		cfg.JSStreamSubjectPrefix = getCleanJSStreamSubjectPrefix(cfg.EventTypePrefix)
-	}
 	return cfg
-}
-
-func getCleanJSStreamSubjectPrefix(prefix string) string {
-	return invalidSubjectPrefixCharacters.ReplaceAllString(prefix, "")
 }

--- a/components/eventing-controller/pkg/env/nats_config_test.go
+++ b/components/eventing-controller/pkg/env/nats_config_test.go
@@ -16,14 +16,13 @@ func Test_GetNatsConfig(t *testing.T) {
 	idleConnTimeout := time.Second * 40
 
 	envs := map[string]string{
-		"NATS_URL":                 "NATS_URL",
-		"JS_STREAM_NAME":           "kyma",
-		"JS_STREAM_SUBJECT_PREFIX": "kyma",
-		"EVENT_TYPE_PREFIX":        "EVENT_TYPE_PREFIX",
-		"MAX_IDLE_CONNS":           fmt.Sprintf("%d", maxIdleConns),
-		"MAX_CONNS_PER_HOST":       fmt.Sprintf("%d", maxConnsPerHost),
-		"MAX_IDLE_CONNS_PER_HOST":  fmt.Sprintf("%d", maxIdleConnsPerHost),
-		"IDLE_CONN_TIMEOUT":        fmt.Sprintf("%v", idleConnTimeout),
+		"NATS_URL":                "NATS_URL",
+		"JS_STREAM_NAME":          "kyma",
+		"EVENT_TYPE_PREFIX":       "EVENT_TYPE_PREFIX",
+		"MAX_IDLE_CONNS":          fmt.Sprintf("%d", maxIdleConns),
+		"MAX_CONNS_PER_HOST":      fmt.Sprintf("%d", maxConnsPerHost),
+		"MAX_IDLE_CONNS_PER_HOST": fmt.Sprintf("%d", maxIdleConnsPerHost),
+		"IDLE_CONN_TIMEOUT":       fmt.Sprintf("%v", idleConnTimeout),
 	}
 
 	defer func() {
@@ -51,97 +50,4 @@ func Test_GetNatsConfig(t *testing.T) {
 	require.Equal(t, config.IdleConnTimeout, idleConnTimeout)
 
 	require.Equal(t, config.JSStreamName, envs["JS_STREAM_NAME"])
-	// JSStreamSubjectPrefix would be `EVENTTYPEPREFIX`
-	// because JSStreamSubjectPrefix is cleaned up for non-alphanumeric characters.
-	require.Equal(t, config.JSStreamSubjectPrefix, "EVENTTYPEPREFIX")
-}
-
-func Test_JSStreamSubjectPrefix(t *testing.T) {
-	maxIdleConns := 10
-	maxConnsPerHost := 20
-	maxIdleConnsPerHost := 30
-	idleConnTimeout := time.Second * 40
-	maxReconnects, reconnectWait := 1, time.Second
-
-	envs := map[string]string{
-		"NATS_URL":                 "NATS_URL",
-		"JS_STREAM_NAME":           "kyma",
-		"JS_STREAM_SUBJECT_PREFIX": "kyma",
-		"MAX_IDLE_CONNS":           fmt.Sprintf("%d", maxIdleConns),
-		"MAX_CONNS_PER_HOST":       fmt.Sprintf("%d", maxConnsPerHost),
-		"MAX_IDLE_CONNS_PER_HOST":  fmt.Sprintf("%d", maxIdleConnsPerHost),
-		"IDLE_CONN_TIMEOUT":        fmt.Sprintf("%v", idleConnTimeout),
-	}
-
-	// set initial env variables
-	for k, v := range envs {
-		require.NoError(t, os.Setenv(k, v))
-	}
-
-	// define defer to unset env variables
-	defer func() {
-		for k := range envs {
-			require.NoError(t, os.Unsetenv(k))
-		}
-	}()
-
-	// define test cases
-	testCases := []struct {
-		name                      string
-		givenEventTypePrefix      string
-		wantJSStreamSubjectPrefix string
-	}{
-		{
-			name:                      "When eventTypePrefix is empty",
-			givenEventTypePrefix:      "",
-			wantJSStreamSubjectPrefix: "kyma",
-		},
-		{
-			name:                      "When eventTypePrefix is non-empty",
-			givenEventTypePrefix:      "one.two.three",
-			wantJSStreamSubjectPrefix: "one.two.three",
-		},
-	}
-	// run test cases
-	for _, tc := range testCases {
-		tc := tc
-		t.Run(tc.name, func(t *testing.T) {
-			// given
-			require.NoError(t, os.Setenv("EVENT_TYPE_PREFIX", tc.givenEventTypePrefix))
-
-			// when
-			config := GetNatsConfig(maxReconnects, reconnectWait)
-
-			// then
-			require.Equal(t, config.JSStreamSubjectPrefix, tc.wantJSStreamSubjectPrefix)
-		})
-	}
-}
-
-func Test_getCleanJSStreamSubjectPrefix(t *testing.T) {
-	// define test cases
-	testCases := []struct {
-		name        string
-		givenPrefix string
-		wantPrefix  string
-	}{
-		{
-			name:        "when the prefix does not contain any alpha-numeric characters except dot",
-			givenPrefix: "testapp.Segment1Part1Part2.Segment2Part1Part2",
-			wantPrefix:  "testapp.Segment1Part1Part2.Segment2Part1Part2",
-		},
-		{
-			name:        "when the prefix contains alpha-numeric characters except dot",
-			givenPrefix: "testapp@@.Segment1$%-Part1>>-Part2-Ä.Segment2**##-Part1##-Part2-Ä",
-			wantPrefix:  "testapp.Segment1Part1Part2.Segment2Part1Part2",
-		},
-	}
-
-	// run test cases
-	for _, tc := range testCases {
-		tc := tc
-		t.Run(tc.name, func(t *testing.T) {
-			require.Equal(t, getCleanJSStreamSubjectPrefix(tc.givenPrefix), tc.wantPrefix)
-		})
-	}
 }

--- a/components/eventing-controller/pkg/handlers/jetstream.go
+++ b/components/eventing-controller/pkg/handlers/jetstream.go
@@ -197,7 +197,7 @@ func (js *JetStream) SyncSubscription(subscription *eventingv1alpha1.Subscriptio
 
 	callback := js.getCallback(subKeyPrefix)
 	for _, subject := range subscription.Status.CleanEventTypes {
-		jsSubject := js.GetJestreamSubject(subject)
+		jsSubject := js.GetJetstreamSubject(subject)
 		jsSubKey := NewSubscriptionSubjectIdentifier(subscription, jsSubject)
 
 		// check if the subscription already exists and if it is valid.
@@ -247,7 +247,7 @@ func (js *JetStream) DeleteSubscription(subscription *eventingv1alpha1.Subscript
 	// cleanup consumers on nats-server
 	// in-case data in js.subscriptions[] was lost due to handler restart
 	for _, subject := range subscription.Status.CleanEventTypes {
-		jsSubject := js.GetJestreamSubject(subject)
+		jsSubject := js.GetJetstreamSubject(subject)
 		jsSubKey := NewSubscriptionSubjectIdentifier(subscription, jsSubject)
 		if err := js.deleteConsumerFromJetStream(jsSubKey.ConsumerName(), log); err != nil {
 			return err
@@ -260,8 +260,8 @@ func (js *JetStream) DeleteSubscription(subscription *eventingv1alpha1.Subscript
 	return nil
 }
 
-// GetJestreamSubject appends the prefix to subject.
-func (js *JetStream) GetJestreamSubject(subject string) string {
+// GetJetstreamSubject appends the prefix to subject.
+func (js *JetStream) GetJetstreamSubject(subject string) string {
 	return fmt.Sprintf("%s.%s", env.JetstreamSubjectPrefix, subject)
 }
 
@@ -476,7 +476,7 @@ func (js *JetStream) deleteConsumerFromJetStream(name string, log *zap.SugaredLo
 func (js *JetStream) GetJetStreamSubjects(subjects []string) []string {
 	var result []string
 	for _, subject := range subjects {
-		result = append(result, js.GetJestreamSubject(subject))
+		result = append(result, js.GetJetstreamSubject(subject))
 	}
 	return result
 }

--- a/components/eventing-controller/pkg/handlers/jetstream_test.go
+++ b/components/eventing-controller/pkg/handlers/jetstream_test.go
@@ -199,7 +199,7 @@ func TestJetStreamSubAfterSync_NoChange(t *testing.T) {
 	// check if the NATS subscription are the same (have same metadata)
 	// by comparing the metadata of nats subscription
 	require.Len(t, jsBackend.subscriptions, 1)
-	jsSubject := jsBackend.GetJestreamSubject(subject)
+	jsSubject := jsBackend.GetJetstreamSubject(subject)
 	jsSubKey := NewSubscriptionSubjectIdentifier(sub, jsSubject)
 	jsSub := jsBackend.subscriptions[jsSubKey]
 	require.NotNil(t, jsSub)
@@ -290,7 +290,7 @@ func TestJetStreamSubAfterSync_SinkChange(t *testing.T) {
 	// check if the NATS subscription are the same (have same metadata)
 	// by comparing the metadata of nats subscription
 	require.Len(t, jsBackend.subscriptions, 1)
-	jsSubject := jsBackend.GetJestreamSubject(subject)
+	jsSubject := jsBackend.GetJetstreamSubject(subject)
 	jsSubKey := NewSubscriptionSubjectIdentifier(sub, jsSubject)
 	jsSub := jsBackend.subscriptions[jsSubKey]
 	require.NotNil(t, jsSub)
@@ -384,7 +384,7 @@ func TestJetStreamSubAfterSync_FiltersChange(t *testing.T) {
 	// check if the NATS subscription are NOT the same after sync
 	// because the subscriptions should have being re-created for new subject
 	require.Len(t, jsBackend.subscriptions, 1)
-	jsSubject := jsBackend.GetJestreamSubject(newSubject)
+	jsSubject := jsBackend.GetJetstreamSubject(newSubject)
 	jsSubKey := NewSubscriptionSubjectIdentifier(sub, jsSubject)
 	jsSub := jsBackend.subscriptions[jsSubKey]
 	require.NotNil(t, jsSub)
@@ -477,7 +477,7 @@ func TestJetStreamSubAfterSync_FilterAdded(t *testing.T) {
 	// Because we have two filters (i.e. two subjects)
 	require.Len(t, jsBackend.subscriptions, 2)
 	// Verify that the nats subscriptions for first subject was not re-created
-	jsSubject := jsBackend.GetJestreamSubject(firstSubject)
+	jsSubject := jsBackend.GetJetstreamSubject(firstSubject)
 	jsSubKey := NewSubscriptionSubjectIdentifier(sub, jsSubject)
 	jsSub := jsBackend.subscriptions[jsSubKey]
 	require.NotNil(t, jsSub)
@@ -577,7 +577,7 @@ func TestJetStreamSubAfterSync_FilterRemoved(t *testing.T) {
 	// Check if total existing NATS subscriptions are correct
 	require.Len(t, jsBackend.subscriptions, 1)
 	// Verify that the nats subscriptions for first subject was not re-created
-	jsSubject := jsBackend.GetJestreamSubject(firstSubject)
+	jsSubject := jsBackend.GetJetstreamSubject(firstSubject)
 	jsSubKey := NewSubscriptionSubjectIdentifier(sub, jsSubject)
 	jsSub := jsBackend.subscriptions[jsSubKey]
 	require.NotNil(t, jsSub)
@@ -687,7 +687,7 @@ func TestJetStreamSubAfterSync_MultipleSubs(t *testing.T) {
 
 	// check if the NATS subscription are NOT the same after sync for subscription 1
 	// because the subscriptions should have being re-created for new subject
-	jsSubject := jsBackend.GetJestreamSubject(newSubject)
+	jsSubject := jsBackend.GetJetstreamSubject(newSubject)
 	jsSubKey := NewSubscriptionSubjectIdentifier(sub, jsSubject)
 	jsSub := jsBackend.subscriptions[jsSubKey]
 	require.NotNil(t, jsSub)
@@ -708,7 +708,7 @@ func TestJetStreamSubAfterSync_MultipleSubs(t *testing.T) {
 	// check if the NATS subscription are same after sync for subscription 2
 	// because the subscriptions should NOT have being re-created as
 	// subscription 2 was not modified
-	jsSubject = jsBackend.GetJestreamSubject(cleanSubjectSub2)
+	jsSubject = jsBackend.GetJetstreamSubject(cleanSubjectSub2)
 	jsSubKey = NewSubscriptionSubjectIdentifier(sub2, jsSubject)
 	jsSub = jsBackend.subscriptions[jsSubKey]
 	require.NotNil(t, jsSub)
@@ -918,7 +918,7 @@ func TestJSSubscriptionWithMaxInFlightChange(t *testing.T) {
 	// then
 	require.Eventually(t, func() bool {
 		// fetch consumer info from JetStream
-		consumerName := NewSubscriptionSubjectIdentifier(sub, jsBackend.GetJestreamSubject(sub.Status.CleanEventTypes[0])).ConsumerName()
+		consumerName := NewSubscriptionSubjectIdentifier(sub, jsBackend.GetJetstreamSubject(sub.Status.CleanEventTypes[0])).ConsumerName()
 		consumerInfo, err := jsBackend.jsCtx.ConsumerInfo(jsBackend.config.JSStreamName, consumerName)
 		require.NoError(t, err)
 
@@ -1015,9 +1015,9 @@ func TestJSSubscriptionUsingCESDK(t *testing.T) {
 	require.NoError(t, err)
 
 	subject := evtesting.CloudEventType
-	require.NoError(t, SendBinaryCloudEventToJetStream(jsBackend, jsBackend.GetJestreamSubject(subject), evtesting.CloudEventData))
+	require.NoError(t, SendBinaryCloudEventToJetStream(jsBackend, jsBackend.GetJetstreamSubject(subject), evtesting.CloudEventData))
 	require.NoError(t, subscriber.CheckEvent(evtesting.CloudEventData))
-	require.NoError(t, SendStructuredCloudEventToJetStream(jsBackend, jsBackend.GetJestreamSubject(subject), evtesting.StructuredCloudEvent))
+	require.NoError(t, SendStructuredCloudEventToJetStream(jsBackend, jsBackend.GetJetstreamSubject(subject), evtesting.StructuredCloudEvent))
 	require.NoError(t, subscriber.CheckEvent("\""+evtesting.EventData+"\""))
 	require.NoError(t, jsBackend.DeleteSubscription(sub))
 }

--- a/components/eventing-controller/pkg/handlers/jetstream_test.go
+++ b/components/eventing-controller/pkg/handlers/jetstream_test.go
@@ -199,7 +199,7 @@ func TestJetStreamSubAfterSync_NoChange(t *testing.T) {
 	// check if the NATS subscription are the same (have same metadata)
 	// by comparing the metadata of nats subscription
 	require.Len(t, jsBackend.subscriptions, 1)
-	jsSubject := jsBackend.GetJsSubjectToSubscribe(subject)
+	jsSubject := jsBackend.GetJestreamSubject(subject)
 	jsSubKey := NewSubscriptionSubjectIdentifier(sub, jsSubject)
 	jsSub := jsBackend.subscriptions[jsSubKey]
 	require.NotNil(t, jsSub)
@@ -290,7 +290,7 @@ func TestJetStreamSubAfterSync_SinkChange(t *testing.T) {
 	// check if the NATS subscription are the same (have same metadata)
 	// by comparing the metadata of nats subscription
 	require.Len(t, jsBackend.subscriptions, 1)
-	jsSubject := jsBackend.GetJsSubjectToSubscribe(subject)
+	jsSubject := jsBackend.GetJestreamSubject(subject)
 	jsSubKey := NewSubscriptionSubjectIdentifier(sub, jsSubject)
 	jsSub := jsBackend.subscriptions[jsSubKey]
 	require.NotNil(t, jsSub)
@@ -384,7 +384,7 @@ func TestJetStreamSubAfterSync_FiltersChange(t *testing.T) {
 	// check if the NATS subscription are NOT the same after sync
 	// because the subscriptions should have being re-created for new subject
 	require.Len(t, jsBackend.subscriptions, 1)
-	jsSubject := jsBackend.GetJsSubjectToSubscribe(newSubject)
+	jsSubject := jsBackend.GetJestreamSubject(newSubject)
 	jsSubKey := NewSubscriptionSubjectIdentifier(sub, jsSubject)
 	jsSub := jsBackend.subscriptions[jsSubKey]
 	require.NotNil(t, jsSub)
@@ -477,7 +477,7 @@ func TestJetStreamSubAfterSync_FilterAdded(t *testing.T) {
 	// Because we have two filters (i.e. two subjects)
 	require.Len(t, jsBackend.subscriptions, 2)
 	// Verify that the nats subscriptions for first subject was not re-created
-	jsSubject := jsBackend.GetJsSubjectToSubscribe(firstSubject)
+	jsSubject := jsBackend.GetJestreamSubject(firstSubject)
 	jsSubKey := NewSubscriptionSubjectIdentifier(sub, jsSubject)
 	jsSub := jsBackend.subscriptions[jsSubKey]
 	require.NotNil(t, jsSub)
@@ -577,7 +577,7 @@ func TestJetStreamSubAfterSync_FilterRemoved(t *testing.T) {
 	// Check if total existing NATS subscriptions are correct
 	require.Len(t, jsBackend.subscriptions, 1)
 	// Verify that the nats subscriptions for first subject was not re-created
-	jsSubject := jsBackend.GetJsSubjectToSubscribe(firstSubject)
+	jsSubject := jsBackend.GetJestreamSubject(firstSubject)
 	jsSubKey := NewSubscriptionSubjectIdentifier(sub, jsSubject)
 	jsSub := jsBackend.subscriptions[jsSubKey]
 	require.NotNil(t, jsSub)
@@ -687,7 +687,7 @@ func TestJetStreamSubAfterSync_MultipleSubs(t *testing.T) {
 
 	// check if the NATS subscription are NOT the same after sync for subscription 1
 	// because the subscriptions should have being re-created for new subject
-	jsSubject := jsBackend.GetJsSubjectToSubscribe(newSubject)
+	jsSubject := jsBackend.GetJestreamSubject(newSubject)
 	jsSubKey := NewSubscriptionSubjectIdentifier(sub, jsSubject)
 	jsSub := jsBackend.subscriptions[jsSubKey]
 	require.NotNil(t, jsSub)
@@ -708,7 +708,7 @@ func TestJetStreamSubAfterSync_MultipleSubs(t *testing.T) {
 	// check if the NATS subscription are same after sync for subscription 2
 	// because the subscriptions should NOT have being re-created as
 	// subscription 2 was not modified
-	jsSubject = jsBackend.GetJsSubjectToSubscribe(cleanSubjectSub2)
+	jsSubject = jsBackend.GetJestreamSubject(cleanSubjectSub2)
 	jsSubKey = NewSubscriptionSubjectIdentifier(sub2, jsSubject)
 	jsSub = jsBackend.subscriptions[jsSubKey]
 	require.NotNil(t, jsSub)
@@ -918,7 +918,7 @@ func TestJSSubscriptionWithMaxInFlightChange(t *testing.T) {
 	// then
 	require.Eventually(t, func() bool {
 		// fetch consumer info from JetStream
-		consumerName := NewSubscriptionSubjectIdentifier(sub, sub.Status.CleanEventTypes[0]).ConsumerName()
+		consumerName := NewSubscriptionSubjectIdentifier(sub, jsBackend.GetJestreamSubject(sub.Status.CleanEventTypes[0])).ConsumerName()
 		consumerInfo, err := jsBackend.jsCtx.ConsumerInfo(jsBackend.config.JSStreamName, consumerName)
 		require.NoError(t, err)
 
@@ -1015,9 +1015,9 @@ func TestJSSubscriptionUsingCESDK(t *testing.T) {
 	require.NoError(t, err)
 
 	subject := evtesting.CloudEventType
-	require.NoError(t, SendBinaryCloudEventToJetStream(jsBackend, jsBackend.GetJsSubjectToSubscribe(subject), evtesting.CloudEventData))
+	require.NoError(t, SendBinaryCloudEventToJetStream(jsBackend, jsBackend.GetJestreamSubject(subject), evtesting.CloudEventData))
 	require.NoError(t, subscriber.CheckEvent(evtesting.CloudEventData))
-	require.NoError(t, SendStructuredCloudEventToJetStream(jsBackend, jsBackend.GetJsSubjectToSubscribe(subject), evtesting.StructuredCloudEvent))
+	require.NoError(t, SendStructuredCloudEventToJetStream(jsBackend, jsBackend.GetJestreamSubject(subject), evtesting.StructuredCloudEvent))
 	require.NoError(t, subscriber.CheckEvent("\""+evtesting.EventData+"\""))
 	require.NoError(t, jsBackend.DeleteSubscription(sub))
 }
@@ -1189,7 +1189,6 @@ type TestEnvironment struct {
 func setupTestEnvironment(t *testing.T) *TestEnvironment {
 	natsServer, natsPort := startNATSServer(evtesting.WithJetStreamEnabled())
 	natsConfig := defaultNatsConfig(natsServer.ClientURL())
-	natsConfig.JSStreamSubjectPrefix = evtesting.EventTypePrefix
 	defaultLogger, err := logger.New(string(kymalogger.JSON), string(kymalogger.INFO))
 	require.NoError(t, err)
 

--- a/components/eventing-controller/pkg/handlers/test_helpers.go
+++ b/components/eventing-controller/pkg/handlers/test_helpers.go
@@ -230,11 +230,11 @@ func SendEventToJetStream(jsClient *JetStream, data string) error {
 	eventType := eventingtesting.OrderCreatedEventType
 	eventTime := time.Now().Format(time.RFC3339)
 	sampleEvent := NewNatsMessagePayload(data, "id", eventingtesting.EventSource, eventTime, eventType)
-	return jsClient.conn.Publish(jsClient.GetJestreamSubject(eventType), []byte(sampleEvent))
+	return jsClient.conn.Publish(jsClient.GetJetstreamSubject(eventType), []byte(sampleEvent))
 }
 
 func SendEventToJetStreamOnEventType(jsClient *JetStream, eventType string, data string) error {
 	eventTime := time.Now().Format(time.RFC3339)
 	sampleEvent := NewNatsMessagePayload(data, "id", eventingtesting.EventSource, eventTime, eventType)
-	return jsClient.conn.Publish(jsClient.GetJestreamSubject(eventType), []byte(sampleEvent))
+	return jsClient.conn.Publish(jsClient.GetJetstreamSubject(eventType), []byte(sampleEvent))
 }

--- a/components/eventing-controller/pkg/handlers/test_helpers.go
+++ b/components/eventing-controller/pkg/handlers/test_helpers.go
@@ -230,11 +230,11 @@ func SendEventToJetStream(jsClient *JetStream, data string) error {
 	eventType := eventingtesting.OrderCreatedEventType
 	eventTime := time.Now().Format(time.RFC3339)
 	sampleEvent := NewNatsMessagePayload(data, "id", eventingtesting.EventSource, eventTime, eventType)
-	return jsClient.conn.Publish(jsClient.GetJsSubjectToSubscribe(eventType), []byte(sampleEvent))
+	return jsClient.conn.Publish(jsClient.GetJestreamSubject(eventType), []byte(sampleEvent))
 }
 
 func SendEventToJetStreamOnEventType(jsClient *JetStream, eventType string, data string) error {
 	eventTime := time.Now().Format(time.RFC3339)
 	sampleEvent := NewNatsMessagePayload(data, "id", eventingtesting.EventSource, eventTime, eventType)
-	return jsClient.conn.Publish(jsClient.GetJsSubjectToSubscribe(eventType), []byte(sampleEvent))
+	return jsClient.conn.Publish(jsClient.GetJestreamSubject(eventType), []byte(sampleEvent))
 }

--- a/components/eventing-controller/pkg/object/equality_test.go
+++ b/components/eventing-controller/pkg/object/equality_test.go
@@ -456,9 +456,8 @@ func TestPublisherProxyDeploymentEqual(t *testing.T) {
 		LimitsMemory:   "128Mi",
 	}
 	natsConfig := env.NatsConfig{
-		EventTypePrefix:       "prefix",
-		JSStreamName:          "kyma",
-		JSStreamSubjectPrefix: "prefix",
+		EventTypePrefix: "prefix",
+		JSStreamName:    "kyma",
 	}
 	defaultNATSPublisher := deployment.NewNATSPublisherDeployment(natsConfig, publisherCfg)
 	defaultBEBPublisher := deployment.NewBEBPublisherDeployment(publisherCfg)

--- a/components/eventing-controller/pkg/subscriptionmanager/jetstream/jetstream_test.go
+++ b/components/eventing-controller/pkg/subscriptionmanager/jetstream/jetstream_test.go
@@ -87,7 +87,6 @@ func getNATSConf(natsURL string) env.NatsConfig {
 		ReconnectWait:           time.Second,
 		EventTypePrefix:         controllertesting.EventTypePrefix,
 		JSStreamName:            controllertesting.EventTypePrefix,
-		JSStreamSubjectPrefix:   controllertesting.EventTypePrefix,
 		JSStreamStorageType:     handlers.JetStreamStorageTypeMemory,
 		JSStreamRetentionPolicy: handlers.JetStreamRetentionPolicyInterest,
 	}

--- a/components/eventing-controller/testing/nats/matchers.go
+++ b/components/eventing-controller/testing/nats/matchers.go
@@ -1,6 +1,7 @@
 package nats
 
 import (
+	"github.com/kyma-project/kyma/components/eventing-controller/pkg/handlers"
 	"github.com/nats-io/nats.go"
 	"github.com/onsi/gomega"
 	gomegatypes "github.com/onsi/gomega/types"
@@ -24,7 +25,8 @@ func BeJetStreamSubscriptionWithSubject(subject string) gomegatypes.GomegaMatche
 		if err != nil {
 			return false
 		}
-		return info.Config.FilterSubject == subject
+		js := handlers.JetStream{}
+		return info.Config.FilterSubject == js.GetJestreamSubject(subject)
 	}, gomega.BeTrue())
 }
 

--- a/components/eventing-controller/testing/nats/matchers.go
+++ b/components/eventing-controller/testing/nats/matchers.go
@@ -26,7 +26,7 @@ func BeJetStreamSubscriptionWithSubject(subject string) gomegatypes.GomegaMatche
 			return false
 		}
 		js := handlers.JetStream{}
-		return info.Config.FilterSubject == js.GetJestreamSubject(subject)
+		return info.Config.FilterSubject == js.GetJetstreamSubject(subject)
 	}, gomega.BeTrue())
 }
 

--- a/components/eventing-controller/testing/test_helpers.go
+++ b/components/eventing-controller/testing/test_helpers.go
@@ -61,8 +61,7 @@ const (
            "data":"` + EventData + `"
         }`
 
-	JSStreamName          = "kyma"
-	JSStreamSubjectPrefix = "prefix"
+	JSStreamName = "kyma"
 )
 
 type APIRuleOption func(r *apigatewayv1alpha1.APIRule)

--- a/resources/eventing/charts/controller/templates/deployment.yaml
+++ b/resources/eventing/charts/controller/templates/deployment.yaml
@@ -76,8 +76,6 @@ spec:
             value: {{ .Values.jetstream.maxMessages | quote }}
           - name: JS_STREAM_MAX_BYTES
             value: {{ .Values.jetstream.maxBytes | quote }}
-          - name: JS_STREAM_SUBJECT_PREFIX
-            value: {{ .Values.jetstream.subjectPrefix | quote }}
           resources:
             requests:
               cpu: {{ .Values.resources.requests.cpu }}

--- a/resources/eventing/charts/controller/values.yaml
+++ b/resources/eventing/charts/controller/values.yaml
@@ -78,8 +78,6 @@ jetstream:
   # Configs for the stream used for storing events
   # Name of the JetStream stream where all events are stored.
   streamName: sap
-  # Subject prefix for the JetStream stream when eventTypePrefix is not provided.
-  subjectPrefix: kyma
   # Retention policy determines when messages are deleted from the stream:
   # (more info https://docs.nats.io/using-nats/developer/develop_jetstream/model_deep_dive#stream-limits-retention-and-policy):
   # - interest: When all known observables have acknowledged a message, it can be removed.

--- a/resources/eventing/values.yaml
+++ b/resources/eventing/values.yaml
@@ -5,11 +5,11 @@ global:
   images:
     eventing_controller:
       name: eventing-controller
-      version: PR-14414
+      version: PR-14262
       pullPolicy: "IfNotPresent"
     publisher_proxy:
       name: event-publisher-proxy
-      version: PR-14414
+      version: PR-14262
     nats:
       name: nats
       version: 2.8.2-alpine


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- Use a hardcoded Jetstream prefix whenever an event is being published (EPP part) and received from NATS backend (eventing-controller)
- Adjust the tests, remove redundant ones

**Related issue(s)**
https://github.com/kyma-project/kyma/issues/13825