### PR TITLE
bump `prometheus-nats-exporter` and `nats-config-reloader`

### DIFF
--- a/resources/eventing/values.yaml
+++ b/resources/eventing/values.yaml
@@ -16,11 +16,11 @@ global:
       directory: external
     nats_config_reloader:
       name: natsio/nats-server-config-reloader
-      version: 0.7.0
+      version: 0.7.2
       directory: external
     prometheus_nats_exporter:
       name: natsio/prometheus-nats-exporter
-      version: 0.9.3
+      version: 0.10.0
       directory: external
 
   jetstream:


### PR DESCRIPTION
bump `nats-config-reloader` to [`0.7.2`](https://hub.docker.com/layers/nats-server-config-reloader/natsio/nats-server-config-reloader/0.7.2/images/sha256-7e660b7c8e7dd54b982e38c3d3440a46fa60e9505e9164fd26d5515129e84cd9?context=explore) and `nats-prometheus-exporter` to [`0.10.0`](https://hub.docker.com/layers/prometheus-nats-exporter/natsio/prometheus-nats-exporter/0.10.0/images/sha256-5400de7cf9cd9fbda4ef3d6f5d236560e43bc6d1bf09b021ce4611d0dc4ff21a?context=explore) to prevent potential security vulnerabilities. 