### PR TITLE
Use nodejs16 in fast-integration tests

### DIFF
--- a/tests/fast-integration/monitoring/prometheus.js
+++ b/tests/fast-integration/monitoring/prometheus.js
@@ -176,6 +176,7 @@ function shouldIgnoreTarget(target) {
     // Ignore the pods that are created during tests.
     '-testsuite-',
     'test',
+    'nodejs16-',
     'nodejs12-',
     'nodejs14-',
     'upgrade',

--- a/tests/fast-integration/test/fixtures/commerce-mock/lastorder-function.yaml
+++ b/tests/fast-integration/test/fixtures/commerce-mock/lastorder-function.yaml
@@ -8,7 +8,7 @@ metadata:
   name: lastorder
 spec:
   deps: '{ "name": "orders", "version": "1.0.0", "dependencies": {"axios": "^0.19.2"}}'
-  runtime: nodejs14
+  runtime: nodejs16
   source: |
     let lastOrder = {};
     let lastEvent = {};


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

-use nodejs16 as function runtime in FIT

**Related issue(s)**
https://github.com/kyma-project/kyma/issues/14067