### PR TITLE
[Telemetry Operator] Fix output config builder - duplicate format and port

### DIFF
--- a/components/telemetry-operator/internal/fluentbit/config/builder/output.go
+++ b/components/telemetry-operator/internal/fluentbit/config/builder/output.go
@@ -40,11 +40,14 @@ func generateCustomOutput(output *telemetryv1alpha1.Output, fsBufferLimit string
 func generateHTTPOutput(httpOutput *telemetryv1alpha1.HTTPOutput, fsBufferLimit string, name string) string {
 	sb := NewOutputSectionBuilder()
 	sb.AddConfigParam("name", "http")
-	sb.AddConfigParam("port", "443")
 	sb.AddConfigParam("allow_duplicated_headers", "true")
-	sb.AddConfigParam("format", "json")
 	sb.AddConfigParam("match", fmt.Sprintf("%s.*", name))
 	sb.AddConfigParam("storage.total_limit_size", fsBufferLimit)
+	sb.AddIfNotEmpty("uri", httpOutput.URI)
+	sb.AddIfNotEmpty("compress", httpOutput.Compress)
+	sb.AddIfNotEmptyOrDefault("port", httpOutput.Port, "443")
+	sb.AddIfNotEmptyOrDefault("format", httpOutput.Format, "json")
+
 	if httpOutput.Host.IsDefined() {
 		value := resolveValue(httpOutput.Host, name)
 		sb.AddConfigParam("host", value)
@@ -57,20 +60,17 @@ func generateHTTPOutput(httpOutput *telemetryv1alpha1.HTTPOutput, fsBufferLimit 
 		value := resolveValue(httpOutput.User, name)
 		sb.AddConfigParam("http_user", value)
 	}
-	sb.AddIfNotEmpty("port", httpOutput.Port)
-	sb.AddIfNotEmpty("uri", httpOutput.URI)
-	sb.AddIfNotEmpty("format", httpOutput.Format)
-	sb.AddIfNotEmpty("compress", httpOutput.Compress)
+	tlsEnabled := "on"
 	if httpOutput.TLSConfig.Disabled {
-		sb.AddConfigParam("tls", "off")
-	} else {
-		sb.AddConfigParam("tls", "on")
+		tlsEnabled = "off"
 	}
+	sb.AddConfigParam("tls", tlsEnabled)
+	tlsVerify := "on"
 	if httpOutput.TLSConfig.SkipCertificateValidation {
-		sb.AddConfigParam("tls.verify", "off")
-	} else {
-		sb.AddConfigParam("tls.verify", "on")
+		tlsVerify = "off"
 	}
+	sb.AddConfigParam("tls.verify", tlsVerify)
+
 	return sb.Build()
 }
 

--- a/components/telemetry-operator/internal/fluentbit/config/builder/output_test.go
+++ b/components/telemetry-operator/internal/fluentbit/config/builder/output_test.go
@@ -35,11 +35,11 @@ func TestCreateOutputSectionWithHTTPOutput(t *testing.T) {
     name                     http
     match                    foo.*
     allow_duplicated_headers true
-    format                   json
+    format                   yaml
     host                     localhost
     http_passwd              password
     http_user                user
-    port                     443
+    port                     1234
     storage.total_limit_size 1G
     tls                      on
     tls.verify               on
@@ -50,17 +50,13 @@ func TestCreateOutputSectionWithHTTPOutput(t *testing.T) {
 		Spec: telemetryv1alpha1.LogPipelineSpec{
 			Output: telemetryv1alpha1.Output{
 				HTTP: telemetryv1alpha1.HTTPOutput{
-					Dedot: true,
-					Host: telemetryv1alpha1.ValueType{
-						Value: "localhost",
-					},
-					User: telemetryv1alpha1.ValueType{
-						Value: "user",
-					},
-					Password: telemetryv1alpha1.ValueType{
-						Value: "password",
-					},
-					URI: "/customindex/kyma",
+					Dedot:    true,
+					Port:     "1234",
+					Host:     telemetryv1alpha1.ValueType{Value: "localhost"},
+					User:     telemetryv1alpha1.ValueType{Value: "user"},
+					Password: telemetryv1alpha1.ValueType{Value: "password"},
+					URI:      "/customindex/kyma",
+					Format:   "yaml",
 				},
 			},
 		},
@@ -94,12 +90,9 @@ func TestCreateOutputSectionWithHTTPOutputWithSecretReference(t *testing.T) {
 			Output: telemetryv1alpha1.Output{
 				HTTP: telemetryv1alpha1.HTTPOutput{
 					Dedot: true,
-					Host: telemetryv1alpha1.ValueType{
-						Value: "localhost",
-					},
-					User: telemetryv1alpha1.ValueType{
-						Value: "user",
-					},
+					URI:   "/my-uri",
+					Host:  telemetryv1alpha1.ValueType{Value: "localhost"},
+					User:  telemetryv1alpha1.ValueType{Value: "user"},
 					Password: telemetryv1alpha1.ValueType{
 						ValueFrom: telemetryv1alpha1.ValueFromType{
 							SecretKey: telemetryv1alpha1.SecretKeyRef{
@@ -109,7 +102,6 @@ func TestCreateOutputSectionWithHTTPOutputWithSecretReference(t *testing.T) {
 							},
 						},
 					},
-					URI: "/my-uri",
 				},
 			},
 		},
@@ -140,9 +132,7 @@ func TestCreateOutputSectionWithLokiOutput(t *testing.T) {
 		Spec: telemetryv1alpha1.LogPipelineSpec{
 			Output: telemetryv1alpha1.Output{
 				Loki: telemetryv1alpha1.LokiOutput{
-					URL: telemetryv1alpha1.ValueType{
-						Value: "http:loki:3100",
-					},
+					URL: telemetryv1alpha1.ValueType{Value: "http:loki:3100"},
 					Labels: map[string]string{
 						"job":        "telemetry-fluent-bit",
 						"cluster-id": "123"},
@@ -151,6 +141,7 @@ func TestCreateOutputSectionWithLokiOutput(t *testing.T) {
 			},
 		},
 	}
+
 	logPipeline.Name = "foo"
 	pipelineConfig := PipelineConfig{FsBufferLimit: "1G"}
 

--- a/components/telemetry-operator/internal/fluentbit/config/builder/section_builder.go
+++ b/components/telemetry-operator/internal/fluentbit/config/builder/section_builder.go
@@ -51,6 +51,15 @@ func (sb *SectionBuilder) AddIfNotEmpty(key string, value string) *SectionBuilde
 	return sb
 }
 
+func (sb *SectionBuilder) AddIfNotEmptyOrDefault(key string, value string, defaultValue string) *SectionBuilder {
+	if value == "" {
+		sb.AddConfigParam(key, defaultValue)
+	} else {
+		sb.AddConfigParam(key, value)
+	}
+	return sb
+}
+
 func (sb *SectionBuilder) Build() string {
 	sort.Slice(sb.params, func(i, j int) bool {
 		if sb.params[i].Key != sb.params[j].Key {

--- a/resources/telemetry/values.yaml
+++ b/resources/telemetry/values.yaml
@@ -4,7 +4,7 @@ global:
   images:
     telemetry_operator:
       name: "telemetry-operator"
-      version: "PR-15227"
+      version: "PR-15247"
     fluent_bit:
       name: "fluent-bit"
       version: "1.9.6-ec0ac757"


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- If set `format` and `port` are duplicated and written to the config. This fixes that

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->