### PR TITLE
Change default URI for Fluent Bit HTTP output

### DIFF
--- a/components/telemetry-operator/internal/fluentbit/config_builder.go
+++ b/components/telemetry-operator/internal/fluentbit/config_builder.go
@@ -119,7 +119,6 @@ func getHTTPOutputDefaults() map[string]string {
 		"tls":                      "on",
 		"tls.verify":               "on",
 		"allow_duplicated_headers": "true",
-		"uri":                      "/customindex/kyma",
 		"format":                   "json",
 	}
 	return result

--- a/components/telemetry-operator/internal/fluentbit/config_builder_test.go
+++ b/components/telemetry-operator/internal/fluentbit/config_builder_test.go
@@ -109,7 +109,6 @@ func TestFilter(t *testing.T) {
     storage.total_limit_size 1G
     tls on
     tls.verify on
-    uri /customindex/kyma
 
 `
 	filters := []telemetryv1alpha1.Filter{
@@ -230,6 +229,7 @@ func TestHTTPOutput(t *testing.T) {
 					Password: telemetryv1alpha1.ValueType{
 						Value: "password",
 					},
+					URI: "/customindex/kyma",
 				},
 			},
 		},

--- a/resources/telemetry/values.yaml
+++ b/resources/telemetry/values.yaml
@@ -4,7 +4,7 @@ global:
   images:
     telemetry_operator:
       name: "telemetry-operator"
-      version: "f2689a5b"
+      version: "PR-14973"
     fluent_bit:
       name: "fluent-bit"
       version: "1.9.6-fdfefada"


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- Keep Fluent Bit's default URI for the http output plugin

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
See also #14863 