### PR TITLE
Update nats charts to version 0.17.3

### DIFF
--- a/resources/eventing/charts/nats/Chart.yaml
+++ b/resources/eventing/charts/nats/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v2
 name: nats
 description: Helm chart for nats
-version: 0.9.0
+version: 0.17.3

--- a/resources/eventing/charts/nats/README.md
+++ b/resources/eventing/charts/nats/README.md
@@ -23,24 +23,12 @@ $ kubectl -n nats port-forward nats-1 4222
 
 ## Configuration
 
-### Server Image
-
-```yaml
-nats:
-  image: nats:2.8.4-alpine
-  pullPolicy: IfNotPresent
-```
-
 ### Limits
 
 ```yaml
 nats:
   # The number of connect attempts against discovered routes.
   connectRetries: 30
-
-  # How many seconds should pass before sending a PING
-  # to a client that has no activity.
-  pingInterval:
 
   # Server settings.
   limits:
@@ -81,12 +69,6 @@ https://docs.nats.io/nats-server/configuration/clustering#nats-server-clustering
 cluster:
   enabled: true
   replicas: 3
-```
-
-Example:
-
-```sh
-$ helm install nats nats/nats --set cluster.enabled=true
 ```
 
 ## JetStream

--- a/resources/eventing/charts/nats/README.md
+++ b/resources/eventing/charts/nats/README.md
@@ -23,6 +23,14 @@ $ kubectl -n nats port-forward nats-1 4222
 
 ## Configuration
 
+### Server Image
+
+```yaml
+nats:
+  image: nats:2.8.4-alpine
+  pullPolicy: IfNotPresent
+```
+
 ### Limits
 
 ```yaml
@@ -32,19 +40,19 @@ nats:
 
   # How many seconds should pass before sending a PING
   # to a client that has no activity.
-  pingInterval: 
+  pingInterval:
 
   # Server settings.
   limits:
-    maxConnections: 
-    maxSubscriptions: 
-    maxControlLine: 
-    maxPayload: 
+    maxConnections:
+    maxSubscriptions:
+    maxControlLine:
+    maxPayload:
 
-    writeDeadline: 
-    maxPending: 
-    maxPings: 
-    lameDuckDuration: 
+    writeDeadline:
+    maxPending:
+    maxPings:
+    lameDuckDuration:
 
   # Number of seconds to wait for client connections to end after the pod termination is requested
   terminationGracePeriodSeconds: 60
@@ -52,29 +60,40 @@ nats:
 
 ### Logging
 
-> **NOTE**: It is not recommended to enable trace or debug in production, since enabling it will significantly degrade performance.
+*Note*: It is not recommended to enable trace or debug in production since enabling it will significantly degrade performance.
 
 ```yaml
 nats:
   logging:
-    debug: 
-    trace: 
-    logtime: 
-    connectErrorReports: 
-    reconnectErrorReports: 
+    debug:
+    trace:
+    logtime:
+    connectErrorReports:
+    reconnectErrorReports:
 ```
-### Clustering
 
-If clustering is enabled, then a 3-node cluster will be set up. You can find more information in the [NATS documentation](https://docs.nats.io/running-a-nats-service/introduction/running/nats-kubernetes/helm-charts#clustering).
+## Clustering
+
+If clustering is enabled, then a 3-node cluster will be setup. More info at:
+https://docs.nats.io/nats-server/configuration/clustering#nats-server-clustering
 
 ```yaml
 cluster:
   enabled: true
   replicas: 3
 ```
-### JetStream
 
-To set up memory and file storage with JetStream, use this configuration: 
+Example:
+
+```sh
+$ helm install nats nats/nats --set cluster.enabled=true
+```
+
+## JetStream
+
+### Setting up Memory and File Storage
+
+File Storage is **always** recommended, since JetStream's RAFT Meta Group will be persisted to file storage.  The Storage Class used should be block storage.  NFS is not recommended.
 
 ```yaml
 nats:

--- a/resources/eventing/charts/nats/templates/_helpers.tpl
+++ b/resources/eventing/charts/nats/templates/_helpers.tpl
@@ -5,6 +5,10 @@ Expand the name of the chart.
 {{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 
+{{- define "nats.namespace" -}}
+{{- default .Release.Namespace .Values.namespaceOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
 
 {{- define "nats.fullname" -}}
 {{- if .Values.fullnameOverride -}}
@@ -32,7 +36,7 @@ Common labels
 {{- define "nats.labels" -}}
 helm.sh/chart: {{ include "nats.chart" . }}
 {{- range $name, $value := .Values.commonLabels }}
-{{ $name }}: {{ $value }}
+{{ $name }}: {{ tpl $value $ }}
 {{- end }}
 {{ include "nats.selectorLabels" . }}
 {{- if .Chart.AppVersion }}
@@ -45,8 +49,8 @@ app.kubernetes.io/managed-by: {{ .Release.Service }}
 Selector labels
 */}}
 {{- define "nats.selectorLabels" -}}
-{{- if .Values.nats.selectorLabels -}}
-{{ .Values.nats.selectorLabels | toYaml }}
+{{- if .Values.nats.selectorLabels }}
+{{ tpl (toYaml .Values.nats.selectorLabels) . }}
 {{- else -}}
 app.kubernetes.io/name: {{ include "nats.name" . }}
 app.kubernetes.io/instance: {{ .Release.Name }}
@@ -59,7 +63,11 @@ kyma-project.io/dashboard: eventing
 Return the proper NATS image name
 */}}
 {{- define "nats.clusterAdvertise" -}}
+{{- if $.Values.useFQDN }}
 {{- printf "$(POD_NAME).%s.$(POD_NAMESPACE).svc.%s" (include "nats.fullname" . ) $.Values.k8sClusterDomain }}
