### PR TITLE
Fix content-type header in serverless tutorial

### DIFF
--- a/docs/03-tutorials/00-serverless/svls-11-set-asynchronous-connection-of-functions.md
+++ b/docs/03-tutorials/00-serverless/svls-11-set-asynchronous-connection-of-functions.md
@@ -96,7 +96,7 @@ This tutorial shows only one possible use case. There are many more use cases on
       export KYMA_DOMAIN={KYMA_DOMAIN_VARIABLE}
       
       curl -X POST https://incoming.${KYMA_DOMAIN}
-      -H 'Content-Type: application/json'
+      -H 'Content-Type: application/cloudevents+json'
       -d '{"foo":"bar"}'
       ```
 ### Create the receiver Function


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:
- Add a necessary header that enables `ce-*` headers when publishing events from function code
