### PR TITLE
Fix the link to the Migration Script in the Migration Guide for 2.3

### DIFF
--- a/docs/migration-guide-2.2-2.3.md
+++ b/docs/migration-guide-2.2-2.3.md
@@ -3,4 +3,4 @@ title: Migration Guide 2.2-2.3
 ---
 
 Due to the removal of the deprecated Application Connectivity components (such as Application Registry, Connector Service, and Connection Token Handler), some obsolete resources must be deleted.
-When you upgrade from Kyma 2.2 to 2.3, either run the script [`2.2-2.3-cleanup-app-connector-resources.sh`](assets/2.2-2.3-cleanup-app-connector-resources.sh) or perform the required steps from that script manually.
+When you upgrade from Kyma 2.2 to 2.3, either run the script [`2.2-2.3-cleanup-app-connector-resources.sh`](https://github.com/kyma-project/kyma/blob/release-2.3/docs/assets/2.2-2.3-cleanup-app-connector-resources.sh) or perform the required steps from that script manually.


### PR DESCRIPTION
**Description**

The link to the migration script that was included in the migration guide is relative, which means it only works in GitHub, but when clicked on from the Website, it leads to `404`. 
This PR changes it to the direct link.

Changes proposed in this pull request:

- Fix the link to the [Migration Script](https://github.com/kyma-project/kyma/blob/release-2.3/docs/assets/2.2-2.3-cleanup-app-connector-resources.sh) in the Migration Guide for 2.3