+{{- else }}
+{{- printf "$(POD_NAME).%s.$(POD_NAMESPACE)" (include "nats.fullname" . ) }}
+{{- end }}
 {{- end }}
 
 {{/*
@@ -67,8 +75,19 @@ Return the NATS cluster routes.
 */}}
 {{- define "nats.clusterRoutes" -}}
 {{- $name := (include "nats.fullname" . ) -}}
+{{- $namespace := (include "nats.namespace" . ) -}}
 {{- range $i, $e := until (.Values.cluster.replicas | int) -}}
-{{- printf "nats://%s-%d.%s.%s.svc.%s:6222," $name $i $name $.Release.Namespace $.Values.k8sClusterDomain -}}
+{{- if $.Values.useFQDN }}
+{{- printf "nats://%s-%d.%s.%s.svc.%s:6222," $name $i $name $namespace $.Values.k8sClusterDomain -}}
+{{- else }}
+{{- printf "nats://%s-%d.%s.%s:6222," $name $i $name $namespace -}}
+{{- end }}
+{{- end -}}
+{{- end }}
+
+{{- define "nats.extraRoutes" -}}
+{{- range $i, $url := .Values.cluster.extraRoutes -}}
+{{- printf "%s," $url -}}
 {{- end -}}
 {{- end }}
 
@@ -82,6 +101,6 @@ Usage:
   {{- if typeIs "string" .value }}
     {{- tpl .value .context }}
   {{- else }}
-    {{- tpl (.value | toYaml) .context }}
+    {{- tpl (toYaml .value) .context }}
   {{- end }}
 {{- end -}}

--- a/resources/eventing/charts/nats/templates/configmap.yaml
+++ b/resources/eventing/charts/nats/templates/configmap.yaml
@@ -8,8 +8,22 @@ metadata:
     {{- include "nats.labels" . | nindent 4 }}
 data:
   nats.conf: |
+    # NATS Clients Port
+    port: {{ .Values.nats.ports.client }}
+
     # PID file shared with configuration reloader.
     pid_file: "/var/run/nats/nats.pid"
+
+    {{- if .Values.nats.config }}
+    ###########
+    #         #
+    # Imports #
+    #         #
+    ###########
+    {{- range .Values.nats.config }}
+    include ./{{ .name }}/{{ .name }}.conf
+    {{- end}}
+    {{- end }}
 
     ###############
     #             #
@@ -17,9 +31,17 @@ data:
     #             #
     ###############
     http: 8222
-    server_name: $POD_NAME
+    server_name: {{- if .Values.nats.serverNamePrefix  }}$SERVER_NAME{{- else }}$POD_NAME{{- end }}
 
-    {{- if .Values.global.jetstream.enabled }}
+    {{- if .Values.nats.serverTags }}
+    server_tags: [
+      {{- range .Values.nats.serverTags }}
+        "{{ . }}",
+      {{- end }}
+    ]
+    {{- end }}
+
+    {{- if .Values.global.jetstream.enabled  }}
     ###################################
     #                                 #
     # NATS JetStream                  #
@@ -52,6 +74,10 @@ data:
       {{- .Values.nats.jetstream.fileStorage.size }}
       {{- end }}
       {{- end }}
+
+      {{- if .Values.nats.jetstream.uniqueTag }}
+      unique_tag: {{ .Values.nats.jetstream.uniqueTag }}
+      {{- end }}
     }
     {{- end }}
 
@@ -78,6 +104,7 @@ data:
 
       routes = [
         {{ include "nats.clusterRoutes" . }}
+        {{ include "nats.extraRoutes" . }}
       ]
       cluster_advertise: $CLUSTER_ADVERTISE
 
@@ -139,6 +166,10 @@ data:
 
     {{- with .Values.nats.limits.writeDeadline }}
     write_deadline: {{ . }}
+    {{- end }}
+
+    {{- with .Values.nats.limits.lameDuckGracePeriod }}
+    lame_duck_grace_period: {{ . }}
     {{- end }}
 
     {{- with .Values.nats.limits.lameDuckDuration }}

--- a/resources/eventing/charts/nats/templates/configmap.yaml
+++ b/resources/eventing/charts/nats/templates/configmap.yaml
@@ -14,34 +14,15 @@ data:
     # PID file shared with configuration reloader.
     pid_file: "/var/run/nats/nats.pid"
 
-    {{- if .Values.nats.config }}
-    ###########
-    #         #
-    # Imports #
-    #         #
-    ###########
-    {{- range .Values.nats.config }}
-    include ./{{ .name }}/{{ .name }}.conf
-    {{- end}}
-    {{- end }}
-
     ###############
     #             #
     # Monitoring  #
     #             #
     ###############
     http: 8222
-    server_name: {{- if .Values.nats.serverNamePrefix  }}$SERVER_NAME{{- else }}$POD_NAME{{- end }}
+    server_name: $POD_NAME
 
-    {{- if .Values.nats.serverTags }}
-    server_tags: [
-      {{- range .Values.nats.serverTags }}
-        "{{ . }}",
-      {{- end }}
-    ]
-    {{- end }}
-
-    {{- if .Values.global.jetstream.enabled  }}
+    {{- if .Values.global.jetstream.enabled }}
     ###################################
     #                                 #
     # NATS JetStream                  #
@@ -104,7 +85,6 @@ data:
 
       routes = [
         {{ include "nats.clusterRoutes" . }}
-        {{ include "nats.extraRoutes" . }}
       ]
       cluster_advertise: $CLUSTER_ADVERTISE
 

--- a/resources/eventing/charts/nats/templates/service.yaml
+++ b/resources/eventing/charts/nats/templates/service.yaml
@@ -14,7 +14,6 @@ spec:
   selector:
     {{- include "nats.selectorLabels" . | nindent 4 }}
   clusterIP: None
