### PR TITLE
Script for Application Connector Cleanup added

### DIFF
--- a/docs/assets/2.2-2.3-cleanup-app-connector-resources.sh
+++ b/docs/assets/2.2-2.3-cleanup-app-connector-resources.sh
@@ -29,3 +29,7 @@ kubectl delete clusterrole,clusterrolebinding -l app=connection-token-handler
 kubectl delete podsecuritypolicy/connection-token-handler --ignore-not-found=true
 kubectl delete tokenrequest --all -A
 kubectl delete crd tokenrequests.applicationconnector.kyma-project.io
+
+echo "Cleaning up orphaned resources"
+kubectl delete -n kyma-system configmap ory-oathkeeper-rules
+kubectl delete -n kyma-system prometheusrules.monitoring.coreos.com monitoring-kyma-prometheus.rules

--- a/docs/assets/2.2-2.3-cleanup-app-connector-resources.sh
+++ b/docs/assets/2.2-2.3-cleanup-app-connector-resources.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+echo "Deleting Application Connectivity related resources"
+kubectl delete job/application-connector-certs-setup-job -n kyma-integration
+
+echo "Deleting Application Registry"
+kubectl delete service,servicemonitor,role,rolebinding,deployment -l app=application-registry -n kyma-integration
+kubectl delete clusterrole -l app=application-registry
+kubectl delete peerauthentication/application-registry-policy -n kyma-integration
+kubectl delete podsecuritypolicy/application-registry
+kubectl delete cm/application-registry-dashboard -n kyma-system
+kubectl delete svc application-registry-metrics -n kyma-integration
+
+echo "Deleting Connector Service"
+kubectl delete vs,svc,servicemonitor,role,rolebinding,configmap,deployment,authorizationpolicy -l app=connector-service -n kyma-integration
+kubectl delete sa/connector-service -n kyma-integration
+kubectl delete peerauthentication/connector-service-policy -n kyma-integration
+kubectl delete podsecuritypolicy/connector-service
+kubectl delete destinationrule/connector-service-external-api-rule -n kyma-integration
+kubectl delete cm/connector-service-dashboard -n kyma-system
+kubectl delete svc connector-service-metrics -n kyma-integration
+
+echo "Deleting Connection Token Handler"
+kubectl delete sa,deployment -l app=connection-token-handler -n kyma-integration
+kubectl delete clusterrole,clusterrolebinding -l app=connection-token-handler
+kubectl delete podsecuritypolicy/connection-token-handler
+
+for NAMESPACE in $(kubectl get tokenrequest -A -o=custom-columns=NS:.metadata.namespace | uniq | tail -n +2)
+do
+  kubectl delete tokenrequest --all -n "$NAMESPACE"
+done
+
+kubectl delete crd tokenrequests.applicationconnector.kyma-project.io

--- a/docs/assets/2.2-2.3-cleanup-app-connector-resources.sh
+++ b/docs/assets/2.2-2.3-cleanup-app-connector-resources.sh
@@ -1,36 +1,31 @@
 #!/usr/bin/env bash
 echo "Deleting Application Connectivity related resources"
-kubectl delete job/application-connector-certs-setup-job -n kyma-integration
+kubectl delete job/application-connector-certs-setup-job -n kyma-integration --ignore-not-found=true
 kubectl delete role,rolebinding -l app=application-connector-certs-setup-job -n kyma-integration
-kubectl delete role/application-connector-certs-setup-job-ca-cert-role -n istio-system
-kubectl delete rolebinding/application-connector-certs-setup-job-ca-cert-rolebinding -n istio-system
-kubectl delete sa/application-connector-certs-setup-job -n kyma-integration
+kubectl delete role/application-connector-certs-setup-job-ca-cert-role -n istio-system --ignore-not-found=true
+kubectl delete rolebinding/application-connector-certs-setup-job-ca-cert-rolebinding -n istio-system --ignore-not-found=true
+kubectl delete sa/application-connector-certs-setup-job -n kyma-integration --ignore-not-found=true
 
 echo "Deleting Application Registry"
 kubectl delete service,servicemonitor,role,rolebinding,deployment -l app=application-registry -n kyma-integration
 kubectl delete clusterrole -l app=application-registry
-kubectl delete peerauthentication/application-registry-policy -n kyma-integration
-kubectl delete podsecuritypolicy/application-registry
-kubectl delete cm/application-registry-dashboard -n kyma-system
-kubectl delete svc application-registry-metrics -n kyma-integration
+kubectl delete peerauthentication/application-registry-policy -n kyma-integration --ignore-not-found=true
+kubectl delete podsecuritypolicy/application-registry --ignore-not-found=true
+kubectl delete cm/application-registry-dashboard -n kyma-system --ignore-not-found=true
+kubectl delete svc application-registry-metrics -n kyma-integration --ignore-not-found=true
 
 echo "Deleting Connector Service"
 kubectl delete vs,svc,servicemonitor,role,rolebinding,configmap,deployment,authorizationpolicy -l app=connector-service -n kyma-integration
