### PR TITLE
make MergeParsersConfig permutation invariant

### DIFF
--- a/components/telemetry-operator/controllers/telemetry/logparser_controller.go
+++ b/components/telemetry-operator/controllers/telemetry/logparser_controller.go
@@ -73,7 +73,7 @@ func (r *LogParserReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 	}
 
 	if changed {
-		log.V(1).Info("Fluent Bit configuration was updated. Restarting the DaemonSet due to log parser change")
+		log.V(1).Info("Fluent Bit parser configuration was updated. Restarting the DaemonSet")
 
 		if err = r.Update(ctx, &logParser); err != nil {
 			log.Error(err, "Failed updating log parser")
@@ -89,7 +89,7 @@ func (r *LogParserReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 			telemetryv1alpha1.FluentBitDSRestartedReason,
 			telemetryv1alpha1.LogParserPending,
 		)
-		if err = r.updateLogPipelineStatus(ctx, req.NamespacedName, condition); err != nil {
+		if err = r.updateLogParserStatus(ctx, req.NamespacedName, condition); err != nil {
 			return ctrl.Result{Requeue: shouldRetryOn(err)}, err
 		}
 	}
@@ -112,7 +112,7 @@ func (r *LogParserReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 			telemetryv1alpha1.LogParserRunning,
 		)
 
-		if err = r.updateLogPipelineStatus(ctx, req.NamespacedName, condition); err != nil {
+		if err = r.updateLogParserStatus(ctx, req.NamespacedName, condition); err != nil {
 			return ctrl.Result{RequeueAfter: requeueTime}, err
 		}
 	}
@@ -127,7 +127,7 @@ func (r *LogParserReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		Complete(r)
 }
 
-func (r *LogParserReconciler) updateLogPipelineStatus(ctx context.Context, name types.NamespacedName, condition *telemetryv1alpha1.LogParserCondition) error {
+func (r *LogParserReconciler) updateLogParserStatus(ctx context.Context, name types.NamespacedName, condition *telemetryv1alpha1.LogParserCondition) error {
 	log := logf.FromContext(ctx)
 
 	var logParser telemetryv1alpha1.LogParser
@@ -136,7 +136,7 @@ func (r *LogParserReconciler) updateLogPipelineStatus(ctx context.Context, name 
 		return err
 	}
 
-	// Do not update status if the log pipeline is being deleted
+	// Do not update status if the log parser is being deleted
 	if logParser.DeletionTimestamp != nil {
 		return nil
 	}

--- a/components/telemetry-operator/internal/fluentbit/config_builder.go
+++ b/components/telemetry-operator/internal/fluentbit/config_builder.go
@@ -240,15 +240,25 @@ func generateMatchCondition(logPipelineName string) string {
 
 // MergeParsersConfig merges Fluent Bit parsers to a single Fluent Bit configuration.
 func MergeParsersConfig(logParsers *telemetryv1alpha1.LogParserList) string {
-	var sb strings.Builder
+	logParsersMap := make(map[string]string, len(logParsers.Items))
+	logParsersNames := make([]string, 0, len(logParsers.Items))
+
 	for _, logParser := range logParsers.Items {
-		var parser string
 		if logParser.DeletionTimestamp == nil {
-			name := fmt.Sprintf("Name %s", logParser.Name)
-			parser = fmt.Sprintf("%s\n%s", logParser.Spec.Parser, name)
-			sb.WriteString(BuildConfigSection(ParserConfigHeader, parser))
+			logParsersMap[logParser.Name] = logParser.Spec.Parser
+			logParsersNames = append(logParsersNames, logParser.Name)
 		}
 	}
+
+	sort.Strings(logParsersNames)
+
+	var sb strings.Builder
+	for _, logParserName := range logParsersNames {
+			name := fmt.Sprintf("Name %s", logParserName)
+			parser := fmt.Sprintf("%s\n%s", logParsersMap[logParserName], name)
+			sb.WriteString(BuildConfigSection(ParserConfigHeader, parser))
+	}
+
 	return sb.String()
 }
 

--- a/components/telemetry-operator/internal/fluentbit/config_builder.go
+++ b/components/telemetry-operator/internal/fluentbit/config_builder.go
@@ -240,25 +240,18 @@ func generateMatchCondition(logPipelineName string) string {
 
 // MergeParsersConfig merges Fluent Bit parsers to a single Fluent Bit configuration.
 func MergeParsersConfig(logParsers *telemetryv1alpha1.LogParserList) string {
-	logParsersMap := make(map[string]string, len(logParsers.Items))
-	logParsersNames := make([]string, 0, len(logParsers.Items))
-
-	for _, logParser := range logParsers.Items {
-		if logParser.DeletionTimestamp == nil {
-			logParsersMap[logParser.Name] = logParser.Spec.Parser
-			logParsersNames = append(logParsersNames, logParser.Name)
-		}
-	}
-
-	sort.Strings(logParsersNames)
+	sort.Slice(logParsers.Items, func(i, j int) bool {
+		return logParsers.Items[i].Name < logParsers.Items[j].Name
+	})
 
 	var sb strings.Builder
-	for _, logParserName := range logParsersNames {
-			name := fmt.Sprintf("Name %s", logParserName)
-			parser := fmt.Sprintf("%s\n%s", logParsersMap[logParserName], name)
+	for _, logParser := range logParsers.Items {
+		if logParser.DeletionTimestamp == nil {
+			name := fmt.Sprintf("Name %s", logParser.Name)
+			parser := fmt.Sprintf("%s\n%s", logParser.Spec.Parser, name)
 			sb.WriteString(BuildConfigSection(ParserConfigHeader, parser))
+		}
 	}
-
 	return sb.String()
 }
 

--- a/components/telemetry-operator/internal/parserSync/parser.go
+++ b/components/telemetry-operator/internal/parserSync/parser.go
@@ -37,7 +37,7 @@ func NewLogParserSyncer(client client.Client,
 	return &lps
 }
 
-// Synchronize LogParser with ConfigMap of DaemonSetUtils parsers.
+// SyncParsersConfigMap synchronizes LogParser with ConfigMap of DaemonSetUtils parsers.
 func (s *LogParserSyncer) SyncParsersConfigMap(ctx context.Context, logParser *telemetryv1alpha1.LogParser) (bool, error) {
 	log := logf.FromContext(ctx)
 	cm, err := s.Utils.GetOrCreateConfigMap(ctx, s.DaemonSetConfig.FluentBitParsersConfigMap)
@@ -91,7 +91,6 @@ func (s *LogParserSyncer) SyncParsersConfigMap(ctx context.Context, logParser *t
 			controllerutil.AddFinalizer(logParser, parserConfigMapFinalizer)
 			changed = true
 		}
-
 	}
 
 	if !changed {


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- With the current implementation, deploying multiple Logparser CRs results in endless restarts of the telemetry fluent bit pod.
- The logic in the Logparser controller/reconciler loop is the reason:
    - Assuming that there are 5 CRs, the controller creates a ConfigMap entry with the content of 1 CR and then adds the content of the 4 other CRs to the ConfigMap entry
    - Since the status of each CR is still `Pending`, it is requeued and processed again by the controller. It is processed again until the status is `Running`.
    - Next, each CR creates a new parser config using the `MergeParsersConfig` function and reads the existing parser config from the ConfigMap entry. It then compares both for equality. If the parser configs are equal, the config didn't change, the CR status changes to `Running` and it is not processed again. If they are not equal, the CR is processed again.
    - Here comes the problem: The generated parser config of the `MergeParsersConfig` function always was different from the ConfigMap entry.  The `MergeParsersConfig` function retrieves  all Logparsers CRs, iterates over them and generates the config. However, the order of the CRs, i.e. `[CR1, CR2, CR3, CR4, CR5]` and `[CR2, CR1, CR3, CR4, CR5]`, resulted in different configs.
    - As a result, each CR recreated the ConfigMap entry, which is why the configs never reached a final state where they configs were the same for all CRs. This is the cause for the endless controller loop.
 - This PR changes the `MergeParsersConfig` function to be permutation invariant, i.e. `MergeParsersConfig([CR1, CR2, CR3, CR4, CR5]) == MergeParsersConfig([CR2, CR1, CR3, CR4, CR5])` for all possible permutations by ordering the CRs beforehand


**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