-  publishNotReadyAddresses: true
   ports:
   {{- if .Values.nats.profiling.enabled }}
   - name: profiling
@@ -50,6 +49,3 @@ spec:
     {{- end }}
   - name: gateways
     port: {{ .Values.nats.ports.gateways }}
-    {{- if .Values.appProtocol.enabled }}
-    appProtocol: tcp
-    {{- end }}

--- a/resources/eventing/charts/nats/templates/service.yaml
+++ b/resources/eventing/charts/nats/templates/service.yaml
@@ -49,3 +49,6 @@ spec:
     {{- end }}
   - name: gateways
     port: {{ .Values.nats.ports.gateways }}
+    {{- if .Values.appProtocol.enabled }}
+    appProtocol: tcp
+    {{- end }}

--- a/resources/eventing/charts/nats/templates/service.yaml
+++ b/resources/eventing/charts/nats/templates/service.yaml
@@ -8,14 +8,13 @@ metadata:
     {{- include "nats.labels" . | nindent 4 }}
   {{- if .Values.serviceAnnotations}}
   annotations:
-  {{- range $key, $value := .Values.serviceAnnotations }}
-    {{ $key }}: {{ $value | quote }}
-  {{- end }}
+    {{- toYaml .Values.serviceAnnotations | nindent 4 }}
   {{- end }}
 spec:
   selector:
     {{- include "nats.selectorLabels" . | nindent 4 }}
   clusterIP: None
+  publishNotReadyAddresses: true
   ports:
   {{- if .Values.nats.profiling.enabled }}
   - name: profiling

--- a/resources/eventing/charts/nats/templates/statefulset.yaml
+++ b/resources/eventing/charts/nats/templates/statefulset.yaml
@@ -40,38 +40,30 @@ spec:
       labels:
         {{- include "nats.selectorLabels" . | nindent 8 }}
         {{- if .Values.statefulSetPodLabels }}
-        {{- tpl (toYaml .Values.statefulSetPodLabels) . | nindent 8 }}
+        {{ toYaml .Values.statefulSetPodLabels | nindent 8 }}
         {{- end }}
     spec:
-      {{- with .Values.securityContext }}
+{{- if or .Values.priorityClassName .Values.global.priorityClassName }}
+      priorityClassName: {{ coalesce .Values.priorityClassName .Values.global.priorityClassName }}
+{{- end }}
+{{- with .Values.securityContext }}
       securityContext:
-        {{- toYaml . | nindent 8 }}
-      {{- end }}
-      {{- with .Values.affinity }}
+{{ toYaml . | indent 8 }}
+{{- end }}
+{{- with .Values.affinity }}
       affinity:
-        {{- tpl (toYaml .) $ | nindent 8 }}
-      {{- end }}
-      {{- if .Values.priorityClassName }}
-      priorityClassName: {{ .Values.priorityClassName | quote }}
-      {{- end }}
+{{- tpl (toYaml .) $ | nindent 8 }}
+{{- end }}
       # Common volumes for the containers.
       volumes:
       - name: config-volume
-        {{- if .Values.nats.customConfigSecret }}
+        {{ if .Values.nats.customConfigSecret }}
         secret:
           secretName: {{ .Values.nats.customConfigSecret.name }}
-        {{- else }}
+        {{ else }}
         configMap:
           name: {{ include "nats.fullname" . }}-config
-        {{- end }}
-
-      {{- /* User extended config volumes*/}}
-      {{- if .Values.nats.config }}
-      # User extended config volumes
-      {{- with .Values.nats.config }}
-      {{- toYaml . | nindent 6 }}
-      {{- end }}
-      {{- end }}
+        {{ end }}
 
       # Local volume shared with the reloader.
       - name: pid
@@ -143,11 +135,6 @@ spec:
           - containerPort: 7777
             name: metrics
       {{- end }}
-
-      {{- if .Values.additionalContainers }}
-      {{- toYaml .Values.additionalContainers | nindent 6 }}
-      {{- end }}
-
       - name: nats
         image: "{{ include "imageurl" (dict "reg" .Values.global.containerRegistry "img" .Values.global.images.nats) }}"
         imagePullPolicy: {{ .Values.nats.pullPolicy }}
@@ -191,8 +178,6 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.name
-        - name: SERVER_NAME
-          value: {{ .Values.nats.serverNamePrefix }}$(POD_NAME)
         - name: POD_NAMESPACE
           valueFrom:
             fieldRef:
@@ -245,31 +230,10 @@ spec:
         {{- end }}
         {{- end }}
 
-        {{- with .Values.nats.healthcheck.readiness }}
-        {{- if .enabled }}
-        readinessProbe:
-          httpGet:
-            path: /
-            port: 8222
-          initialDelaySeconds: {{ .initialDelaySeconds }}
-          timeoutSeconds: {{ .timeoutSeconds }}
-          periodSeconds: {{ .periodSeconds }}
-          successThreshold: {{ .successThreshold }}
-          failureThreshold: {{ .failureThreshold }}
-        {{- end }}
-        {{- end }}
-
         {{- if .Values.nats.healthcheck.startup.enabled }}
         startupProbe:
           httpGet:
-            {{- $simpleVersion := .Values.global.images.nats.version | default "latest" | regexFind "\\d+(\\.\\d+)?(\\.\\d+)?" | default "2.7.1"  }}
-            {{- if and .Values.nats.healthcheck.enableHealthz (or (not .Values.nats.healthcheck.detectHealthz) (semverCompare ">=2.7.1" $simpleVersion)) }}
-            # for NATS server versions >=2.7.1, healthz will be enabled to allow for a grace period
-            # in case of JetStream enabled deployments to form quorum and streams to catch up.
             path: /healthz
