### PR TITLE
Use nodejs v16.16 in serverless runtime

### DIFF
--- a/components/function-runtimes/nodejs16/Dockerfile
+++ b/components/function-runtimes/nodejs16/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:16-alpine3.14
+FROM node:16-alpine3.16
 
 ARG NODE_ENV
 ENV NODE_ENV $NODE_ENV


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Bump node version in nodejs16 serverless runtime (CVE-2022-32215, CVE-2022-32214, CVE-2022-32213)


**Related issue(s)**
https://github.com/nodejs/node/issues/43946