### PR TITLE
Added description to eventing dashboards

### DIFF
--- a/resources/eventing/charts/dashboards/templates/jetstream.yaml
+++ b/resources/eventing/charts/dashboards/templates/jetstream.yaml
@@ -1170,7 +1170,7 @@ data:
                 }
              ],
              "title":"Message Acks Pending",
-             "description": "Number of messages forwarded to the dispatcher but have not been acknowledged by the dispatcher (per consumer)",
+             "description": "Number of messages forwarded to the dispatcher that have not been acknowledged by the dispatcher (per consumer)",
              "type":"timeseries"
           },
           {

--- a/resources/eventing/charts/dashboards/templates/jetstream.yaml
+++ b/resources/eventing/charts/dashboards/templates/jetstream.yaml
@@ -1030,95 +1030,6 @@ data:
                    "mappings":[
 
                    ],
-                   "thresholds":{
-                      "mode":"absolute",
-                      "steps":[
-                         {
-                            "color":"green",
-                            "value":null
-                         },
-                         {
-                            "color":"red",
-                            "value":80
-                         }
-                      ]
-                   },
-                   "unit":"short"
-                },
-                "overrides":[
-
-                ]
-             },
-             "gridPos":{
-                "h":6,
-                "w":8,
-                "x":0,
-                "y":20
-             },
-             "id":21,
-             "options":{
-                "legend":{
-                   "calcs":[
-
-                   ],
-                   "displayMode":"list",
-                   "placement":"bottom"
-                },
-                "tooltip":{
-                   "mode":"single"
-                }
-             },
-             "pluginVersion":"8.3.4",
-             "targets":[
-                {
-                   "expr":"sum(nats_consumer_num_redelivered{pod=~\"$server\",stream_name=~\"$stream\",consumer_desc=~\"$consumer\"}) by (consumer_desc)",
-                   "hide":false,
-                   "interval":"",
-                   "legendFormat":"{{consumer_desc}}",
-                   "refId":"A"
-                }
-             ],
-             "title":"Pending Re-delivery Messages",
-             "description": "Total number of messages to be re-delivered to the dispatcher per consumer",
-             "type":"timeseries"
-          },
-          {
-             "fieldConfig":{
-                "defaults":{
-                   "color":{
-                      "mode":"palette-classic"
-                   },
-                   "custom":{
-                      "axisLabel":"",
-                      "axisPlacement":"auto",
-                      "barAlignment":0,
-                      "drawStyle":"line",
-                      "fillOpacity":10,
-                      "gradientMode":"none",
-                      "hideFrom":{
-                         "legend":false,
-                         "tooltip":false,
-                         "viz":false
-                      },
-                      "lineInterpolation":"linear",
-                      "lineWidth":1,
-                      "pointSize":5,
-                      "scaleDistribution":{
-                         "type":"linear"
-                      },
-                      "showPoints":"never",
-                      "spanNulls":true,
-                      "stacking":{
-                         "group":"A",
-                         "mode":"none"
-                      },
-                      "thresholdsStyle":{
-                         "mode":"off"
-                      }
-                   },
-                   "mappings":[
-
-                   ],
                    "min":0,
                    "thresholds":{
                       "mode":"absolute",
@@ -1140,11 +1051,11 @@ data:
                 ]
              },
              "gridPos":{
-                "h":6,
-                "w":8,
-                "x":8,
-                "y":20
-             },
+               "h":6,
+               "w":8,
+               "x":0,
+               "y":20
+            },
              "id":26,
              "options":{
                 "legend":{
@@ -1169,7 +1080,7 @@ data:
                 }
              ],
              "title":"Pending Messages",
-             "description": "Number of messages pending to be forwarded to the dispatcher per consumer",
+             "description": "Number of messages pending to be forwarded to the dispatcher (per consumer)",
              "type":"timeseries"
           },
           {
@@ -1230,11 +1141,11 @@ data:
                 ]
              },
              "gridPos":{
-                "h":6,
-                "w":8,
-                "x":16,
-                "y":20
-             },
+                 "h":6,
+                 "w":8,
+                 "x":8,
+                 "y":20
+              },
              "id":27,
              "options":{
                 "legend":{
@@ -1260,6 +1171,95 @@ data:
              ],
              "title":"Message Acks Pending",
              "description": "Number of messages forwarded to the dispatcher but have not been acknowledged by the dispatcher (per consumer)",
+             "type":"timeseries"
+          },
+          {
+             "fieldConfig":{
+                "defaults":{
+                   "color":{
+                      "mode":"palette-classic"
+                   },
+                   "custom":{
+                      "axisLabel":"",
+                      "axisPlacement":"auto",
+                      "barAlignment":0,
+                      "drawStyle":"line",
+                      "fillOpacity":10,
+                      "gradientMode":"none",
+                      "hideFrom":{
+                         "legend":false,
+                         "tooltip":false,
+                         "viz":false
+                      },
+                      "lineInterpolation":"linear",
+                      "lineWidth":1,
+                      "pointSize":5,
+                      "scaleDistribution":{
+                         "type":"linear"
+                      },
+                      "showPoints":"never",
+                      "spanNulls":true,
+                      "stacking":{
+                         "group":"A",
+                         "mode":"none"
+                      },
+                      "thresholdsStyle":{
+                         "mode":"off"
+                      }
+                   },
+                   "mappings":[
+
+                   ],
+                   "thresholds":{
+                      "mode":"absolute",
+                      "steps":[
+                         {
+                            "color":"green",
+                            "value":null
+                         },
+                         {
+                            "color":"red",
+                            "value":80
+                         }
+                      ]
+                   },
+                   "unit":"short"
+                },
+                "overrides":[
+
+                ]
+             },
+             "gridPos":{
+                 "h":6,
+                 "w":8,
+                 "x":16,
+                 "y":20
+              },
+             "id":21,
+             "options":{
+                "legend":{
+                   "calcs":[
+
+                   ],
+                   "displayMode":"list",
+                   "placement":"bottom"
+                },
+                "tooltip":{
+                   "mode":"single"
+                }
+             },
+             "pluginVersion":"8.3.4",
+             "targets":[
+                {
+                   "expr":"sum(nats_consumer_num_redelivered{pod=~\"$server\",stream_name=~\"$stream\",consumer_desc=~\"$consumer\"}) by (consumer_desc)",
+                   "hide":false,
+                   "interval":"",
+                   "legendFormat":"{{consumer_desc}}",
+                   "refId":"A"
+                }
+             ],
+             "title":"Pending Re-delivery Messages",
+             "description": "Total number of messages to be re-delivered to the dispatcher (per consumer)",
              "type":"timeseries"
           }
        ],

