### PR TITLE
Unify labels in serverless components

### DIFF
--- a/resources/serverless/charts/docker-registry/templates/deployment.yaml
+++ b/resources/serverless/charts/docker-registry/templates/deployment.yaml
@@ -5,10 +5,12 @@ kind: Deployment
 metadata:
   name: {{ template "docker-registry.fullname" . }}
   labels:
-    app: {{ template "docker-registry.name" . }}
-    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
-    release: {{ .Release.Name }}
-    heritage: {{ .Release.Service }}
+    app: "{{ .Release.Name }}"
+    app.kubernetes.io/name: "{{ .Release.Name }}"
+    app.kubernetes.io/instance: "{{ .Release.Name }}"
+    app.kubernetes.io/component: '{{ template "docker-registry.name" . }}'
+    app.kubernetes.io/version: "{{ .Values.global.images.registry.version }}"
+
 spec:
   selector:
     matchLabels:

--- a/resources/serverless/charts/webhook/templates/deployment.yaml
+++ b/resources/serverless/charts/webhook/templates/deployment.yaml
@@ -30,7 +30,10 @@ spec:
         {{ include "tplValue" ( dict "value" .Values.pod.annotations "context" . ) | nindent 8 }}
       {{- end }}
       labels:
-        {{- include "tplValue" ( dict "value" .Values.commonLabels "context" . ) | nindent 8 }}
+        app: {{ template "webhook.fullname" . }}
+        app.kubernetes.io/name: {{ template "webhook.fullname" . }}
+        app.kubernetes.io/instance: "{{ .Release.Name }}"
+      role: webhook
     spec:
       serviceAccountName: {{ template "webhook.fullname" . }}
       volumes:

--- a/resources/serverless/charts/webhook/templates/deployment.yaml
+++ b/resources/serverless/charts/webhook/templates/deployment.yaml
@@ -33,7 +33,7 @@ spec:
         app: {{ template "webhook.fullname" . }}
         app.kubernetes.io/name: {{ template "webhook.fullname" . }}
         app.kubernetes.io/instance: "{{ .Release.Name }}"
-      role: webhook
+        role: webhook
     spec:
       serviceAccountName: {{ template "webhook.fullname" . }}
       volumes:

--- a/resources/serverless/charts/webhook/values.yaml
+++ b/resources/serverless/charts/webhook/values.yaml
@@ -8,10 +8,11 @@ image:
   pullPolicy: IfNotPresent
 
 commonLabels:
-  app: '{{ template "webhook.fullname" . }}'
-  app.kubernetes.io/name: '{{ template "webhook.fullname" . }}'
+  app: "{{ .Release.Name }}"
+  app.kubernetes.io/name: "{{ .Release.Name }}"
   app.kubernetes.io/instance: "{{ .Release.Name }}"
-  role: webhook
+  app.kubernetes.io/component: '{{ template "webhook.fullname" . }}'
+  app.kubernetes.io/version: "{{ .Values.global.images.function_webhook.version }}"
 
 deployment:
   replicas: 1

--- a/resources/serverless/values.yaml
+++ b/resources/serverless/values.yaml
@@ -61,9 +61,9 @@ global:
     app: '{{ template "name" . }}'
     version: "{{ .Values.global.images.function_controller.version }}"
     app.kubernetes.io/name: '{{ template "name" . }}'
+    app.kubernetes.io/component: '{{ template "fullname" . }}-controller'
     app.kubernetes.io/instance: "{{ .Release.Name }}"
     app.kubernetes.io/version: "{{ .Values.global.images.function_controller.version }}"
-    helm.sh/chart: '{{ include "chart" . }}'
   dockerServicePort: 5000
   ingress:
     domainName:

--- a/resources/serverless/values.yaml
+++ b/resources/serverless/values.yaml
@@ -58,11 +58,10 @@ tests:
 global:
   domainName: "kyma.example.com"
   commonLabels:
-    app: '{{ template "name" . }}'
-    version: "{{ .Values.global.images.function_controller.version }}"
-    app.kubernetes.io/name: '{{ template "name" . }}'
-    app.kubernetes.io/component: '{{ template "fullname" . }}-controller'
+    app: "{{ .Release.Name }}"
+    app.kubernetes.io/name: "{{ .Release.Name }}"
     app.kubernetes.io/instance: "{{ .Release.Name }}"
+    app.kubernetes.io/component: '{{ template "fullname" . }}-controller'
     app.kubernetes.io/version: "{{ .Values.global.images.function_controller.version }}"
   dockerServicePort: 5000
   ingress:


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:
This PR slightly changes the labels on the serverless components to align more with k8s best practices. However, it doesn't make any changes to the selector labels. The selector labels are immutable, and that would break upgrades.

- Align labels for server components with https://kubernetes.io/docs/concepts/overview/working-with-objects/common-labels/.
- ...
- ...

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
[#15099](https://github.com/kyma-project/kyma/issues/15099)