### PR TITLE
Crd runtime as string 15016

### DIFF
--- a/components/function-controller/config/crd/bases/serverless.kyma-project.io_functions.yaml
+++ b/components/function-controller/config/crd/bases/serverless.kyma-project.io_functions.yaml
@@ -526,13 +526,7 @@ spec:
                     type: object
                 type: object
               runtime:
-                description: Runtime enumerates runtimes that are currently supported
-                  by Function Controller. It is a subset of RuntimeExtended.
-                enum:
-                - nodejs12
-                - nodejs14
-                - nodejs16
-                - python39
+                description: Runtime specifies the name of the Function's runtime.
                 type: string
               runtimeImageOverride:
                 type: string

--- a/components/function-controller/config/crd/bases/serverless.kyma-project.io_functions.yaml
+++ b/components/function-controller/config/crd/bases/serverless.kyma-project.io_functions.yaml
@@ -627,16 +627,7 @@ spec:
               reference:
                 type: string
               runtime:
-                description: RuntimeExtended enumerates runtimes that are either currently
-                  supported or no longer supported but there still might be "read-only"
-                  Functions using them
-                enum:
-                - nodejs12
-                - nodejs14
-                - nodejs16
-                - nodejs10
-                - python38
-                - python39
+                description: Runtime specifies the name of the Function's runtime.
                 type: string
               runtimeImageOverride:
                 type: string

--- a/components/function-controller/config/crd/crd-serverless.yaml
+++ b/components/function-controller/config/crd/crd-serverless.yaml
@@ -637,16 +637,7 @@ spec:
               reference:
                 type: string
               runtime:
-                description: RuntimeExtended enumerates runtimes that are either currently
-                  supported or no longer supported but there still might be "read-only"
-                  Functions using them
-                enum:
-                - nodejs12
-                - nodejs14
-                - nodejs16
-                - nodejs10
-                - python38
-                - python39
+                description: Runtime specifies the name of the Function's runtime.
                 type: string
               runtimeImageOverride:
                 type: string

--- a/components/function-controller/config/crd/crd-serverless.yaml
+++ b/components/function-controller/config/crd/crd-serverless.yaml
@@ -536,13 +536,7 @@ spec:
                     type: object
                 type: object
               runtime:
-                description: Runtime enumerates runtimes that are currently supported
-                  by Function Controller. It is a subset of RuntimeExtended.
-                enum:
-                - nodejs12
-                - nodejs14
-                - nodejs16
-                - python39
+                description: Runtime specifies the name of the Function's runtime.
                 type: string
               runtimeImageOverride:
                 type: string

--- a/components/function-controller/internal/controllers/serverless/fsm.go
+++ b/components/function-controller/internal/controllers/serverless/fsm.go
@@ -126,7 +126,7 @@ func buildStateFnGenericUpdateStatus(condition serverlessv1alpha2.Condition, rep
 			currentFunction.Status.Commit = commit
 		}
 
-		currentFunction.Status.Runtime = serverlessv1alpha2.RuntimeExtended(s.instance.Spec.Runtime)
+		currentFunction.Status.Runtime = s.instance.Spec.Runtime
 		currentFunction.Status.RuntimeImageOverride = s.instance.Spec.RuntimeImageOverride
 
 		if !equalFunctionStatus(currentFunction.Status, s.instance.Status) {

--- a/components/function-controller/internal/controllers/serverless/gitops_test.go
+++ b/components/function-controller/internal/controllers/serverless/gitops_test.go
@@ -82,7 +82,7 @@ func Test_isOnSourceChange(t *testing.T) {
 						Reference: "1",
 					},
 					Commit:  "1",
-					Runtime: v1alpha2.RuntimeExtendedNodeJs12,
+					Runtime: v1alpha2.NodeJs12,
 				},
 			},
 			revision:       "1",

