### PR TITLE
Fix a typo in the Application Gateway URL for the Compass scenario in documentation

### DIFF
--- a/docs/05-technical-reference/ac-01-application-gateway-details.md
+++ b/docs/05-technical-reference/ac-01-application-gateway-details.md
@@ -13,7 +13,7 @@ The suffix and the port number differ depending on whether you're using Kyma in 
 | **Kyma mode** | **Application Gateway URL** |
 |-----------|-------------------------|
 | Standalone | `http://central-application-gateway.kyma-system:8080/{APP_NAME}/{SERVICE_NAME}/{TARGET_PATH}` |
-| Compass | `http://central-application-gateway.kyma-integration:8082/{APP_NAME}/{SERVICE_NAME}/{API_ENTRY_NAME}/{TARGET_PATH}` |
+| Compass | `http://central-application-gateway.kyma-system:8082/{APP_NAME}/{SERVICE_NAME}/{API_ENTRY_NAME}/{TARGET_PATH}` |
 
 The placeholders in the URLs map to the following:
 

--- a/milv.config.yaml
+++ b/milv.config.yaml
@@ -51,4 +51,4 @@ files:
   - path: "./kyma/docs/05-technical-reference/ac-01-application-gateway-details.md"
     config:
       external-links-to-ignore: [ "http://central-application-gateway.kyma-system:8080/{APP_NAME}/{SERVICE_NAME}/{TARGET_PATH",
-      "http://central-application-gateway.kyma-integration:8082/{APP_NAME}/{SERVICE_NAME}/{API_ENTRY_NAME}/{TARGET_PATH"]
+      "http://central-application-gateway.kyma-system:8082/{APP_NAME}/{SERVICE_NAME}/{API_ENTRY_NAME}/{TARGET_PATH"]


### PR DESCRIPTION
**Description**

The Application Gateway URL described in the documentation was copy-pasted from another place with the wrong Namespace in it (`kyma-integration` instead of `kyma-system`). This PR fixes it. 

Changes proposed in this pull request:

- Change the `kyma-integration` Namespace to `kyma-system` in the Application Gateway URL for the Compass scenario in [ac-01-application-gateway-details.md](https://github.com/kyma-project/kyma/blob/main/docs/05-technical-reference/ac-01-application-gateway-details.md)
- Fix the URL in the MILV ignore list

**Related issue**
#14740 

**Related PR**
#14777 