### PR TITLE
Bumped kyma override version in eventing fast-integration tests

### DIFF
--- a/tests/fast-integration/eventing-test/prow/config/skr_config.json
+++ b/tests/fast-integration/eventing-test/prow/config/skr_config.json
@@ -1,3 +1,3 @@
 {
-  "kymaOverridesVersion": "2.4.2"
+  "kymaOverridesVersion": "2.5.2"
 }


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- Bumped kyma override version in eventing fast-integration tests to `2.5.2`