-            {{- else }}
-            path: /
-            {{- end }}
             port: 8222
         {{- with .Values.nats.healthcheck.startup }}
           initialDelaySeconds: {{ .initialDelaySeconds }}

--- a/resources/eventing/charts/nats/templates/statefulset.yaml
+++ b/resources/eventing/charts/nats/templates/statefulset.yaml
@@ -6,11 +6,9 @@ metadata:
   namespace: {{ .Release.Namespace | quote }}
   labels:
     {{- include "nats.labels" . | nindent 4 }}
-    {{- if .Values.statefulSetAnnotations}}
+  {{- if .Values.statefulSetAnnotations }}
   annotations:
-  {{- range $key, $value := .Values.statefulSetAnnotations }}
-    {{ $key }}: {{ $value | quote }}
-  {{- end }}
+    {{- toYaml .Values.statefulSetAnnotations | nindent 4 }}
   {{- end }}
 spec:
   selector:
@@ -22,48 +20,58 @@ spec:
   replicas: 1
   {{- end }}
   serviceName: {{ include "nats.fullname" . }}
+  podManagementPolicy: {{ .Values.podManagementPolicy }}
   template:
     metadata:
-      {{- if or .Values.exporter.enabled .Values.podAnnotations }}
+      {{- if or .Values.exporter.enabled .Values.nats.configChecksumAnnotation .Values.podAnnotations }}
       annotations:
       {{- if .Values.exporter.enabled }}
         prometheus.io/path: /metrics
         prometheus.io/port: "7777"
         prometheus.io/scrape: "true"
       {{- end }}
-      {{- if .Values.podAnnotations }}
-      {{- range $key, $value := .Values.podAnnotations }}
-        {{ $key }}: {{ $value | quote }}
+      {{- if .Values.nats.configChecksumAnnotation }}
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
       {{- end }}
+      {{- if .Values.podAnnotations }}
+        {{- toYaml .Values.podAnnotations | nindent 8 }}
       {{- end }}
       {{- end }}
       labels:
         {{- include "nats.selectorLabels" . | nindent 8 }}
         {{- if .Values.statefulSetPodLabels }}
-        {{ toYaml .Values.statefulSetPodLabels | nindent 8 }}
+        {{- tpl (toYaml .Values.statefulSetPodLabels) . | nindent 8 }}
         {{- end }}
     spec:
-{{- if or .Values.priorityClassName .Values.global.priorityClassName }}
-      priorityClassName: {{ coalesce .Values.priorityClassName .Values.global.priorityClassName }}
-{{- end }}
-{{- with .Values.securityContext }}
+      {{- with .Values.securityContext }}
       securityContext:
-{{ toYaml . | indent 8 }}
-{{- end }}
-{{- with .Values.affinity }}
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
       affinity:
-{{- tpl (toYaml .) $ | nindent 8 }}
-{{- end }}
+        {{- tpl (toYaml .) $ | nindent 8 }}
+      {{- end }}
+      {{- if .Values.priorityClassName }}
+      priorityClassName: {{ .Values.priorityClassName | quote }}
+      {{- end }}
       # Common volumes for the containers.
       volumes:
       - name: config-volume
-        {{ if .Values.nats.customConfigSecret }}
+        {{- if .Values.nats.customConfigSecret }}
         secret:
           secretName: {{ .Values.nats.customConfigSecret.name }}
-        {{ else }}
+        {{- else }}
         configMap:
           name: {{ include "nats.fullname" . }}-config
-        {{ end }}
+        {{- end }}
+
+      {{- /* User extended config volumes*/}}
+      {{- if .Values.nats.config }}
+      # User extended config volumes
+      {{- with .Values.nats.config }}
+      {{- toYaml . | nindent 6 }}
+      {{- end }}
+      {{- end }}
 
       # Local volume shared with the reloader.
       - name: pid
@@ -135,6 +143,11 @@ spec:
           - containerPort: 7777
             name: metrics
       {{- end }}
+
+      {{- if .Values.additionalContainers }}
+      {{- toYaml .Values.additionalContainers | nindent 6 }}
+      {{- end }}
+
       - name: nats
         image: "{{ include "imageurl" (dict "reg" .Values.global.containerRegistry "img" .Values.global.images.nats) }}"
         imagePullPolicy: {{ .Values.nats.pullPolicy }}
@@ -163,11 +176,11 @@ spec:
         {{- end }}
 
         command:
-         - "nats-server"
-         - "--config"
-         - "/etc/nats-config/nats.conf"
+        - "nats-server"
+        - "--config"
+        - "/etc/nats-config/nats.conf"
         {{- if .Values.nats.profiling.enabled }}
-         - "--profile={{ .Values.nats.profiling.port }}"
+        - "--profile={{ .Values.nats.profiling.port }}"
         {{- end }}
 
         # Required to be able to define an environment variable
@@ -178,6 +191,8 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.name
+        - name: SERVER_NAME
+          value: {{ .Values.nats.serverNamePrefix }}$(POD_NAME)
         - name: POD_NAMESPACE
           valueFrom:
             fieldRef:
@@ -206,34 +221,78 @@ spec:
             mountPath: {{ .Values.nats.jetstream.fileStorage.storageDirectory }}
           {{- end }}
 
-        # Liveness/Readiness probes against the monitoring.
-        #
+        #######################
+        #                     #
+        # Healthcheck Probes  #
+        #                     #
+        #######################
+        {{- if .Values.nats.healthcheck }}
+
+        {{- with .Values.nats.healthcheck.liveness }}
+        {{- if .enabled }}
         livenessProbe:
           httpGet:
             path: /
             port: 8222
