### PR TITLE
bump dependency nats-io/nats-server to v2.8.3 in event-publisher-proxy

### DIFF
--- a/components/event-publisher-proxy/go.mod
+++ b/components/event-publisher-proxy/go.mod
@@ -7,9 +7,9 @@ require (
 	github.com/cloudevents/sdk-go/v2 v2.10.0
 	github.com/google/uuid v1.3.0
 	github.com/kelseyhightower/envconfig v1.4.0
-	github.com/kyma-project/kyma/components/application-operator v0.0.0-20220523094428-f942f9739ec5
-	github.com/kyma-project/kyma/components/eventing-controller v0.0.0-20220523094428-f942f9739ec5
-	github.com/nats-io/nats-server/v2 v2.8.2
+	github.com/kyma-project/kyma/components/application-operator v0.0.0-20220524065628-a4b532883fbe
+	github.com/kyma-project/kyma/components/eventing-controller v0.0.0-20220524065628-a4b532883fbe
+	github.com/nats-io/nats-server/v2 v2.8.3
 	github.com/nats-io/nats.go v1.15.0
 	github.com/onsi/gomega v1.19.0
 	github.com/pkg/errors v0.9.1

--- a/components/event-publisher-proxy/go.mod
+++ b/components/event-publisher-proxy/go.mod
@@ -7,8 +7,8 @@ require (
 	github.com/cloudevents/sdk-go/v2 v2.10.0
 	github.com/google/uuid v1.3.0
 	github.com/kelseyhightower/envconfig v1.4.0
-	github.com/kyma-project/kyma/components/application-operator v0.0.0-20220520125427-4dc23d902b32
-	github.com/kyma-project/kyma/components/eventing-controller v0.0.0-20220520125427-4dc23d902b32
+	github.com/kyma-project/kyma/components/application-operator v0.0.0-20220523094428-f942f9739ec5
+	github.com/kyma-project/kyma/components/eventing-controller v0.0.0-20220523094428-f942f9739ec5
 	github.com/nats-io/nats-server/v2 v2.8.2
 	github.com/nats-io/nats.go v1.15.0
 	github.com/onsi/gomega v1.19.0

--- a/components/event-publisher-proxy/go.mod
+++ b/components/event-publisher-proxy/go.mod
@@ -7,8 +7,8 @@ require (
 	github.com/cloudevents/sdk-go/v2 v2.10.0
 	github.com/google/uuid v1.3.0
 	github.com/kelseyhightower/envconfig v1.4.0
-	github.com/kyma-project/kyma/components/application-operator v0.0.0-20220519113004-f9d1a6ba99e7
-	github.com/kyma-project/kyma/components/eventing-controller v0.0.0-20220519113004-f9d1a6ba99e7
+	github.com/kyma-project/kyma/components/application-operator v0.0.0-20220520125427-4dc23d902b32
+	github.com/kyma-project/kyma/components/eventing-controller v0.0.0-20220520125427-4dc23d902b32
 	github.com/nats-io/nats-server/v2 v2.8.2
 	github.com/nats-io/nats.go v1.15.0
 	github.com/onsi/gomega v1.19.0

--- a/components/event-publisher-proxy/go.sum
+++ b/components/event-publisher-proxy/go.sum
@@ -582,12 +582,16 @@ github.com/kyma-project/kyma/components/application-operator v0.0.0-202205201254
 github.com/kyma-project/kyma/components/application-operator v0.0.0-20220520125427-4dc23d902b32/go.mod h1:PV3PpVnVBfOi21hX0MsS4XYDsX+EGYUrpLC67oIjzeQ=
 github.com/kyma-project/kyma/components/application-operator v0.0.0-20220523094428-f942f9739ec5 h1:APFhUe8dihsgv8wTenKh50+W4Bu5InGuJatCd66DUfQ=
 github.com/kyma-project/kyma/components/application-operator v0.0.0-20220523094428-f942f9739ec5/go.mod h1:PV3PpVnVBfOi21hX0MsS4XYDsX+EGYUrpLC67oIjzeQ=
+github.com/kyma-project/kyma/components/application-operator v0.0.0-20220524065628-a4b532883fbe h1:sWePpZq/9pOzjJRQtdb82ajO7R9GOKrvTkH8A4RCEVk=
+github.com/kyma-project/kyma/components/application-operator v0.0.0-20220524065628-a4b532883fbe/go.mod h1:PV3PpVnVBfOi21hX0MsS4XYDsX+EGYUrpLC67oIjzeQ=
 github.com/kyma-project/kyma/components/eventing-controller v0.0.0-20220519113004-f9d1a6ba99e7 h1:tj0YS47CUZVcPcvav43TUDyDD456+5k1Az5wcuIZmS4=
 github.com/kyma-project/kyma/components/eventing-controller v0.0.0-20220519113004-f9d1a6ba99e7/go.mod h1:YGD2/Cn4L1MRlGL1LiRjq4l/CO/paWM4gwklPjgdyBg=
 github.com/kyma-project/kyma/components/eventing-controller v0.0.0-20220520125427-4dc23d902b32 h1:UQ7nb034bAIg1C0g3NctjOsj+vAXoU4lylwcK2JzFJY=
 github.com/kyma-project/kyma/components/eventing-controller v0.0.0-20220520125427-4dc23d902b32/go.mod h1:7bOfihx2BxqxdHo5IRI2n1JfEhpVRVZSKDo7yIzZ87Y=
 github.com/kyma-project/kyma/components/eventing-controller v0.0.0-20220523094428-f942f9739ec5 h1:l9p2Rfa1EFBA0qk0YgaQZT+SL8XP3Ptn5D2+UpRBSyI=
 github.com/kyma-project/kyma/components/eventing-controller v0.0.0-20220523094428-f942f9739ec5/go.mod h1:7bOfihx2BxqxdHo5IRI2n1JfEhpVRVZSKDo7yIzZ87Y=
+github.com/kyma-project/kyma/components/eventing-controller v0.0.0-20220524065628-a4b532883fbe h1:4y61V20+i2grhsbl0x9gUL2XQqProSe4owhRZTB4BWU=
+github.com/kyma-project/kyma/components/eventing-controller v0.0.0-20220524065628-a4b532883fbe/go.mod h1:7bOfihx2BxqxdHo5IRI2n1JfEhpVRVZSKDo7yIzZ87Y=
 github.com/lann/builder v0.0.0-20180802200727-47ae307949d0/go.mod h1:dXGbAdH5GtBTC4WfIxhKZfyBF/HBFgRZSWwZ9g/He9o=
 github.com/lann/ps v0.0.0-20150810152359-62de8c46ede0/go.mod h1:vmVJ0l/dxyfGW6FmdpVm2joNMFikkuWg0EoCKLGUMNw=
 github.com/lib/pq v1.2.0/go.mod h1:5WUZQaWbwv1U+lTReE5YruASi9Al49XbQIvNi/34Woo=
@@ -682,6 +686,8 @@ github.com/nats-io/nats-server/v2 v2.1.2/go.mod h1:Afk+wRZqkMQs/p45uXdrVLuab3gwv
 github.com/nats-io/nats-server/v2 v2.3.4/go.mod h1:3mtbaN5GkCo/Z5T3nNj0I0/W1fPkKzLiDC6jjWJKp98=
 github.com/nats-io/nats-server/v2 v2.8.2 h1:5m1VytMEbZx0YINvKY+X2gXdLNwP43uLXnFRwz8j8KE=
 github.com/nats-io/nats-server/v2 v2.8.2/go.mod h1:vIdpKz3OG+DCg4q/xVPdXHoztEyKDWRtykQ4N7hd7C4=
+github.com/nats-io/nats-server/v2 v2.8.3 h1:5jCAOZ62OeL0YSVhMotP17zk4K/N5bAHGwxyIGspjM8=
+github.com/nats-io/nats-server/v2 v2.8.3/go.mod h1:8zZa+Al3WsESfmgSs98Fi06dRWLH5Bnq90m5bKD/eT4=
 github.com/nats-io/nats.go v1.9.1/go.mod h1:ZjDU1L/7fJ09jvUSRVBR2e7+RnLiiIQyqyzEE/Zbp4w=
 github.com/nats-io/nats.go v1.11.1-0.20210623165838-4b75fc59ae30/go.mod h1:BPko4oXsySz4aSWeFgOHLZs3G4Jq4ZAyE6/zMCxRT6w=
 github.com/nats-io/nats.go v1.14.0/go.mod h1:BPko4oXsySz4aSWeFgOHLZs3G4Jq4ZAyE6/zMCxRT6w=

--- a/components/event-publisher-proxy/go.sum
+++ b/components/event-publisher-proxy/go.sum
@@ -580,10 +580,14 @@ github.com/kyma-project/kyma/components/application-operator v0.0.0-202205191130
 github.com/kyma-project/kyma/components/application-operator v0.0.0-20220519113004-f9d1a6ba99e7/go.mod h1:9pe+mc3dOScffwfL6J24kQcU5CGZwGyl4zNm1YlRJbQ=
 github.com/kyma-project/kyma/components/application-operator v0.0.0-20220520125427-4dc23d902b32 h1:zgCfJsr0PTB7Pp29gwRniseOgwpfsTM4lg6WcxpKyzI=
 github.com/kyma-project/kyma/components/application-operator v0.0.0-20220520125427-4dc23d902b32/go.mod h1:PV3PpVnVBfOi21hX0MsS4XYDsX+EGYUrpLC67oIjzeQ=
+github.com/kyma-project/kyma/components/application-operator v0.0.0-20220523094428-f942f9739ec5 h1:APFhUe8dihsgv8wTenKh50+W4Bu5InGuJatCd66DUfQ=
+github.com/kyma-project/kyma/components/application-operator v0.0.0-20220523094428-f942f9739ec5/go.mod h1:PV3PpVnVBfOi21hX0MsS4XYDsX+EGYUrpLC67oIjzeQ=
 github.com/kyma-project/kyma/components/eventing-controller v0.0.0-20220519113004-f9d1a6ba99e7 h1:tj0YS47CUZVcPcvav43TUDyDD456+5k1Az5wcuIZmS4=
 github.com/kyma-project/kyma/components/eventing-controller v0.0.0-20220519113004-f9d1a6ba99e7/go.mod h1:YGD2/Cn4L1MRlGL1LiRjq4l/CO/paWM4gwklPjgdyBg=
 github.com/kyma-project/kyma/components/eventing-controller v0.0.0-20220520125427-4dc23d902b32 h1:UQ7nb034bAIg1C0g3NctjOsj+vAXoU4lylwcK2JzFJY=
 github.com/kyma-project/kyma/components/eventing-controller v0.0.0-20220520125427-4dc23d902b32/go.mod h1:7bOfihx2BxqxdHo5IRI2n1JfEhpVRVZSKDo7yIzZ87Y=
+github.com/kyma-project/kyma/components/eventing-controller v0.0.0-20220523094428-f942f9739ec5 h1:l9p2Rfa1EFBA0qk0YgaQZT+SL8XP3Ptn5D2+UpRBSyI=
+github.com/kyma-project/kyma/components/eventing-controller v0.0.0-20220523094428-f942f9739ec5/go.mod h1:7bOfihx2BxqxdHo5IRI2n1JfEhpVRVZSKDo7yIzZ87Y=
 github.com/lann/builder v0.0.0-20180802200727-47ae307949d0/go.mod h1:dXGbAdH5GtBTC4WfIxhKZfyBF/HBFgRZSWwZ9g/He9o=
 github.com/lann/ps v0.0.0-20150810152359-62de8c46ede0/go.mod h1:vmVJ0l/dxyfGW6FmdpVm2joNMFikkuWg0EoCKLGUMNw=
 github.com/lib/pq v1.2.0/go.mod h1:5WUZQaWbwv1U+lTReE5YruASi9Al49XbQIvNi/34Woo=

--- a/components/event-publisher-proxy/go.sum
+++ b/components/event-publisher-proxy/go.sum
@@ -578,8 +578,12 @@ github.com/kyma-project/kyma/common/logging v0.0.0-20220517093305-874da3685d05/g
 github.com/kyma-project/kyma/components/application-operator v0.0.0-20220517093305-874da3685d05/go.mod h1:9pe+mc3dOScffwfL6J24kQcU5CGZwGyl4zNm1YlRJbQ=
 github.com/kyma-project/kyma/components/application-operator v0.0.0-20220519113004-f9d1a6ba99e7 h1:8dEMbnHkVTilorF5heR3Onpsr4IHOm2yFF+CfEB78j0=
 github.com/kyma-project/kyma/components/application-operator v0.0.0-20220519113004-f9d1a6ba99e7/go.mod h1:9pe+mc3dOScffwfL6J24kQcU5CGZwGyl4zNm1YlRJbQ=
+github.com/kyma-project/kyma/components/application-operator v0.0.0-20220520125427-4dc23d902b32 h1:zgCfJsr0PTB7Pp29gwRniseOgwpfsTM4lg6WcxpKyzI=
+github.com/kyma-project/kyma/components/application-operator v0.0.0-20220520125427-4dc23d902b32/go.mod h1:PV3PpVnVBfOi21hX0MsS4XYDsX+EGYUrpLC67oIjzeQ=
 github.com/kyma-project/kyma/components/eventing-controller v0.0.0-20220519113004-f9d1a6ba99e7 h1:tj0YS47CUZVcPcvav43TUDyDD456+5k1Az5wcuIZmS4=
 github.com/kyma-project/kyma/components/eventing-controller v0.0.0-20220519113004-f9d1a6ba99e7/go.mod h1:YGD2/Cn4L1MRlGL1LiRjq4l/CO/paWM4gwklPjgdyBg=
+github.com/kyma-project/kyma/components/eventing-controller v0.0.0-20220520125427-4dc23d902b32 h1:UQ7nb034bAIg1C0g3NctjOsj+vAXoU4lylwcK2JzFJY=
+github.com/kyma-project/kyma/components/eventing-controller v0.0.0-20220520125427-4dc23d902b32/go.mod h1:7bOfihx2BxqxdHo5IRI2n1JfEhpVRVZSKDo7yIzZ87Y=
 github.com/lann/builder v0.0.0-20180802200727-47ae307949d0/go.mod h1:dXGbAdH5GtBTC4WfIxhKZfyBF/HBFgRZSWwZ9g/He9o=
 github.com/lann/ps v0.0.0-20150810152359-62de8c46ede0/go.mod h1:vmVJ0l/dxyfGW6FmdpVm2joNMFikkuWg0EoCKLGUMNw=
 github.com/lib/pq v1.2.0/go.mod h1:5WUZQaWbwv1U+lTReE5YruASi9Al49XbQIvNi/34Woo=

--- a/resources/eventing/values.yaml
+++ b/resources/eventing/values.yaml
@@ -9,7 +9,7 @@ global:
       pullPolicy: "IfNotPresent"
     publisher_proxy:
       name: event-publisher-proxy
-      version: PR-14349
+      version: PR-14359
     nats:
       name: nats
       version: 2.8.2-alpine


### PR DESCRIPTION
This PR bumps the dependency `application-operator` in component `event-publisher-proxy` to prevent potential security issue.