### PR TITLE
test: use `T.Setenv` to set env vars in tests

### DIFF
--- a/components/eventing-controller/pkg/deployment/publisher_deployment_test.go
+++ b/components/eventing-controller/pkg/deployment/publisher_deployment_test.go
@@ -2,15 +2,12 @@ package deployment
 
 import (
 	"fmt"
-	"os"
 	"strings"
 	"testing"
 
 	appsv1 "k8s.io/api/apps/v1"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
-
 	v1 "k8s.io/api/core/v1"
 
 	"github.com/kyma-project/kyma/components/eventing-controller/pkg/env"
@@ -134,16 +131,8 @@ func Test_GetNATSEnvVars(t *testing.T) {
 	}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			defer func() {
-				for k := range tc.givenEnvs {
-					err := os.Unsetenv(k)
-					require.NoError(t, err)
-				}
-			}()
-
 			for k, v := range tc.givenEnvs {
-				err := os.Setenv(k, v)
-				require.NoError(t, err)
+				t.Setenv(k, v)
 			}
 			backendConfig := env.GetBackendConfig()
 			envVars := getNATSEnvVars(tc.givenNatsConfig, backendConfig.PublisherConfig)
@@ -205,16 +194,8 @@ func Test_GetLogEnvVars(t *testing.T) {
 	}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			defer func() {
-				for k := range tc.givenEnvs {
-					err := os.Unsetenv(k)
-					require.NoError(t, err)
-				}
-			}()
-
 			for k, v := range tc.givenEnvs {
-				err := os.Setenv(k, v)
-				require.NoError(t, err)
+				t.Setenv(k, v)
 			}
 			backendConfig := env.GetBackendConfig()
 			envVars := getLogEnvVars(backendConfig.PublisherConfig)
@@ -256,16 +237,8 @@ func Test_GetBEBEnvVars(t *testing.T) {
 	}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			defer func() {
-				for k := range tc.givenEnvs {
-					err := os.Unsetenv(k)
-					require.NoError(t, err)
-				}
-			}()
-
 			for k, v := range tc.givenEnvs {
-				err := os.Setenv(k, v)
-				require.NoError(t, err)
+				t.Setenv(k, v)
 			}
 			backendConfig := env.GetBackendConfig()
 			envVars := getBEBEnvVars(backendConfig.PublisherConfig)

--- a/components/eventing-controller/pkg/ems/auth/auth_test.go
+++ b/components/eventing-controller/pkg/ems/auth/auth_test.go
@@ -2,7 +2,6 @@ package auth
 
 import (
 	"net/http"
-	"os"
 	"testing"
 
 	"github.com/kyma-project/kyma/components/eventing-controller/pkg/env"
@@ -17,15 +16,9 @@ const (
 )
 
 func TestAuthenticator(t *testing.T) {
-	if err := os.Setenv("CLIENT_ID", "foo"); err != nil {
-		t.Errorf("error while setting env var CLIENT_ID")
-	}
-	if err := os.Setenv("CLIENT_SECRET", "foo"); err != nil {
-		t.Errorf("error while setting env var CLIENT_SECRET")
-	}
-	if err := os.Setenv("TOKEN_ENDPOINT", "foo"); err != nil {
-		t.Errorf("error while setting env var TOKEN_ENDPOINT")
-	}
+	t.Setenv("CLIENT_ID", "foo")
+	t.Setenv("CLIENT_SECRET", "foo")
+	t.Setenv("TOKEN_ENDPOINT", "foo")
 	cfg := env.Config{}
 	// authenticate
 	client := NewAuthenticatedClient(cfg)

--- a/components/eventing-controller/pkg/env/backend_config_test.go
+++ b/components/eventing-controller/pkg/env/backend_config_test.go
@@ -1,7 +1,6 @@
 package env
 
 import (
-	"os"
 	"testing"
 
 	. "github.com/onsi/gomega"
@@ -15,16 +14,9 @@ func Test_GetBackendConfig(t *testing.T) {
 		"PUBLISHER_REQUESTS_MEMORY": "128Mi",
 		"PUBLISHER_REQUEST_TIMEOUT": "10s",
 	}
-	defer func() {
-		for k := range envs {
-			err := os.Unsetenv(k)
-			g.Expect(err).ShouldNot(HaveOccurred())
-		}
-	}()
 
 	for k, v := range envs {
-		err := os.Setenv(k, v)
-		g.Expect(err).ShouldNot(HaveOccurred())
+		t.Setenv(k, v)
 	}
 	backendConfig := GetBackendConfig()
 	// Ensure optional variables can be set

--- a/components/eventing-controller/pkg/env/config_test.go
+++ b/components/eventing-controller/pkg/env/config_test.go
@@ -1,7 +1,6 @@
 package env
 
 import (
-	"os"
 	"testing"
 	"time"
 
@@ -23,16 +22,9 @@ func Test_GetConfig(t *testing.T) {
 		"BEB_NAMESPACE":              "/test",
 		"WEBHOOK_ACTIVATION_TIMEOUT": "60s",
 	}
-	defer func() {
-		for k := range envs {
-			err := os.Unsetenv(k)
-			g.Expect(err).ShouldNot(HaveOccurred())
-		}
-	}()
 
 	for k, v := range envs {
-		err := os.Setenv(k, v)
-		g.Expect(err).ShouldNot(HaveOccurred())
+		t.Setenv(k, v)
 	}
 	config := GetConfig()
 	// Ensure required variables can be set

--- a/components/eventing-controller/pkg/env/nats_config_test.go
+++ b/components/eventing-controller/pkg/env/nats_config_test.go
@@ -2,7 +2,6 @@ package env
 
 import (
 	"fmt"
-	"os"
 	"testing"
 	"time"
 
@@ -27,14 +26,8 @@ func Test_GetNatsConfig(t *testing.T) {
 		"IDLE_CONN_TIMEOUT":       fmt.Sprintf("%v", idleConnTimeout),
 	}
 
-	defer func() {
-		for k := range envs {
-			require.NoError(t, os.Unsetenv(k))
-		}
-	}()
-
 	for k, v := range envs {
-		require.NoError(t, os.Setenv(k, v))
+		t.Setenv(k, v)
 	}
 
 	maxReconnects, reconnectWait := 1, time.Second

--- a/components/function-controller/pkg/apis/serverless/v1alpha1/function_validation_test.go
+++ b/components/function-controller/pkg/apis/serverless/v1alpha1/function_validation_test.go
@@ -1,7 +1,6 @@
 package v1alpha1
 
 import (
-	"os"
 	"testing"
 
 	"github.com/vrischmann/envconfig"
@@ -14,11 +13,8 @@ import (
 )
 
 func TestFunctionSpec_validateResources(t *testing.T) {
-	g := gomega.NewWithT(t)
-	err := os.Setenv("RESERVED_ENVS", "K_CONFIGURATION")
-	g.Expect(err).ShouldNot(gomega.HaveOccurred())
-	err = os.Setenv("FUNCTION_REPLICAS_MIN_VALUE", "1")
-	g.Expect(err).ShouldNot(gomega.HaveOccurred())
+	t.Setenv("RESERVED_ENVS", "K_CONFIGURATION")
+	t.Setenv("FUNCTION_REPLICAS_MIN_VALUE", "1")
 
 	for testName, testData := range map[string]struct {
 		givenFunc              Function

--- a/resources/eventing/values.yaml
+++ b/resources/eventing/values.yaml
@@ -5,7 +5,7 @@ global:
   images:
     eventing_controller:
       name: eventing-controller
-      version: PR-14770
+      version: PR-14736
       pullPolicy: "IfNotPresent"
     publisher_proxy:
       name: event-publisher-proxy

--- a/resources/serverless/values.yaml
+++ b/resources/serverless/values.yaml
@@ -76,7 +76,7 @@ global:
       directory: "tpi"
     function_controller:
       name: "function-controller"
-      version: "PR-14718"
+      version: "PR-14736"
     function_webhook:
       name: "function-webhook"
       version: "PR-14718"


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

This PR replaces `os.Setenv` with `t.Setenv`. Starting from Go 1.17, we can use `t.Setenv` to set environment variable in test. The environment variable is automatically restored to its original value when the test and all its subtests complete. This ensures that each test does not start with leftover environment variables from previous completed tests.

Reference: https://pkg.go.dev/testing#T.Setenv

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