-          initialDelaySeconds: 10
-          timeoutSeconds: 5
+          initialDelaySeconds: {{ .initialDelaySeconds }}
+          timeoutSeconds: {{ .timeoutSeconds }}
+          periodSeconds: {{ .periodSeconds }}
+          successThreshold: {{ .successThreshold }}
+          failureThreshold: {{ .failureThreshold }}
+          {{- if .terminationGracePeriodSeconds }}
+          terminationGracePeriodSeconds: {{ .terminationGracePeriodSeconds }}
+          {{- end }}
+        {{- end }}
+        {{- end }}
+
+        {{- with .Values.nats.healthcheck.readiness }}
+        {{- if .enabled }}
         readinessProbe:
           httpGet:
             path: /
             port: 8222
-          initialDelaySeconds: 10
-          timeoutSeconds: 5
+          initialDelaySeconds: {{ .initialDelaySeconds }}
+          timeoutSeconds: {{ .timeoutSeconds }}
+          periodSeconds: {{ .periodSeconds }}
+          successThreshold: {{ .successThreshold }}
+          failureThreshold: {{ .failureThreshold }}
+        {{- end }}
+        {{- end }}
+
+        {{- if .Values.nats.healthcheck.startup.enabled }}
+        startupProbe:
+          httpGet:
+            {{- $simpleVersion := .Values.global.images.nats.version | default "latest" | regexFind "\\d+(\\.\\d+)?(\\.\\d+)?" | default "2.7.1"  }}
+            {{- if and .Values.nats.healthcheck.enableHealthz (or (not .Values.nats.healthcheck.detectHealthz) (semverCompare ">=2.7.1" $simpleVersion)) }}
+            # for NATS server versions >=2.7.1, healthz will be enabled to allow for a grace period
+            # in case of JetStream enabled deployments to form quorum and streams to catch up.
+            path: /healthz
+            {{- else }}
+            path: /
+            {{- end }}
+            port: 8222
+        {{- with .Values.nats.healthcheck.startup }}
+          initialDelaySeconds: {{ .initialDelaySeconds }}
+          timeoutSeconds: {{ .timeoutSeconds }}
+          periodSeconds: {{ .periodSeconds }}
+          successThreshold: {{ .successThreshold }}
+          failureThreshold: {{ .failureThreshold }}
+        {{- end }}
+        {{- end }}
+
+        {{- end }}
 
         # Gracefully stop NATS Server on pod deletion or image upgrade.
         #
         lifecycle:
           preStop:
             exec:
-              # Using the alpine based NATS image, we add an extra sleep that is
-              # the same amount as the terminationGracePeriodSeconds to allow
-              # the NATS Server to gracefully terminate the client connections.
+              # send the lame duck shutdown signal to trigger a graceful shutdown
+              # nats-server will ignore the TERM signal it receives after this
               #
               command:
-              - "/bin/sh"
-              - "-c"
-              - "nats-server -sl=ldm=/var/run/nats/nats.pid && /bin/sleep {{ .Values.nats.terminationGracePeriodSeconds }}"
+              - "nats-server"
+              - "-sl=ldm=/var/run/nats/nats.pid"
 
   volumeClaimTemplates:
   {{- if and .Values.global.jetstream.enabled (eq .Values.global.jetstream.storage "file") (not .Values.nats.jetstream.fileStorage.existingClaim) }}
@@ -246,15 +305,11 @@ spec:
         name: {{ include "nats.fullname" . }}-js-pvc
         {{- if .Values.nats.jetstream.fileStorage.annotations }}
         annotations:
-        {{- range $key, $value := .Values.nats.jetstream.fileStorage.annotations }}
-          {{ $key }}: {{ $value | quote }}
-        {{- end }}
+          {{- toYaml .Values.nats.jetstream.fileStorage.annotations | nindent 10 }}
         {{- end }}
       spec:
         accessModes:
-        {{- range .Values.nats.jetstream.fileStorage.accessModes }}
-          - {{ . | quote }}
-        {{- end }}
+          {{- toYaml .Values.nats.jetstream.fileStorage.accessModes | nindent 10 }}
         resources:
           requests:
             storage: {{ .Values.nats.jetstream.fileStorage.size }}

--- a/resources/eventing/charts/nats/templates/statefulset.yaml
+++ b/resources/eventing/charts/nats/templates/statefulset.yaml
@@ -20,7 +20,9 @@ spec:
   replicas: 1
   {{- end }}
   serviceName: {{ include "nats.fullname" . }}
+
   podManagementPolicy: {{ .Values.podManagementPolicy }}
+
   template:
     metadata:
       {{- if or .Values.exporter.enabled .Values.nats.configChecksumAnnotation .Values.podAnnotations }}
@@ -57,13 +59,8 @@ spec:
       # Common volumes for the containers.
       volumes:
       - name: config-volume
-        {{ if .Values.nats.customConfigSecret }}
-        secret:
-          secretName: {{ .Values.nats.customConfigSecret.name }}
-        {{ else }}
         configMap:
           name: {{ include "nats.fullname" . }}-config
-        {{ end }}
 
       # Local volume shared with the reloader.
       - name: pid
@@ -163,11 +160,11 @@ spec:
         {{- end }}
 
         command:
-        - "nats-server"
-        - "--config"
-        - "/etc/nats-config/nats.conf"
+         - "nats-server"
+         - "--config"
+         - "/etc/nats-config/nats.conf"
         {{- if .Values.nats.profiling.enabled }}
-        - "--profile={{ .Values.nats.profiling.port }}"
+         - "--profile={{ .Values.nats.profiling.port }}"
         {{- end }}
 
         # Required to be able to define an environment variable

--- a/resources/eventing/charts/nats/templates/statefulset.yaml
+++ b/resources/eventing/charts/nats/templates/statefulset.yaml
@@ -227,6 +227,20 @@ spec:
         {{- end }}
         {{- end }}
 
