### PR TITLE
Enhance Application Connectivity documentation following the new flow introduction

### DIFF
--- a/docs/05-technical-reference/00-architecture/ac-03-application-gateway.md
+++ b/docs/05-technical-reference/00-architecture/ac-03-application-gateway.md
@@ -13,7 +13,7 @@ which are either unsecured or secured with various security mechanisms and prote
 
 1. A Function calls Application Gateway. 
 2. Application Gateway extracts the Application name and the service name from the path. Using the extracted Application name, Application Gateway finds the respective Application custom resource and obtains the information about the registered external API, such as the API URL and security credentials. 
-3. Application Gateway gets a token from the OAuth server. The OAuth server can be additionally [secured with a client TLS certificate](../../03-tutorials/00-application-connectivity/ac-04-register-secured-api.md#register-an-oauth-20-mtls-secured-api).
+3. Application Gateway gets a token from the OAuth server.
 4. Application Gateway gets a CSRF token from the endpoint exposed by the upstream service. This step is optional and is valid only for the API which was registered with a CSRF token enabled.
 5. Application Gateway calls the target API.
 

--- a/docs/05-technical-reference/00-architecture/ac-03-application-gateway.md
+++ b/docs/05-technical-reference/00-architecture/ac-03-application-gateway.md
@@ -13,7 +13,7 @@ which are either unsecured or secured with various security mechanisms and prote
 
 1. A Function calls Application Gateway. 
 2. Application Gateway extracts the Application name and the service name from the path. Using the extracted Application name, Application Gateway finds the respective Application custom resource and obtains the information about the registered external API, such as the API URL and security credentials. 
-3. Application Gateway gets a token from the OAuth server. The OAuth server can be additionally [secured with a client TLS certificate](../../03-tutorials/00-application-connectivity/ac-04-register-secured-api.md#register-an-oauth-20-mtls-secured-api) .
+3. Application Gateway gets a token from the OAuth server. The OAuth server can be additionally [secured with a client TLS certificate](../../03-tutorials/00-application-connectivity/ac-04-register-secured-api.md#register-an-oauth-20-mtls-secured-api).
 4. Application Gateway gets a CSRF token from the endpoint exposed by the upstream service. This step is optional and is valid only for the API which was registered with a CSRF token enabled.
 5. Application Gateway calls the target API.
 

--- a/docs/05-technical-reference/00-architecture/ac-03-application-gateway.md
+++ b/docs/05-technical-reference/00-architecture/ac-03-application-gateway.md
@@ -9,7 +9,7 @@ which are either unsecured or secured with various security mechanisms and prote
 
 ![Application Gateway Diagram](assets/ac-architecture-proxy-service.svg)
 
-<!-- TODO: mention that the path in Compass scenario contains API Bundle and API definition -->
+> **NOTE:** See how the [Gateway URL differs](../ac-01-application-gateway-details.md#application-gateway-url) for the [Standalone and Compass modes](../../01-overview/main-areas/application-connectivity/README.md).
 
 1. A Function calls Application Gateway. 
 2. Application Gateway extracts the Application name and the service name from the path. Using the extracted Application name, Application Gateway finds the respective Application custom resource and obtains the information about the registered external API, such as the API URL and security credentials. 

--- a/docs/05-technical-reference/ac-01-application-gateway-details.md
+++ b/docs/05-technical-reference/ac-01-application-gateway-details.md
@@ -4,6 +4,26 @@ title: Application Gateway details
 
 Application Gateway is an intermediary component between a Function or a service and an external API.
 
+## Application Gateway URL
+
+To call a remote system's API from a workload with Application Gateway, you use the URL to the `central-application-gateway.kyma-system` service at an appropriate port and with a respective suffix to access the API of a specific application.
+
+The suffix and the port number differ depending on whether you're using Kyma in the [Standalone or Compass mode](../01-overview/main-areas/application-connectivity/README.md). 
+
+- For the Standalone mode, they are:
+  - URL: `http://central-application-gateway.kyma-system:8080/{APP_NAME}/{SERVICE_NAME}/{TARGET_PATH}`
+  - Port: `8080`
+  
+- For the Compass mode, they are:
+  - URL: `http://central-application-gateway.kyma-integration:8082/{APP_NAME}/{SERVICE_NAME}/{API_ENTRY_NAME}/{TARGET_PATH}`
+  - Port: `8082`
+
+Where:
+
+- `APP_NAME` is the name of the Application CR.
+- `SERVICE_NAME` represents the API Definition.
+- `TAGRET_PATH` is the destination API URL.
+
 ## Proxying requests
 <!-- TODO: describe the structure of the Secret storing credentials -->
 Application Gateway proxies requests from Functions and services in Kyma to external APIs based on the configuration stored in Secrets.

--- a/docs/05-technical-reference/ac-01-application-gateway-details.md
+++ b/docs/05-technical-reference/ac-01-application-gateway-details.md
@@ -8,7 +8,20 @@ Application Gateway is an intermediary component between a Function or a service
 
 To call a remote system's API from a workload with Application Gateway, you use the URL to the `central-application-gateway.kyma-system` service at an appropriate port and with a respective suffix to access the API of a specific application.
 
-The suffix and the port number differ depending on whether you're using Kyma in the [Standalone or Compass mode](../01-overview/main-areas/application-connectivity/README.md). 
+The suffix and the port number differ depending on whether you're using Kyma in the [Standalone or Compass mode](../01-overview/main-areas/application-connectivity/README.md):
+
+| Kyma mode | Application Gateway URL | Port number |
+|-----------|-------------------------|-------------|
+| Standalone | `http://central-application-gateway.kyma-system:8080/{APP_NAME}/{SERVICE_NAME}/{TARGET_PATH}` | `8080` |
+| Compass | `http://central-application-gateway.kyma-integration:8082/{APP_NAME}/{SERVICE_NAME}/{API_ENTRY_NAME}/{TARGET_PATH}` | `8082` |
+
+The placeholders in the URLs map to the following:
+
+- `APP_NAME` is the name of the Application CR.
+- `SERVICE_NAME` represents the API Definition.
+- `TAGRET_PATH` is the destination API URL.
+
+--------
 
 - For the Standalone mode, they are:
   - URL: `http://central-application-gateway.kyma-system:8080/{APP_NAME}/{SERVICE_NAME}/{TARGET_PATH}`

--- a/docs/05-technical-reference/ac-01-application-gateway-details.md
+++ b/docs/05-technical-reference/ac-01-application-gateway-details.md
@@ -10,10 +10,10 @@ To call a remote system's API from a workload with Application Gateway, you use 
 
 The suffix and the port number differ depending on whether you're using Kyma in the [Standalone or Compass mode](../01-overview/main-areas/application-connectivity/README.md):
 
-| Kyma mode | Application Gateway URL | Port number |
-|-----------|-------------------------|-------------|
-| Standalone | `http://central-application-gateway.kyma-system:8080/{APP_NAME}/{SERVICE_NAME}/{TARGET_PATH}` | `8080` |
-| Compass | `http://central-application-gateway.kyma-integration:8082/{APP_NAME}/{SERVICE_NAME}/{API_ENTRY_NAME}/{TARGET_PATH}` | `8082` |
+| Kyma mode | Application Gateway URL |
+|-----------|-------------------------|
+| Standalone | `http://central-application-gateway.kyma-system:8080/{APP_NAME}/{SERVICE_NAME}/{TARGET_PATH}` |
+| Compass | `http://central-application-gateway.kyma-integration:8082/{APP_NAME}/{SERVICE_NAME}/{API_ENTRY_NAME}/{TARGET_PATH}` |
 
 The placeholders in the URLs map to the following:
 

--- a/docs/05-technical-reference/ac-01-application-gateway-details.md
+++ b/docs/05-technical-reference/ac-01-application-gateway-details.md
@@ -10,7 +10,7 @@ To call a remote system's API from a workload with Application Gateway, you use 
 
 The suffix and the port number differ depending on whether you're using Kyma in the [Standalone or Compass mode](../01-overview/main-areas/application-connectivity/README.md):
 
-| Kyma mode | Application Gateway URL |
+| **Kyma mode** | **Application Gateway URL** |
 |-----------|-------------------------|
 | Standalone | `http://central-application-gateway.kyma-system:8080/{APP_NAME}/{SERVICE_NAME}/{TARGET_PATH}` |
 | Compass | `http://central-application-gateway.kyma-integration:8082/{APP_NAME}/{SERVICE_NAME}/{API_ENTRY_NAME}/{TARGET_PATH}` |

--- a/docs/05-technical-reference/ac-01-application-gateway-details.md
+++ b/docs/05-technical-reference/ac-01-application-gateway-details.md
@@ -19,7 +19,7 @@ The placeholders in the URLs map to the following:
 
 - `APP_NAME` is the name of the Application CR.
 - `SERVICE_NAME` represents the API Definition.
-- `TAGRET_PATH` is the destination API URL.
+- `TARGET_PATH` is the destination API URL.
 
 ## Proxying requests
 <!-- TODO: describe the structure of the Secret storing credentials -->

--- a/docs/05-technical-reference/ac-01-application-gateway-details.md
+++ b/docs/05-technical-reference/ac-01-application-gateway-details.md
@@ -21,22 +21,6 @@ The placeholders in the URLs map to the following:
 - `SERVICE_NAME` represents the API Definition.
 - `TAGRET_PATH` is the destination API URL.
 
---------
-
-- For the Standalone mode, they are:
-  - URL: `http://central-application-gateway.kyma-system:8080/{APP_NAME}/{SERVICE_NAME}/{TARGET_PATH}`
-  - Port: `8080`
-  
-- For the Compass mode, they are:
-  - URL: `http://central-application-gateway.kyma-integration:8082/{APP_NAME}/{SERVICE_NAME}/{API_ENTRY_NAME}/{TARGET_PATH}`
-  - Port: `8082`
-
-Where:
-
-- `APP_NAME` is the name of the Application CR.
-- `SERVICE_NAME` represents the API Definition.
-- `TAGRET_PATH` is the destination API URL.
-
 ## Proxying requests
 <!-- TODO: describe the structure of the Secret storing credentials -->
 Application Gateway proxies requests from Functions and services in Kyma to external APIs based on the configuration stored in Secrets.

--- a/docs/05-technical-reference/ac-01-application-gateway-details.md
+++ b/docs/05-technical-reference/ac-01-application-gateway-details.md
@@ -22,54 +22,10 @@ The placeholders in the URLs map to the following:
 - `TARGET_PATH` is the destination API URL.
 
 ## Proxying requests
-<!-- TODO: describe the structure of the Secret storing credentials -->
-Application Gateway proxies requests from Functions and services in Kyma to external APIs based on the configuration stored in Secrets.
 
-An example **CONFIGURATION** for APIs secured with OAuth looks as follows:
+Application Gateway proxies requests from Functions and services in Kyma to external APIs based on the configuration stored in [Application CR](00-custom-resources/ac-01-application.md) and Kubernetes Secrets.
 
-```json
-{
-    "credentials": {
-        "clientId": "{OAUTH_CLIENT_ID}",
-        "clientSecret": "{OAUTH_CLIENT_SECRET}",
-        "requestParameters": {},
-        "tokenUrl": "{OAUTH_TOKEN_URL}"
-    },
-    "csrfConfig": {
-        "tokenUrl": "{CSRF_TOKEN_URL}"
-    },
-    "requestParameters": {
-        "headers": {
-            "Content-Type": ["application/json"]
-        },
-        "queryParameters": {
-            "limit": ["50"]
-        }
-    }
-}
-```
-
-An example **CONFIGURATION** for APIs secured with BasicAuth looks as follows:
-
-```json
-{
-    "credentials": {
-      "username":"{USERNAME}",
-      "password":"{PASSWORD}"
-    },
-    "csrfConfig": {
-        "tokenUrl": "{CSRF_TOKEN_URL}"
-    },
-    "requestParameters": {
-        "headers": {
-            "Content-Type": ["application/json"]
-        },
-        "queryParameters": {
-            "limit": ["50"]
-        }
-    }
-}
-```
+For example configurations and Secrets, see the [tutorial on registering a secured API](https://kyma-project.io/docs/kyma/latest/03-tutorials/00-application-connectivity/ac-04-register-secured-api/).
 
 > **NOTE:** All APIs defined in a single Secret use the same configuration - the same credentials, CSRF tokens, and request parameters.
 

--- a/docs/05-technical-reference/ac-01-application-gateway-details.md
+++ b/docs/05-technical-reference/ac-01-application-gateway-details.md
@@ -25,7 +25,7 @@ The placeholders in the URLs map to the following:
 
 Application Gateway proxies requests from Functions and services in Kyma to external APIs based on the configuration stored in [Application CR](00-custom-resources/ac-01-application.md) and Kubernetes Secrets.
 
-For example configurations and Secrets, see the [tutorial on registering a secured API](https://kyma-project.io/docs/kyma/latest/03-tutorials/00-application-connectivity/ac-04-register-secured-api/).
+For example configurations and Secrets, see the [tutorial on registering a secured API](../03-tutorials/00-application-connectivity/ac-04-register-secured-api.md).
 
 > **NOTE:** All APIs defined in a single Secret use the same configuration - the same credentials, CSRF tokens, and request parameters.
 

--- a/docs/05-technical-reference/ac-01-application-gateway-details.md
+++ b/docs/05-technical-reference/ac-01-application-gateway-details.md
@@ -23,9 +23,9 @@ The placeholders in the URLs map to the following:
 
 ## Proxying requests
 
-Application Gateway proxies requests from Functions and services in Kyma to external APIs based on the configuration stored in [Application CR](00-custom-resources/ac-01-application.md) and Kubernetes Secrets.
+Application Gateway proxies requests from Functions and services in Kyma to external APIs based on the configuration stored in the [Application CR](00-custom-resources/ac-01-application.md) and Kubernetes Secrets.
 
-For example configurations and Secrets, see the [tutorial on registering a secured API](../03-tutorials/00-application-connectivity/ac-04-register-secured-api.md).
+For examples of configurations and Secrets, see the [tutorial on registering a secured API](../03-tutorials/00-application-connectivity/ac-04-register-secured-api.md).
 
 > **NOTE:** All APIs defined in a single Secret use the same configuration - the same credentials, CSRF tokens, and request parameters.
 

--- a/docs/05-technical-reference/ra-01-configuring-runtime.md
+++ b/docs/05-technical-reference/ra-01-configuring-runtime.md
@@ -22,5 +22,5 @@ The data mapping between Director and Kyma looks as follows:
 | **Director (Compass)**    | **Kyma**                      |
 |---------------------------|-------------------------------|
 | Application               | Application CR                |
-| API Bundle                | service in the Application CR |
-| API Definition            | entry under the service       |
+| API Bundle                | Service in the Application CR |
+| API Definition            | Entry under the service       |

--- a/docs/05-technical-reference/ra-01-configuring-runtime.md
+++ b/docs/05-technical-reference/ra-01-configuring-runtime.md
@@ -3,15 +3,24 @@ title: Configuring the Runtime
 ---
 
 <!-- TODO: mention that Compass Runtime Agent fetches credentials from the Director and creates Secrets used by Application Gateway -->
-> **NOTE:** To represent API and Event Definitions of the Applications connected to a Runtime, Open Service Broker API usage is recommended.
+
+> **NOTE:** To represent API and Event Definitions of the Applications connected to a Runtime, we recommend that you use the Open Service Broker API.
 
 Runtime Agent periodically requests for the configuration of its Runtime from Compass.
 Changes in the configuration for the Runtime are applied by Runtime Agent on the Runtime.
 
 To fetch the Runtime configuration, Runtime Agent calls the [`applicationsForRuntime`](https://github.com/kyma-incubator/compass/blob/master/components/director/pkg/graphql/schema.graphql) query offered by the Compass component called Director.
 The response for the query contains Applications assigned for the Runtime.
-Each Application contains only credentials that are valid for the Runtime that called the query.
+Each Application contains only credentials that are valid for the Runtime that called the query. Runtime Agent uses the credentials to create Secrets used by Application Gateway. 
 Each Runtime Agent can fetch the configurations for Runtimes that belong to its tenant.
 
 Runtime Agent reports back to the Director the Runtime-specific [LabelDefinitions](https://github.com/kyma-incubator/compass/blob/master/docs/compass/03-04-labels.md#labeldefinitions), which represent Runtime configuration, together with their values.
-Runtime-specific LabelDefinitions are Events Gateway URL and Runtime Console URL.
+Runtime-specific LabelDefinitions are Event Gateway URL and Runtime Console URL.
+
+The data representation in Director is mapped to the data representation in Kyma as follows: 
+
+| **Director (Compass)**    | **Kyma**                  |
+|---------------------------|---------------------------|
+| Application               | Application CR            |
+| API Bundle                | service in Application CR |
+| API definition            | entry under the service   |

--- a/docs/05-technical-reference/ra-01-configuring-runtime.md
+++ b/docs/05-technical-reference/ra-01-configuring-runtime.md
@@ -17,7 +17,7 @@ Each Runtime Agent can fetch the configurations for Runtimes that belong to its 
 Runtime Agent reports back to the Director the Runtime-specific [LabelDefinitions](https://github.com/kyma-incubator/compass/blob/master/docs/compass/03-04-labels.md#labeldefinitions), which represent Runtime configuration, together with their values.
 Runtime-specific LabelDefinitions are Event Gateway URL and Runtime Console URL.
 
-The data representation in Director is mapped to the data representation in Kyma as follows: 
+The data mapping between Director and Kyma looks as follows: 
 
 | **Director (Compass)**    | **Kyma**                  |
 |---------------------------|---------------------------|

--- a/docs/05-technical-reference/ra-01-configuring-runtime.md
+++ b/docs/05-technical-reference/ra-01-configuring-runtime.md
@@ -19,8 +19,8 @@ Runtime-specific LabelDefinitions are Event Gateway URL and Runtime Console URL.
 
 The data mapping between Director and Kyma looks as follows: 
 
-| **Director (Compass)**    | **Kyma**                  |
-|---------------------------|---------------------------|
-| Application               | Application CR            |
-| API Bundle                | service in Application CR |
-| API definition            | entry under the service   |
+| **Director (Compass)**    | **Kyma**                      |
+|---------------------------|-------------------------------|
+| Application               | Application CR                |
+| API Bundle                | service in the Application CR |
+| API Definition            | entry under the service       |

--- a/milv.config.yaml
+++ b/milv.config.yaml
@@ -48,7 +48,7 @@ files:
   - path: "./kyma/docs/04-operation-guides/troubleshooting/evnt-02-jetstream-troubleshooting.md"
     config:
       external-links-to-ignore: [ "https://grafana.com/grafana/dashboards/14725" ]
-  - path: "./kyma/docs/migration-guide-2.3-2.4.md"
+  - path: "./kyma/docs/05-technical-reference/ac-01-application-gateway-details.md"
     config:
-      external-links-to-ignore: [ "https://github.com/kyma-project/kyma/blob/release-2.4/docs/assets/2.3-2.4-cleanup-orphaned-svcat-resources.sh" ]
-#TODO: remove this entry for migration guide 2.3-2.4 together with the migration guide after 2.4 release
+      external-links-to-ignore: [ "http://central-application-gateway.kyma-system:8080/{APP_NAME}/{SERVICE_NAME}/{TARGET_PATH",
+      "http://central-application-gateway.kyma-integration:8082/{APP_NAME}/{SERVICE_NAME}/{API_ENTRY_NAME}/{TARGET_PATH"]


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- In [ac-03-application-gateway.md](https://github.com/kyma-project/kyma/blob/main/docs/05-technical-reference/00-architecture/ac-03-application-gateway.md), mention that the path in the Compass scenario contains the API Bundle and API definition. See [this PR](https://github.com/kyma-project/kyma/pull/12259/files).
- In [ac-01-application-gateway-details.md](https://github.com/kyma-project/kyma/blob/main/docs/05-technical-reference/ac-01-application-gateway-details.md), describe the structure of the Secret storing credentials. 
- In [ra-01-configuring-runtime.md](https://github.com/kyma-project/kyma/blob/main/docs/05-technical-reference/ra-01-configuring-runtime.md), mention that Compass Runtime Agent fetches credentials from Director and creates secrets used by Application Gateway. See [this comment](https://github.com/kyma-project/kyma/pull/12259/files#r723025197).
- In [ra-01-configuring-runtime.md](https://github.com/kyma-project/kyma/blob/main/docs/05-technical-reference/ra-01-configuring-runtime.md), mention how Application, API Bundle, and API definition are mapped. 

**Related issue(s)**
#14740 