### PR TITLE
Fix flaky integration backend reconciler test

### DIFF
--- a/components/eventing-controller/controllers/backend/reconciler_test.go
+++ b/components/eventing-controller/controllers/backend/reconciler_test.go
@@ -618,16 +618,11 @@ func ensurePublisherProxyDeploymentUpdated(ctx context.Context, opts ...deployme
 
 		err = k8sClient.Update(ctx, d)
 		Expect(err).Should(BeNil())
-	})
-
-	By("Making sure publisher proxy deployment ResourceVersion is changed", func() {
-		Eventually(publisherProxyDeploymentResourceVersionGetter(ctx), timeout, pollingInterval).ShouldNot(Equal(resourceVersionBeforeUpdate))
-
-		d, err := publisherProxyDeploymentGetter(ctx)()
-		Expect(err).Should(BeNil())
-		Expect(d).ShouldNot(BeNil())
-
 		resourceVersionAfterUpdate = d.ResourceVersion
+
+		// make sure publisher proxy deployment ResourceVersion is changed
+		Expect(resourceVersionAfterUpdate).ShouldNot(Equal(resourceVersionBeforeUpdate))
+		Expect(publisherProxyDeploymentResourceVersionGetter(ctx)()).ShouldNot(Equal(resourceVersionBeforeUpdate))
 	})
 
 	return resourceVersionAfterUpdate

--- a/resources/eventing/values.yaml
+++ b/resources/eventing/values.yaml
@@ -5,7 +5,7 @@ global:
   images:
     eventing_controller:
       name: eventing-controller
-      version: PR-14770
+      version: PR-14775
       pullPolicy: "IfNotPresent"
     publisher_proxy:
       name: event-publisher-proxy


### PR DESCRIPTION
**Description of the problem**

The flakiness was in the test, where was tested the removal of non-allowed EPP annotations. The following code checked the annotations: 

```go
// preserve only allowed annotations
desiredPublisher.Spec.Template.ObjectMeta.Annotations = make(map[string]string)
  for k, v := range currentPublisher.Spec.Template.ObjectMeta.Annotations {
    if _, ok := allowedAnnotations[k]; ok {
	    desiredPublisher.Spec.Template.ObjectMeta.Annotations[k] = v
    }
}
```
and if there were some un-allowed, the EPP was simply updated and the un-allowed annotations were removed.

The test executed the following steps:
1. fetch the EPP
2. add un-allowed annotations
3. check that EPP was updated (fetch the ResourceVersion of deployment)
3.1 the (envTest) reconciler should kick in and update the EPP by removing the un-allowed annotations and hence change the ResourceVersion of the EPP deployment
4. Check that the ResourceVersion was changed

The problem (which lead to flakiness) was in the 3rd step. The following code checked that the EPP deployment was updated after adding the un-allowed annotations:

```go
By("Updating publisher proxy deployment", func() {
		d, err := publisherProxyDeploymentGetter(ctx)()

		resourceVersionBeforeUpdate = d.ResourceVersion

		err = k8sClient.Update(ctx, d)
	})

	By("Making sure publisher proxy deployment ResourceVersion is changed", func() {
                //takes a while
		Eventually(publisherProxyDeploymentResourceVersionGetter(ctx), timeout, pollingInterval).ShouldNot(Equal(resourceVersionBeforeUpdate)) 

		d, err := publisherProxyDeploymentGetter(ctx)()

		resourceVersionAfterUpdate = d.ResourceVersion
	})

```

What happened is that between line 
```go 
err = k8sClient.Update(ctx, d)
``` 
and 
```go 
Eventually(publisherProxyDeploymentResourceVersionGetter(ctx), timeout, pollingInterval).ShouldNot(Equal(resourceVersionBeforeUpdate)) 
``` 

the EPP deployment was already changed and the un-allowed annotations were added. So sometimes the reconciler 
managed to update the EPP before the `Eventually` line fetched the updated EPP. That means, that the EPP deployment was 
already fetched with the final ResourceVersion updated by the backend reconciler, but the next step of the test still expected the EPP to be updated.

**How this PR approached this problem**

Do not fetch the new ResourceVersion of EPP from the server, but take the result of the `Update()` method, as it already returns the new ResourceVersion. By ensuring that update returned no error, we can be sure, that the deployment was also updated on the k8s Server.

**Random 15 test executions results**

Before change: 🛑🛑🛑🛑🛑🟢🟢🟢🟢🛑🟢🟢🟢🛑🟢
After change:    🟢🟢🟢🟢🟢🟢🟢🟢🟢🟢🟢🟢🟢🟢🟢

Check [here](https://status.build.kyma-project.io/pr-history/?org=kyma-project&repo=kyma&pr=14775) 8 consecutive runs of the `controller` job, which executes this test.

**Related issue(s)**
https://github.com/kyma-project/kyma/issues/14208