### PR TITLE
Adjust ory-oathkeeper health probes

### DIFF
--- a/resources/ory/charts/oathkeeper/templates/deployment-sidecar.yaml
+++ b/resources/ory/charts/oathkeeper/templates/deployment-sidecar.yaml
@@ -104,7 +104,7 @@ spec:
               port: http-api
             initialDelaySeconds: 45
             periodSeconds: 10
-            failureThreshold: 10
+            failureThreshold: 30
           resources:
             {{- toYaml .Values.deployment.resources | nindent 12 }}
           securityContext:

--- a/resources/ory/charts/oathkeeper/templates/deployment-sidecar.yaml
+++ b/resources/ory/charts/oathkeeper/templates/deployment-sidecar.yaml
@@ -89,7 +89,6 @@ spec:
             httpGet:
               path: /health/alive
               port: http-api
-            initialDelaySeconds: 15
             periodSeconds: 10
             failureThreshold: 10
           readinessProbe:
@@ -98,14 +97,14 @@ spec:
               port: http-api
             initialDelaySeconds: 45
             periodSeconds: 10
-            failureThreshold: 10
+            failureThreshold: 40
           startupProbe:
             httpGet:
               path: /health/alive
               port: http-api
             initialDelaySeconds: 45
             periodSeconds: 10
-            failureThreshold: 30
+            failureThreshold: 10
           resources:
             {{- toYaml .Values.deployment.resources | nindent 12 }}
           securityContext:

--- a/resources/ory/values.yaml
+++ b/resources/ory/values.yaml
@@ -247,6 +247,8 @@ oathkeeper:
       maxReplicas: 3
       targetMemoryUtilizationPercentage: 75
       targetCPUUtilizationPercentage: 80
+    annotations:
+      readiness.status.sidecar.istio.io/initialDelaySeconds: "10"
   oathkeeper-maester:
     deployment:
       annotations:


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- Increase the failureThreshold for readiness probe
- Increase initial delay for istio-proxy health check

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
