### PR TITLE
Add v1alpha1 webhooks for serverless

### DIFF
--- a/components/function-controller/cmd/webhook/main.go
+++ b/components/function-controller/cmd/webhook/main.go
@@ -54,8 +54,10 @@ func main() {
 		panic(errors.Wrap(err, "while reading env variables"))
 	}
 
-	validationConfig := webhook.ReadValidationConfigOrDie()
-	defaultingConfig := webhook.ReadDefaultingConfigOrDie()
+	validationConfigv1alpha1 := webhook.ReadValidationConfigV1Alpha1OrDie()
+	validationConfigv1alpha2 := webhook.ReadValidationConfigV1Alpha2OrDie()
+	defaultingConfigv1alpha1 := webhook.ReadDefaultingConfigV1Alpha1OrDie()
+	defaultingConfigv1alpha2 := webhook.ReadDefaultingConfigV1Alpha2OrDie()
 
 	// manager setup
 	log.Info("setting up controller-manager")
@@ -96,12 +98,12 @@ func main() {
 
 	whs.Register(resources.FunctionDefaultingWebhookPath,
 		&ctrlwebhook.Admission{
-			Handler: webhook.NewDefaultingWebhook(defaultingConfig, mgr.GetClient()),
+			Handler: webhook.NewDefaultingWebhook(defaultingConfigv1alpha1, defaultingConfigv1alpha2, mgr.GetClient()),
 		},
 	)
 	whs.Register(resources.FunctionValidationWebhookPath,
 		&ctrlwebhook.Admission{
-			Handler: webhook.NewValidatingHook(validationConfig, mgr.GetClient()),
+			Handler: webhook.NewValidatingHook(validationConfigv1alpha1, validationConfigv1alpha2, mgr.GetClient()),
 		},
 	)
 

--- a/components/function-controller/internal/webhook/config.go
+++ b/components/function-controller/internal/webhook/config.go
@@ -1,6 +1,7 @@
 package webhook
 
 import (
+	serverlessv1alpha1 "github.com/kyma-project/kyma/components/function-controller/pkg/apis/serverless/v1alpha1"
 	serverlessv1alpha2 "github.com/kyma-project/kyma/components/function-controller/pkg/apis/serverless/v1alpha2"
 	"github.com/pkg/errors"
 	"github.com/vrischmann/envconfig"
@@ -13,7 +14,41 @@ type Config struct {
 	WebhookPort        int    `envconfig:"default=8443"`
 }
 
-func ReadDefaultingConfigOrDie() *serverlessv1alpha2.DefaultingConfig {
+//TODO: We should split configuration to seperate env or use file to pass configuration per version.
+func ReadDefaultingConfigV1Alpha1OrDie() *serverlessv1alpha1.DefaultingConfig {
+	defaultingCfg := &serverlessv1alpha1.DefaultingConfig{}
+	if err := envconfig.InitWithPrefix(defaultingCfg, "WEBHOOK_DEFAULTING"); err != nil {
+		panic(errors.Wrap(err, "while reading env defaulting variables"))
+	}
+
+	functionReplicasPresets, err := serverlessv1alpha1.ParseReplicasPresets(defaultingCfg.Function.Replicas.PresetsMap)
+	if err != nil {
+		panic(errors.Wrap(err, "while parsing function replicas presets"))
+	}
+	defaultingCfg.Function.Replicas.Presets = functionReplicasPresets
+
+	functionResourcesPresets, err := serverlessv1alpha1.ParseResourcePresets(defaultingCfg.Function.Resources.PresetsMap)
+	if err != nil {
+		panic(errors.Wrap(err, "while parsing function resources presets"))
+	}
+	defaultingCfg.Function.Resources.Presets = functionResourcesPresets
+
+	buildResourcesPresets, err := serverlessv1alpha1.ParseResourcePresets(defaultingCfg.BuildJob.Resources.PresetsMap)
+	if err != nil {
+		panic(errors.Wrap(err, "while parsing build resources presets"))
+	}
+	defaultingCfg.BuildJob.Resources.Presets = buildResourcesPresets
+
+	runtimePresets, err := serverlessv1alpha1.ParseRuntimePresets(defaultingCfg.Function.Resources.RuntimePresetsMap)
+	if err != nil {
+		panic(errors.Wrap(err, "while parsing runtime preset"))
+	}
+	defaultingCfg.Function.Resources.RuntimePresets = runtimePresets
+
+	return defaultingCfg
+}
+
+func ReadDefaultingConfigV1Alpha2OrDie() *serverlessv1alpha2.DefaultingConfig {
 	defaultingCfg := &serverlessv1alpha2.DefaultingConfig{}
 	if err := envconfig.InitWithPrefix(defaultingCfg, "WEBHOOK_DEFAULTING"); err != nil {
 		panic(errors.Wrap(err, "while reading env defaulting variables"))
@@ -46,7 +81,15 @@ func ReadDefaultingConfigOrDie() *serverlessv1alpha2.DefaultingConfig {
 	return defaultingCfg
 }
 
-func ReadValidationConfigOrDie() *serverlessv1alpha2.ValidationConfig {
+func ReadValidationConfigV1Alpha1OrDie() *serverlessv1alpha1.ValidationConfig {
+	validationCfg := &serverlessv1alpha1.ValidationConfig{}
+	if err := envconfig.InitWithPrefix(validationCfg, "WEBHOOK_VALIDATION"); err != nil {
+		panic(errors.Wrap(err, "while reading env defaulting variables"))
+	}
+	return validationCfg
+}
+
+func ReadValidationConfigV1Alpha2OrDie() *serverlessv1alpha2.ValidationConfig {
 	validationCfg := &serverlessv1alpha2.ValidationConfig{}
 	if err := envconfig.InitWithPrefix(validationCfg, "WEBHOOK_VALIDATION"); err != nil {
 		panic(errors.Wrap(err, "while reading env defaulting variables"))

--- a/components/function-controller/internal/webhook/defaulting_webhook.go
+++ b/components/function-controller/internal/webhook/defaulting_webhook.go
@@ -38,7 +38,7 @@ func (w *DefaultingWebHook) Handle(_ context.Context, req admission.Request) adm
 	if req.Kind.Kind == "GitRepository" {
 		return w.handleGitRepoDefaulting()
 	}
-	return admission.Errored(http.StatusBadRequest, fmt.Errorf("invalid kind: %v", req.RequestKind.Kind))
+	return admission.Errored(http.StatusBadRequest, fmt.Errorf("invalid kind: %v", req.Kind.Kind))
 }
 
 func (w *DefaultingWebHook) InjectDecoder(decoder *admission.Decoder) error {

--- a/components/function-controller/internal/webhook/defaulting_webhook.go
+++ b/components/function-controller/internal/webhook/defaulting_webhook.go
@@ -9,7 +9,6 @@ import (
 
 	"net/http"
 
-	"github.com/kyma-project/kyma/components/function-controller/internal/webhook/resources"
 	serverlessv1alpha1 "github.com/kyma-project/kyma/components/function-controller/pkg/apis/serverless/v1alpha1"
 
 	serverlessv1alpha2 "github.com/kyma-project/kyma/components/function-controller/pkg/apis/serverless/v1alpha2"
@@ -50,7 +49,7 @@ func (w *DefaultingWebHook) InjectDecoder(decoder *admission.Decoder) error {
 func (w *DefaultingWebHook) handleFunctionDefaulting(req admission.Request) admission.Response {
 	var f interface{}
 	switch req.Kind.Version {
-	case resources.ServerlessV1Alpha1Version:
+	case serverlessv1alpha1.FunctionVersion:
 		{
 			fn := &serverlessv1alpha1.Function{}
 			if err := w.decoder.Decode(req, fn); err != nil {
@@ -59,7 +58,7 @@ func (w *DefaultingWebHook) handleFunctionDefaulting(req admission.Request) admi
 			fn.Default(w.configAlphaV1)
 			f = fn
 		}
-	case resources.ServerlessV1Alpha2Version:
+	case serverlessv1alpha2.FunctionVersion:
 		{
 			fn := &serverlessv1alpha2.Function{}
 			if err := w.decoder.Decode(req, fn); err != nil {

--- a/components/function-controller/internal/webhook/defaulting_webhook.go
+++ b/components/function-controller/internal/webhook/defaulting_webhook.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+
 	"github.com/pkg/errors"
 
 	"net/http"

--- a/components/function-controller/internal/webhook/defaulting_webhook_test.go
+++ b/components/function-controller/internal/webhook/defaulting_webhook_test.go
@@ -5,6 +5,8 @@ import (
 	"net/http"
 	"testing"
 
+	"github.com/kyma-project/kyma/components/function-controller/internal/webhook/resources"
+
 	serverlessv1alpha2 "github.com/kyma-project/kyma/components/function-controller/pkg/apis/serverless/v1alpha2"
 	"github.com/stretchr/testify/require"
 	v1 "k8s.io/api/admission/v1"
@@ -88,7 +90,7 @@ func TestDefaultingWebHook_Handle(t *testing.T) {
 				ctx: context.Background(),
 				req: admission.Request{
 					AdmissionRequest: v1.AdmissionRequest{
-						RequestKind: &metav1.GroupVersionKind{Kind: "Function"},
+						Kind: metav1.GroupVersionKind{Kind: "Function", Version: resources.ServerlessV1Alpha2Version},
 						Object: runtime.RawExtension{
 							Raw: []byte(`{
 								"apiVersion": "serverless.kyma-project.io/v1alpha2",
@@ -114,7 +116,7 @@ func TestDefaultingWebHook_Handle(t *testing.T) {
 				},
 			},
 			want: want{
-				// 6 patch operations added
+				// 7 patch operations added
 				// add /spec/resources
 				// add /spec/buildResources
 				// add /spec/sources/inline/dependencies
@@ -136,7 +138,7 @@ func TestDefaultingWebHook_Handle(t *testing.T) {
 				ctx: context.Background(),
 				req: admission.Request{
 					AdmissionRequest: v1.AdmissionRequest{
-						RequestKind: &metav1.GroupVersionKind{Kind: "Function"},
+						Kind: metav1.GroupVersionKind{Kind: "Function", Version: resources.ServerlessV1Alpha2Version},
 						Object: runtime.RawExtension{
 							Raw: []byte(`bad request`),
 						},
@@ -158,7 +160,7 @@ func TestDefaultingWebHook_Handle(t *testing.T) {
 				ctx: context.Background(),
 				req: admission.Request{
 					AdmissionRequest: v1.AdmissionRequest{
-						RequestKind: &metav1.GroupVersionKind{Kind: "Function"},
+						Kind: metav1.GroupVersionKind{Kind: "Function", Version: resources.ServerlessV1Alpha2Version},
 						Object: runtime.RawExtension{
 							Raw: []byte(`{
 								"apiVersion": "serverless.kyma-project.io/v1alpha2",
@@ -186,9 +188,9 @@ func TestDefaultingWebHook_Handle(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			w := &DefaultingWebHook{
-				config:  tt.fields.config,
-				client:  tt.fields.client,
-				decoder: tt.fields.decoder,
+				configAlphaV2: tt.fields.config,
+				client:        tt.fields.client,
+				decoder:       tt.fields.decoder,
 			}
 			got := w.Handle(tt.args.ctx, tt.args.req)
 

--- a/components/function-controller/internal/webhook/defaulting_webhook_test.go
+++ b/components/function-controller/internal/webhook/defaulting_webhook_test.go
@@ -2,10 +2,12 @@ package webhook
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 	"testing"
 
-	"github.com/kyma-project/kyma/components/function-controller/internal/webhook/resources"
+	serverlessv1alpha1 "github.com/kyma-project/kyma/components/function-controller/pkg/apis/serverless/v1alpha1"
+	"github.com/stretchr/testify/assert"
 
 	serverlessv1alpha2 "github.com/kyma-project/kyma/components/function-controller/pkg/apis/serverless/v1alpha2"
 	"github.com/stretchr/testify/require"
@@ -20,9 +22,10 @@ import (
 
 func TestDefaultingWebHook_Handle(t *testing.T) {
 	type fields struct {
-		config  *serverlessv1alpha2.DefaultingConfig
-		client  ctrlclient.Client
-		decoder *admission.Decoder
+		configv1alpha1 *serverlessv1alpha1.DefaultingConfig
+		configv1alpha2 *serverlessv1alpha2.DefaultingConfig
+		client         ctrlclient.Client
+		decoder        *admission.Decoder
 	}
 	type args struct {
 		ctx context.Context
@@ -44,9 +47,9 @@ func TestDefaultingWebHook_Handle(t *testing.T) {
 		want   want
 	}{
 		{
-			name: "Set function defaults successfully",
+			name: "Set function defaults successfully v1alpha2",
 			fields: fields{
-				config: &serverlessv1alpha2.DefaultingConfig{
+				configv1alpha2: &serverlessv1alpha2.DefaultingConfig{
 					Function: serverlessv1alpha2.FunctionDefaulting{
 						Replicas: serverlessv1alpha2.FunctionReplicasDefaulting{
 							DefaultPreset: "S",
@@ -90,7 +93,7 @@ func TestDefaultingWebHook_Handle(t *testing.T) {
 				ctx: context.Background(),
 				req: admission.Request{
 					AdmissionRequest: v1.AdmissionRequest{
-						Kind: metav1.GroupVersionKind{Kind: "Function", Version: resources.ServerlessV1Alpha2Version},
+						Kind: metav1.GroupVersionKind{Kind: "Function", Version: serverlessv1alpha2.FunctionVersion},
 						Object: runtime.RawExtension{
 							Raw: []byte(`{
 								"apiVersion": "serverless.kyma-project.io/v1alpha2",
@@ -128,9 +131,45 @@ func TestDefaultingWebHook_Handle(t *testing.T) {
 			},
 		},
 		{
-			name: "Bad request",
+			name: "Set function defaults successfully v1alpha1",
 			fields: fields{
-				config:  &serverlessv1alpha2.DefaultingConfig{},
+				configv1alpha1: &serverlessv1alpha1.DefaultingConfig{
+					Function: serverlessv1alpha1.FunctionDefaulting{
+						Replicas: serverlessv1alpha1.FunctionReplicasDefaulting{
+							DefaultPreset: "S",
+							Presets: map[string]serverlessv1alpha1.ReplicasPreset{
+								"S": {
+									Min: int32(1),
+									Max: int32(1),
+								},
+							},
+						},
+						Resources: serverlessv1alpha1.FunctionResourcesDefaulting{
+							DefaultPreset: "S",
+							Presets: map[string]serverlessv1alpha1.ResourcesPreset{
+								"S": {
+									RequestCPU:    "100m",
+									RequestMemory: "128Mi",
+									LimitCPU:      "200m",
+									LimitMemory:   "256Mi",
+								},
+							},
+						},
+					},
+					BuildJob: serverlessv1alpha1.BuildJobDefaulting{
+						Resources: serverlessv1alpha1.BuildJobResourcesDefaulting{
+							DefaultPreset: "normal",
+							Presets: map[string]serverlessv1alpha1.ResourcesPreset{
+								"normal": {
+									RequestCPU:    "700m",
+									RequestMemory: "700Mi",
+									LimitCPU:      "1100m",
+									LimitMemory:   "1100Mi",
+								},
+							},
+						},
+					},
+				},
 				client:  fake.NewClientBuilder().Build(),
 				decoder: decoder,
 			},
@@ -138,7 +177,49 @@ func TestDefaultingWebHook_Handle(t *testing.T) {
 				ctx: context.Background(),
 				req: admission.Request{
 					AdmissionRequest: v1.AdmissionRequest{
-						Kind: metav1.GroupVersionKind{Kind: "Function", Version: resources.ServerlessV1Alpha2Version},
+						Kind: metav1.GroupVersionKind{Kind: serverlessv1alpha1.FunctionKind, Version: serverlessv1alpha1.FunctionVersion},
+						Object: runtime.RawExtension{
+							Raw: []byte(`{
+								"apiVersion": "serverless.kyma-project.io/v1alpha1",
+								"kind": "Function",
+								"metadata": {
+									"labels": {
+										"serverless.kyma-project.io/function-resources-preset": "S"
+									},
+									"name": "testfunc",
+									"namespace": "default"
+								},
+								"spec": {
+									"source": "def main(event, context):\n  return \"hello world\"\n"
+								}
+							}`),
+						},
+					},
+				},
+			},
+			want: want{
+				// 6 patch operations added
+				// add /spec/resources
+				// add /spec/buildResources
+				// add /spec/minReplicas
+				// add /spec/maxReplicas
+				// add /status
+				// add /metadata/creationTimestamp
+				operationsCount: 6,
+			},
+		},
+		{
+			name: "Bad request",
+			fields: fields{
+				configv1alpha2: &serverlessv1alpha2.DefaultingConfig{},
+				client:         fake.NewClientBuilder().Build(),
+				decoder:        decoder,
+			},
+			args: args{
+				ctx: context.Background(),
+				req: admission.Request{
+					AdmissionRequest: v1.AdmissionRequest{
+						Kind: metav1.GroupVersionKind{Kind: "Function", Version: serverlessv1alpha2.FunctionVersion},
 						Object: runtime.RawExtension{
 							Raw: []byte(`bad request`),
 						},
@@ -160,7 +241,7 @@ func TestDefaultingWebHook_Handle(t *testing.T) {
 				ctx: context.Background(),
 				req: admission.Request{
 					AdmissionRequest: v1.AdmissionRequest{
-						Kind: metav1.GroupVersionKind{Kind: "Function", Version: resources.ServerlessV1Alpha2Version},
+						Kind: metav1.GroupVersionKind{Kind: "Function", Version: serverlessv1alpha2.FunctionVersion},
 						Object: runtime.RawExtension{
 							Raw: []byte(`{
 								"apiVersion": "serverless.kyma-project.io/v1alpha2",
@@ -188,7 +269,8 @@ func TestDefaultingWebHook_Handle(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			w := &DefaultingWebHook{
-				configAlphaV2: tt.fields.config,
+				configAlphaV2: tt.fields.configv1alpha2,
+				configAlphaV1: tt.fields.configv1alpha1,
 				client:        tt.fields.client,
 				decoder:       tt.fields.decoder,
 			}
@@ -196,7 +278,7 @@ func TestDefaultingWebHook_Handle(t *testing.T) {
 
 			if tt.want.operationsCount != 0 {
 				require.True(t, got.Allowed)
-				require.Equal(t, tt.want.operationsCount, len(got.Patches))
+				assert.Equal(t, tt.want.operationsCount, len(got.Patches), fmt.Sprintf("%+v", got.Patches))
 			}
 			if tt.want.statusCode != 0 {
 				require.False(t, got.Allowed)

--- a/components/function-controller/internal/webhook/fixtures_test.go
+++ b/components/function-controller/internal/webhook/fixtures_test.go
@@ -1,0 +1,84 @@
+package webhook
+
+import (
+	"encoding/json"
+	"testing"
+
+	serverlessv1alpha1 "github.com/kyma-project/kyma/components/function-controller/pkg/apis/serverless/v1alpha1"
+	serverlessv1alpha2 "github.com/kyma-project/kyma/components/function-controller/pkg/apis/serverless/v1alpha2"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func ValidV1Alpha2Function(t *testing.T) string {
+	f := serverlessv1alpha2.Function{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       serverlessv1alpha2.FunctionKind,
+			APIVersion: serverlessv1alpha2.FunctionApiVersion,
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "testfunc",
+			Namespace: "default",
+		},
+		Spec: serverlessv1alpha2.FunctionSpec{
+			ResourceConfiguration: serverlessv1alpha2.ResourceConfiguration{
+				Build: serverlessv1alpha2.ResourceRequirements{
+					Resources: corev1.ResourceRequirements{
+						Limits: map[corev1.ResourceName]resource.Quantity{
+							"cpu":    resource.MustParse("700m"),
+							"memory": resource.MustParse("700Mi"),
+						},
+						Requests: map[corev1.ResourceName]resource.Quantity{
+							"cpu":    resource.MustParse("200m"),
+							"memory": resource.MustParse("200Mi"),
+						},
+					},
+				},
+				Function: serverlessv1alpha2.ResourceRequirements{
+					Resources: corev1.ResourceRequirements{
+						Limits: map[corev1.ResourceName]resource.Quantity{
+							"cpu":    resource.MustParse("400m"),
+							"memory": resource.MustParse("512Mi"),
+						},
+						Requests: map[corev1.ResourceName]resource.Quantity{
+							"cpu":    resource.MustParse("200m"),
+							"memory": resource.MustParse("256Mi"),
+						},
+					},
+				},
+			},
+			Source: serverlessv1alpha2.Source{
+				Inline: &serverlessv1alpha2.InlineSource{
+					Source: `def main(event, context):\n  return \"hello world\"\n`,
+				}},
+			Runtime: serverlessv1alpha2.Python39,
+		}}
+
+	out, err := json.Marshal(f)
+	require.NoError(t, err)
+	return string(out)
+}
+
+func ValidV1Alpha1Function(t *testing.T) string {
+	f := serverlessv1alpha1.Function{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       serverlessv1alpha1.FunctionKind,
+			APIVersion: serverlessv1alpha1.FunctionApiVersion,
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "testfunc",
+			Namespace: "default",
+		},
+		Spec: serverlessv1alpha1.FunctionSpec{
+			Source:  `def main(event, context):\n  return \"hello world\"\n`,
+			Deps:    "",
+			Runtime: serverlessv1alpha1.Python39,
+		},
+	}
+
+	out, err := json.Marshal(f)
+	require.NoError(t, err)
+	return string(out)
+}

--- a/components/function-controller/internal/webhook/resources/webhook_config.go
+++ b/components/function-controller/internal/webhook/resources/webhook_config.go
@@ -4,6 +4,9 @@ import (
 	"context"
 	"reflect"
 
+	serverlessv1alpha1 "github.com/kyma-project/kyma/components/function-controller/pkg/apis/serverless/v1alpha1"
+	serverlessv1alpha2 "github.com/kyma-project/kyma/components/function-controller/pkg/apis/serverless/v1alpha2"
+
 	"github.com/pkg/errors"
 	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
 	apiErrors "k8s.io/apimachinery/pkg/api/errors"
@@ -25,11 +28,9 @@ const (
 	ValidatingWebHook WebHookType = "Validating"
 
 	serverlessAPIGroup          = "serverless.kyma-project.io"
-	ServerlessV1Alpha1Version   = "v1alpha1"
-	ServerlessV1Alpha2Version   = "v1alpha2"
-	ServerlessCurrentAPIVersion = ServerlessV1Alpha2Version
+	ServerlessCurrentAPIVersion = serverlessv1alpha2.FunctionVersion
 
-	DeprecatedServerlessAPIVersion = ServerlessV1Alpha1Version
+	DeprecatedServerlessAPIVersion = serverlessv1alpha1.FunctionVersion
 	DefaultingWebhookName          = "defaulting.webhook.serverless.kyma-project.io"
 	SecretMutationWebhookName      = "mutating.secret.webhook.serverless.kyma-project.io"
 	ValidationWebhookName          = "validation.webhook.serverless.kyma-project.io"

--- a/components/function-controller/internal/webhook/resources/webhook_config.go
+++ b/components/function-controller/internal/webhook/resources/webhook_config.go
@@ -24,10 +24,12 @@ const (
 	MutatingWebhook   WebHookType = "Mutating"
 	ValidatingWebHook WebHookType = "Validating"
 
-	serverlessAPIGroup   = "serverless.kyma-project.io"
-	serverlessAPIVersion = "v1alpha2"
+	serverlessAPIGroup          = "serverless.kyma-project.io"
+	ServerlessV1Alpha1Version   = "v1alpha1"
+	ServerlessV1Alpha2Version   = "v1alpha2"
+	ServerlessCurrentAPIVersion = ServerlessV1Alpha2Version
 
-	DepricatedServerlessAPIVersion = "v1alpha1"
+	DeprecatedServerlessAPIVersion = ServerlessV1Alpha1Version
 	DefaultingWebhookName          = "defaulting.webhook.serverless.kyma-project.io"
 	SecretMutationWebhookName      = "mutating.secret.webhook.serverless.kyma-project.io"
 	ValidationWebhookName          = "validation.webhook.serverless.kyma-project.io"
@@ -56,14 +58,14 @@ func ensureMutatingWebhookConfigFor(ctx context.Context, client ctlrclient.Clien
 	mwhc := &admissionregistrationv1.MutatingWebhookConfiguration{}
 	if err := client.Get(ctx, types.NamespacedName{Name: DefaultingWebhookName}, mwhc); err != nil {
 		if apiErrors.IsNotFound(err) {
-			return client.Create(ctx, createMutatingWebhookConfiguration(config))
+			return errors.Wrap(client.Create(ctx, createMutatingWebhookConfiguration(config)), "while creating webhook mutation configuration")
 		}
 		return errors.Wrapf(err, "failed to get defaulting MutatingWebhookConfiguration: %s", DefaultingWebhookName)
 	}
 	ensuredMwhc := createMutatingWebhookConfiguration(config)
 	if !reflect.DeepEqual(ensuredMwhc.Webhooks, mwhc.Webhooks) {
 		ensuredMwhc.ObjectMeta = *mwhc.ObjectMeta.DeepCopy()
-		return client.Update(ctx, ensuredMwhc)
+		return errors.Wrap(client.Update(ctx, ensuredMwhc), "while updating webhook mutation configuration")
 	}
 	return nil
 }
@@ -128,7 +130,7 @@ func getFunctionMutatingWebhookCfg(config WebhookConfig) admissionregistrationv1
 						serverlessAPIGroup,
 					},
 					APIVersions: []string{
-						serverlessAPIVersion,
+						ServerlessCurrentAPIVersion, DeprecatedServerlessAPIVersion,
 					},
 					Resources: []string{"functions", "functions/status"},
 					Scope:     &scope,
@@ -222,7 +224,7 @@ func createValidatingWebhookConfiguration(config WebhookConfig) *admissionregist
 								serverlessAPIGroup,
 							},
 							APIVersions: []string{
-								serverlessAPIVersion,
+								ServerlessCurrentAPIVersion, DeprecatedServerlessAPIVersion,
 							},
 							Resources: []string{"functions", "functions/status"},
 							Scope:     &scope,
@@ -238,7 +240,7 @@ func createValidatingWebhookConfiguration(config WebhookConfig) *admissionregist
 								serverlessAPIGroup,
 							},
 							APIVersions: []string{
-								serverlessAPIVersion,
+								ServerlessCurrentAPIVersion,
 							},
 							Resources: []string{"gitrepositories", "gitrepositories/status"},
 							Scope:     &scope,

--- a/components/function-controller/internal/webhook/validating_webhook.go
+++ b/components/function-controller/internal/webhook/validating_webhook.go
@@ -39,7 +39,7 @@ func (w *ValidatingWebHook) Handle(_ context.Context, req admission.Request) adm
 		return w.handleFunctionValidation(req)
 	}
 
-	return admission.Errored(http.StatusBadRequest, fmt.Errorf("invalid kind: %v", req.RequestKind.Kind))
+	return admission.Errored(http.StatusBadRequest, fmt.Errorf("invalid kind: %v", req.Kind.Kind))
 }
 
 func (w *ValidatingWebHook) InjectDecoder(decoder *admission.Decoder) error {

--- a/components/function-controller/internal/webhook/validating_webhook.go
+++ b/components/function-controller/internal/webhook/validating_webhook.go
@@ -3,8 +3,9 @@ package webhook
 import (
 	"context"
 	"fmt"
-	"github.com/pkg/errors"
 	"net/http"
+
+	"github.com/pkg/errors"
 
 	"github.com/kyma-project/kyma/components/function-controller/internal/webhook/resources"
 	serverlessv1alpha1 "github.com/kyma-project/kyma/components/function-controller/pkg/apis/serverless/v1alpha1"

--- a/components/function-controller/internal/webhook/validating_webhook.go
+++ b/components/function-controller/internal/webhook/validating_webhook.go
@@ -3,7 +3,11 @@ package webhook
 import (
 	"context"
 	"fmt"
+	"github.com/pkg/errors"
 	"net/http"
+
+	"github.com/kyma-project/kyma/components/function-controller/internal/webhook/resources"
+	serverlessv1alpha1 "github.com/kyma-project/kyma/components/function-controller/pkg/apis/serverless/v1alpha1"
 
 	serverlessv1alpha2 "github.com/kyma-project/kyma/components/function-controller/pkg/apis/serverless/v1alpha2"
 	v1 "k8s.io/api/admission/v1"
@@ -12,15 +16,17 @@ import (
 )
 
 type ValidatingWebHook struct {
-	config  *serverlessv1alpha2.ValidationConfig
-	client  ctrlclient.Client
-	decoder *admission.Decoder
+	configv1alpha1 *serverlessv1alpha1.ValidationConfig
+	configv1alpha2 *serverlessv1alpha2.ValidationConfig
+	client         ctrlclient.Client
+	decoder        *admission.Decoder
 }
 
-func NewValidatingHook(config *serverlessv1alpha2.ValidationConfig, client ctrlclient.Client) *ValidatingWebHook {
+func NewValidatingHook(configv1alpha1 *serverlessv1alpha1.ValidationConfig, configv1alpha2 *serverlessv1alpha2.ValidationConfig, client ctrlclient.Client) *ValidatingWebHook {
 	return &ValidatingWebHook{
-		config: config,
-		client: client,
+		configv1alpha1: configv1alpha1,
+		configv1alpha2: configv1alpha2,
+		client:         client,
 	}
 }
 func (w *ValidatingWebHook) Handle(_ context.Context, req admission.Request) admission.Response {
@@ -29,7 +35,7 @@ func (w *ValidatingWebHook) Handle(_ context.Context, req admission.Request) adm
 		return admission.Allowed("")
 	}
 
-	if req.RequestKind.Kind == "Function" {
+	if req.Kind.Kind == "Function" {
 		return w.handleFunctionValidation(req)
 	}
 
@@ -42,12 +48,29 @@ func (w *ValidatingWebHook) InjectDecoder(decoder *admission.Decoder) error {
 }
 
 func (w *ValidatingWebHook) handleFunctionValidation(req admission.Request) admission.Response {
-	f := &serverlessv1alpha2.Function{}
-	if err := w.decoder.Decode(req, f); err != nil {
-		return admission.Errored(http.StatusBadRequest, err)
-	}
-	if err := f.Validate(w.config); err != nil {
-		return admission.Denied(fmt.Sprintf("validation failed: %s", err.Error()))
+	switch req.Kind.Version {
+	case resources.ServerlessV1Alpha1Version:
+		{
+			fn := &serverlessv1alpha1.Function{}
+			if err := w.decoder.Decode(req, fn); err != nil {
+				return admission.Errored(http.StatusBadRequest, err)
+			}
+			if err := fn.Validate(w.configv1alpha1); err != nil {
+				return admission.Denied(fmt.Sprintf("validation failed: %s", err.Error()))
+			}
+		}
+	case resources.ServerlessV1Alpha2Version:
+		{
+			fn := &serverlessv1alpha2.Function{}
+			if err := w.decoder.Decode(req, fn); err != nil {
+				return admission.Errored(http.StatusBadRequest, err)
+			}
+			if err := fn.Validate(w.configv1alpha2); err != nil {
+				return admission.Denied(fmt.Sprintf("validation failed: %s", err.Error()))
+			}
+		}
+	default:
+		return admission.Errored(http.StatusBadRequest, errors.Errorf("Invalid resource version provided: %s", req.Kind.Version))
 	}
 	return admission.Allowed("")
 }

--- a/components/function-controller/internal/webhook/validating_webhook.go
+++ b/components/function-controller/internal/webhook/validating_webhook.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/pkg/errors"
 
-	"github.com/kyma-project/kyma/components/function-controller/internal/webhook/resources"
 	serverlessv1alpha1 "github.com/kyma-project/kyma/components/function-controller/pkg/apis/serverless/v1alpha1"
 
 	serverlessv1alpha2 "github.com/kyma-project/kyma/components/function-controller/pkg/apis/serverless/v1alpha2"
@@ -50,7 +49,7 @@ func (w *ValidatingWebHook) InjectDecoder(decoder *admission.Decoder) error {
 
 func (w *ValidatingWebHook) handleFunctionValidation(req admission.Request) admission.Response {
 	switch req.Kind.Version {
-	case resources.ServerlessV1Alpha1Version:
+	case serverlessv1alpha1.FunctionVersion:
 		{
 			fn := &serverlessv1alpha1.Function{}
 			if err := w.decoder.Decode(req, fn); err != nil {
@@ -60,7 +59,7 @@ func (w *ValidatingWebHook) handleFunctionValidation(req admission.Request) admi
 				return admission.Denied(fmt.Sprintf("validation failed: %s", err.Error()))
 			}
 		}
-	case resources.ServerlessV1Alpha2Version:
+	case serverlessv1alpha2.FunctionVersion:
 		{
 			fn := &serverlessv1alpha2.Function{}
 			if err := w.decoder.Decode(req, fn); err != nil {

--- a/components/function-controller/internal/webhook/validating_webhook_test.go
+++ b/components/function-controller/internal/webhook/validating_webhook_test.go
@@ -5,6 +5,8 @@ import (
 	"net/http"
 	"testing"
 
+	"github.com/kyma-project/kyma/components/function-controller/internal/webhook/resources"
+
 	serverlessv1alpha2 "github.com/kyma-project/kyma/components/function-controller/pkg/apis/serverless/v1alpha2"
 	"github.com/stretchr/testify/require"
 	v1 "k8s.io/api/admission/v1"
@@ -40,7 +42,7 @@ func TestValidatingWebHook_Handle(t *testing.T) {
 		{
 			name: "Accept valid git function",
 			fields: fields{
-				config:  ReadValidationConfigOrDie(),
+				config:  ReadValidationConfigV1Alpha2OrDie(),
 				client:  fake.NewClientBuilder().Build(),
 				decoder: decoder,
 			},
@@ -48,7 +50,7 @@ func TestValidatingWebHook_Handle(t *testing.T) {
 				ctx: context.Background(),
 				req: admission.Request{
 					AdmissionRequest: v1.AdmissionRequest{
-						RequestKind: &metav1.GroupVersionKind{Kind: "Function"},
+						Kind: metav1.GroupVersionKind{Kind: "Function", Version: resources.ServerlessV1Alpha2Version},
 						Object: runtime.RawExtension{
 							Raw: []byte(`{
   "apiVersion": "serverless.kyma-project.io/v1alpha2",
@@ -105,7 +107,7 @@ func TestValidatingWebHook_Handle(t *testing.T) {
 		{
 			name: "Accept valid function",
 			fields: fields{
-				config:  ReadValidationConfigOrDie(),
+				config:  ReadValidationConfigV1Alpha2OrDie(),
 				client:  fake.NewClientBuilder().Build(),
 				decoder: decoder,
 			},
@@ -113,7 +115,7 @@ func TestValidatingWebHook_Handle(t *testing.T) {
 				ctx: context.Background(),
 				req: admission.Request{
 					AdmissionRequest: v1.AdmissionRequest{
-						RequestKind: &metav1.GroupVersionKind{Kind: "Function"},
+						Kind: metav1.GroupVersionKind{Kind: "Function", Version: resources.ServerlessV1Alpha2Version},
 						Object: runtime.RawExtension{
 							Raw: []byte(`{"apiVersion": "serverless.kyma-project.io/v1alpha2",
 								"kind": "Function",
@@ -167,7 +169,7 @@ func TestValidatingWebHook_Handle(t *testing.T) {
 		{
 			name: "Deny invalid function",
 			fields: fields{
-				config:  ReadValidationConfigOrDie(),
+				config:  ReadValidationConfigV1Alpha2OrDie(),
 				client:  fake.NewClientBuilder().Build(),
 				decoder: decoder,
 			},
@@ -175,7 +177,7 @@ func TestValidatingWebHook_Handle(t *testing.T) {
 				ctx: context.Background(),
 				req: admission.Request{
 					AdmissionRequest: v1.AdmissionRequest{
-						RequestKind: &metav1.GroupVersionKind{Kind: "Function"},
+						Kind: metav1.GroupVersionKind{Kind: "Function", Version: resources.ServerlessV1Alpha2Version},
 						Object: runtime.RawExtension{
 							Raw: []byte(`{"apiVersion": "serverless.kyma-project.io/v1alpha2",
 								"kind": "Function",
@@ -196,7 +198,7 @@ func TestValidatingWebHook_Handle(t *testing.T) {
 		{
 			name: "Bad request",
 			fields: fields{
-				config:  ReadValidationConfigOrDie(),
+				config:  ReadValidationConfigV1Alpha2OrDie(),
 				client:  fake.NewClientBuilder().Build(),
 				decoder: decoder,
 			},
@@ -204,7 +206,7 @@ func TestValidatingWebHook_Handle(t *testing.T) {
 				ctx: context.Background(),
 				req: admission.Request{
 					AdmissionRequest: v1.AdmissionRequest{
-						RequestKind: &metav1.GroupVersionKind{Kind: "Function"},
+						Kind: metav1.GroupVersionKind{Kind: "Function", Version: resources.ServerlessV1Alpha2Version},
 						Object: runtime.RawExtension{
 							Raw: []byte(`{"bad request"`),
 						},
@@ -216,7 +218,7 @@ func TestValidatingWebHook_Handle(t *testing.T) {
 		{
 			name: "Deny on invalid kind",
 			fields: fields{
-				config:  ReadValidationConfigOrDie(),
+				config:  ReadValidationConfigV1Alpha2OrDie(),
 				client:  fake.NewClientBuilder().Build(),
 				decoder: decoder,
 			},
@@ -224,7 +226,7 @@ func TestValidatingWebHook_Handle(t *testing.T) {
 				ctx: context.Background(),
 				req: admission.Request{
 					AdmissionRequest: v1.AdmissionRequest{
-						RequestKind: &metav1.GroupVersionKind{Kind: "Function"},
+						Kind: metav1.GroupVersionKind{Kind: "Function", Version: resources.ServerlessV1Alpha2Version},
 						Object: runtime.RawExtension{
 							Raw: []byte(`{
 								"apiVersion": "serverless.kyma-project.io/v1alpha2",
@@ -247,9 +249,9 @@ func TestValidatingWebHook_Handle(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			w := &ValidatingWebHook{
-				config:  tt.fields.config,
-				client:  tt.fields.client,
-				decoder: tt.fields.decoder,
+				configv1alpha2: tt.fields.config,
+				client:         tt.fields.client,
+				decoder:        tt.fields.decoder,
 			}
 			got := w.Handle(tt.args.ctx, tt.args.req)
 			require.Equal(t, tt.responseCode, got.Result.Code)

--- a/components/function-controller/pkg/apis/serverless/v1alpha1/groupversion_info.go
+++ b/components/function-controller/pkg/apis/serverless/v1alpha1/groupversion_info.go
@@ -28,9 +28,16 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/scheme"
 )
 
+const (
+	FunctionKind       = "Function"
+	FunctionVersion    = "v1alpha1"
+	FunctionGroup      = "serverless.kyma-project.io"
+	FunctionApiVersion = FunctionGroup + "/" + FunctionVersion
+)
+
 var (
 	// GroupVersion is group version used to register these objects
-	GroupVersion = schema.GroupVersion{Group: "serverless.kyma-project.io", Version: "v1alpha1"}
+	GroupVersion = schema.GroupVersion{Group: FunctionGroup, Version: FunctionVersion}
 
 	// SchemeBuilder is used to add go types to the GroupVersionKind scheme
 	SchemeBuilder = &scheme.Builder{GroupVersion: GroupVersion}

--- a/components/function-controller/pkg/apis/serverless/v1alpha2/groupversion_info.go
+++ b/components/function-controller/pkg/apis/serverless/v1alpha2/groupversion_info.go
@@ -28,9 +28,16 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/scheme"
 )
 
+const (
+	FunctionKind       = "Function"
+	FunctionVersion    = "v1alpha2"
+	FunctionGroup      = "serverless.kyma-project.io"
+	FunctionApiVersion = FunctionGroup + "/" + FunctionVersion
+)
+
 var (
 	// GroupVersion is group version used to register these objects
-	GroupVersion = schema.GroupVersion{Group: "serverless.kyma-project.io", Version: "v1alpha2"}
+	GroupVersion = schema.GroupVersion{Group: FunctionGroup, Version: FunctionVersion}
 
 	// SchemeBuilder is used to add go types to the GroupVersionKind scheme
 	SchemeBuilder = &scheme.Builder{GroupVersion: GroupVersion}

--- a/resources/serverless/values.yaml
+++ b/resources/serverless/values.yaml
@@ -76,13 +76,13 @@ global:
       directory: "tpi"
     function_controller:
       name: "function-controller"
-      version: "PR-14946"
+      version: "PR-15049"
     function_webhook:
       name: "function-webhook"
-      version: "PR-14946"
+      version: "PR-15049"
     function_build_init:
       name: "function-build-init"
-      version: "PR-14946"
+      version: "PR-15049"
     function_runtime_nodejs12:
       name: "function-runtime-nodejs12"
       version: "PR-15038"


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- restore validation and defaulting webhook for v1alpha1 functions\

**Related issue(s)**
https://github.com/kyma-project/kyma/issues/14593
