### PR TITLE
bump controller-runtime v0.12.1 in Event-Publisher-Proxy

### DIFF
--- a/components/event-publisher-proxy/go.mod
+++ b/components/event-publisher-proxy/go.mod
@@ -7,8 +7,8 @@ require (
 	github.com/cloudevents/sdk-go/v2 v2.9.0
 	github.com/google/uuid v1.3.0
 	github.com/kelseyhightower/envconfig v1.4.0
-	github.com/kyma-project/kyma/components/application-operator v0.0.0-20220513144018-68e48ee051c6
-	github.com/kyma-project/kyma/components/eventing-controller v0.0.0-20220513144018-68e48ee051c6
+	github.com/kyma-project/kyma/components/application-operator v0.0.0-20220517093305-874da3685d05
+	github.com/kyma-project/kyma/components/eventing-controller v0.0.0-20220517093305-874da3685d05
 	github.com/nats-io/nats-server/v2 v2.8.2
 	github.com/nats-io/nats.go v1.15.0
 	github.com/onsi/gomega v1.19.0
@@ -21,7 +21,7 @@ require (
 	k8s.io/api v0.24.0
 	k8s.io/apimachinery v0.24.0
 	k8s.io/client-go v0.24.0
-	sigs.k8s.io/controller-runtime v0.12.0
+	sigs.k8s.io/controller-runtime v0.12.1
 )
 
 require (

--- a/components/event-publisher-proxy/go.sum
+++ b/components/event-publisher-proxy/go.sum
@@ -577,10 +577,10 @@ github.com/kubernetes-sigs/service-catalog v0.3.1/go.mod h1:MUAf+rdT06kiNpLXRAIq
 github.com/kyma-incubator/api-gateway v0.0.0-20220318061314-9fd030a8cbd1/go.mod h1:2UUHTqQkCTzi+og/+EV6lPKxFAnKl36ogWCQOxDIVUg=
 github.com/kyma-project/kyma/common/logging v0.0.0-20220506151527-6c74f7543a36/go.mod h1:7FWH0Lyls2xumj836aa+LVP8jhnJSv6wSlxC+2HAJ1s=
 github.com/kyma-project/kyma/components/application-operator v0.0.0-20220506151527-6c74f7543a36/go.mod h1:9pe+mc3dOScffwfL6J24kQcU5CGZwGyl4zNm1YlRJbQ=
-github.com/kyma-project/kyma/components/application-operator v0.0.0-20220513144018-68e48ee051c6 h1:Nyj4yFfHMdyRuz0dKwRqNAbJRlpjaYMsmjAvb6OvarM=
-github.com/kyma-project/kyma/components/application-operator v0.0.0-20220513144018-68e48ee051c6/go.mod h1:9pe+mc3dOScffwfL6J24kQcU5CGZwGyl4zNm1YlRJbQ=
-github.com/kyma-project/kyma/components/eventing-controller v0.0.0-20220513144018-68e48ee051c6 h1:vrU1RbJoVDs30XgCp3tdDhzIofUtMmZUc5J6OItCuJY=
-github.com/kyma-project/kyma/components/eventing-controller v0.0.0-20220513144018-68e48ee051c6/go.mod h1:n34qjMuhyt1cNreIZeMlMB6oY5nSMFHMD53Tsdv9u7U=
+github.com/kyma-project/kyma/components/application-operator v0.0.0-20220517093305-874da3685d05 h1:VSnXsW0Q/7rV0Qr7acJH8HEF+qBYFzn8+8MoCtlhnj4=
+github.com/kyma-project/kyma/components/application-operator v0.0.0-20220517093305-874da3685d05/go.mod h1:9pe+mc3dOScffwfL6J24kQcU5CGZwGyl4zNm1YlRJbQ=
+github.com/kyma-project/kyma/components/eventing-controller v0.0.0-20220517093305-874da3685d05 h1:xR/zvL3c+YCor2kTwGytlAFrtmmcuhiqxW6KmZu/Q+k=
+github.com/kyma-project/kyma/components/eventing-controller v0.0.0-20220517093305-874da3685d05/go.mod h1:n34qjMuhyt1cNreIZeMlMB6oY5nSMFHMD53Tsdv9u7U=
 github.com/lann/builder v0.0.0-20180802200727-47ae307949d0/go.mod h1:dXGbAdH5GtBTC4WfIxhKZfyBF/HBFgRZSWwZ9g/He9o=
 github.com/lann/ps v0.0.0-20150810152359-62de8c46ede0/go.mod h1:vmVJ0l/dxyfGW6FmdpVm2joNMFikkuWg0EoCKLGUMNw=
 github.com/lib/pq v1.2.0/go.mod h1:5WUZQaWbwv1U+lTReE5YruASi9Al49XbQIvNi/34Woo=
@@ -1623,8 +1623,8 @@ sigs.k8s.io/controller-runtime v0.6.0/go.mod h1:CpYf5pdNY/B352A1TFLAS2JVSlnGQ5O2
 sigs.k8s.io/controller-runtime v0.8.3/go.mod h1:U/l+DUopBc1ecfRZ5aviA9JDmGFQKvLf5YkZNx2e0sU=
 sigs.k8s.io/controller-runtime v0.9.6/go.mod h1:q6PpkM5vqQubEKUKOM6qr06oXGzOBcCby1DA9FbyZeA=
 sigs.k8s.io/controller-runtime v0.11.2/go.mod h1:P6QCzrEjLaZGqHsfd+os7JQ+WFZhvB8MRFsn4dWF7O4=
-sigs.k8s.io/controller-runtime v0.12.0 h1:gA4zphrmHFc7ihmY/+GyyE0BxKD+OYdb5+DjD2azFAQ=
-sigs.k8s.io/controller-runtime v0.12.0/go.mod h1:BKhxlA4l7FPK4AQcsuL4X6vZeWnKDXez/vp1Y8dxTU0=
+sigs.k8s.io/controller-runtime v0.12.1 h1:4BJY01xe9zKQti8oRjj/NeHKRXthf1YkYJAgLONFFoI=
+sigs.k8s.io/controller-runtime v0.12.1/go.mod h1:BKhxlA4l7FPK4AQcsuL4X6vZeWnKDXez/vp1Y8dxTU0=
 sigs.k8s.io/controller-tools v0.5.0/go.mod h1:JTsstrMpxs+9BUj6eGuAaEb6SDSPTeVtUyp0jmnAM/I=
 sigs.k8s.io/json v0.0.0-20211020170558-c049b76a60c6/go.mod h1:p4QtZmO4uMYipTQNzagwnNoseA6OxSUutVw05NhYDRs=
 sigs.k8s.io/json v0.0.0-20211208200746-9f7c6b3444d2 h1:kDi4JBNAsJWfz1aEXhO8Jg87JJaPNLh5tIzYHgStQ9Y=

--- a/resources/eventing/values.yaml
+++ b/resources/eventing/values.yaml
@@ -9,7 +9,7 @@ global:
       pullPolicy: "IfNotPresent"
     publisher_proxy:
       name: event-publisher-proxy
-      version: PR-14304
+      version: PR-14318
     nats:
       name: nats
       version: 2.8.2-alpine


### PR DESCRIPTION
This PR bumps `sigs.k8s.io/controller-runtime` to `v0.12.1` in `Event-Publisher-Proxy` to prevent potential security issues.