-kubectl delete sa/connector-service -n kyma-integration
-kubectl delete peerauthentication/connector-service-policy -n kyma-integration
-kubectl delete podsecuritypolicy/connector-service
-kubectl delete destinationrule/connector-service-external-api-rule -n kyma-integration
-kubectl delete cm/connector-service-dashboard -n kyma-system
-kubectl delete svc connector-service-metrics -n kyma-integration
+kubectl delete sa/connector-service -n kyma-integration --ignore-not-found=true
+kubectl delete peerauthentication/connector-service-policy -n kyma-integration --ignore-not-found=true
+kubectl delete podsecuritypolicy/connector-service --ignore-not-found=true
+kubectl delete destinationrule/connector-service-external-api-rule -n kyma-integration --ignore-not-found=true
+kubectl delete cm/connector-service-dashboard -n kyma-system --ignore-not-found=true
+kubectl delete svc connector-service-metrics -n kyma-integration --ignore-not-found=true
 
 echo "Deleting Connection Token Handler"
 kubectl delete sa,deployment -l app=connection-token-handler -n kyma-integration
 kubectl delete clusterrole,clusterrolebinding -l app=connection-token-handler
-kubectl delete podsecuritypolicy/connection-token-handler
-
-for NAMESPACE in $(kubectl get tokenrequest -A -o=custom-columns=NS:.metadata.namespace | uniq | tail -n +2)
-do
-  kubectl delete tokenrequest --all -n "$NAMESPACE"
-done
-
+kubectl delete podsecuritypolicy/connection-token-handler --ignore-not-found=true
+kubectl delete tokenrequest --all -A
 kubectl delete crd tokenrequests.applicationconnector.kyma-project.io

--- a/docs/assets/2.2-2.3-cleanup-app-connector-resources.sh
+++ b/docs/assets/2.2-2.3-cleanup-app-connector-resources.sh
@@ -1,6 +1,10 @@
 #!/usr/bin/env bash
 echo "Deleting Application Connectivity related resources"
 kubectl delete job/application-connector-certs-setup-job -n kyma-integration
+kubectl delete role,rolebinding -l app=application-connector-certs-setup-job -n kyma-integration
+kubectl delete role/application-connector-certs-setup-job-ca-cert-role -n istio-system
+kubectl delete rolebinding/application-connector-certs-setup-job-ca-cert-rolebinding -n istio-system
+kubectl delete sa/application-connector-certs-setup-job -n kyma-integration
 
 echo "Deleting Application Registry"
 kubectl delete service,servicemonitor,role,rolebinding,deployment -l app=application-registry -n kyma-integration

--- a/docs/migration-guide-2.2-2.3.md
+++ b/docs/migration-guide-2.2-2.3.md
@@ -3,4 +3,4 @@ title: Migration Guide 2.2-2.3
 ---
 
 Due to the removal of the deprecated Application Connectivity components (such as Application Registry, Connector Service, and Connection Token Handler), some obsolete resources must be deleted.
-When you upgrade from Kyma 2.2 to 2.3, either run the script [`2.2-2.3-cleanup-app-connector-resources.sh`](https://github.com/kyma-project/kyma/blob/release-2.3/docs/assets/2.2-2.3-cleanup-app-connector-resources.sh) found in [`/assets`](https://github.com/kyma-project/kyma/tree/release-2.3/docs/assets) or perform the required steps from that script manually.
+When you upgrade from Kyma 2.2 to 2.3, either run the script [`2.2-2.3-cleanup-app-connector-resources.sh`](assets/2.2-2.3-cleanup-app-connector-resources.sh) or perform the required steps from that script manually.

--- a/docs/migration-guide-2.2-2.3.md
+++ b/docs/migration-guide-2.2-2.3.md
@@ -1,0 +1,6 @@
+---
+title: Migration Guide 2.2-2.3
+---
+
+Due to removal of deprecated Application Connectivity components such as Application Registry, Connector Service and Connection Token handler, some obsolete resources must be deleted.
+When you upgrade from Kyma 2.2 to 2.3, either run the script [`2.2-2.3-cleanup-app-connector-resources.sh`](https://github.com/kyma-project/kyma/blob/release-2.3/docs/assets/2.2-2.3-cleanup-app-connector-resources.sh) found in [`/assets`](https://github.com/kyma-project/kyma/tree/release-2.3/docs/assets) or perform the required steps from that script manually.

--- a/docs/migration-guide-2.2-2.3.md
+++ b/docs/migration-guide-2.2-2.3.md
@@ -2,5 +2,5 @@
 title: Migration Guide 2.2-2.3
 ---
 
-Due to removal of deprecated Application Connectivity components such as Application Registry, Connector Service and Connection Token handler, some obsolete resources must be deleted.
+Due to the removal of the deprecated Application Connectivity components (such as Application Registry, Connector Service, and Connection Token Handler), some obsolete resources must be deleted.
 When you upgrade from Kyma 2.2 to 2.3, either run the script [`2.2-2.3-cleanup-app-connector-resources.sh`](https://github.com/kyma-project/kyma/blob/release-2.3/docs/assets/2.2-2.3-cleanup-app-connector-resources.sh) found in [`/assets`](https://github.com/kyma-project/kyma/tree/release-2.3/docs/assets) or perform the required steps from that script manually.


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:
- Script for cleaning up all k8s resources related to Application Connector no longer needed after upgrading to Kyma 2.3

Motivation:
- The following components will be removed in Kyma 2.3:
  - Application Registry
  - Connector Service
  - Token Request Handler
  - Certs Setup job    
- When user upgrades Kyma from version 2.2 to 2.3 the resources related to the above components won't be removed automatically.

The script needs to be executed when migrating from Kyma 2.2 to Kyma 2.3

**Related issue(s)**
#12353, #13718