### PR TITLE
bump base image to alpine 3.16

### DIFF
--- a/components/eventing-controller/Dockerfile
+++ b/components/eventing-controller/Dockerfile
@@ -1,5 +1,5 @@
 # Build the controller binary
-FROM eu.gcr.io/kyma-project/external/golang:1.18.2-alpine3.15 as builder
+FROM eu.gcr.io/kyma-project/external/golang:1.18.2-alpine3.16 as builder
 ARG DOCK_PKG_DIR=/go/src/github.com/kyma-project/kyma/components/eventing-controller
 WORKDIR $DOCK_PKG_DIR
 


### PR DESCRIPTION
bump docker base image to alpine 3.16 (golang 1.18.2)