### PR TITLE
Remove license-puller usage from components

### DIFF
--- a/common/makefiles/docs/generic-make-go.md
+++ b/common/makefiles/docs/generic-make-go.md
@@ -65,7 +65,7 @@ Although these rules do not appear in the Makefile, they are generated.
 
 The generic Makefile contains such a line of code:
 ```makefile
-MOUNT_TARGETS = build resolve ensure dep-status check-imports imports check-fmt fmt errcheck vet generate pull-licenses gqlgen
+MOUNT_TARGETS = build resolve ensure dep-status check-imports imports check-fmt fmt errcheck vet generate gqlgen
 $(foreach t,$(MOUNT_TARGETS),$(eval $(call buildpack-mount,$(t))))
 ```
 For all the rules defined in **MOUNT_TARGETS**, the `buildpack-mount` Function is called. It dynamically defines a new rule:

--- a/common/makefiles/generic-make-go.mk
+++ b/common/makefiles/generic-make-go.mk
@@ -104,7 +104,7 @@ release-dep: resolve dep-status verify build-image push-image ## Release dep bas
 
 ##@ Common Docker
 .PHONY: build-image push-image
-build-image: pull-licenses-local ## Build the docker image
+build-image: ## Build the docker image
 	docker build -t $(IMG_NAME) .
 push-image: post-pr-tag-image ## Build and push the docker image. Needs DOCKER_PUSH_REPOSITORY DOCKER_PUSH_DIRECTORY 
 	docker tag $(IMG_NAME) $(IMG_NAME):$(TAG)
@@ -209,15 +209,6 @@ check-gqlgen:
 		git status -s pkg/graphql; \
 		exit 1; \
 	fi;
-
-pull-licenses: pull-licenses-local
-
-pull-licenses-local: ## Download licenses to store them in the docker image
-ifdef LICENSE_PULLER_PATH
-	bash $(LICENSE_PULLER_PATH)
-else
-	mkdir -p licenses
-endif
 
 # Targets copying sources to buildpack
 COPY_TARGETS = test

--- a/components/application-broker/Makefile
+++ b/components/application-broker/Makefile
@@ -10,5 +10,5 @@ VERIFY_IGNORE := /vendor\|/automock\|/testdata\|/pkg
 release:
 	$(MAKE) gomod-release-local
 
-build-image: pull-licenses
+build-image:
 	docker build -t $(IMG_NAME) -f cmd/broker/Dockerfile .

--- a/components/event-publisher-proxy/Makefile
+++ b/components/event-publisher-proxy/Makefile
@@ -57,7 +57,7 @@ $(cmds): %:
 
 # Example:
 #   make event-publisher-proxy.image
-$(cmds_images): %.image: build-local pull-licenses
+$(cmds_images): %.image: build-local
 	$(eval $@_img_name := $*)
 	@echo "+ Building container image $($@_img_name)"
 	docker image build -f cmd/$*/Dockerfile -t $($@_img_name) .

--- a/components/function-controller/Makefile
+++ b/components/function-controller/Makefile
@@ -21,9 +21,6 @@ else
 GOBIN=$(shell go env GOBIN)
 endif
 
-pull-licenses-local:
-	@echo "Omitting licenses will not be pulled."	
-
 release:
 	$(MAKE) gomod-release-local
 

--- a/tests/application-gateway-legacy-tests/Makefile
+++ b/tests/application-gateway-legacy-tests/Makefile
@@ -16,7 +16,7 @@ release:
 test-local:
 	@echo "Tests are not to be run at this stage."
 
-build-image: pull-licenses
+build-image:
 	docker build -t $(APP_NAME):latest . -f ./test/helmtest/Dockerfile --build-arg TEST_EXECUTOR_IMAGE=$(TEST_EXECUTOR_IMG_NAME):$(TAG)
 	docker build -t $(TEST_EXECUTOR_APP_NAME):latest . -f ./test/executor/Dockerfile
 

--- a/tests/components/api-gateway/Makefile
+++ b/tests/components/api-gateway/Makefile
@@ -18,16 +18,9 @@ path-to-referenced-charts:
 
 release: build-image push-image
 
-build-image: pull-licenses
+build-image:
 	docker build -t $(IMG_NAME) .
 
 push-image:
 	docker tag $(IMG_NAME) $(IMG_NAME):$(TAG)
 	docker push $(IMG_NAME):$(TAG)
-
-pull-licenses:
-ifdef LICENSE_PULLER_PATH
-	bash $(LICENSE_PULLER_PATH)
-else
-	mkdir -p licenses
-endif


### PR DESCRIPTION
/kind cleanup
/area ci

Remove all occurrences of license-puller from Kyma.

Closes #14478
