### PR TITLE
Increase timeout while waiting for virtualservice on fast integration tests

### DIFF
--- a/tests/fast-integration/utils/index.js
+++ b/tests/fast-integration/utils/index.js
@@ -591,7 +591,7 @@ async function printContainerLogs(selector, container, namespace = 'default', ti
   process.stdout.write('Done getting logs\n');
 }
 
-function waitForVirtualService(namespace, apiRuleName, timeout = 20000) {
+function waitForVirtualService(namespace, apiRuleName, timeout = 30000) {
   const path = `/apis/networking.istio.io/v1beta1/namespaces/${namespace}/virtualservices`;
   const query = {
     labelSelector: `apirule.gateway.kyma-project.io/v1alpha1=${apiRuleName}.${namespace}`,


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Increase timeout to wait for Virtual Service readiness

**Related issue(s)**
flaky tests due t timeout: https://status.build.kyma-project.io/job-history/gs/kyma-prow-logs/logs/kyma-upgrade-gardener-kyma2-to-main-reconciler-main
