### PR TITLE
bump the build image to golang 1.18.2 in EPP

### DIFF
--- a/components/event-publisher-proxy/cmd/event-publisher-proxy/Dockerfile
+++ b/components/event-publisher-proxy/cmd/event-publisher-proxy/Dockerfile
@@ -1,4 +1,4 @@
-FROM eu.gcr.io/kyma-project/external/golang:1.18.1-alpine3.15 as builder
+FROM eu.gcr.io/kyma-project/external/golang:1.18.2-alpine3.15 as builder
 
 ARG DOCK_PKG_DIR=/go/src/github.com/kyma-project/kyma/components/event-publisher-proxy
 

--- a/resources/eventing/values.yaml
+++ b/resources/eventing/values.yaml
@@ -9,7 +9,7 @@ global:
       pullPolicy: "IfNotPresent"
     publisher_proxy:
       name: event-publisher-proxy
-      version: PR-14177
+      version: PR-14268
     nats:
       name: nats
       version: 2.8.2-alpine


### PR DESCRIPTION
This PR bumps the version of `golang` 1.18.2. 