--- a/resources/eventing/charts/dashboards/templates/jetstream.yaml
+++ b/resources/eventing/charts/dashboards/templates/jetstream.yaml
@@ -101,7 +101,8 @@ data:
                    "refId":"A"
                 }
              ],
-             "title":"Storage Used",
+             "title":"File Storage Used (%)",
+             "description": "Percentage of file storage used by streams for storing messages",
              "type":"gauge"
           },
           {
@@ -156,7 +157,8 @@ data:
                    "refId":"A"
                 }
              ],
-             "title":"Total Storage Used",
+             "title":"File Storage Used",
+             "description": "Total file storage used by streams for storing messages",
              "type":"stat"
           },
           {
@@ -219,7 +221,8 @@ data:
                    "refId":"A"
                 }
              ],
-             "title":"Memory Used",
+             "title":"In-Memory Storage Used (%)",
+             "description": "Percentage of in-memory storage used by streams for storing messages",
              "type":"gauge"
           },
           {
@@ -274,7 +277,8 @@ data:
                    "refId":"A"
                 }
              ],
-             "title":"Memory Used",
+             "title":"In-Memory Storage Used",
+             "description": "Total in-memory storage used by streams for storing messages",
              "type":"stat"
           },
           {
@@ -334,6 +338,7 @@ data:
                 }
              ],
              "title":"Connections",
+             "description": "Total number of active clients connected to NATS",
              "type":"stat"
           },
           {
@@ -388,7 +393,8 @@ data:
                    "refId":"A"
                 }
              ],
-             "title":"Max Storage",
+             "title":"Max File Storage",
+             "description": "Maximum amount of file storage allowed to be used by streams for storing messages",
              "type":"stat"
           },
           {
@@ -443,7 +449,8 @@ data:
                    "refId":"A"
                 }
              ],
-             "title":"Total Memory",
+             "title":"Max In-Memory Storage",
+             "description": "Maximum amount of in-memory storage allowed to be used by streams for storing messages",
              "type":"stat"
           },
           {
@@ -502,6 +509,7 @@ data:
                 }
              ],
              "title":"Total Consumers",
+             "description": "Total number of consumers on NATS server",
              "type":"stat"
           },
           {
@@ -1165,7 +1173,8 @@ data:
        "schemaVersion":34,
        "style":"dark",
        "tags":[
-
+          "kyma",
+          "eventing"
        ],
        "templating":{
           "list":[

--- a/resources/eventing/charts/dashboards/templates/jetstream.yaml
+++ b/resources/eventing/charts/dashboards/templates/jetstream.yaml
@@ -518,13 +518,13 @@ data:
                 "h":1,
                 "w":24,
                 "x":0,
-                "y":6
+                "y":7
              },
              "id":19,
              "panels":[
 
              ],
-             "title":"Stream metrics",
+             "title":"Stream Metrics",
              "type":"row"
           },
           {
@@ -585,9 +585,9 @@ data:
              },
              "gridPos":{
                 "h":6,
-                "w":8,
+                "w":6,
                 "x":0,
-                "y":7
+                "y":8
              },
              "id":17,
              "options":{
@@ -611,7 +611,8 @@ data:
                    "refId":"A"
                 }
              ],
