### PR TITLE
Add troubleshooting guide for how to free JS storage

### DIFF
--- a/components/event-publisher-proxy/pkg/sender/jetstream.go
+++ b/components/event-publisher-proxy/pkg/sender/jetstream.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"strings"
 
 	"github.com/kyma-project/kyma/components/eventing-controller/logger"
 	"go.uber.org/zap"
@@ -17,8 +18,9 @@ import (
 )
 
 const (
-	natsBackend         = "nats"
-	jestreamHandlerName = "jetstream-handler"
+	natsBackend           = "nats"
+	jestreamHandlerName   = "jetstream-handler"
+	noSpaceLeftErrMessage = "no space left on device"
 )
 
 // compile time check
@@ -71,6 +73,9 @@ func (s *JetstreamMessageSender) Send(_ context.Context, event *event.Event) (in
 	_, err = jsCtx.PublishMsg(msg)
 	if err != nil {
 		s.namedLogger().Errorw("Cannot send event to backend", "error", err)
+		if strings.Contains(err.Error(), noSpaceLeftErrMessage) {
+			return http.StatusInsufficientStorage, err
+		}
 		return http.StatusInternalServerError, err
 	}
 	return http.StatusNoContent, nil

--- a/docs/04-operation-guides/troubleshooting/eventing/evnt-04-free-jetstream-storage.md
+++ b/docs/04-operation-guides/troubleshooting/eventing/evnt-04-free-jetstream-storage.md
@@ -1,0 +1,29 @@
+---
+title: Free NATS JetStream file storage when it gets full
+---
+
+## Symptom
+
+Free NATS JetStream file storage when it gets full.
+
+## Cause
+
+NATS JetStream uses [Interest retention policy](https://docs.nats.io/using-nats/developer/develop_jetstream/model_deep_dive) in Kyma per default.
+It means, that as long as there are consumers on the stream, which the published event's subject, the messages will be kept in the stream if they cannot be delivered to the sink.
+
+In some cases, it might happen, that the NATS JetStream storage gets full due to too many undelivered events.
+In order to not lose events, JetStream backend will just stop receiving and the user will get `507 Insufficient Storage` Error from Publisher Proxy or `no space left on device` from the Backend directly.
+This means, that the Backend's storage is full and no further events can be persisted to the stream.
+
+## Remedy
+
+There are several ways of how to free the space on NATS JetStream Backend:
+
+- The published events might be too large, so the consumer isn't fast enough to deliver them, before the storage gets full. In that case eiter wait until the events get delivered or extend the NATS Backend by additional replicas.
+
+
+- Check if the sink is reachable and can accept the events.
+
+
+- Due to `Interest` Policy, the events published to the subject, which doesn't match any consumer filter, will not be kept in the stream.
+  You can delete a Kyma Subscription, which will automatically remove all the pending messages in the stream, which were published the Subscription's subject. 

--- a/docs/04-operation-guides/troubleshooting/eventing/evnt-04-free-jetstream-storage.md
+++ b/docs/04-operation-guides/troubleshooting/eventing/evnt-04-free-jetstream-storage.md
@@ -18,6 +18,8 @@ This retention policy keeps messages in the stream if they can't be delivered to
 If there are too many undelivered events, the NATS JetStream storage may get full.
 To prevent event loss, the backend stops receiving events, and no further events can be persisted to the stream.
 
+>**NOTE:** Remember, that if you delete a Subscriber(sink), but there is still a Kyma Subscription pointing to that sink in place, the events published to that Subscription will pile up in the stream and possibly delay the event delivery to other Subscribers.
+
 ## Remedy
 
 There are several ways to free the space on NATS JetStream backend:

--- a/docs/04-operation-guides/troubleshooting/eventing/evnt-04-free-jetstream-storage.md
+++ b/docs/04-operation-guides/troubleshooting/eventing/evnt-04-free-jetstream-storage.md
@@ -18,7 +18,7 @@ This retention policy keeps messages in the stream if they can't be delivered to
 If there are too many undelivered events, the NATS JetStream storage may get full.
 To prevent event loss, the backend stops receiving events, and no further events can be persisted to the stream.
 
->**NOTE:** Remember, that if you delete a Subscriber(sink), but there is still a Kyma Subscription pointing to that sink in place, the events published to that Subscription will pile up in the stream and possibly delay the event delivery to other Subscribers.
+> **NOTE:** If you delete a Subscriber (sink) while there is still a Kyma Subscription pointing to that sink, the events published to that Subscription pile up in the stream and possibly delay the event delivery to other Subscribers.
 
 ## Remedy
 

--- a/resources/eventing/values.yaml
+++ b/resources/eventing/values.yaml
@@ -5,7 +5,7 @@ global:
   images:
     eventing_controller:
       name: eventing-controller
-      version: PR-14839
+      version: PR-14881
       pullPolicy: "IfNotPresent"
     publisher_proxy:
       name: event-publisher-proxy


### PR DESCRIPTION
**Description**

Reasoning: https://github.com/kyma-project/kyma/issues/14475#issuecomment-1194038815

Changes proposed in this pull request:

- add troubleshooting guide of how to free the space, when the JS Backend gets full
- change the HTTP status to more fitting one in the EPP
