### PR TITLE
Bump nodejs16 alpine image

### DIFF
--- a/components/function-runtimes/nodejs16/Dockerfile
+++ b/components/function-runtimes/nodejs16/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:16-alpine3.14
+FROM node:16-alpine3.16
 
 ARG NODE_ENV
 ENV NODE_ENV $NODE_ENV

--- a/resources/serverless/values.yaml
+++ b/resources/serverless/values.yaml
@@ -85,13 +85,13 @@ global:
       version: "PR-14946"
     function_runtime_nodejs12:
       name: "function-runtime-nodejs12"
-      version: "PR-14951"
+      version: "PR-15038"
     function_runtime_nodejs14:
       name: "function-runtime-nodejs14"
-      version: "PR-14951"
+      version: "PR-15038"
     function_runtime_nodejs16:
       name: "function-runtime-nodejs16"
-      version: "PR-14951"
+      version: "PR-15038"
     function_runtime_python39:
       name: "function-runtime-python39"
       version: "PR-14951"


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Use latest node16-alpine3.16 image in kyma serverless