+        {{- with .Values.nats.healthcheck.readiness }}
+        {{- if .enabled }}
+        readinessProbe:
+          httpGet:
+            path: /
+            port: 8222
+          initialDelaySeconds: {{ .initialDelaySeconds }}
+          timeoutSeconds: {{ .timeoutSeconds }}
+          periodSeconds: {{ .periodSeconds }}
+          successThreshold: {{ .successThreshold }}
+          failureThreshold: {{ .failureThreshold }}
+        {{- end }}
+        {{- end }}
+
         {{- if .Values.nats.healthcheck.startup.enabled }}
         startupProbe:
           httpGet:

--- a/resources/eventing/charts/nats/values.yaml
+++ b/resources/eventing/charts/nats/values.yaml
@@ -13,15 +13,6 @@ nats:
     leafnodes: 7422
     gateways: 7522
 
-  # The servers name prefix, must be used for example when we want a NATS cluster
-  # spanning multiple Kubernetes clusters.
-  serverNamePrefix: ""
-
-  # Server Tags
-  serverTags:
-  # - "foo"
-  # - "bar"
-
   # Toggle profiling.
   # This enables nats-server pprof (profiling) port, so you can see goroutines
   # stacks, memory heap sizes, etc.
@@ -30,9 +21,6 @@ nats:
     port: 6000
 
   healthcheck:
-    # /healthz health check endpoint was introduced in NATS Server 2.7.1
-    # Attempt to detect /healthz support by inspecting if tag is >=2.7.1
-    detectHealthz: true
     # Enable /healthz startupProbe for controlled upgrades of NATS JetStream
     enableHealthz: true
 
@@ -60,19 +48,6 @@ nats:
       failureThreshold: 3
       # Only for Kubernetes +1.22 that have pod level probes enabled.
       terminationGracePeriodSeconds:
-
-    # Periodically check for the server to be ready for connections while
-    # the NATS container is running.
-    # Disabled by default since covered by startup probe and it is the same
-    # as the liveness check.
-    readiness:
-      enabled: true
-
-      initialDelaySeconds: 10
-      timeoutSeconds: 5
-      periodSeconds: 10
-      successThreshold: 1
-      failureThreshold: 3
 
     # Enable startup checks to confirm server is ready for traffic.
     # This is recommended for JetStream deployments since in cluster mode
@@ -131,10 +106,6 @@ nats:
     maxPending:
     maxPings:
 
-    # How many seconds should pass before sending a PING
-    # to a client that has no activity.
-    pingInterval:
-
     # grace period after pod begins shutdown before starting to close client connections
     lameDuckGracePeriod: "10s"
 
@@ -150,33 +121,6 @@ nats:
     logtime:
     connectErrorReports:
     reconnectErrorReports:
-
-  # customConfigSecret can be used to use an custom secret for the config
-  # of the NATS Server.
-  # NOTE: For this to work the name of the configuration has to be
-  # called `nats.conf`.
-  # e.g. kubectl create secret generic custom-nats-conf --from-file nats.conf
-  # customConfigSecret:
-  #  name:
-  #
-  # Alternately, the generated config can be extended with extra imports using the below syntax.
-  # The benefit of this is that cluster settings can be built up via helm values, but external
-  # secrets can be referenced and imported alongside it.
-  #
-  # config:
-  #   <name-of-config-item>:
-  #     <configMap|secret>
-  #       name: "<configMap|secret name>"
-  #
-  # e.g:
-  #
-  #  config:
-  #    - name: ssh-key
-  #      secret:
-  #        secretName: ssh-key
-  #    - name: config-vol
-  #      configMap:
-  #        name: log-config
 
   jetstream:
     #enabled: JetStream can be enabled via .Values.global.jetstream.enabled
@@ -233,7 +177,6 @@ nats:
       # key: "value"
 
 nameOverride: ""
-namespaceOverride: ""
 
 # Toggle whether to use setup a Pod Security Context
 # ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
@@ -271,29 +214,11 @@ statefulSetPodLabels:
 # Annotations to add to the NATS Service
 serviceAnnotations: {}
 
-# additionalContainers are the sidecar containers to add to the NATS StatefulSet
-additionalContainers: []
-
-# additionalVolumes are the additional volumes to add to the NATS StatefulSet
-additionalVolumes: []
-
-# additionalVolumeMounts are the additional volume mounts to add to the nats-server and nats-server-config-reloader containers
-additionalVolumeMounts: []
-
 cluster:
-  enabled: true
+  enabled: false
   name: eventing-nats
   replicas: 3
   noAdvertise: false
-
-  # Explicitly set routes for clustering.
-  # When JetStream is enabled, the serverName must be unique in the cluster.
-  extraRoutes: []
-
-  # authorization:
-  #   user: foo
-  #   password: pwd
-  #   timeout: 0.5
 
 appProtocol:
   enabled: true
@@ -301,9 +226,6 @@ appProtocol:
 # Cluster Domain configured on the kubelets
 # https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/
 k8sClusterDomain: cluster.local
-
-# Define if NATS is using FQDN name for clustering (i.e. nats-0.nats.default.svc.cluster.local) or short name (i.e. nats-0.nats.default).
-useFQDN: true
 
 # Add labels to all the deployed resources
 commonLabels: {}

--- a/resources/eventing/charts/nats/values.yaml
+++ b/resources/eventing/charts/nats/values.yaml
@@ -13,12 +13,82 @@ nats:
     leafnodes: 7422
     gateways: 7522
 
+  # The servers name prefix, must be used for example when we want a NATS cluster
+  # spanning multiple Kubernetes clusters.
+  serverNamePrefix: ""
+
+  # Server Tags
+  serverTags:
+  # - "foo"
+  # - "bar"
+
   # Toggle profiling.
   # This enables nats-server pprof (profiling) port, so you can see goroutines
   # stacks, memory heap sizes, etc.
   profiling:
     enabled: false
     port: 6000
