### PR TITLE
Add rewrite_tag filter per LogPipeline

### DIFF
--- a/components/telemetry-operator/controllers/logpipeline_controller.go
+++ b/components/telemetry-operator/controllers/logpipeline_controller.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/kyma-project/kyma/components/telemetry-operator/internal/fluentbit"
 	"github.com/kyma-project/kyma/components/telemetry-operator/internal/sync"
 
 	"github.com/prometheus/client_golang/prometheus"
@@ -50,18 +51,16 @@ type LogPipelineReconciler struct {
 }
 
 // NewLogPipelineReconciler returns a new LogPipelineReconciler using the given FluentBit config arguments
-func NewLogPipelineReconciler(client client.Client, scheme *runtime.Scheme, namespace string, sectionsCm string, parsersCm string, daemonSet string, envSecret string, filesCm string) *LogPipelineReconciler {
+func NewLogPipelineReconciler(client client.Client, scheme *runtime.Scheme, daemonSetConfig sync.FluentBitDaemonSetConfig, emitterConfig fluentbit.EmitterConfig) *LogPipelineReconciler {
 	var lpr LogPipelineReconciler
 	lpr.Client = client
 	lpr.Scheme = scheme
 	lpr.Syncer = sync.NewLogPipelineSyncer(client,
-		types.NamespacedName{Name: sectionsCm, Namespace: namespace},
-		types.NamespacedName{Name: parsersCm, Namespace: namespace},
-		types.NamespacedName{Name: filesCm, Namespace: namespace},
-		types.NamespacedName{Name: envSecret, Namespace: namespace},
+		daemonSetConfig,
+		emitterConfig,
 	)
+	lpr.FluentBitDaemonSet = daemonSetConfig.FluentBitDaemonSetName
 
-	lpr.FluentBitDaemonSet = types.NamespacedName{Name: daemonSet, Namespace: namespace}
 	lpr.FluentBitRestartsCount = prometheus.NewCounter(prometheus.CounterOpts{
 		Name: "telemetry_operator_fluentbit_restarts_total",
 		Help: "Number of triggered FluentBit restarts",

--- a/components/telemetry-operator/internal/fluentbit/config_builder_test.go
+++ b/components/telemetry-operator/internal/fluentbit/config_builder_test.go
@@ -3,6 +3,7 @@ package fluentbit
 import (
 	"testing"
 
+	telemetryv1alpha1 "github.com/kyma-project/kyma/components/telemetry-operator/api/v1alpha1"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -30,4 +31,25 @@ func TestBuildSectionWithWrongIndentation(t *testing.T) {
 	actual := BuildConfigSection(ParserConfigHeader, content)
 
 	assert.Equal(t, expected, actual, "Fluent Bit config indentation has not been fixed")
+}
+
+func TestGenerateEmitter(t *testing.T) {
+	emitterConfig := EmitterConfig{
+		InputTag:    "kube",
+		BufferLimit: "10M",
+		StorageType: "filesystem",
+	}
+	logPipeline := telemetryv1alpha1.LogPipeline{}
+	logPipeline.Name = "test"
+
+	expected := `
+name                  rewrite_tag
+match                 kube.*
+Rule                  $log "^.*$" test true
+Emitter_Name          test
+Emitter_Storage.type  filesystem
+Emitter_Mem_Buf_Limit 10M`
+
+	actual := generateEmitter(emitterConfig, &logPipeline)
+	assert.Equal(t, expected, actual, "Fluent Bit Emitter config is invalid")
 }

--- a/components/telemetry-operator/internal/sync/sync.go
+++ b/components/telemetry-operator/internal/sync/sync.go
@@ -23,26 +23,28 @@ const (
 	filesFinalizer             = "FLUENT_BIT_FILES"
 )
 
-type LogPipelineSyncer struct {
-	client.Client
+type FluentBitDaemonSetConfig struct {
+	FluentBitDaemonSetName     types.NamespacedName
 	FluentBitSectionsConfigMap types.NamespacedName
 	FluentBitParsersConfigMap  types.NamespacedName
 	FluentBitFilesConfigMap    types.NamespacedName
 	FluentBitEnvSecret         types.NamespacedName
 }
 
+type LogPipelineSyncer struct {
+	client.Client
+	DaemonSetConfig FluentBitDaemonSetConfig
+	EmitterConfig   fluentbit.EmitterConfig
+}
+
 func NewLogPipelineSyncer(client client.Client,
-	sectionsCm types.NamespacedName,
-	parsersCm types.NamespacedName,
-	filesCm types.NamespacedName,
-	envSecret types.NamespacedName,
+	daemonSetConfig FluentBitDaemonSetConfig,
+	emitterConfig fluentbit.EmitterConfig,
 ) *LogPipelineSyncer {
 	var lps LogPipelineSyncer
 	lps.Client = client
-	lps.FluentBitSectionsConfigMap = sectionsCm
-	lps.FluentBitParsersConfigMap = parsersCm
-	lps.FluentBitFilesConfigMap = filesCm
-	lps.FluentBitEnvSecret = envSecret
+	lps.DaemonSetConfig = daemonSetConfig
+	lps.EmitterConfig = emitterConfig
 	return &lps
 }
 
@@ -75,7 +77,7 @@ func (s *LogPipelineSyncer) SyncAll(ctx context.Context, logPipeline *telemetryv
 // Synchronize LogPipeline with ConfigMap of FluentBit sections (Input, Filter and Output).
 func (s *LogPipelineSyncer) syncSectionsConfigMap(ctx context.Context, logPipeline *telemetryv1alpha1.LogPipeline) (bool, error) {
 	log := logf.FromContext(ctx)
-	cm, err := s.getOrCreateConfigMap(ctx, s.FluentBitSectionsConfigMap)
+	cm, err := s.getOrCreateConfigMap(ctx, s.DaemonSetConfig.FluentBitSectionsConfigMap)
 	if err != nil {
 		return false, err
 	}
@@ -90,7 +92,7 @@ func (s *LogPipelineSyncer) syncSectionsConfigMap(ctx context.Context, logPipeli
 			changed = true
 		}
 	} else {
-		fluentBitConfig := fluentbit.MergeSectionsConfig(logPipeline)
+		fluentBitConfig := fluentbit.MergeSectionsConfig(logPipeline, s.EmitterConfig)
 		if cm.Data == nil {
 			data := make(map[string]string)
 			data[cmKey] = fluentBitConfig
@@ -120,7 +122,7 @@ func (s *LogPipelineSyncer) syncSectionsConfigMap(ctx context.Context, logPipeli
 // Synchronize LogPipeline with ConfigMap of FluentBit parsers (Parser and MultiLineParser).
 func (s *LogPipelineSyncer) syncParsersConfigMap(ctx context.Context, logPipeline *telemetryv1alpha1.LogPipeline) (bool, error) {
 	log := logf.FromContext(ctx)
-	cm, err := s.getOrCreateConfigMap(ctx, s.FluentBitParsersConfigMap)
+	cm, err := s.getOrCreateConfigMap(ctx, s.DaemonSetConfig.FluentBitParsersConfigMap)
 	if err != nil {
 		return false, err
 	}
@@ -193,7 +195,7 @@ func (s *LogPipelineSyncer) syncParsersConfigMap(ctx context.Context, logPipelin
 // Synchronize file references with Fluent Bit files ConfigMap.
 func (s *LogPipelineSyncer) syncFilesConfigMap(ctx context.Context, logPipeline *telemetryv1alpha1.LogPipeline) (bool, error) {
 	log := logf.FromContext(ctx)
-	cm, err := s.getOrCreateConfigMap(ctx, s.FluentBitFilesConfigMap)
+	cm, err := s.getOrCreateConfigMap(ctx, s.DaemonSetConfig.FluentBitFilesConfigMap)
 	if err != nil {
 		return false, err
 	}
@@ -237,7 +239,7 @@ func (s *LogPipelineSyncer) syncFilesConfigMap(ctx context.Context, logPipeline 
 // Copy referenced secrets to global Fluent Bit environment secret.
 func (s *LogPipelineSyncer) syncSecretRefs(ctx context.Context, logPipeline *telemetryv1alpha1.LogPipeline) (bool, error) {
 	log := logf.FromContext(ctx)
-	secret, err := s.getOrCreateSecret(ctx, s.FluentBitEnvSecret)
+	secret, err := s.getOrCreateSecret(ctx, s.DaemonSetConfig.FluentBitEnvSecret)
 	if err != nil {
 		return false, err
 	}

--- a/components/telemetry-operator/internal/webhook/logpipeline_webhook.go
+++ b/components/telemetry-operator/internal/webhook/logpipeline_webhook.go
@@ -48,12 +48,13 @@ type LogPipelineValidator struct {
 	fluentBitConfigMap types.NamespacedName
 	configValidator    fluentbit.ConfigValidator
 	pluginValidator    fluentbit.PluginValidator
+	emitterConfig      fluentbit.EmitterConfig
 	fsWrapper          fs.Wrapper
 
 	decoder *admission.Decoder
 }
 
-func NewLogPipeLineValidator(client client.Client, fluentBitConfigMap string, namespace string, configValidator fluentbit.ConfigValidator, pluginValidator fluentbit.PluginValidator, fsWrapper fs.Wrapper) *LogPipelineValidator {
+func NewLogPipeLineValidator(client client.Client, fluentBitConfigMap string, namespace string, configValidator fluentbit.ConfigValidator, pluginValidator fluentbit.PluginValidator, emitterConfig fluentbit.EmitterConfig, fsWrapper fs.Wrapper) *LogPipelineValidator {
 	return &LogPipelineValidator{
 		Client: client,
 		fluentBitConfigMap: types.NamespacedName{
@@ -63,6 +64,7 @@ func NewLogPipeLineValidator(client client.Client, fluentBitConfigMap string, na
 		configValidator: configValidator,
 		pluginValidator: pluginValidator,
 		fsWrapper:       fsWrapper,
+		emitterConfig:   emitterConfig,
 	}
 }
 
@@ -155,7 +157,7 @@ func (v *LogPipelineValidator) getFluentBitConfig(ctx context.Context, currentBa
 		})
 	}
 
-	sectionsConfig := fluentbit.MergeSectionsConfig(logPipeline)
+	sectionsConfig := fluentbit.MergeSectionsConfig(logPipeline, v.emitterConfig)
 	configFiles = append(configFiles, fs.File{
 		Path: fluentBitSectionsConfigDirectory,
 		Name: logPipeline.Name + ".conf",

--- a/components/telemetry-operator/internal/webhook/suite_test.go
+++ b/components/telemetry-operator/internal/webhook/suite_test.go
@@ -25,6 +25,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/kyma-project/kyma/components/telemetry-operator/internal/fluentbit"
 	fluentbitmocks "github.com/kyma-project/kyma/components/telemetry-operator/internal/fluentbit/mocks"
 	fsmocks "github.com/kyma-project/kyma/components/telemetry-operator/internal/fs/mocks"
 	"k8s.io/client-go/kubernetes/scheme"
@@ -104,6 +105,12 @@ var _ = BeforeSuite(func() {
 	})
 	Expect(err).NotTo(HaveOccurred())
 
+	emitterConfig := fluentbit.EmitterConfig{
+		InputTag:    "kube",
+		BufferLimit: "10M",
+		StorageType: "filesystem",
+	}
+
 	configValidatorMock = &fluentbitmocks.ConfigValidator{}
 	pluginValidatorMock = &fluentbitmocks.PluginValidator{}
 	fsWrapperMock = &fsmocks.Wrapper{}
@@ -113,6 +120,7 @@ var _ = BeforeSuite(func() {
 		ControllerNamespace,
 		configValidatorMock,
 		pluginValidatorMock,
+		emitterConfig,
 		fsWrapperMock,
 	)
 

--- a/components/telemetry-operator/main.go
+++ b/components/telemetry-operator/main.go
@@ -25,6 +25,8 @@ import (
 	"github.com/go-logr/zapr"
 	"github.com/kyma-project/kyma/components/telemetry-operator/internal/fluentbit"
 	"github.com/kyma-project/kyma/components/telemetry-operator/internal/fs"
+	"github.com/kyma-project/kyma/components/telemetry-operator/internal/sync"
+	"k8s.io/apimachinery/pkg/types"
 
 	"github.com/kyma-project/kyma/components/telemetry-operator/internal/webhook"
 	k8sWebhook "sigs.k8s.io/controller-runtime/pkg/webhook"
@@ -57,6 +59,9 @@ var (
 	fluentBitFilesConfigMap    string
 	fluentBitPath              string
 	fluentBitPluginDirectory   string
+	fluentBitInputTag          string
+	fluentBitBufferLimit       string
+	fluentBitStorageType       string
 	logFormat                  string
 	logLevel                   string
 	certDir                    string
@@ -96,6 +101,9 @@ func main() {
 	flag.StringVar(&fluentBitNs, "fluent-bit-ns", "", "Fluent Bit namespace")
 	flag.StringVar(&fluentBitPath, "fluent-bit-path", "fluent-bit/bin/fluent-bit", "Fluent Bit binary path")
 	flag.StringVar(&fluentBitPluginDirectory, "fluent-bit-plugin-directory", "fluent-bit/lib", "Fluent Bit plugin directory")
+	flag.StringVar(&fluentBitInputTag, "fluent-bit-input-tag", "telemetry-kube", "Fluent Bit base tag of the input to use")
+	flag.StringVar(&fluentBitBufferLimit, "fluent-bit-buffer-limit", "10M", "Fluent Bit buffer limit per log pipeline")
+	flag.StringVar(&fluentBitStorageType, "fluent-bit-storage-type", "filesystem", "Fluent Bit buffering mechanism (filesystem or memory)")
 	flag.StringVar(&logFormat, "log-format", getEnvOrDefault("APP_LOG_FORMAT", "text"), "Log format (json or text)")
 	flag.StringVar(&logLevel, "log-level", getEnvOrDefault("APP_LOG_LEVEL", "debug"), "Log level (debug, info, warn, error, fatal)")
 	flag.StringVar(&certDir, "cert-dir", "/var/run/telemetry-webhook", "Webhook TLS certificate directory")
@@ -134,6 +142,35 @@ func main() {
 		os.Exit(1)
 	}
 
+	emitterConfig := fluentbit.EmitterConfig{
+		InputTag:    fluentBitInputTag,
+		BufferLimit: fluentBitBufferLimit,
+		StorageType: fluentBitStorageType,
+	}
+
+	daemonSetConfig := sync.FluentBitDaemonSetConfig{
+		FluentBitDaemonSetName: types.NamespacedName{
+			Namespace: fluentBitNs,
+			Name:      fluentBitDaemonSet,
+		},
+		FluentBitSectionsConfigMap: types.NamespacedName{
+			Name:      fluentBitSectionsConfigMap,
+			Namespace: fluentBitNs,
+		},
+		FluentBitParsersConfigMap: types.NamespacedName{
+			Name:      fluentBitParsersConfigMap,
+			Namespace: fluentBitNs,
+		},
+		FluentBitFilesConfigMap: types.NamespacedName{
+			Name:      fluentBitFilesConfigMap,
+			Namespace: fluentBitNs,
+		},
+		FluentBitEnvSecret: types.NamespacedName{
+			Name:      fluentBitEnvSecret,
+			Namespace: fluentBitNs,
+		},
+	}
+
 	logPipelineValidator := webhook.NewLogPipeLineValidator(mgr.GetClient(),
 		fluentBitConfigMap,
 		fluentBitNs,
@@ -141,6 +178,7 @@ func main() {
 		fluentbit.NewPluginValidator(
 			strings.SplitN(strings.ReplaceAll(allowedFilterPlugins, " ", ""), ",", len(allowedFilterPlugins)),
 			strings.SplitN(strings.ReplaceAll(allowedOutputPlugins, " ", ""), ",", len(allowedOutputPlugins))),
+		emitterConfig,
 		fs.NewWrapper(),
 	)
 	mgr.GetWebhookServer().Register(
@@ -150,12 +188,8 @@ func main() {
 	reconciler := controllers.NewLogPipelineReconciler(
 		mgr.GetClient(),
 		mgr.GetScheme(),
-		fluentBitNs,
-		fluentBitSectionsConfigMap,
-		fluentBitParsersConfigMap,
-		fluentBitDaemonSet,
-		fluentBitEnvSecret,
-		fluentBitFilesConfigMap)
+		daemonSetConfig,
+		emitterConfig)
 	if err = reconciler.SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "Failed to create controller", "controller", "LogPipeline")
 		os.Exit(1)
@@ -205,6 +239,9 @@ func validateFlags() error {
 	}
 	if logLevel != "debug" && logLevel != "info" && logLevel != "warn" && logLevel != "error" && logLevel != "fatal" {
 		return errors.New("--log-level has to be one of debug, info, warn, error, fatal")
+	}
+	if fluentBitStorageType != "filesystem" && fluentBitStorageType != "memory" {
+		return errors.New("--fluent-bit-storage-type has to be either filesystem or memory")
 	}
 	return nil
 }

--- a/resources/telemetry/charts/fluent-bit/templates/configmap.yaml
+++ b/resources/telemetry/charts/fluent-bit/templates/configmap.yaml
@@ -9,11 +9,11 @@ data:
   custom_parsers.conf: |
     {{- (tpl .Values.config.customParsers $) | nindent 4 }}
   fluent-bit.conf: |
-    @INCLUDE dynamic/*.conf
     {{- (tpl .Values.config.service $)  | nindent 4 }}
     {{- (tpl .Values.config.inputs $)  | nindent 4 }}
     {{- (tpl .Values.config.filters $)  | nindent 4 }}
     {{- (tpl .Values.config.outputs $)  | nindent 4 }}
+    @INCLUDE dynamic/*.conf
   {{- range $key, $val := .Values.config.extraFiles }}
   {{ $key }}: |
     {{- (tpl $val $) | nindent 4 }}

--- a/resources/telemetry/charts/fluent-bit/values.yaml
+++ b/resources/telemetry/charts/fluent-bit/values.yaml
@@ -297,6 +297,7 @@ config:
         HTTP_Listen 0.0.0.0
         HTTP_Port {{ .Values.metricsPort }}
         Health_Check On
+        storage.path /data/flb-storage/
 
   ## https://docs.fluentbit.io/manual/pipeline/inputs
   inputs: |
@@ -304,11 +305,11 @@ config:
         Name tail
         Path /var/log/containers/*.log
         multiline.parser docker, cri
-        Tag kube.*
+        Tag telemetry-kube.*
         Mem_Buf_Limit 5MB
         Skip_Long_Lines On
         Refresh_Interval 10
-        DB /data/flb_kube_loki.db
+        DB /data/flb_kube.db
 
   ## https://docs.fluentbit.io/manual/pipeline/filters
   filters: |


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

This PR adds a dedicated rewrite_tag filter per LogPipeline to the generated Fluent Bit with filesystem buffer for isolation purposes.

Changes proposed in this pull request:

- Add rewrite_tag filter to generated Fluent Bit configurations
- Refactor handling references to Fluent Bit configuration in telemetry-operator 
- Implement recent findings about Fluent Bit in telemetry chart

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
Fixes #14141 