### PR TITLE
Fix typos in the _Register a secured API_ tutorial

### DIFF
--- a/docs/03-tutorials/00-application-connectivity/ac-04-register-secured-api.md
+++ b/docs/03-tutorials/00-application-connectivity/ac-04-register-secured-api.md
@@ -44,7 +44,7 @@ The **credentials** object must contain the following fields:
 | **type**              | Authentication method type. Supported values: `Basic`, `OAuth`, `OAuthWithCert `, `CertGen`.  |
 | **authenticationUrl** | Optional OAuth token URL, valid only for the `OAuth` and `OAuthWithCert` types. |
 
-## Register a  Basic Authentication-secured API
+## Register a Basic Authentication-secured API
 
 This is an example of the **service** object for an API secured with Basic Authentication:
 
@@ -291,7 +291,7 @@ data:
 To create such a Secret, run this command:
 
 ```bash
-kubectl create secret generic {SECRET_NAME} --from-literal headers={HEADERS_JSON} --from-literal headers={QUERY_PARAMS_JSON} -n kyma-integration
+kubectl create secret generic {SECRET_NAME} --from-literal headers={HEADERS_JSON} --from-literal queryParameters={QUERY_PARAMS_JSON} -n kyma-integration
 ```
 
 Additional headers stored in the Secret must be provided in the form of a valid JSON document. This is an example of a headers JSON containing one entry:


### PR DESCRIPTION
**Description**

This PR fixes typos in the [Register a secured API](https://github.com/kyma-project/kyma/blob/main/docs/03-tutorials/00-application-connectivity/ac-04-register-secured-api.md) tutorial.

Changes proposed in this pull request:

- Remove an obsolete space
- Correct the name of a command parameter from `headers` to `queryParams`

**Related PR**
https://github.com/kyma-project/kyma/pull/13984