-             "title":"Stream data size",
+             "title":"Stream Data Size",
+             "description": "Total size of data stored by the streams to persist messages",
              "type":"timeseries"
           },
           {
@@ -672,11 +673,99 @@ data:
              },
              "gridPos":{
                 "h":6,
-                "w":8,
-                "x":8,
-                "y":7
+                "w":6,
+                "x":6,
+                "y":8
              },
              "id":24,
+             "options":{
+                "legend":{
+                   "calcs":[
+
+                   ],
+                   "displayMode":"list",
+                   "placement":"bottom"
+                },
+                "tooltip":{
+                   "mode":"single"
+                }
+             },
+             "pluginVersion":"8.3.4",
+             "targets":[
+                {
+                   "expr":"sum(nats_stream_consumer_count) by (stream_name)",
+                   "interval":"",
+                   "legendFormat":"{{stream_name}}",
+                   "refId":"A"
+                }
+             ],
+             "title":"Stream Consumer Count",
+             "description":"Total number of active consumers per stream",
+             "type":"timeseries"
+          },
+          {
+             "fieldConfig":{
+                "defaults":{
+                   "color":{
+                      "mode":"palette-classic"
+                   },
+                   "custom":{
+                      "axisLabel":"",
+                      "axisPlacement":"auto",
+                      "barAlignment":0,
+                      "drawStyle":"line",
+                      "fillOpacity":10,
+                      "gradientMode":"none",
+                      "hideFrom":{
+                         "legend":false,
+                         "tooltip":false,
+                         "viz":false
+                      },
+                      "lineInterpolation":"linear",
+                      "lineWidth":1,
+                      "pointSize":5,
+                      "scaleDistribution":{
+                         "type":"linear"
+                      },
+                      "showPoints":"never",
+                      "spanNulls":true,
+                      "stacking":{
+                         "group":"A",
+                         "mode":"none"
+                      },
+                      "thresholdsStyle":{
+                         "mode":"off"
+                      }
+                   },
+                   "mappings":[
+
+                   ],
+                   "thresholds":{
+                      "mode":"absolute",
+                      "steps":[
+                         {
+                            "color":"green",
+                            "value":null
+                         },
+                         {
+                            "color":"red",
+                            "value":80
+                         }
+                      ]
+                   },
+                   "unit":"short"
+                },
+                "overrides":[
+
+                ]
+             },
+             "gridPos":{
+                "h":6,
+                "w":6,
+                "x":12,
+                "y":8
+             },
+             "id":36,
              "options":{
                 "legend":{
                    "calcs":[
@@ -698,7 +787,8 @@ data:
                    "refId":"A"
                 }
              ],
-             "title":"Stream message count",
+             "title":"Stream Message Count",
+             "description": "Total number of messages stored by the streams",
              "type":"timeseries"
           },
           {
@@ -759,9 +849,9 @@ data:
              },
              "gridPos":{
                 "h":6,
-                "w":8,
-                "x":16,
-                "y":7
+                "w":6,
+                "x":18,
+                "y":8
              },
              "id":20,
              "options":{
@@ -787,6 +877,7 @@ data:
                 }
              ],
              "title":"Message Rate (per second)",
+             "description": "Number of messages published to streams per second",
              "type":"timeseries"
           },
           {
@@ -980,14 +1071,15 @@ data:
              "pluginVersion":"8.3.4",
              "targets":[
                 {
-                   "expr":"sum(nats_consumer_delivered_consumer_seq{pod=~\"$server\",stream_name=~\"$stream\",consumer_desc=~\"$consumer\"}) by (consumer_desc)",
+                   "expr":"sum(nats_consumer_num_redelivered{pod=~\"$server\",stream_name=~\"$stream\",consumer_desc=~\"$consumer\"}) by (consumer_desc)",
                    "hide":false,
                    "interval":"",
                    "legendFormat":"{{consumer_desc}}",
                    "refId":"A"
                 }
              ],
-             "title":"Total delivered messages",
+             "title":"Pending Re-delivery Messages",
+             "description": "Total number of messages to be re-delivered to the dispatcher per consumer",
              "type":"timeseries"
           },
           {
@@ -1076,7 +1168,8 @@ data:
                    "refId":"A"
                 }
              ],
-             "title":"Pending messages",
+             "title":"Pending Messages",
+             "description": "Number of messages pending to be forwarded to the dispatcher per consumer",
              "type":"timeseries"
           },
           {
@@ -1166,6 +1259,7 @@ data:
                 }
              ],
              "title":"Message Acks Pending",
