### PR TITLE
Enable telemetry component

### DIFF
--- a/installation/resources/components.yaml
+++ b/installation/resources/components.yaml
@@ -9,6 +9,7 @@ prerequisites:
 components:
   - name: "istio-resources"
   - name: "logging"
+  - name: "telemetry"
   - name: "tracing"
   - name: "kiali"
   - name: "monitoring"

--- a/resources/logging/values.yaml
+++ b/resources/logging/values.yaml
@@ -15,7 +15,7 @@ tracing:
   jaegerAgentHost:
 
 fluent-bit:
-  enabled: true
+  enabled: false
 
 loki:
   enabled: true
@@ -46,7 +46,7 @@ global:
       name: kyma-gateway
       namespace: kyma-system
   telemetry:
-    enabled: false
+    enabled: true
   tracing:
     enabled: true
   highPriorityClassName: "kyma-system-priority"

--- a/tests/fast-integration/logging/loki.js
+++ b/tests/fast-integration/logging/loki.js
@@ -50,7 +50,7 @@ function parseJson(str) {
 }
 
 async function verifyIstioAccessLogFormat(startTimestamp) {
-  const query = '{container="istio-proxy",job="fluent-bit",namespace="kyma-system",pod="logging-loki-0"}';
+  const query = '{container="istio-proxy",namespace="kyma-system",pod="logging-loki-0"}';
 
   const responseBody = await queryLoki(query, startTimestamp);
 

--- a/tests/fast-integration/telemetry-test/telemetry-test.js
+++ b/tests/fast-integration/telemetry-test/telemetry-test.js
@@ -143,14 +143,14 @@ describe('Telemetry Operator tests, prepare the environment', function() {
   });
 
   it('Should push the logs to the loki output', async () => {
-    const labels = '{job="telemetry-fluent-bit", namespace="kyma-system"}';
+    const labels = '{namespace="kyma-system"}';
     const logsPresent = await logsPresentInLoki(labels, testStartTimestamp);
     assert.isTrue(logsPresent, 'No logs present in Loki');
   });
 
   it('Should parse the logs using regex', async () => {
     try {
-      const labels = '{job="telemetry-fluent-bit", namespace="default"}|json|pass="bar"|user="foo"';
+      const labels = '{namespace="default"}|json|pass="bar"|user="foo"';
       const logsPresent = await logsPresentInLoki(labels, testStartTimestamp);
       assert.isTrue(logsPresent, 'No parsed logs present in Loki');
     } catch (e) {
@@ -164,7 +164,7 @@ describe('Telemetry Operator tests, prepare the environment', function() {
 
   it('Should push the logs to the http mockserver', async () => {
     // The mockserver prints received logs to stdout, which should finally be pushed to Loki by the other pipeline
-    const labels = '{job="telemetry-fluent-bit", namespace="mockserver"}';
+    const labels = '{namespace="mockserver"}';
     const logsPresent = await logsPresentInLoki(labels, testStartTimestamp);
     assert.isTrue(logsPresent, 'No logs received by mockserver present in Loki');
   });
@@ -175,7 +175,7 @@ describe('Telemetry Operator tests, prepare the environment', function() {
     await updateLogPipeline(lokiPipeline);
 
     await sleep(10 * 1000);
-    const labels = '{job="telemetry-fluent-bit", namespace="kyma-system"}';
+    const labels = '{namespace="kyma-system"}';
     const logsPresent = await logsPresentInLoki(labels, testStartTimestamp);
     assert.isTrue(logsPresent, 'No kyma-system logs present in Loki');
   });


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Enable the installation of the telemetry component.

Changes proposed in this pull request:

- Enable telemetry chart to be installed by default (including Fluent Bit and operator)
- Disable Fluent Bit from logging chart
- Adapt Logging test to check access logs also from telemetry-fluent-bit

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
Related issue: #13143 