### PR TITLE
Remove unnecessary environment variables from fast integration test Dockerfile

### DIFF
--- a/tests/fast-integration/image/Dockerfile
+++ b/tests/fast-integration/image/Dockerfile
@@ -1,11 +1,6 @@
 FROM alpine:3.14.6
 
-ENV KUBECONFIG=/KUBECONFIG/kubeconfig.yaml
-ENV EVENTMESH_SECRET_FILE=/EMS/ems.json
 ENV FIT_MAKE_TARGET=ci-skr
-
-VOLUME /KUBECONFIG
-VOLUME /EMS
 
 SHELL ["/bin/ash", "-o", "pipefail", "-c"]
 


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Remove unnecessary environment variables from fast integration test Dockerfile.
This gives a confusing error message otherwise:
```
> fast-integration-tests@0.0.1-alpha.12 test-skr
> mocha --timeout 15000 --inline-diffs --check-leaks --reporter mocha-multi-reporters --reporter-options configFile=mocha-reporter-config.json ./skr-test/test.js

ENOENT: no such file or directory, open '/KUBECONFIG/kubeconfig.yaml'
Error: ENOENT: no such file or directory, open '/EMS/ems.json'
```
The env vars will be set by helm instead.