--- a/components/function-controller/internal/controllers/serverless/system_state.go
+++ b/components/function-controller/internal/controllers/serverless/system_state.go
@@ -613,7 +613,7 @@ func (s *systemState) gitFnSrcChanged(commit string) bool {
 	return s.instance.Status.Commit == "" ||
 		commit != s.instance.Status.Commit ||
 		s.instance.Spec.Source.GitRepository.Reference != s.instance.Status.Reference ||
-		serverlessv1alpha2.RuntimeExtended(s.instance.Spec.Runtime) != s.instance.Status.Runtime ||
+		s.instance.Spec.Runtime != s.instance.Status.Runtime ||
 		s.instance.Spec.Source.GitRepository.BaseDir != s.instance.Status.BaseDir ||
 		getConditionStatus(s.instance.Status.Conditions, serverlessv1alpha2.ConditionConfigurationReady) == corev1.ConditionFalse
 

--- a/components/function-controller/internal/webhook/conversion_webhook.go
+++ b/components/function-controller/internal/webhook/conversion_webhook.go
@@ -244,7 +244,7 @@ func (w *ConvertingWebhook) convertGitRepositoryV1Alpha1ToV1Alpha2(in *serverles
 func (w *ConvertingWebhook) convertStatusV1Alpha1ToV1Alpha2(in *serverlessv1alpha1.FunctionStatus, out *serverlessv1alpha2.FunctionStatus) {
 	out.Repository = serverlessv1alpha2.Repository(in.Repository)
 	out.Commit = in.Commit
-	out.Runtime = serverlessv1alpha2.RuntimeExtended(in.Runtime)
+	out.Runtime = serverlessv1alpha2.Runtime(in.Runtime)
 	out.RuntimeImageOverride = in.RuntimeImageOverride
 
 	out.Conditions = []serverlessv1alpha2.Condition{}

--- a/components/function-controller/pkg/apis/serverless/v1alpha2/function_types.go
+++ b/components/function-controller/pkg/apis/serverless/v1alpha2/function_types.go
@@ -184,22 +184,6 @@ const (
 	ConditionReasonMinReplicasNotAvailable        ConditionReason = "MinReplicasNotAvailable"
 )
 
-//TODO: to remove
-
-// RuntimeExtended enumerates runtimes that are either currently supported or
-// no longer supported but there still might be "read-only" Functions using them
-// +kubebuilder:validation:Enum=nodejs12;nodejs14;nodejs16;nodejs10;python38;python39
-type RuntimeExtended string
-
-const (
-	RuntimeExtendedNodeJs10 RuntimeExtended = "nodejs10"
-	RuntimeExtendedNodeJs12 RuntimeExtended = "nodejs12"
-	RuntimeExtendedNodeJs14 RuntimeExtended = "nodejs14"
-	RuntimeExtendedNodeJs16 RuntimeExtended = "nodejs16"
-	RuntimeExtendedPython38 RuntimeExtended = "python38"
-	RuntimeExtendedPython39 RuntimeExtended = "python39"
-)
-
 type Condition struct {
 	Type               ConditionType      `json:"type,omitempty"`
 	Status             v1.ConditionStatus `json:"status" description:"status of the condition, one of True, False, Unknown"`
@@ -215,8 +199,8 @@ type Repository struct {
 
 // FunctionStatus defines the observed state of Function
 type FunctionStatus struct {
-	Runtime              RuntimeExtended `json:"runtime,omitempty"`
-	Conditions           []Condition     `json:"conditions,omitempty"`
+	Runtime              Runtime     `json:"runtime,omitempty"`
+	Conditions           []Condition `json:"conditions,omitempty"`
 	Repository           `json:",inline,omitempty"`
 	Commit               string `json:"commit,omitempty"`
 	RuntimeImageOverride string `json:"runtimeImageOverride,omitempty"`

--- a/components/function-controller/pkg/apis/serverless/v1alpha2/function_types.go
+++ b/components/function-controller/pkg/apis/serverless/v1alpha2/function_types.go
@@ -21,9 +21,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-// Runtime enumerates runtimes that are currently supported by Function Controller.
-// It is a subset of RuntimeExtended.
-// +kubebuilder:validation:Enum=nodejs12;nodejs14;nodejs16;python39
+// Runtime specifies the name of the Function's runtime.
 type Runtime string
 
 const (
@@ -185,6 +183,8 @@ const (
 	ConditionReasonHorizontalPodAutoscalerUpdated ConditionReason = "HorizontalPodAutoscalerUpdated"
 	ConditionReasonMinReplicasNotAvailable        ConditionReason = "MinReplicasNotAvailable"
 )
+
+//TODO: to remove
 
 // RuntimeExtended enumerates runtimes that are either currently supported or
 // no longer supported but there still might be "read-only" Functions using them

--- a/components/function-controller/pkg/apis/serverless/v1alpha2/function_validation.go
+++ b/components/function-controller/pkg/apis/serverless/v1alpha2/function_validation.go
@@ -52,6 +52,7 @@ type validationFunction func(*ValidationConfig) error
 func (fn *Function) getBasicValidations() []validationFunction {
 	return []validationFunction{
 		fn.validateObjectMeta,
+		fn.Spec.validateRuntime,
 		fn.Spec.validateEnv,
 		fn.Spec.validateLabels,
 		fn.Spec.validateReplicas,
@@ -160,6 +161,15 @@ func (spec *FunctionSpec) validateGitAuthType(_ *ValidationConfig) error {
 	default:
 		return ErrInvalidGitRepositoryAuthType
 	}
+}
+
+func (spec *FunctionSpec) validateRuntime(_ *ValidationConfig) error {
+	runtimeName := spec.Runtime
+	switch runtimeName {
+	case Python39, NodeJs12, NodeJs14, NodeJs16:
+		return nil
+	}
+	return fmt.Errorf("spec.runtime contains unsupported value")
 }
 
 func (spec *FunctionSpec) validateEnv(vc *ValidationConfig) error {

--- a/components/function-controller/pkg/apis/serverless/v1alpha2/function_validation_test.go
+++ b/components/function-controller/pkg/apis/serverless/v1alpha2/function_validation_test.go
@@ -140,6 +140,25 @@ func TestFunctionSpec_validateResources(t *testing.T) {
 			},
 			expectedError: gomega.BeNil(),
 		},
+		"Should return error on unexpected runtime name": {
+			givenFunc: Function{
+				ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "test"},
+				Spec: FunctionSpec{
+					Runtime: "unknown-runtime-name",
+					Source: Source{
+						Inline: &InlineSource{
+							Source: "test-source",
+						},
+					},
+				},
+			},
+			expectedError: gomega.HaveOccurred(),
+			specifiedExpectedError: gomega.And(
+				gomega.ContainSubstring(
+					"spec.runtime",
+				),
+			),
+		},
 		"Should return error when more than one source is filled": {
 			givenFunc: Function{
 				ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "test"},

--- a/installation/resources/crds/serverless/crd-serverless.yaml
+++ b/installation/resources/crds/serverless/crd-serverless.yaml
@@ -637,16 +637,7 @@ spec:
               reference:
                 type: string
               runtime:
-                description: RuntimeExtended enumerates runtimes that are either currently
-                  supported or no longer supported but there still might be "read-only"
-                  Functions using them
-                enum:
-                - nodejs12
-                - nodejs14
-                - nodejs16
-                - nodejs10
-                - python38
-                - python39
+                description: Runtime specifies the name of the Function's runtime.
                 type: string
               runtimeImageOverride:
                 type: string

--- a/installation/resources/crds/serverless/crd-serverless.yaml
+++ b/installation/resources/crds/serverless/crd-serverless.yaml
@@ -536,13 +536,7 @@ spec:
                     type: object
                 type: object
               runtime:
-                description: Runtime enumerates runtimes that are currently supported
-                  by Function Controller. It is a subset of RuntimeExtended.
-                enum:
-                - nodejs12
-                - nodejs14
-                - nodejs16
-                - python39
+                description: Runtime specifies the name of the Function's runtime.
                 type: string
               runtimeImageOverride:
                 type: string

--- a/resources/serverless/values.yaml
+++ b/resources/serverless/values.yaml
@@ -76,13 +76,13 @@ global:
       directory: "tpi"
     function_controller:
       name: "function-controller"
-      version: "PR-15114"
+      version: "PR-15121"
     function_webhook:
       name: "function-webhook"
-      version: "PR-15114"
+      version: "PR-15121"
     function_build_init:
       name: "function-build-init"
-      version: "PR-15114"
+      version: "PR-15121"
     function_runtime_nodejs12:
       name: "function-runtime-nodejs12"
       version: "PR-15038"


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- In function CRD spec.runtime changed from enum to string

**Related issue(s)**
See also #15016