+             "description": "Number of messages forwarded to the dispatcher but have not been acknowledged by the dispatcher (per consumer)",
              "type":"timeseries"
           }
        ],

--- a/resources/eventing/charts/dashboards/templates/nats.yaml
+++ b/resources/eventing/charts/dashboards/templates/nats.yaml
@@ -851,7 +851,10 @@ data:
        "refresh": false,
        "schemaVersion": 27,
        "style": "dark",
-       "tags": [],
+       "tags": [
+          "kyma",
+          "eventing"
+        ],
        "templating": {
          "list": []
        },

--- a/resources/eventing/charts/dashboards/templates/nats.yaml
+++ b/resources/eventing/charts/dashboards/templates/nats.yaml
@@ -133,6 +133,7 @@ data:
              }
            ],
            "title": "Server CPU",
+           "description": "CPU consumption by NATS servers",
            "type": "timeseries"
          },
          {
@@ -219,6 +220,7 @@ data:
              }
            ],
            "title": "Server Memory",
+           "description": "Memory consumption by NATS servers",
            "type": "timeseries"
          },
          {
@@ -317,6 +319,7 @@ data:
              }
            ],
            "title": "Bytes In",
+           "description": "Amount of data received by NATS servers",
            "type": "timeseries"
          },
          {
@@ -401,6 +404,7 @@ data:
              }
            ],
            "title": "NATS Msgs In",
+           "description": "Total number of messages received by NATS servers including the count of NATS internal messages",
            "type": "timeseries"
          },
          {
@@ -485,6 +489,7 @@ data:
              }
            ],
            "title": "Bytes Out",
+           "description": "Amount of data sent out by NATS servers",
            "type": "timeseries"
          },
          {
@@ -569,6 +574,7 @@ data:
              }
            ],
            "title": "NATS Msgs Out",
+           "description": "Total number of messages sent by NATS servers including the count of NATS internal messages",
            "type": "timeseries"
          },
          {
@@ -670,6 +676,7 @@ data:
              }
            ],
            "title": "Connections",
+           "description": "Total number of active clients connected to NATS servers",
            "type": "timeseries"
          },
          {
@@ -758,6 +765,7 @@ data:
              }
            ],
            "title": "Subscriptions",
+           "description": "Total number of subscriptions on NATS servers including the count of NATS internal subscriptions",
            "type": "timeseries"
          },
          {
@@ -845,6 +853,7 @@ data:
              }
            ],
            "title": "Slow Consumers",
+           "description": "Total number of slow consumers identified by the NATS Servers. A slow consumer is a subscriber that cannot keep up with the message flow delivered from the NATS server.",
            "type": "timeseries"
          }
        ],

--- a/tests/fast-integration/eventing-test/nats-dashboard-queries.json
+++ b/tests/fast-integration/eventing-test/nats-dashboard-queries.json
@@ -72,6 +72,10 @@
     "query":"sum(nats_stream_total_bytes) by (stream_name)"
   },
   {
+    "title":"NATS JetStream: Stream consumer count",
+    "query":"sum(nats_stream_consumer_count) by (stream_name)"
+  },
+  {
     "title":"NATS JetStream: Stream message count",
     "query":"sum(nats_stream_total_messages) by (stream_name)"
   },
@@ -88,8 +92,8 @@
     "query":"- sum(rate(nats_consumer_delivered_consumer_seq{pod=~\"$server\",stream_name=~\"$stream\",consumer_name=~\"$consumer\",consumer_name=~\"$consumer\"}[$__rate_interval])) by (consumer_name)"
   },
   {
-    "title":"NATS JetStream: Total delivered messages",
-    "query":"sum(nats_consumer_delivered_consumer_seq{pod=~\"$server\",stream_name=~\"$stream\",consumer_name=~\"$consumer\"}) by (consumer_name)"
+    "title":"NATS JetStream: Pending Re-delivery Messages",
+    "query":"sum(nats_consumer_num_redelivered{pod=~\"$server\",stream_name=~\"$stream\",consumer_name=~\"$consumer\"}) by (consumer_name)"
   },
   {
     "title":"NATS JetStream: Pending messages",


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- Added description to eventing dashboards
- Replaced `Total delivered messages` widget by `Pending Re-delivery Messages`, because `Total delivered messages` widget was incorrectly counting messages.
- Changed the sequence of widgets in NATS JetStream dashboard

**NATS Servers**
![image](https://user-images.githubusercontent.com/9897945/169334158-34fd05f5-f1ec-435c-88ae-f66968b4ce93.png)

**NATS JetStream**
![image](https://user-images.githubusercontent.com/9897945/169334331-21d99738-eccc-44f7-80ae-f76e2c04df65.png)


**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
- https://github.com/kyma-project/kyma/issues/14134