### PR TITLE
increase istio access logs creation timeout

### DIFF
--- a/tests/fast-integration/logging/index.js
+++ b/tests/fast-integration/logging/index.js
@@ -22,7 +22,7 @@ function istioAccessLogsTests(startTimestamp) {
 
     it('Should create the Istio Access Logs resource for Loki', async () => {
       await k8sApply(istioAccessLogsResource, namespace);
-      await sleep(10000); // wait 10 seconds until resource is ready
+      await sleep(20000); // wait 20 seconds until resource is ready
     });
 
     it('Should query Loki and verify format of Istio Access Logs', async () => {


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- https://status.build.kyma-project.io/view/gs/kyma-prow-logs/logs/kyma-integration-k3d/1556537078693498880 and https://status.build.kyma-project.io/view/gs/kyma-prow-logs/logs/kyma-integration-k3d/1556521979098435584 failed because of `Cannot read property 'values' of undefined`. 
- Probably the istio access logs resource was not creating any logs yet
- This PR increases the timeout after the creation of the istio access logs resource from 10 to 20 seconds

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