+
+  healthcheck:
+    # /healthz health check endpoint was introduced in NATS Server 2.7.1
+    # Attempt to detect /healthz support by inspecting if tag is >=2.7.1
+    detectHealthz: true
+    # Enable /healthz startupProbe for controlled upgrades of NATS JetStream
+    enableHealthz: true
+
+    # Enable liveness checks.  If this fails, then the NATS Server will restarted.
+    liveness:
+      enabled: true
+
+      initialDelaySeconds: 10
+      timeoutSeconds: 5
+      # NOTE: liveness check + terminationGracePeriodSeconds can introduce unecessarily long outages
+      # due to the coupling between liveness probe and terminationGracePeriodSeconds.
+      # To avoid this, we make the periodSeconds of the liveness check to be about half the default
+      # time that it takes for lame duck graceful stop.
+      #
+      # In case of using Kubernetes +1.22 with probe-level terminationGracePeriodSeconds
+      # we could revise this but for now keep a minimal liveness check.
+      #
+      # More info:
+      #
+      #  https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/#probe-level-terminationgraceperiodseconds
+      #  https://github.com/kubernetes/kubernetes/issues/64715
+      #
+      periodSeconds: 30
+      successThreshold: 1
+      failureThreshold: 3
+      # Only for Kubernetes +1.22 that have pod level probes enabled.
+      terminationGracePeriodSeconds:
+
+    # Periodically check for the server to be ready for connections while
+    # the NATS container is running.
+    # Disabled by default since covered by startup probe and it is the same
+    # as the liveness check.
+    readiness:
+      enabled: true
+
+      initialDelaySeconds: 10
+      timeoutSeconds: 5
+      periodSeconds: 10
+      successThreshold: 1
+      failureThreshold: 3
+
+    # Enable startup checks to confirm server is ready for traffic.
+    # This is recommended for JetStream deployments since in cluster mode
+    # it will try to ensure that the server is ready to serve streams.
+    startup:
+      enabled: true
+
+      initialDelaySeconds: 10
+      timeoutSeconds: 5
+      periodSeconds: 10
+      successThreshold: 1
+      failureThreshold: 30
+
+  # Adds a hash of the ConfigMap as a pod annotation
+  # This will cause the StatefulSet to roll when the ConfigMap is updated
+  configChecksumAnnotation: true
 
   # securityContext for the nats container
   securityContext:
@@ -61,6 +131,13 @@ nats:
     maxPending:
     maxPings:
 
+    # How many seconds should pass before sending a PING
+    # to a client that has no activity.
+    pingInterval:
+
+    # grace period after pod begins shutdown before starting to close client connections
+    lameDuckGracePeriod: "10s"
+
     # NOTE: this should be at least the same as 'terminationGracePeriodSeconds'
     lameDuckDuration: "120s"
 
@@ -81,12 +158,34 @@ nats:
   # e.g. kubectl create secret generic custom-nats-conf --from-file nats.conf
   # customConfigSecret:
   #  name:
+  #
+  # Alternately, the generated config can be extended with extra imports using the below syntax.
+  # The benefit of this is that cluster settings can be built up via helm values, but external
+  # secrets can be referenced and imported alongside it.
+  #
+  # config:
+  #   <name-of-config-item>:
+  #     <configMap|secret>
+  #       name: "<configMap|secret name>"
+  #
+  # e.g:
+  #
+  #  config:
+  #    - name: ssh-key
+  #      secret:
+  #        secretName: ssh-key
+  #    - name: config-vol
+  #      configMap:
+  #        name: log-config
 
   jetstream:
     #enabled: JetStream can be enabled via .Values.global.jetstream.enabled
 
     # Jetstream Domain
     domain:
+
+    # Jetstream Unique Tag prevent placing a stream in the same availability zone twice.
+    uniqueTag:
 
     ##########################
     #                        #
@@ -134,6 +233,7 @@ nats:
       # key: "value"
 
 nameOverride: ""
+namespaceOverride: ""
 
 # Toggle whether to use setup a Pod Security Context
 # ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
@@ -171,11 +271,29 @@ statefulSetPodLabels:
 # Annotations to add to the NATS Service
 serviceAnnotations: {}
 
+# additionalContainers are the sidecar containers to add to the NATS StatefulSet
+additionalContainers: []
+
+# additionalVolumes are the additional volumes to add to the NATS StatefulSet
+additionalVolumes: []
+
+# additionalVolumeMounts are the additional volume mounts to add to the nats-server and nats-server-config-reloader containers
+additionalVolumeMounts: []
+
 cluster:
   enabled: false
   name: eventing-nats
   replicas: 3
   noAdvertise: false
+
+  # Explicitly set routes for clustering.
+  # When JetStream is enabled, the serverName must be unique in the cluster.
+  extraRoutes: []
+
+  # authorization:
+  #   user: foo
+  #   password: pwd
+  #   timeout: 0.5
 
 appProtocol:
   enabled: true
@@ -184,8 +302,16 @@ appProtocol:
 # https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/
 k8sClusterDomain: cluster.local
 
+# Define if NATS is using FQDN name for clustering (i.e. nats-0.nats.default.svc.cluster.local) or short name (i.e. nats-0.nats.default).
+useFQDN: true
+
 # Add labels to all the deployed resources
 commonLabels: {}
+
+
+# podManagementPolicy controls how pods are created during initial scale up,
+# when replacing pods on nodes, or when scaling down.
+podManagementPolicy: Parallel # TODO for now is OrderedReady
 
 # Prometheus NATS Exporter configuration.
 exporter:

