### PR TITLE
refactor extracting of fluent bit dry run output

### DIFF
--- a/components/telemetry-operator/internal/fluentbit/config_validator.go
+++ b/components/telemetry-operator/internal/fluentbit/config_validator.go
@@ -81,23 +81,29 @@ func listPlugins(pluginPath string) ([]string, error) {
 
 // extractError extracts the error message from the output of fluent-bit
 // Thereby, it supports the following error patterns:
-// 1. Error <msg>\nError: Configuration file contains errors. Aborting
-// 2. Error: <msg>. Aborting
-// 3. [<time>] [  Error] File <filename>\n[<time>] [  Error] Error in line 4: <msg> Error: Configuration file contains errors. Aborting
+// 1. [<time>] [error] [config] error in path/to/file.conf:3: <msg>
+// 2. [<time>] [error] [config] <msg>
+// 3. [<time>] [error] <msg>
+// 4. error<msg>
 func extractError(output string) string {
 	rColors := regexp.MustCompile(ansiColorsRegex)
 	output = rColors.ReplaceAllString(output, "")
 
-	r1 := regexp.MustCompile(`(?P<description>Error[^\]].+)\n(?P<label>Error:.+)`)
+	r1 := regexp.MustCompile(`.*(?P<label>\[error]\s\[config].+:\s)(?P<description>.+)`)
 	if r1Matches := r1.FindStringSubmatch(output); r1Matches != nil {
-		return r1Matches[1] // 0: complete output, 1: description, 2: label
+		return r1Matches[2] // 0: complete output, 1: label, 2: description
 	}
 
-	r2 := regexp.MustCompile(`.*(?P<label>Error:\s)(?P<description>.+\.)`)
+	r2 := regexp.MustCompile(`.*(?P<label>\[error]\s\[config]\s)(?P<description>.+)`)
 	if r2Matches := r2.FindStringSubmatch(output); r2Matches != nil {
 		return r2Matches[2] // 0: complete output, 1: label, 2: description
 	}
 
-	r3 := regexp.MustCompile(`Error\s.+`)
-	return r3.FindString(output)
+	r3 := regexp.MustCompile(`.*(?P<label>\[error]\s)(?P<description>.+)`)
+	if r3Matches := r3.FindStringSubmatch(output); r3Matches != nil {
+		return r3Matches[2] // 0: complete output, 1: label, 2: description
+	}
+
+	r4 := regexp.MustCompile(`error.+`)
+	return r4.FindString(output)
 }

--- a/components/telemetry-operator/internal/fluentbit/config_validator_test.go
+++ b/components/telemetry-operator/internal/fluentbit/config_validator_test.go
@@ -20,19 +20,24 @@ func TestExtractError(t *testing.T) {
 			expectedError: "",
 		},
 		{
-			name:          "Single line error present",
-			output:        "\u001b[1m\u001B[91mError\u001B[0m: Invalid flush value. Aborting",
-			expectedError: "Invalid flush value.",
+			name:          "Invalid Flush value",
+			output:        "[2022/05/24 16:20:55] [\u001b[1m\u001B[91merror\u001B[0m] invalid flush value, aborting.",
+			expectedError: "invalid flush value, aborting.",
 		},
 		{
-			name:          "Multiline error present",
-			output:        "Error setting up tail.0 plugin property 'Mem_Buf_Limit'\nError: Configuration file contains errors. Aborting",
-			expectedError: "Error setting up tail.0 plugin property 'Mem_Buf_Limit'",
+			name:          "Plugin does not exist",
+			output:        "[2022/05/24 16:54:56] [error] [config] section 'abc' tried to instance a plugin name that don't exists\n[2022/05/24 16:54:56] [error] configuration file contains errors, aborting.",
+			expectedError: "section 'abc' tried to instance a plugin name that don't exists",
 		},
 		{
-			name:          "Multiline error with logs present",
-			output:        "[2022/03/21 09:36:37] [  Error] File /tmp/dry-rundabf0a0d-f27c-4bb8-860e-e90553aa6ef8/dynamic/logpipeline.conf\n[2022/03/21 09:36:37] [  Error] Error in line 3: Invalid indentation level\nError: Configuration file contains errors. Aborting",
-			expectedError: "Error in line 3: Invalid indentation level",
+			name:          "Invalid memory buffer limit",
+			output:        "[2022/05/24 15:56:05] [error] [config] could not configure property 'Mem_Buf_Limit' on input plugin with section name 'tail'\nconfiguration test is successful",
+			expectedError: "could not configure property 'Mem_Buf_Limit' on input plugin with section name 'tail'",
+		},
+		{
+			name:          "Invalid indentation level",
+			output:        "[2022/05/24 15:59:59] [error] [config] error in dynamic-parsers/parsers.conf:3: invalid indentation level\n",
+			expectedError: "invalid indentation level",
 		},
 	}
 	for _, tc := range testCases {


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- With the update of fluent-bit in the telemetry operator [Dockerfile](https://github.com/kyma-project/kyma/blob/main/components/telemetry-operator/Dockerfile#L22), the output of the `fluent-bit --dry-run` changed. - This functionality is used in the validation webhook to validate the fluent bit configuration
- This PR refactors the regexes for extracting the errors from the `fluent bit --dry-run` output to work with the current fluent bit version (1.9.3)

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
