### PR TITLE
Introduce dummy input for default log pipeline

### DIFF
--- a/resources/telemetry/charts/fluent-bit/values.yaml
+++ b/resources/telemetry/charts/fluent-bit/values.yaml
@@ -321,6 +321,12 @@ config:
         DB /data/flb_kube.db
         storage.type  filesystem
 
+    [INPUT]
+        Name tail
+        Path /null.log
+        Tag null.*
+        Alias dummy
+
   ## https://docs.fluentbit.io/manual/pipeline/filters
   filters: |
     [FILTER]
@@ -335,7 +341,8 @@ config:
   outputs: |
     [OUTPUT]
         Name null
-        Match tele.*
+        Match null.*
+        Alias dummy
   ## https://docs.fluentbit.io/manual/pipeline/parsers
   customParsers: |
     [PARSER]


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Fluent Bit needs an input and output plugin to start without crashing immediately. We defined a `null` output plugin in the telemetry chart to allow Fluent Bit to start even without having a `LogPipeline` defined. This output would create a log pipeline that processes all container logs. 

This PR connects the `null` output to a separate input, which does not read any logs, to save resources.

Changes proposed in this pull request:

- Use dummy Fluent Bit input that does not read any logs for default pipeline

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
