### PR TITLE
Catch the error, when the JetStream storage gets full

### DIFF
--- a/components/event-publisher-proxy/pkg/sender/jetstream.go
+++ b/components/event-publisher-proxy/pkg/sender/jetstream.go
@@ -5,8 +5,9 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	natsserver "github.com/nats-io/nats-server/v2/server"
 	"net/http"
+
+	natsserver "github.com/nats-io/nats-server/v2/server"
 
 	"github.com/kyma-project/kyma/components/eventing-controller/logger"
 	"go.uber.org/zap"

--- a/resources/eventing/values.yaml
+++ b/resources/eventing/values.yaml
@@ -9,7 +9,7 @@ global:
       pullPolicy: "IfNotPresent"
     publisher_proxy:
       name: event-publisher-proxy
-      version: 15214
+      version: PR-15214
     nats:
       name: nats
       version: 2.8.4-alpine

--- a/resources/eventing/values.yaml
+++ b/resources/eventing/values.yaml
@@ -9,7 +9,7 @@ global:
       pullPolicy: "IfNotPresent"
     publisher_proxy:
       name: event-publisher-proxy
-      version: PR-15297
+      version: 15214
     nats:
       name: nats
       version: 2.8.4-alpine


### PR DESCRIPTION
**Description**

when the JetStream PVC storage gets full, the JetStream gets disabled. Currently there is no direct error from NATS, that the storage is full. This PR introduces the custom logic to intercept that error. Furthermore, it improves the error output in case there is other reason, JetStream got disabled.

**Changes proposed in this PR**
- catch the error, when the storage gets full and js get disabled and propagate it to the user
- do not log the `Event dispatched` in case of the error and improve the send message signature and the log message

**logs/output example**

_old state_

error output:
```
{"level":"INFO","timestamp":"2022-08-23T08:04:45Z","logger":"jetstream-handler","caller":"sender/jetstream.go:77","message":"Sending event:Context Attributes,\n  specversion: 1.0\n  type: sap.kyma.custom.noapp.order.created.v1\n  source: noapp\n  id: A2111-1111-1111\n  datacontenttype: application/json\nExtensions,\n  b3sampled: 1\n  eventtypeversion: v1\nData,\n  \"{\\\"foo123\\\":\\\"bar\\\"}\"\n to backend, stream name:sap","context":{"backend":"nats","jetstream enabled":true}}
{"level":"ERROR","timestamp":"2022-08-23T08:04:45Z","logger":"jetstream-handler","caller":"sender/jetstream.go:80","message":"Cannot send event to backend","context":{"backend":"nats","jetstream enabled":true,"error":"nats: no response from stream"}}
{"level":"INFO","timestamp":"2022-08-23T08:04:45Z","logger":"nats-handler","caller":"nats/handler.go:195","message":"Event dispatched","context":{"id":"A2111-1111-1111","source":"noapp","before":"sap.kyma.custom.noapp.order.created.v1","after":"sap.kyma.custom.noapp.order.created.v1","statusCode":500,"duration":0.505664311,"responseBody":"nats: no response from stream"}}
```
EPP response:
<img width="336" alt="image" src="https://user-images.githubusercontent.com/15933100/186105685-ace2b239-93d5-44af-a50a-53b668fd18c9.png">

EPP logs, when publishing was successful:
```
{"level":"INFO","timestamp":"2022-08-23T10:34:40+02:00","logger":"nats-handler","caller":"nats/handler.go:217","message":"CloudEvent received id:[8945ec08-256b-11eb-9928-acde48001122]","context":{}}
{"level":"INFO","timestamp":"2022-08-23T10:34:40+02:00","logger":"nats-handler","caller":"nats/handler.go:195","message":"Event dispatched","context":{"id":"8945ec08-256b-11eb-9928-acde48001122","source":"/default/sap.kyma/id","before":"prefix.testapp1023.order.created.v1","after":"prefix.testapp1023.order.created.v1","statusCode":204,"duration":0.000033629,"responseBody":""}}
            
```

_new state_

error output:
```
{"level":"INFO","timestamp":"2022-08-23T08:04:45Z","logger":"jetstream-handler","caller":"sender/jetstream.go:77","message":"Sending event:Context Attributes,\n  specversion: 1.0\n  type: sap.kyma.custom.noapp.order.created.v1\n  source: noapp\n  id: A2111-1111-1111\n  datacontenttype: application/json\nExtensions,\n  b3sampled: 1\n  eventtypeversion: v1\nData,\n  \"{\\\"foo123\\\":\\\"bar\\\"}\"\n to backend, stream name:sap","context":{"backend":"nats","jetstream enabled":true}}
{"level":"ERROR","timestamp":"2022-08-23T07:56:41Z","logger":"jetstream-handler","caller":"sender/jetstream.go:81","message":"Cannot send event to backend","context":{"backend":"nats","jetstream enabled":true,"accountInfoErr":"JetStream system temporarily unavailable"}}
{"level":"ERROR","timestamp":"2022-08-23T07:56:41Z","logger":"nats-handler","caller":"nats/handler.go:213","message":"Failed to send the event to EventingBackend","context":{"id":"A2111-1111-1111","source":"noapp","before":"sap.kyma.custom.noapp.order.created.v1","after":"sap.kyma.custom.noapp.order.created.v1","statusCode":507,"duration":0.003430241,"responseBody":"JetStream is disabled due to full storage"}}
```
EPP response:
<img width="345" alt="image" src="https://user-images.githubusercontent.com/15933100/185946654-5814bf0e-bad4-462f-834b-79bdb3fd6701.png">

EPP logs, when publishing was successful:
```
{"level":"INFO","timestamp":"2022-08-23T11:04:08+02:00","logger":"nats-handler","caller":"nats/handler.go:236","message":"CloudEvent received id:[8945ec08-256b-11eb-9928-acde48001122]","context":{}}
{"level":"INFO","timestamp":"2022-08-23T11:04:08+02:00","logger":"nats-handler","caller":"nats/handler.go:211","message":"Event was successfully sent to EventingBackend","context":{"id":"8945ec08-256b-11eb-9928-acde48001122","source":"/default/sap.kyma/id","before":"prefix.testapp1023.order.created.v1","after":"prefix.testapp1023.order.created.v1","statusCode":204,"duration":0.000125174}}
```


