### PR TITLE
Fix wrong priorityClassName

### DIFF
--- a/resources/ory/charts/hydra/templates/deployment.yaml
+++ b/resources/ory/charts/hydra/templates/deployment.yaml
@@ -204,8 +204,8 @@ spec:
       initContainers:
 {{ tpl .Values.deployment.extraInitContainers . | indent 8 }}
       {{- end }}
-      {{- if .Values.priorityClassName }}
-      priorityClassName: {{ .Values.priorityClassName }}
+      {{- if .Values.global.priorityClassName }}
+      priorityClassName: {{ .Values.global.priorityClassName }}
       {{- end }}
       {{- with .Values.deployment.nodeSelector }}
       nodeSelector:


### PR DESCRIPTION
Revert changing value from `.Values.global.priorityClassName` to `.Values.priorityClassName`