### PR TITLE
added extensionProviders for envoy access logs to have logs in JSON format

### DIFF
--- a/resources/istio/values.yaml
+++ b/resources/istio/values.yaml
@@ -48,6 +48,12 @@ meshConfig:
         address: "zipkin.kyma-system:9411"
   enablePrometheusMerge: false
   enableTracing: "{{ .Values.global.tracing.enabled }}"
+  extensionProviders:
+    - name: envoy
+      envoyFileAccessLog:
+        path: "/dev/stdout"
+        logFormat:
+          labels: {}
 
 components:
   egressGateways:


### PR DESCRIPTION

<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- reduced cherry-pick of #14918
- adds only the envoy extension provider to have existing telemetry resources working again
- ...

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
- reduced backport of #14918
- backport for https://github.com/kyma-project/kyma/issues/14909