### PR TITLE
add logging-fluent-bit cleanup script  to 2.5-2.6 migration guide

### DIFF
--- a/docs/assets/2.5-2.6-cleanup-logging-fluent-bit.sh
+++ b/docs/assets/2.5-2.6-cleanup-logging-fluent-bit.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+
+echo "Deleting logging Fluent Bit resources"
+
+kubectl delete -n kyma-system clusterroles.rbac.authorization.k8s.io logging-fluent-bit
+kubectl delete -n kyma-system clusterrolebindings.rbac.authorization.k8s.io logging-fluent-bit
+kubectl delete -n kyma-system configmap logging-fluent-bit
+kubectl delete -n kyma-system configmap logging-fluent-bit-grafana-dashboard
+kubectl delete -n kyma-system daemonsets.apps logging-fluent-bit
+kubectl delete -n kyma-system peerauthentications.security.istio.io logging-fluent-bit-metrics
+kubectl delete -n kyma-system podsecuritypolicys.policy 000-logging-fluent-bit
+kubectl delete -n kyma-system prometheusrules.monitoring.coreos.com logging-fluent-bit-kyma-fluent-bit.rules
+kubectl delete -n kyma-system secret logging-fluent-bit-es-ca-secret
+kubectl delete -n kyma-system service logging-fluent-bit
+kubectl delete -n kyma-system serviceaccount logging-fluent-bit
+kubectl delete -n kyma-system servicemonitors.monitoring.coreos.com logging-fluent-bit

--- a/docs/migration-guide-2.5-2.6.md
+++ b/docs/migration-guide-2.5-2.6.md
@@ -2,4 +2,4 @@
 title: Migration Guide 2.5-2.6
 ---
 
-Due to the enablement of the telemetry component by default, some logging resources must be deleted. When you upgrade from Kyma 2.5 to 2.6, either run the script 2.5-2.6-cleanup-logging-fluent-bit.sh or perform the required steps from that script manually.
+Due to the enablement of the telemetry component by default, some logging resources must be deleted. When you upgrade from Kyma 2.5 to 2.6, either run the script [2.5-2.6-cleanup-logging-fluent-bit.sh](./assets/2.5-2.6-cleanup-logging-fluent-bit.sh) or perform the required steps from that script manually.

--- a/docs/migration-guide-2.5-2.6.md
+++ b/docs/migration-guide-2.5-2.6.md
@@ -1,0 +1,5 @@
+---
+title: Migration Guide 2.5-2.6
+---
+
+Due to the enablement of the telemetry component by default, some logging resources must be deleted. When you upgrade from Kyma 2.5 to 2.6, either run the script 2.5-2.6-cleanup-logging-fluent-bit.sh or perform the required steps from that script manually.

--- a/docs/migration-guide-2.5-2.6.md
+++ b/docs/migration-guide-2.5-2.6.md
@@ -2,4 +2,4 @@
 title: Migration Guide 2.5-2.6
 ---
 
-Due to the enablement of the telemetry component by default, some logging resources must be deleted. When you upgrade from Kyma 2.5 to 2.6, either run the script [2.5-2.6-cleanup-logging-fluent-bit.sh](./assets/2.5-2.6-cleanup-logging-fluent-bit.sh) or perform the required steps from that script manually.
+Due to the enablement of the telemetry component by default, some logging resources must be deleted. When you upgrade from Kyma 2.5 to 2.6, either run the script [2.5-2.6-cleanup-logging-fluent-bit.sh](./assets/2.5-2.6-cleanup-logging-fluent-bit.sh) or run the commands from the script manually.


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- With Kyma 2.6, the telemetry component is enabled by default introducing its own fluent bit.
- Therefore, the fluent bit resources of the logging component are not needed anymore
- This PR provides a cleanup script to delete the logging fluent bit resources

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
See also https://github.com/kyma-project/kyma/issues/13143