### PR TITLE
Rework tests nats subscriber

### DIFF
--- a/components/eventing-controller/controllers/backend/reconciler_test.go
+++ b/components/eventing-controller/controllers/backend/reconciler_test.go
@@ -667,8 +667,8 @@ func bebSecretExists(ctx context.Context) bool {
 	return len(secretList.Items) > 0
 }
 
-// creates a secret containing the oauth2 credentials that is expected to be
-// created by the Hydra operator
+// createOAuth2Secret creates a secret containing the oauth2 credentials that is expected to be
+// created by the Hydra operator.
 func createOAuth2Secret(ctx context.Context, clientID, clientSecret []byte) {
 	sec := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{

--- a/components/eventing-controller/pkg/handlers/nats.go
+++ b/components/eventing-controller/pkg/handlers/nats.go
@@ -327,7 +327,7 @@ func (n *Nats) doWithRetry(ctx context.Context, params cev2context.RetryParams, 
 		if cev2protocol.IsACK(result) {
 			return result
 		}
-		n.namedLogger().Errorw("Failed to CloudEvent dispatch", "id", ce.ID(), "source", ce.Source(), "type", ce.Type(), "error", result, "retry", retry)
+		n.namedLogger().Errorw("Failed to dispatch CloudEvent", "id", ce.ID(), "source", ce.Source(), "type", ce.Type(), "error", result, "retry", retry)
 		// Try again?
 		if err := params.Backoff(ctx, retry+1); err != nil {
 			// do not try again.

--- a/components/eventing-controller/pkg/handlers/nats_test.go
+++ b/components/eventing-controller/pkg/handlers/nats_test.go
@@ -7,22 +7,67 @@ import (
 	"testing"
 	"time"
 
-	"github.com/kyma-project/kyma/components/eventing-controller/pkg/handlers/metrics"
-
 	"github.com/avast/retry-go/v3"
-	cev2event "github.com/cloudevents/sdk-go/v2/event"
+	cenats "github.com/cloudevents/sdk-go/protocol/nats/v2"
+	ce "github.com/cloudevents/sdk-go/v2"
+	cebinding "github.com/cloudevents/sdk-go/v2/binding"
+	ceevent "github.com/cloudevents/sdk-go/v2/event"
 	kymalogger "github.com/kyma-project/kyma/common/logging/logger"
-	"github.com/nats-io/nats.go"
-	. "github.com/onsi/gomega"
-
 	eventingv1alpha1 "github.com/kyma-project/kyma/components/eventing-controller/api/v1alpha1"
 	"github.com/kyma-project/kyma/components/eventing-controller/logger"
 	"github.com/kyma-project/kyma/components/eventing-controller/pkg/application/applicationtest"
 	"github.com/kyma-project/kyma/components/eventing-controller/pkg/application/fake"
 	"github.com/kyma-project/kyma/components/eventing-controller/pkg/env"
 	"github.com/kyma-project/kyma/components/eventing-controller/pkg/handlers/eventtype"
+	"github.com/kyma-project/kyma/components/eventing-controller/pkg/handlers/metrics"
 	eventingtesting "github.com/kyma-project/kyma/components/eventing-controller/testing"
+	"github.com/nats-io/nats.go"
+	. "github.com/onsi/gomega"
 )
+
+const (
+	Structured SendEncoding = 0
+	Binary     SendEncoding = 1
+)
+
+type SendEncoding uint8
+
+// SendCloudEventToNATS sends a CloudEvent to a NATS client using a defined encoding method.
+func SendCloudEventToNATS(natsClient *Nats, cloudEvent *ceevent.Event, encoding SendEncoding) error {
+	// create a NATS-sender
+	natsOpts := cenats.NatsOptions()
+	url := natsClient.config.URL
+	subject := cloudEvent.Subject()
+	sender, err := cenats.NewSender(url, subject, natsOpts)
+	if err != nil {
+		return fmt.Errorf("failed to create NATS protocol sender, %s", err.Error())
+	}
+
+	// create a CloudEvent client
+	ceClient, err := ce.NewClient(sender)
+	if err != nil {
+		return fmt.Errorf("failed to create an CloudEvent client, %s", err.Error())
+	}
+
+	// define the encoding for sending the event
+	ctx := contextWithSendEncoding(encoding)
+
+	if result := ceClient.Send(ctx, *cloudEvent); ce.IsUndelivered(result) {
+		return fmt.Errorf("failed to send CloudEvent, %s", result.Error())
+	}
+	return nil
+}
+
+func contextWithSendEncoding(encoding SendEncoding) context.Context {
+	ctx := context.Background()
+	switch encoding {
+	case Structured:
+		ctx = cebinding.WithForceStructured(ctx)
+	case Binary:
+		ctx = cebinding.WithForceBinary(ctx)
+	}
+	return ctx
+}
 
 var (
 	nextSinkPort = &portGenerator{port: 8088}
@@ -33,7 +78,7 @@ func TestConvertMsgToCE(t *testing.T) {
 	testCases := []struct {
 		name               string
 		natsMsg            nats.Msg
-		expectedCloudEvent cev2event.Event
+		expectedCloudEvent ceevent.Event
 		expectedErr        error
 	}{
 		{
@@ -56,7 +101,7 @@ func TestConvertMsgToCE(t *testing.T) {
 				Data:    []byte(NewNatsMessagePayload("foo-data", "", "foosource", eventTime, "fooeventtype")),
 				Sub:     nil,
 			},
-			expectedCloudEvent: cev2event.New(cev2event.CloudEventsVersionV1),
+			expectedCloudEvent: ceevent.New(ceevent.CloudEventsVersionV1),
 			expectedErr:        errors.New("id: MUST be a non-empty string\n"), //nolint:revive
 		},
 	}
@@ -957,20 +1002,28 @@ func TestIsValidSubscription(t *testing.T) {
 
 func TestSubscriptionUsingCESDK(t *testing.T) {
 	g := NewWithT(t)
+	defaultLogger := getLogger(g, kymalogger.INFO)
+
 	natsServer, _ := startNATSServer()
 	defer natsServer.Shutdown()
-	defaultLogger := getLogger(g, kymalogger.INFO)
+
 	natsConfig := env.NatsConfig{
-		URL:           natsServer.ClientURL(),
-		MaxReconnects: 2,
-		ReconnectWait: time.Second,
+		URL:                 natsServer.ClientURL(),
+		MaxReconnects:       2,
+		ReconnectWait:       time.Second,
+		MaxIdleConns:        50,
+		MaxConnsPerHost:     50,
+		MaxIdleConnsPerHost: 2,
+		IdleConnTimeout:     6 * time.Second,
 	}
 	defaultMaxInflight := 1
 	defaultSubsConfig := env.DefaultSubscriptionConfig{MaxInFlightMessages: defaultMaxInflight}
 	natsBackend := NewNats(natsConfig, env.DefaultSubscriptionConfig{MaxInFlightMessages: defaultMaxInflight}, metrics.NewCollector(), defaultLogger)
 	g.Expect(natsBackend.Initialize(nil)).Should(Succeed())
 
-	subscriber := eventingtesting.NewSubscriber()
+	subscriber := eventingtesting.NewSubscriber(
+		eventingtesting.WithCloudEventServeMux(),
+	)
 	defer subscriber.Shutdown()
 	g.Expect(subscriber.IsRunning()).To(BeTrue())
 
@@ -984,19 +1037,24 @@ func TestSubscriptionUsingCESDK(t *testing.T) {
 	err := natsBackend.SyncSubscription(sub)
 	g.Expect(err).To(BeNil())
 
-	subject := eventingtesting.CloudEventType
-	g.Expect(SendBinaryCloudEventToNATS(natsBackend, subject, eventingtesting.CloudEventData)).Should(Succeed())
-	g.Expect(subscriber.CheckEvent(eventingtesting.CloudEventData)).Should(Succeed())
-	g.Expect(SendStructuredCloudEventToNATS(natsBackend, subject, eventingtesting.StructuredCloudEvent)).Should(Succeed())
-	g.Expect(subscriber.CheckEvent("\"" + eventingtesting.EventData + "\"")).Should(Succeed())
+	event, err := eventingtesting.CloudEvent()
+	g.Expect(err).To(BeNil())
+
+	g.Expect(SendCloudEventToNATS(natsBackend, event, Structured)).Should(Succeed())
+	g.Expect(subscriber.CheckEvent(event.String())).Should(Succeed())
+
+	g.Expect(SendCloudEventToNATS(natsBackend, event, Binary)).Should(Succeed())
+	g.Expect(subscriber.CheckEvent(event.String())).Should(Succeed())
+
 	g.Expect(natsBackend.DeleteSubscription(sub)).Should(Succeed())
 }
 
 func TestRetryUsingCESDK(t *testing.T) {
 	g := NewWithT(t)
+	defaultLogger := getLogger(g, kymalogger.INFO)
+
 	natsServer, _ := startNATSServer()
 	defer natsServer.Shutdown()
-	defaultLogger := getLogger(g, kymalogger.INFO)
 
 	natsConfig := env.NatsConfig{
 		URL:           natsServer.ClientURL(),
@@ -1012,25 +1070,29 @@ func TestRetryUsingCESDK(t *testing.T) {
 	natsBackend := NewNats(natsConfig, defaultSubsConfig, metrics.NewCollector(), defaultLogger)
 	g.Expect(natsBackend.Initialize(nil)).Should(Succeed())
 
-	subscriber := eventingtesting.NewSubscriber()
+	subscriber := eventingtesting.NewSubscriber(
+		eventingtesting.WithCloudEventServeMux(),
+	)
 	defer subscriber.Shutdown()
 	g.Expect(subscriber.IsRunning()).To(BeTrue())
 
-	sub := eventingtesting.NewSubscription("sub", "foo",
+	subscription := eventingtesting.NewSubscription("subscription", "foo",
 		eventingtesting.WithOrderCreatedFilter(),
 		eventingtesting.WithSinkURL(subscriber.InternalErrorURL),
 		eventingtesting.WithStatusConfig(defaultSubsConfig),
 	)
 	cleaner := createEventTypeCleaner(eventingtesting.EventTypePrefix, eventingtesting.ApplicationName, defaultLogger)
-	addCleanEventTypesToStatus(sub, cleaner)
-	err := natsBackend.SyncSubscription(sub)
+	addCleanEventTypesToStatus(subscription, cleaner)
+	err := natsBackend.SyncSubscription(subscription)
 	g.Expect(err).To(BeNil())
 
-	subject := eventingtesting.CloudEventType
-	g.Expect(SendStructuredCloudEventToNATS(natsBackend, subject, eventingtesting.StructuredCloudEvent)).Should(Succeed())
-	// Check that the retries are done and that the published data was correctly received
-	g.Expect(subscriber.CheckRetries(maxRetries, "\""+eventingtesting.EventData+"\"")).Should(Succeed())
-	g.Expect(natsBackend.DeleteSubscription(sub)).Should(Succeed())
+	event, err := eventingtesting.CloudEvent()
+	g.Expect(err).To(BeNil())
+
+	g.Expect(SendCloudEventToNATS(natsBackend, event, Structured)).Should(Succeed())
+	// check if the retries are done and if the published data was correctly received
+	g.Expect(subscriber.CheckRetries(maxRetries, event.String())).Should(Succeed())
+	g.Expect(natsBackend.DeleteSubscription(subscription)).Should(Succeed())
 }
 
 func TestSubscription_NATSServerRestart(t *testing.T) {

--- a/components/eventing-controller/testing/event/cehelper/builder.go
+++ b/components/eventing-controller/testing/event/cehelper/builder.go
@@ -1,0 +1,81 @@
+package cehelper
+
+import (
+	"time"
+
+	v2 "github.com/cloudevents/sdk-go/v2"
+)
+
+type EventOpt func(event *v2.Event) error
+
+// NewEvent returns a CloudEvent build from passed EventOpts. This is only a helper that builds around existing
+// CloudEvent functions.
+func NewEvent(opts ...EventOpt) (*v2.Event, error) {
+	e := v2.NewEvent()
+	for _, o := range opts {
+		if err := o(&e); err != nil {
+			return nil, err
+		}
+	}
+	return &e, nil
+}
+
+// WithType is a EventOpt to set the `ce-type` header of a CloudEvent. This will never return an error.
+func WithType(_type string) func(event *v2.Event) error {
+	return func(e *v2.Event) error {
+		e.SetType(_type)
+		return nil
+	}
+}
+
+// WithData is a EventOpt to set the data header of a CloudEvent. It accepts the data as a string and the encoding as an
+// interface. A set of valid encodings can be found here:
+// https://github.com/cloudevents/sdk-go/blob/2d3bb5b2c7e5eeab39e07bd47004cb17a83f0ca6/v2/alias.go#L58
+func WithData(data string, encoding interface{}) func(event *v2.Event) error {
+	return func(e *v2.Event) error {
+		if err := e.SetData(data, encoding); err != nil {
+			return err
+		}
+		return nil
+	}
+}
+
+// WithSubject is a EventOpt to set the `ce-subject` header of a CloudEvent. This will never return an error.
+func WithSubject(subject string) func(event *v2.Event) error {
+	return func(e *v2.Event) error {
+		e.SetSubject(subject)
+		return nil
+	}
+}
+
+// WithID is a EventOpt to set the `ce-id` header of a CloudEvent. This will never return an error.
+func WithID(id string) func(event *v2.Event) error {
+	return func(e *v2.Event) error {
+		e.SetID(id)
+		return nil
+	}
+}
+
+// WithSource is a EventOpt to set the `ce-source` header of a CloudEvent. This will never return an error.
+func WithSource(source string) func(event *v2.Event) error {
+	return func(e *v2.Event) error {
+		e.SetSource(source)
+		return nil
+	}
+}
+
+// WithSpecVersion is a EventOpt to set the `ce-specversion` header of a CloudEvent. This will never return an error.
+func WithSpecVersion(version string) func(event *v2.Event) error {
+	return func(e *v2.Event) error {
+		e.SetSpecVersion(version)
+		return nil
+	}
+}
+
+// WithTime is a EventOpt to set the `ce-time` header of a CloudEvent. This will never return an error.
+func WithTime(timestamp time.Time) func(event *v2.Event) error {
+	return func(e *v2.Event) error {
+		e.SetTime(timestamp)
+		return nil
+	}
+}

--- a/components/eventing-controller/testing/event/cehelper/converter.go
+++ b/components/eventing-controller/testing/event/cehelper/converter.go
@@ -1,0 +1,32 @@
+package cehelper
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	cebinding "github.com/cloudevents/sdk-go/v2/binding"
+	cehttp "github.com/cloudevents/sdk-go/v2/protocol/http"
+)
+
+// RequestToEventString takes a http request that is based on a CloudEvent and tries to convert it to a string that
+// contains all the CloudEvent related data. Here is an example of a possible output:
+//
+// Context Attributes,
+//   specversion: 1.0
+//   type: prefix.testapp1023.order.created.v1
+//   source: /default/sap.kyma/id
+//   subject: prefix.testapp1023.order.created.v1
+//   id: 1.0
+//   time: 2022-07-15T18:40:15.808918Z
+//   datacontenttype: application/json
+// Data,
+//   "{\"foo\":\"bar\"}"
+func RequestToEventString(r *http.Request) (string, error) {
+	msg := cehttp.NewMessageFromHttpRequest(r)
+	event, err := cebinding.ToEvent(context.Background(), msg)
+	if err != nil {
+		return "", fmt.Errorf("failed to build a CloudEvent: %s", err.Error())
+	}
+	return event.String(), nil
+}

--- a/components/eventing-controller/testing/subscriber.go
+++ b/components/eventing-controller/testing/subscriber.go
@@ -10,10 +10,20 @@ import (
 	"strconv"
 	"time"
 
+	"github.com/kyma-project/kyma/components/eventing-controller/testing/event/cehelper"
 	"go.uber.org/atomic"
 
 	"github.com/avast/retry-go/v3"
 	pkgerrors "github.com/pkg/errors"
+)
+
+const (
+	maxNoOfData           = 10
+	maxAttempts           = 10
+	storeEndpoint         = "/store"
+	checkEndpoint         = "/check"
+	internalErrorEndpoint = "/return500"
+	checkRetriesEndpoint  = "/check_retries"
 )
 
 type Subscriber struct {
@@ -26,29 +36,63 @@ type Subscriber struct {
 
 type SubscriberOption func(*Subscriber)
 
-const (
-	maxNoOfData           = 10
-	maxAttempts           = 10
-	storeEndpoint         = "/store"
-	checkEndpoint         = "/check"
-	internalErrorEndpoint = "/return500"
-	checkRetriesEndpoint  = "/check_retries"
-)
+// NewSubscriber creates a simple test Subscriber with http Endpoints to received, store end answer
+// event data. NewSubscriber accepts SubscriberOpts for customization.
+func NewSubscriber(opts ...SubscriberOption) *Subscriber {
+	subscriber := &Subscriber{}
+	for _, opt := range opts {
+		opt(subscriber)
+	}
 
-func getServeMux() *http.ServeMux {
+	if subscriber.server == nil {
+		mux := getDataServeMux()
+		subscriber.server = httptest.NewServer(mux)
+	}
+	subscriber.SinkURL = fmt.Sprintf("%s%s", subscriber.server.URL, storeEndpoint)
+	subscriber.checkURL = fmt.Sprintf("%s%s", subscriber.server.URL, checkEndpoint)
+	subscriber.InternalErrorURL = fmt.Sprintf("%s%s", subscriber.server.URL, internalErrorEndpoint)
+	subscriber.checkRetriesURL = fmt.Sprintf("%s%s", subscriber.server.URL, checkRetriesEndpoint)
+	return subscriber
+}
+
+// WithCloudEventServeMux will make the Subscriber store all CloudEvent-related date ("ce-..." header etc) at its
+// "/store" e Endpoint instead of its default behaviour of only storing the http.Request.Body data.
+func WithCloudEventServeMux() SubscriberOption {
+	return func(subscriber *Subscriber) {
+		mux := getCloudEventServeMux()
+		subscriber.server = httptest.NewServer(mux)
+	}
+}
+
+func WithListener(listener net.Listener) SubscriberOption {
+	return func(subscriber *Subscriber) {
+		mux := getDataServeMux()
+		subscriber.server = httptest.NewUnstartedServer(mux)
+		subscriber.server.Listener.Close()
+		subscriber.server.Listener = listener
+		subscriber.server.Start()
+	}
+}
+
+// getCloudEventServeMux sets the Subscriber up to handle all CloudEvent related data (headers etc.) to test
+// against CloudEvents. Use the WithCloudEventServeMux opt to set the Subscriber with this ServeMux.
+func getCloudEventServeMux() *http.ServeMux {
 	store := make(chan string, maxNoOfData)
 	retries := atomic.Int32{}
 	mux := http.NewServeMux()
 
+	// this Endpoint stores the CloudEvent as a string.
 	mux.HandleFunc(storeEndpoint, func(w http.ResponseWriter, r *http.Request) {
-		data, err := ioutil.ReadAll(r.Body)
+		eventString, err := cehelper.RequestToEventString(r)
 		if err != nil {
 			log.Printf("read data failed: %v", err)
 			w.WriteHeader(http.StatusInternalServerError)
 			return
 		}
-		store <- string(data)
+		store <- eventString
 	})
+	// this Endpoint returns the last stored string. If, after a time out of 0.5 sec, nothing was found in the store
+	// it will return an empty string.
 	mux.HandleFunc(checkEndpoint, func(w http.ResponseWriter, r *http.Request) {
 		var msg string
 		select {
@@ -64,15 +108,17 @@ func getServeMux() *http.ServeMux {
 			return
 		}
 	})
+	// this Endpoint stores the CloudEvent as a string while returning an "Internal Server Error" (code: 500).
 	mux.HandleFunc(internalErrorEndpoint, func(w http.ResponseWriter, r *http.Request) {
-		if data, err := ioutil.ReadAll(r.Body); err != nil {
+		if eventString, err := cehelper.RequestToEventString(r); err != nil {
 			log.Printf("read data failed: %v", err)
 		} else {
-			store <- string(data)
+			store <- eventString
 		}
 		retries.Inc()
 		w.WriteHeader(http.StatusInternalServerError)
 	})
+	// this Endpoint returns the number of attempted retries.
 	mux.HandleFunc(checkRetriesEndpoint, func(w http.ResponseWriter, r *http.Request) {
 		_, err := w.Write([]byte(fmt.Sprintf("%d", retries.Load())))
 		if err != nil {
@@ -84,32 +130,60 @@ func getServeMux() *http.ServeMux {
 	return mux
 }
 
-func NewSubscriber(opts ...SubscriberOption) *Subscriber {
-	subscriber := &Subscriber{}
-	for _, opt := range opts {
-		opt(subscriber)
-	}
+// getDataServeMux sets the Subscriber up to handle the request body data for tests. This is the default ServeMux for
+// the Subscriber. Use this to test against only the event data without any metadata.
+func getDataServeMux() *http.ServeMux {
+	store := make(chan string, maxNoOfData)
+	retries := atomic.Int32{}
+	mux := http.NewServeMux()
 
-	if subscriber.server == nil {
-		mux := getServeMux()
-		subscriber.server = httptest.NewServer(mux)
-	}
-
-	subscriber.SinkURL = fmt.Sprintf("%s%s", subscriber.server.URL, storeEndpoint)
-	subscriber.checkURL = fmt.Sprintf("%s%s", subscriber.server.URL, checkEndpoint)
-	subscriber.InternalErrorURL = fmt.Sprintf("%s%s", subscriber.server.URL, internalErrorEndpoint)
-	subscriber.checkRetriesURL = fmt.Sprintf("%s%s", subscriber.server.URL, checkRetriesEndpoint)
-	return subscriber
-}
-
-func WithListener(listener net.Listener) SubscriberOption {
-	return func(subscriber *Subscriber) {
-		mux := getServeMux()
-		subscriber.server = httptest.NewUnstartedServer(mux)
-		subscriber.server.Listener.Close()
-		subscriber.server.Listener = listener
-		subscriber.server.Start()
-	}
+	// this Endpoint stores the data of the request body.
+	mux.HandleFunc(storeEndpoint, func(w http.ResponseWriter, r *http.Request) {
+		data, err := ioutil.ReadAll(r.Body)
+		if err != nil {
+			log.Printf("read data failed: %v", err)
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+		store <- string(data)
+	})
+	// this Endpoint returns the last stored string. If, after a time out of 0.5 sec, nothing was found in the store
+	// it will return an empty string.
+	mux.HandleFunc(checkEndpoint, func(w http.ResponseWriter, r *http.Request) {
+		var msg string
+		select {
+		case m := <-store:
+			msg = m
+		case <-time.After(500 * time.Millisecond):
+			msg = ""
+		}
+		_, err := w.Write([]byte(msg))
+		if err != nil {
+			log.Printf("write data failed: %v", err)
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+	})
+	// this Endpoint stores the request body as a string while returning an "Internal Server Error" (code: 500).
+	mux.HandleFunc(internalErrorEndpoint, func(w http.ResponseWriter, r *http.Request) {
+		if data, err := ioutil.ReadAll(r.Body); err != nil {
+			log.Printf("read data failed: %v", err)
+		} else {
+			store <- string(data)
+		}
+		retries.Inc()
+		w.WriteHeader(http.StatusInternalServerError)
+	})
+	// this Endpoint returns the number of attempted retries.
+	mux.HandleFunc(checkRetriesEndpoint, func(w http.ResponseWriter, r *http.Request) {
+		_, err := w.Write([]byte(fmt.Sprintf("%d", retries.Load())))
+		if err != nil {
+			log.Printf("check_retries failed: %v", err)
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+	})
+	return mux
 }
 
 func (s *Subscriber) Shutdown() {
@@ -124,24 +198,30 @@ func (s *Subscriber) IsRunning() bool {
 	return s.CheckEvent("") == nil
 }
 
+// CheckEvent checks if the Subscriber received the expected string and will return an error if this is not the case.
 func (s Subscriber) CheckEvent(expectedData string) error {
 	var body []byte
 	delay := time.Second
 	err := retry.Do(
 		func() error {
+			// check if a response was received and that it's code is in 2xx-range
 			resp, err := http.Get(s.checkURL)
 			if err != nil {
 				return pkgerrors.Wrapf(err, "get HTTP request failed")
 			}
 			if !is2XXStatusCode(resp.StatusCode) {
-				return fmt.Errorf("Response code is not 2xx, received Response code is: %d", resp.StatusCode)
+				return fmt.Errorf("expected resonse code 2xx, actual response code: %d", resp.StatusCode)
 			}
+
+			// try to read the response body
 			defer func() { _ = resp.Body.Close() }()
 			body, err = ioutil.ReadAll(resp.Body)
 			if err != nil {
 				return pkgerrors.Wrapf(err, "read data failed")
 			}
-			if string(body) != expectedData {
+
+			// compare response body with expectations
+			if expectedData != string(body) {
 				return fmt.Errorf("event not received")
 			}
 			return nil
@@ -159,7 +239,8 @@ func (s Subscriber) CheckEvent(expectedData string) error {
 	return nil
 }
 
-// CheckRetries checks if the number of retries specified by expectedData was done and that data sent on each retry was correctly received.
+// CheckRetries checks if the number of retries specified by expectedData was done and if the data sent on each retry
+// was correctly received.
 func (s Subscriber) CheckRetries(expectedNoOfRetries int, expectedData string) error {
 	var body []byte
 	delay := time.Second
@@ -170,7 +251,7 @@ func (s Subscriber) CheckRetries(expectedNoOfRetries int, expectedData string) e
 				return pkgerrors.Wrapf(err, "get HTTP request failed")
 			}
 			if !is2XXStatusCode(resp.StatusCode) {
-				return fmt.Errorf("Response code is not 2xx, received Response code is: %d", resp.StatusCode)
+				return fmt.Errorf("expected resonse code 2xx, actual response code: %d", resp.StatusCode)
 			}
 			defer func() { _ = resp.Body.Close() }()
 			body, err = ioutil.ReadAll(resp.Body)

--- a/components/eventing-controller/testing/test_helpers.go
+++ b/components/eventing-controller/testing/test_helpers.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"net"
 	"net/http"
+	"time"
 
 	"github.com/kyma-project/kyma/components/eventing-controller/pkg/env"
 
@@ -23,6 +24,9 @@ import (
 	"github.com/kyma-project/kyma/components/eventing-controller/pkg/ems/api/events/types"
 	"github.com/kyma-project/kyma/components/eventing-controller/pkg/object"
 	"github.com/kyma-project/kyma/components/eventing-controller/utils"
+
+	ce "github.com/cloudevents/sdk-go/v2"
+	"github.com/kyma-project/kyma/components/eventing-controller/testing/event/cehelper"
 )
 
 const (
@@ -61,6 +65,19 @@ const (
 
 	JSStreamName = "kyma"
 )
+
+// CloudEvent returns the pointer to a simple CloudEvent for testing purpose.
+func CloudEvent() (*ce.Event, error) {
+	return cehelper.NewEvent(
+		cehelper.WithSubject(CloudEventType),
+		cehelper.WithSpecVersion(CloudEventSpecVersion),
+		cehelper.WithID(CloudEventSpecVersion),
+		cehelper.WithSource(CloudEventSource),
+		cehelper.WithType(CloudEventType),
+		cehelper.WithData(ce.ApplicationJSON, CloudEventData),
+		cehelper.WithTime(time.Now()),
+	)
+}
 
 type APIRuleOption func(r *apigatewayv1alpha1.APIRule)
 

--- a/resources/eventing/values.yaml
+++ b/resources/eventing/values.yaml
@@ -5,7 +5,7 @@ global:
   images:
     eventing_controller:
       name: eventing-controller
-      version: PR-14805
+      version: PR-14835
       pullPolicy: "IfNotPresent"
     publisher_proxy:
       name: event-publisher-proxy


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

This is a rework of the nats tests in the nats handlers for cloudevents to test not only against event data but against the whole cloud event including it's meta data.

Changes proposed in this pull request:

- check against CE instead of CE data only

**Related issue(s)**
https://github.com/kyma-project/kyma/issues/14521