### PR TITLE
bump golang to 1.18.2 in eventing-controller

### DIFF
--- a/components/eventing-controller/Dockerfile
+++ b/components/eventing-controller/Dockerfile
@@ -1,5 +1,5 @@
 # Build the controller binary
-FROM eu.gcr.io/kyma-project/external/golang:1.18.1-alpine3.15 as builder
+FROM eu.gcr.io/kyma-project/external/golang:1.18.2-alpine3.15 as builder
 ARG DOCK_PKG_DIR=/go/src/github.com/kyma-project/kyma/components/eventing-controller
 WORKDIR $DOCK_PKG_DIR
 

--- a/components/eventing-controller/go.sum
+++ b/components/eventing-controller/go.sum
@@ -576,12 +576,8 @@ github.com/kubernetes-sigs/go-open-service-broker-client v0.0.0-20200527163240-4
 github.com/kubernetes-sigs/service-catalog v0.3.1/go.mod h1:MUAf+rdT06kiNpLXRAIqtPHC3Kgkw63YziVj1VMu3HM=
 github.com/kyma-incubator/api-gateway v0.0.0-20220318061314-9fd030a8cbd1 h1:HUlDBauoIaryCAvnpsjRz6z62WFkGxt+ar/Lais0jf0=
 github.com/kyma-incubator/api-gateway v0.0.0-20220318061314-9fd030a8cbd1/go.mod h1:2UUHTqQkCTzi+og/+EV6lPKxFAnKl36ogWCQOxDIVUg=
-github.com/kyma-project/kyma/common/logging v0.0.0-20220505104927-1bd0c8a0777d h1:wp2Q+sT3VFL6d3CCc5rfwdeNDG/6mJEtiX/+IySMOJo=
-github.com/kyma-project/kyma/common/logging v0.0.0-20220505104927-1bd0c8a0777d/go.mod h1:7FWH0Lyls2xumj836aa+LVP8jhnJSv6wSlxC+2HAJ1s=
 github.com/kyma-project/kyma/common/logging v0.0.0-20220506151527-6c74f7543a36 h1:4o61dyOvAKXBsuC1KZfLIihnqZrR4/uE6RKfzrreirE=
 github.com/kyma-project/kyma/common/logging v0.0.0-20220506151527-6c74f7543a36/go.mod h1:7FWH0Lyls2xumj836aa+LVP8jhnJSv6wSlxC+2HAJ1s=
-github.com/kyma-project/kyma/components/application-operator v0.0.0-20220505114327-5bacf9bfadd4 h1:1XAjuJeuEU/mo2sYQmXMzNtFWwy6e8efZmotl4rL4HE=
-github.com/kyma-project/kyma/components/application-operator v0.0.0-20220505114327-5bacf9bfadd4/go.mod h1:9pe+mc3dOScffwfL6J24kQcU5CGZwGyl4zNm1YlRJbQ=
 github.com/kyma-project/kyma/components/application-operator v0.0.0-20220506151527-6c74f7543a36 h1:q+k+IqovbfaDXTIoxt+26RtcXwF/Ti7uuotySq3xfqM=
 github.com/kyma-project/kyma/components/application-operator v0.0.0-20220506151527-6c74f7543a36/go.mod h1:9pe+mc3dOScffwfL6J24kQcU5CGZwGyl4zNm1YlRJbQ=
 github.com/lann/builder v0.0.0-20180802200727-47ae307949d0/go.mod h1:dXGbAdH5GtBTC4WfIxhKZfyBF/HBFgRZSWwZ9g/He9o=

--- a/resources/eventing/values.yaml
+++ b/resources/eventing/values.yaml
@@ -5,7 +5,7 @@ global:
   images:
     eventing_controller:
       name: eventing-controller
-      version: PR-14209
+      version: PR-14267
       pullPolicy: "IfNotPresent"
     publisher_proxy:
       name: event-publisher-proxy


### PR DESCRIPTION
This PR bumps the version of `golang` 1.18.2.