--- a/resources/eventing/charts/nats/values.yaml
+++ b/resources/eventing/charts/nats/values.yaml
@@ -64,7 +64,7 @@ nats:
 
   # Adds a hash of the ConfigMap as a pod annotation
   # This will cause the StatefulSet to roll when the ConfigMap is updated
-  configChecksumAnnotation: true
+  configChecksumAnnotation: false
 
   # securityContext for the nats container
   securityContext:

--- a/resources/eventing/charts/nats/values.yaml
+++ b/resources/eventing/charts/nats/values.yaml
@@ -235,7 +235,7 @@ commonLabels: {}
 
 # podManagementPolicy controls how pods are created during initial scale up,
 # when replacing pods on nodes, or when scaling down.
-podManagementPolicy: Parallel
+podManagementPolicy: OrderedReady
 
 # Prometheus NATS Exporter configuration.
 exporter:

--- a/resources/eventing/charts/nats/values.yaml
+++ b/resources/eventing/charts/nats/values.yaml
@@ -20,6 +20,7 @@ nats:
     enabled: false
     port: 6000
 
+  # Toggle using health check probes to better detect failures.
   healthcheck:
     # Enable /healthz startupProbe for controlled upgrades of NATS JetStream
     enableHealthz: true
@@ -71,16 +72,12 @@ nats:
     privileged: false
 
   # Toggle to disable client advertisements (connect_urls),
-  # in case of running behind a load balancer (which is not recommended)
+  # in case of running behind a load balancer
   # it might be required to disable advertisements.
   advertise: true
 
   # The number of connect attempts against discovered routes.
   connectRetries: 120
-
-  # How many seconds should pass before sending a PING
-  # to a client that has no activity.
-  pingInterval:
 
   # selector matchLabels for the server and service.
   # If left empty defaults are used.
@@ -106,14 +103,19 @@ nats:
     maxPending:
     maxPings:
 
+    # How many seconds should pass before sending a PING
+    # to a client that has no activity.
+    pingInterval:
+
     # grace period after pod begins shutdown before starting to close client connections
     lameDuckGracePeriod: "10s"
 
-    # NOTE: this should be at least the same as 'terminationGracePeriodSeconds'
+    # duration over which to slowly close client connections after lameDuckGracePeriod has passed
     lameDuckDuration: "120s"
 
-  # Default lame duck duration in the server is 2 minutes.
-  terminationGracePeriodSeconds: 120
+  # terminationGracePeriodSeconds determines how long to wait for graceful shutdown
+  # this should be at least `lameDuckGracePeriod` + `lameDuckDuration` + 20s shutdown overhead
+  terminationGracePeriodSeconds: 150
 
   logging:
     debug: true

--- a/resources/eventing/charts/nats/values.yaml
+++ b/resources/eventing/charts/nats/values.yaml
@@ -50,11 +50,27 @@ nats:
       # Only for Kubernetes +1.22 that have pod level probes enabled.
       terminationGracePeriodSeconds:
 
+    # Periodically check for the server to be ready for connections while
+    # the NATS container is running.
+    # Disabled by default since covered by startup probe and it is the same
+    # as the liveness check.
+    readiness:
+      enabled: true
+
+      initialDelaySeconds: 10
+      timeoutSeconds: 5
+      periodSeconds: 10
+      successThreshold: 1
+      failureThreshold: 3
+
     # Enable startup checks to confirm server is ready for traffic.
     # This is recommended for JetStream deployments since in cluster mode
     # it will try to ensure that the server is ready to serve streams.
+
+    # since this check is recommended to use in cluster mode and the cluster mode ist disabled per default
+    # this check is also defaulted to false
     startup:
-      enabled: true
+      enabled: false
 
       initialDelaySeconds: 10
       timeoutSeconds: 5

--- a/resources/eventing/charts/nats/values.yaml
+++ b/resources/eventing/charts/nats/values.yaml
@@ -281,7 +281,7 @@ additionalVolumes: []
 additionalVolumeMounts: []
 
 cluster:
-  enabled: false
+  enabled: true
   name: eventing-nats
   replicas: 3
   noAdvertise: false
@@ -311,7 +311,7 @@ commonLabels: {}
 
 # podManagementPolicy controls how pods are created during initial scale up,
 # when replacing pods on nodes, or when scaling down.
-podManagementPolicy: Parallel # TODO for now is OrderedReady
+podManagementPolicy: Parallel
 
 # Prometheus NATS Exporter configuration.
 exporter:


### PR DESCRIPTION
**Description**

the purpose of this PR is to stay up-to-date with the [upstream repository](https://github.com/nats-io/k8s/tree/main/helm/charts/nats) charts version 

Changes proposed in this pull request:

- Changes in the ConfigMap:
   - new `lameDuckGracePeriod` and set it to the default, [reference](https://docs.nats.io/running-a-nats-service/configuration) 
- Changes in the StatefulSet:
   - `podManagementPolicy` is now set to `Parallel` in the upstream charts per default, [reference](https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#pod-management-policies). It used to be `OrderedReady` in the past, we still need to decide, which one to use.
   - new properties in the `livenessProbe`, which are for now set to the default upstream values
   - new startupProbe check
   - removed the readiness check, since it is covered by both liveness and startup checks, [reference](https://github.com/nats-io/k8s/blob/main/helm/charts/nats/values.yaml#L61)
- Changes in the `values.yaml`:
   - changed the `lameDuckDuration` and the `terminationGracePeriodSeconds` to the new default values
   - new `configChecksumAnnotation` value, which causes the StatefulSet to roll when the ConfigMap is updated, [reference](https://renehernandez.io/notes/rolling-pods-config-changes/)
   - new `uniqueTag` value, which prevents placing a stream in the same availability zone twice when set
