### PR TITLE
Revert "[Telemetry Operator] Don't restart Fluent Bit pod when the CR is being updated (#15132)

### DIFF
--- a/components/telemetry-operator/controllers/telemetry/logpipeline_controller.go
+++ b/components/telemetry-operator/controllers/telemetry/logpipeline_controller.go
@@ -115,21 +115,21 @@ func (r *LogPipelineReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 		return ctrl.Result{RequeueAfter: requeueTime}, nil
 	}
 
-	result, err := r.Syncer.SyncAll(ctx, &logPipeline)
+	changed, err := r.Syncer.SyncAll(ctx, &logPipeline)
 	if err != nil {
 		return ctrl.Result{Requeue: shouldRetryOn(err)}, nil
 	}
 
 	r.unsupportedTotal.Set(float64(r.Syncer.UnsupportedPluginsTotal))
-	if result.LogPipelineChanged {
+
+	if changed {
+		log.V(1).Info("Fluent Bit configuration was updated. Restarting the DaemonSet due to logpipeline change")
+
 		if err = r.Update(ctx, &logPipeline); err != nil {
 			log.Error(err, "Failed updating log pipeline")
 			return ctrl.Result{Requeue: shouldRetryOn(err)}, err
 		}
-	}
 
-	if result.ConfigurationChanged {
-		log.Info("Fluent Bit configuration was updated. Restarting the DaemonSet due to logpipeline change")
 		if err = r.DaemonSetUtils.RestartFluentBit(ctx); err != nil {
 			log.Error(err, "Failed restarting fluent bit daemon set")
 			return ctrl.Result{Requeue: shouldRetryOn(err)}, err

--- a/components/telemetry-operator/internal/parserSync/parser_test.go
+++ b/components/telemetry-operator/internal/parserSync/parser_test.go
@@ -33,11 +33,10 @@ func TestSyncParsersConfigMapErrorClientErrorReturnsError(t *testing.T) {
 		Spec: telemetryv1alpha1.LogParserSpec{Parser: `
 Format regex`},
 	}
-	res, err := sut.SyncParsersConfigMap(context.Background(), &lp)
+	result, err := sut.SyncParsersConfigMap(context.Background(), &lp)
 
-	var result Result
 	require.Error(t, err)
-	require.Equal(t, res, result)
+	require.Equal(t, result, false)
 }
 
 func TestSuccessfulParserConfigMap(t *testing.T) {
@@ -54,12 +53,9 @@ Format regex`},
 	sut := NewLogParserSyncer(mockClient, daemonSetConfig)
 
 	changed, err := sut.SyncParsersConfigMap(context.Background(), lp)
-	var expectedResult Result
-	expectedResult.ConfigurationChanged = true
-	expectedResult.LogParserChanged = true
 
 	require.NoError(t, err)
-	require.Equal(t, expectedResult, changed)
+	require.Equal(t, true, changed)
 
 	var cm corev1.ConfigMap
 	err = sut.Get(ctx, daemonSetConfig.FluentBitParsersConfigMap, &cm)

--- a/components/telemetry-operator/internal/sync/sync_test.go
+++ b/components/telemetry-operator/internal/sync/sync_test.go
@@ -96,11 +96,10 @@ func TestSyncSectionsConfigMapClientErrorReturnsError(t *testing.T) {
 	sut := NewLogPipelineSyncer(mockClient, daemonSetConfig, pipelineConfig)
 
 	lp := telemetryv1alpha1.LogPipeline{}
-	res, err := sut.syncSectionsConfigMap(context.Background(), &lp)
+	result, err := sut.syncSectionsConfigMap(context.Background(), &lp)
 
-	var result Result
 	require.Error(t, err)
-	require.Equal(t, res, result)
+	require.Equal(t, result, false)
 }
 
 func TestSyncFilesConfigMapErrorClientErrorReturnsError(t *testing.T) {
@@ -110,11 +109,10 @@ func TestSyncFilesConfigMapErrorClientErrorReturnsError(t *testing.T) {
 	sut := NewLogPipelineSyncer(mockClient, daemonSetConfig, pipelineConfig)
 
 	lp := telemetryv1alpha1.LogPipeline{}
-	res, err := sut.syncFilesConfigMap(context.Background(), &lp)
+	result, err := sut.syncFilesConfigMap(context.Background(), &lp)
 
-	var result Result
 	require.Error(t, err)
-	require.Equal(t, res, result)
+	require.Equal(t, result, false)
 }
 
 func TestUnsupportedTotal(t *testing.T) {
@@ -180,7 +178,7 @@ func TestSyncVariablesFromHttpOutput(t *testing.T) {
 	lps := NewLogPipelineSyncer(mockClient, daemonSetConfig, pipelineConfig)
 	restartRequired, err := lps.syncVariables(context.Background())
 	require.NoError(t, err)
-	require.True(t, restartRequired.ConfigurationChanged)
+	require.True(t, restartRequired)
 
 	var envSecret corev1.Secret
 	err = mockClient.Get(context.Background(), types.NamespacedName{Name: "env-secret", Namespace: "cm-ns"}, &envSecret)

--- a/resources/telemetry/values.yaml
+++ b/resources/telemetry/values.yaml
@@ -4,7 +4,7 @@ global:
   images:
     telemetry_operator:
       name: "telemetry-operator"
-      version: "PR-15146"
+      version: "PR-15216"
     fluent_bit:
       name: "fluent-bit"
       version: "1.9.6-ec0ac757"

--- a/resources/telemetry/values.yaml
+++ b/resources/telemetry/values.yaml
@@ -4,7 +4,7 @@ global:
   images:
     telemetry_operator:
       name: "telemetry-operator"
-      version: "PR-15132"
+      version: "PR-15146"
     fluent_bit:
       name: "fluent-bit"
       version: "1.9.6-ec0ac757"


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

The change to the Fluent Bit restart logic in the telemetry-operator has shown to have new problems (#15199). Since the cause for this change has also been fixed in the reconciler, we roll back this for now.

Changes proposed in this pull request:

- Revert commit 750f79ae2bc49496b334438be66fbe39c222fa7c

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
#15199