### PR TITLE
add a replace and exclude for emicklei/go-restful v2 in eventing-controller

### DIFF
--- a/components/eventing-controller/go.mod
+++ b/components/eventing-controller/go.mod
@@ -103,4 +103,4 @@ replace (
 
 replace github.com/emicklei/go-restful => github.com/emicklei/go-restful/v3 v3.8.0 // fix cve-2022-1996, might be okay to be removed after k8s > 1.24.2
 
-exclude github.com/emicklei/go-restful v2.9.5+incompatible
+exclude github.com/emicklei/go-restful v2.9.5+incompatible // fix cve-2022-1996, might be okay to be removed after k8s > 1.24.2

--- a/components/eventing-controller/go.mod
+++ b/components/eventing-controller/go.mod
@@ -100,3 +100,7 @@ replace (
 	k8s.io/kube-openapi => k8s.io/kube-openapi v0.0.0-20220611174630-77c5a1ef51a0 // fix cve-2022-1996, might be okay to be removed after k8s > 1.24.2
 	k8s.io/utils => k8s.io/utils v0.0.0-20220210201930-3a6ce19ff2f9
 )
+
+replace github.com/emicklei/go-restful => github.com/emicklei/go-restful/v3 v3.8.0 // fix cve-2022-1996, might be okay to be removed after k8s > 1.24.2
+
+exclude github.com/emicklei/go-restful v2.9.5+incompatible

--- a/components/eventing-controller/go.sum
+++ b/components/eventing-controller/go.sum
@@ -230,8 +230,6 @@ github.com/eapache/queue v1.1.0/go.mod h1:6eCeP0CKFpHLu8blIFXhExK/dRa7WDZfr6jVFP
 github.com/edsrzf/mmap-go v1.0.0/go.mod h1:YO35OhQPt3KJa3ryjFM5Bs14WD66h8eGKpfaBNrHW5M=
 github.com/elazarl/goproxy v0.0.0-20170405201442-c4fc26588b6e/go.mod h1:/Zj4wYkgs4iZTTu3o/KG3Itv/qCCa8VVMlb3i9OVuzc=
 github.com/elazarl/goproxy v0.0.0-20180725130230-947c36da3153/go.mod h1:/Zj4wYkgs4iZTTu3o/KG3Itv/qCCa8VVMlb3i9OVuzc=
-github.com/emicklei/go-restful v2.9.5+incompatible h1:spTtZBk5DYEvbxMVutUuTyh1Ao2r4iyvLdACqsl/Ljk=
-github.com/emicklei/go-restful v2.9.5+incompatible/go.mod h1:otzb+WCGbkyDHkqmQmT5YD2WR4BBwUdeQoFo8l/7tVs=
 github.com/emicklei/go-restful/v3 v3.8.0 h1:eCZ8ulSerjdAiaNpF7GxXIE7ZCMo1moN1qX+S609eVw=
 github.com/emicklei/go-restful/v3 v3.8.0/go.mod h1:6n3XBCmQQb25CM2LCACGz8ukIrRry+4bhvbpWn3mrbc=
 github.com/envoyproxy/go-control-plane v0.6.9/go.mod h1:SBwIajubJHhxtWwsL9s8ss4safvEdbitLhGGK48rN6g=

--- a/resources/eventing/values.yaml
+++ b/resources/eventing/values.yaml
@@ -5,7 +5,7 @@ global:
   images:
     eventing_controller:
       name: eventing-controller
-      version: PR-14534
+      version: PR-14666
       pullPolicy: "IfNotPresent"
     publisher_proxy:
       name: event-publisher-proxy


### PR DESCRIPTION
replace `github.com/emicklei/go-restful` `v2` with the latest `v3` to prevent security issues.