### PR TITLE
Use nodejs v16.16 in serverless runtime

### DIFF
--- a/resources/serverless/values.yaml
+++ b/resources/serverless/values.yaml
@@ -91,7 +91,7 @@ global:
       version: "05dc6c5b"
     function_runtime_nodejs16:
       name: "function-runtime-nodejs16"
-      version: "05dc6c5b"
+      version: "de9d45d3"
     function_runtime_python39:
       name: "function-runtime-python39"
       version: "05dc6c5b"


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Bump node version in nodejs16 serverless runtime (CVE-2022-32215, CVE-2022-32214, CVE-2022-32213)


**Related issue(s)**
https://github.com/nodejs/node/issues/43946