### PR TITLE
Remove the omitempty from SubscriptionStatus CleanEventTypes

### DIFF
--- a/components/eventing-controller/api/v1alpha1/subscription_types.go
+++ b/components/eventing-controller/api/v1alpha1/subscription_types.go
@@ -238,8 +238,9 @@ type Subscription struct {
 // If the SubscriptionStatus.CleanEventTypes is nil, it will be initialized to an empty slice of stings.
 // It is needed because the Kubernetes APIServer will reject requests containing null in the JSON payload.
 func (s Subscription) MarshalJSON() ([]byte, error) {
+	// Use type alias to copy the subscription without causing an infinite recursion when calling json.Marshal.
 	type Alias Subscription
-	a := (Alias)(s)
+	a := Alias(s)
 	if a.Status.CleanEventTypes == nil {
 		a.Status.InitializeCleanEventTypes()
 	}

--- a/components/eventing-controller/api/v1alpha1/subscription_types_test.go
+++ b/components/eventing-controller/api/v1alpha1/subscription_types_test.go
@@ -4,6 +4,8 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/kyma-project/kyma/components/eventing-controller/pkg/env"
 )
 
@@ -124,4 +126,12 @@ func TestMergeSubsConfigs(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestInitializeCleanEventTypes(t *testing.T) {
+	s := Subscription{}
+	require.Nil(t, s.Status.CleanEventTypes)
+
+	s.Status.InitializeCleanEventTypes()
+	require.NotNil(t, s.Status.CleanEventTypes)
 }

--- a/components/eventing-controller/config/crd/bases/eventing.kyma-project.io_subscriptions.yaml
+++ b/components/eventing-controller/config/crd/bases/eventing.kyma-project.io_subscriptions.yaml
@@ -249,6 +249,7 @@ spec:
                 description: Ready defines the overall readiness status of a subscription
                 type: boolean
             required:
+            - cleanEventTypes
             - ready
             type: object
         type: object

--- a/components/eventing-controller/controllers/subscription/beb/reconciler.go
+++ b/components/eventing-controller/controllers/subscription/beb/reconciler.go
@@ -629,6 +629,10 @@ func getSvcNsAndName(url string) (string, string, error) {
 
 // syncInitialStatus determines the desired initial status and updates it accordingly (if conditions changed)
 func (r *Reconciler) syncInitialStatus(subscription *eventingv1alpha1.Subscription) {
+	if subscription.Status.CleanEventTypes == nil {
+		subscription.Status.InitializeCleanEventTypes()
+	}
+
 	expectedStatus := eventingv1alpha1.SubscriptionStatus{}
 	expectedStatus.InitializeConditions()
 

--- a/components/eventing-controller/controllers/subscription/jetstream/reconciler.go
+++ b/components/eventing-controller/controllers/subscription/jetstream/reconciler.go
@@ -246,11 +246,8 @@ func (r *Reconciler) syncInitialStatus(subscription *eventingv1alpha1.Subscripti
 	cleanedSubjects, err := handlers.GetCleanSubjects(subscription, r.eventTypeCleaner)
 	if err != nil {
 		log.Errorw("Failed to get clean subjects", "error", err)
-		if len(subscription.Status.CleanEventTypes) != 0 {
-			subscription.Status.CleanEventTypes = nil
-			return true, err
-		}
-		return false, err
+		subscription.Status.InitializeCleanEventTypes()
+		return true, err
 	}
 	if !reflect.DeepEqual(subscription.Status.CleanEventTypes, cleanedSubjects) {
 		subscription.Status.CleanEventTypes = cleanedSubjects
@@ -259,6 +256,10 @@ func (r *Reconciler) syncInitialStatus(subscription *eventingv1alpha1.Subscripti
 	subscriptionConfig := eventingv1alpha1.MergeSubsConfigs(subscription.Spec.Config, &r.subsConfig)
 	if subscription.Status.Config == nil || !reflect.DeepEqual(subscriptionConfig, subscription.Status.Config) {
 		subscription.Status.Config = subscriptionConfig
+		statusChanged = true
+	}
+	if subscription.Status.CleanEventTypes == nil {
+		subscription.Status.InitializeCleanEventTypes()
 		statusChanged = true
 	}
 	return statusChanged, nil

--- a/components/eventing-controller/controllers/subscription/jetstream/reconciler_test.go
+++ b/components/eventing-controller/controllers/subscription/jetstream/reconciler_test.go
@@ -54,6 +54,7 @@ func TestUnavailableNATSServer(t *testing.T) {
 	natsPort, err := reconcilertesting.GetFreePort()
 	g.Expect(err).ToNot(gomega.HaveOccurred())
 	ens := setupTestEnsemble(ctx, reconcilertesting.EventTypePrefix, g, natsPort)
+	defer utils.StopTestEnv(ens.TestEnsemble)
 
 	subscription := utils.CreateSubscription(ens.TestEnsemble,
 		reconcilertesting.WithFilter(emptyEventSource, utils.NewUncleanEventType("")),
@@ -86,6 +87,7 @@ func TestCreateSubscription(t *testing.T) {
 	g.Expect(err).ToNot(gomega.HaveOccurred())
 
 	ens := setupTestEnsemble(ctx, reconcilertesting.EventTypePrefix, g, natsPort)
+	defer utils.StopTestEnv(ens.TestEnsemble)
 
 	var testCases = []struct {
 		name                  string
@@ -298,6 +300,7 @@ func TestChangeSubscription(t *testing.T) {
 	natsPort, err := reconcilertesting.GetFreePort()
 	g.Expect(err).ToNot(gomega.HaveOccurred())
 	ens := setupTestEnsemble(ctx, reconcilertesting.EventTypePrefix, g, natsPort)
+	defer utils.StopTestEnv(ens.TestEnsemble)
 
 	var testCases = []struct {
 		name                  string
@@ -535,6 +538,7 @@ func TestEmptyEventTypePrefix(t *testing.T) {
 	natsPort, err := reconcilertesting.GetFreePort()
 	g.Expect(err).NotTo(gomega.HaveOccurred())
 	ens := setupTestEnsemble(ctx, reconcilertesting.EventTypePrefixEmpty, g, natsPort)
+	defer utils.StopTestEnv(ens.TestEnsemble)
 
 	// when
 	subscription := utils.CreateSubscription(ens.TestEnsemble,

--- a/components/eventing-controller/controllers/subscription/nats/reconciler.go
+++ b/components/eventing-controller/controllers/subscription/nats/reconciler.go
@@ -244,11 +244,8 @@ func (r *Reconciler) syncInitialStatus(subscription *eventingv1alpha1.Subscripti
 	cleanEventTypes, err := handlers.GetCleanSubjects(subscription, r.eventTypeCleaner)
 	if err != nil {
 		log.Errorw("Failed to get clean subject", "error", err)
-		if len(subscription.Status.CleanEventTypes) != 0 {
-			subscription.Status.CleanEventTypes = nil
-			return true, err
-		}
-		return false, err
+		subscription.Status.InitializeCleanEventTypes()
+		return true, err
 	}
 	if !reflect.DeepEqual(subscription.Status.CleanEventTypes, cleanEventTypes) {
 		subscription.Status.CleanEventTypes = cleanEventTypes
@@ -257,6 +254,10 @@ func (r *Reconciler) syncInitialStatus(subscription *eventingv1alpha1.Subscripti
 	subscriptionConfig := eventingv1alpha1.MergeSubsConfigs(subscription.Spec.Config, &r.subsConfig)
 	if subscription.Status.Config == nil || !reflect.DeepEqual(subscriptionConfig, subscription.Status.Config) {
 		subscription.Status.Config = subscriptionConfig
+		statusChanged = true
+	}
+	if subscription.Status.CleanEventTypes == nil {
+		subscription.Status.InitializeCleanEventTypes()
 		statusChanged = true
 	}
 	return statusChanged, nil

--- a/components/eventing-controller/controllers/subscription/nats/reconciler_test.go
+++ b/components/eventing-controller/controllers/subscription/nats/reconciler_test.go
@@ -56,6 +56,7 @@ func TestUnavailableNATSServer(t *testing.T) {
 	natsPort, err := reconcilertesting.GetFreePort()
 	g.Expect(err).ToNot(gomega.HaveOccurred())
 	ens := setupTestEnsemble(ctx, reconcilertesting.EventTypePrefix, g, natsPort)
+	defer utils.StopTestEnv(ens.TestEnsemble)
 
 	subscription := utils.CreateSubscription(ens.TestEnsemble,
 		reconcilertesting.WithFilter(emptyEventSource, utils.NewUncleanEventType("")),
@@ -87,6 +88,7 @@ func TestCreateSubscription(t *testing.T) {
 	g.Expect(err).ToNot(gomega.HaveOccurred())
 
 	ens := setupTestEnsemble(ctx, reconcilertesting.EventTypePrefix, g, natsPort)
+	defer utils.StopTestEnv(ens.TestEnsemble)
 
 	var testCases = []struct {
 		name                  string
@@ -298,6 +300,7 @@ func TestChangeSubscription(t *testing.T) {
 	natsPort, err := reconcilertesting.GetFreePort()
 	g.Expect(err).ToNot(gomega.HaveOccurred())
 	ens := setupTestEnsemble(ctx, reconcilertesting.EventTypePrefix, g, natsPort)
+	defer utils.StopTestEnv(ens.TestEnsemble)
 
 	var testCases = []struct {
 		name                  string
@@ -534,6 +537,7 @@ func TestEmptyEventTypePrefix(t *testing.T) {
 	natsPort, err := reconcilertesting.GetFreePort()
 	g.Expect(err).NotTo(gomega.HaveOccurred())
 	ens := setupTestEnsemble(ctx, reconcilertesting.EventTypePrefixEmpty, g, natsPort)
+	defer utils.StopTestEnv(ens.TestEnsemble)
 
 	subscription := utils.CreateSubscription(ens.TestEnsemble,
 		reconcilertesting.WithFilter(emptyEventSource, reconcilertesting.OrderCreatedEventTypeNotCleanPrefixEmpty),

--- a/components/eventing-controller/pkg/handlers/beb.go
+++ b/components/eventing-controller/pkg/handlers/beb.go
@@ -125,7 +125,7 @@ func (b *BEB) SyncSubscription(subscription *eventingv1alpha1.Subscription, clea
 	// check the hash values for ev2 and EMS
 	if newEv2Hash != subscription.Status.Ev2hash {
 		// reset the cleanEventTypes
-		subscription.Status.CleanEventTypes = nil
+		subscription.Status.InitializeCleanEventTypes()
 		// delete & create a new EMS subscription
 		var newEMSHash int64
 		bebSubscription, newEMSHash, err = b.deleteCreateAndHashSubscription(sEv2, cleaner, log)
@@ -160,7 +160,7 @@ func (b *BEB) SyncSubscription(subscription *eventingv1alpha1.Subscription, clea
 		}
 		if newEmsHash != subscription.Status.Emshash {
 			// reset the cleanEventTypes
-			subscription.Status.CleanEventTypes = nil
+			subscription.Status.InitializeCleanEventTypes()
 			// delete & create a new EMS subscription
 			bebSubscription, newEmsHash, err = b.deleteCreateAndHashSubscription(sEv2, cleaner, log)
 			if err != nil {

--- a/components/eventing-controller/pkg/handlers/nats.go
+++ b/components/eventing-controller/pkg/handlers/nats.go
@@ -123,7 +123,7 @@ func GetCleanSubjects(sub *eventingv1alpha1.Subscription, cleaner eventtype.Clea
 	if sub.Spec.Filter != nil {
 		uniqueFilters, err := sub.Spec.Filter.Deduplicate()
 		if err != nil {
-			return nil, errors.Wrap(err, "deduplicate subscription filters failed")
+			return []string{}, errors.Wrap(err, "deduplicate subscription filters failed")
 		}
 		filters = uniqueFilters.Filters
 	}
@@ -132,7 +132,7 @@ func GetCleanSubjects(sub *eventingv1alpha1.Subscription, cleaner eventtype.Clea
 	for _, filter := range filters {
 		subject, err := getCleanSubject(filter, cleaner)
 		if err != nil {
-			return nil, err
+			return []string{}, err
 		}
 		cleanSubjects = append(cleanSubjects, subject)
 	}

--- a/components/eventing-controller/pkg/subscriptionmanager/beb/beb_test.go
+++ b/components/eventing-controller/pkg/subscriptionmanager/beb/beb_test.go
@@ -149,7 +149,7 @@ func TestCleanup(t *testing.T) {
 	g.Expect(err).To(gomega.BeNil())
 	gotSub, err := controllertesting.ToSubscription(unstructuredSub)
 	g.Expect(err).To(gomega.BeNil())
-	expectedSubStatus := eventingv1alpha1.SubscriptionStatus{}
+	expectedSubStatus := eventingv1alpha1.SubscriptionStatus{CleanEventTypes: []string{}}
 	g.Expect(expectedSubStatus).To(gomega.Equal(gotSub.Status))
 
 	// the associated APIRule should be deleted
@@ -157,7 +157,6 @@ func TestCleanup(t *testing.T) {
 	g.Expect(err).ToNot(gomega.BeNil())
 	g.Expect(unstructuredAPIRuleAfterCleanup).To(gomega.BeNil())
 	bebMock.Stop()
-
 }
 
 func startBEBMock() *controllertesting.BEBMock {

--- a/components/eventing-controller/pkg/subscriptionmanager/jetstream/jetstream_test.go
+++ b/components/eventing-controller/pkg/subscriptionmanager/jetstream/jetstream_test.go
@@ -43,7 +43,7 @@ func TestCleanup(t *testing.T) {
 	// then
 	require.NoError(t, err)
 	gotSub := testEnv.getK8sSubscription(t)
-	wantSubStatus := eventingv1alpha1.SubscriptionStatus{}
+	wantSubStatus := eventingv1alpha1.SubscriptionStatus{CleanEventTypes: []string{}}
 	require.Equal(t, wantSubStatus, gotSub.Status)
 	// test JetStream subscriptions/consumers are gone
 	testEnv.consumersEquals(t, 0)

--- a/components/eventing-controller/pkg/subscriptionmanager/nats/nats_test.go
+++ b/components/eventing-controller/pkg/subscriptionmanager/nats/nats_test.go
@@ -125,7 +125,7 @@ func TestCleanup(t *testing.T) {
 	g.Expect(err).To(gomega.BeNil())
 	gotSub, err := controllertesting.ToSubscription(unstructuredSub)
 	g.Expect(err).To(gomega.BeNil())
-	expectedSubStatus := eventingv1alpha1.SubscriptionStatus{}
+	expectedSubStatus := eventingv1alpha1.SubscriptionStatus{CleanEventTypes: []string{}}
 	g.Expect(expectedSubStatus).To(gomega.Equal(gotSub.Status))
 
 	// Test NATS subscriptions are gone

--- a/components/eventing-controller/testing/test_helpers.go
+++ b/components/eventing-controller/testing/test_helpers.go
@@ -293,7 +293,11 @@ func WithSpecConfig(defaultConfig env.DefaultSubscriptionConfig) SubscriptionOpt
 
 func WithStatusCleanEventTypes(cleanEventTypes []string) SubscriptionOpt {
 	return func(sub *eventingv1alpha1.Subscription) {
-		sub.Status.CleanEventTypes = cleanEventTypes
+		if cleanEventTypes == nil {
+			sub.Status.InitializeCleanEventTypes()
+		} else {
+			sub.Status.CleanEventTypes = cleanEventTypes
+		}
 	}
 }
 

--- a/resources/eventing/values.yaml
+++ b/resources/eventing/values.yaml
@@ -5,11 +5,11 @@ global:
   images:
     eventing_controller:
       name: eventing-controller
-      version: 181e40bc
+      version: PR-14881
       pullPolicy: "IfNotPresent"
     publisher_proxy:
       name: event-publisher-proxy
-      version: 3e9ad3ed
+      version: 4d056ca1
     nats:
       name: nats
       version: 2.8.2-alpine


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Remove `omitempty` from the SubscriptionStatus CleanEventTypes.
- Fix TestEnv cleanup for NATS and JetStream tests.
- Fix some flaky tests.

**Related issue(s)**

- https://github.com/kyma-project/kyma/issues/14293.
