### PR TITLE
Refine the Get Started guides and fix the bug in the event delivery verification command

### DIFF
--- a/docs/02-get-started/02-deploy-expose-function.md
+++ b/docs/02-get-started/02-deploy-expose-function.md
@@ -10,6 +10,16 @@ First, let's create the Function and apply it.
 
 <div tabs name="Deploy a Function" group="deploy-expose-function">
   <details open>
+  <summary label="Kyma Dashboard">
+  Kyma Dashboard
+  </summary>
+
+1. In Kyma Dashboard, go to the `default` Namespace.
+2. Go to **Workloads** > **Functions**.
+3. Click on **Create Function +**.
+4. Name the Function `hello-world` and click **Create**.
+  </details>
+  <details>
   <summary label="kubectl">
   kubectl
   </summary>
@@ -22,16 +32,6 @@ kyma apply function
 ```
 
   </details>
-  <details>
-  <summary label="Kyma Dashboard">
-  Kyma Dashboard
-  </summary>
-
-1. In Kyma Dashboard, go to the `default` Namespace.
-2. Go to **Workloads** > **Functions**.
-3. Click on **Create Function +**.
-4. Name the Function `hello-world` and click **Create**.
-  </details>
 </div>
 
 
@@ -41,6 +41,15 @@ Now let's make sure that the Function has been deployed successfully.
 
 <div tabs name="Verify the Function deployment" group="deploy-expose-function">
   <details open>
+  <summary label="Kyma Dashboard">
+  Kyma Dashboard
+  </summary>
+
+The operation was successful if the Function **Status** changed to `RUNNING`.
+
+> **NOTE:** You might need to wait a few seconds for the status to change.
+  </details>
+  <details>
   <summary label="kubectl">
   kubectl
   </summary>
@@ -55,15 +64,6 @@ The operation was successful if the statuses for **CONFIGURED**, **BUILT**, and 
 
 
   </details>
-  <details>
-  <summary label="Kyma Dashboard">
-  Kyma Dashboard
-  </summary>
-
-The operation was successful if the Function **Status** changed to `RUNNING`.
-
-> **NOTE:** You might need to wait a few seconds for the status to change.
-  </details>
 </div>
 
 ## Expose the Function
@@ -76,6 +76,17 @@ First, let's create an [APIRule](../05-technical-reference/00-custom-resources/a
 
 <div tabs name="Expose the Function" group="deploy-expose-function">
   <details open>
+  <summary label="Kyma Dashboard">
+  Kyma Dashboard
+  </summary>
+
+1. In your Function's view, go to the **Configuration** tab.
+2. Click on **Create API Rule +**.
+3. Provide the **Name** (`hello-world`) and **Subdomain** (`hello-world`) and click **Create**.
+
+> **NOTE:** Alternatively, from the left navigation go to **Discovery and Network** > **API Rules**, click on **Create API Rule +**, and continue with step 3, selecting the appropriate **Service** (`hello-world`) from the dropdown menu.
+  </details>
+  <details>
   <summary label="kubectl">
   kubectl
   </summary>
@@ -111,17 +122,6 @@ EOF
 ```
 
   </details>
-  <details>
-  <summary label="Kyma Dashboard">
-  Kyma Dashboard
-  </summary>
-
-1. In your Function's view, go to the **Configuration** tab.
-2. Click on **Create API Rule +**.
-3. Provide the **Name** (`hello-world`) and **Subdomain** (`hello-world`) and click **Create**.
-
-> **NOTE:** Alternatively, from the left navigation go to **Discovery and Network** > **API Rules**, click on **Create API Rule +**, and continue with step 3, selecting the appropriate **Service** (`hello-world`) from the dropdown menu.
-  </details>
 </div>
 
 ### Verify the Function exposure
@@ -130,6 +130,18 @@ Now let's verify that the Function has been exposed successfully.
 
 <div tabs name="Access the Function" group="deploy-expose-function">
   <details open>
+  <summary label="Kyma Dashboard">
+  Kyma Dashboard
+  </summary>
+
+In your Function's **Configuration** tab, click on the APIRule's **Host**.
+This opens the Function's external address as a new page.
+
+> **NOTE:** Alternatively, from the left navigation go to **API Rules**, and click on the **Host** URL there.
+
+The operation was successful if the page says `Hello World!`.
+  </details>
+  <details>
   <summary label="kubectl">
   kubectl
   </summary>
@@ -142,17 +154,5 @@ curl https://hello-world.$CLUSTER_DOMAIN
 
 The operation was successful if the call returns `Hello Serverless`.
 
-  </details>
-  <details>
-  <summary label="Kyma Dashboard">
-  Kyma Dashboard
-  </summary>
-
-In your Function's **Configuration** tab, click on the APIRule's **Host**.
-This opens the Function's external address as a new page.
-
-> **NOTE:** Alternatively, from the left navigation go to **API Rules**, and click on the **Host** URL there.
-
-The operation was successful if the page says `Hello World!`.
   </details>
 </div>

--- a/docs/02-get-started/02-deploy-expose-function.md
+++ b/docs/02-get-started/02-deploy-expose-function.md
@@ -4,8 +4,6 @@ title: Deploy and expose a Function
 
 Now that you've installed Kyma, let's deploy your first Function. We'll call it `hello-world`.
 
->**NOTE:** Read about [Istio sidecars in Kyma and why you want them](../01-overview/main-areas/service-mesh/smsh-03-istio-sidecars-in-kyma.md). Then, check how to [enable automatic Istio sidecar proxy injection](../04-operation-guides/operations/smsh-01-istio-enable-sidecar-injection.md). For more details, see [Default Istio setup in Kyma](../01-overview/main-areas/service-mesh/smsh-02-default-istio-setup-in-kyma.md).
-
 ## Create a function
 
 First, let's create the Function and apply it.

--- a/docs/02-get-started/03-deploy-expose-microservice.md
+++ b/docs/02-get-started/03-deploy-expose-microservice.md
@@ -5,8 +5,6 @@ title: Deploy and expose a microservice
 You already know how to [deploy](02-deploy-expose-function.md#create-a-function) and [expose a Function](02-deploy-expose-function.md#expose-the-function). Let's now do the same with a container microservice.
 We'll use the Kyma example [`orders-service`](https://github.com/kyma-project/examples/blob/master/orders-service/README.md) for this.
 
->**NOTE:** Read about [Istio sidecars in Kyma and why you want them](../01-overview/main-areas/service-mesh/smsh-03-istio-sidecars-in-kyma.md). Then, check how to [enable automatic Istio sidecar proxy injection](../04-operation-guides/operations/smsh-01-istio-enable-sidecar-injection.md). For more details, see [Default Istio setup in Kyma](../01-overview/main-areas/service-mesh/smsh-02-default-istio-setup-in-kyma.md).
-
 ## Deploy the microservice
 
 First, let's create a Deployment that provides the microservice definition and lets you run it on the cluster.

--- a/docs/02-get-started/03-deploy-expose-microservice.md
+++ b/docs/02-get-started/03-deploy-expose-microservice.md
@@ -77,12 +77,11 @@ The operation was successful if the returned number of **readyReplicas** is `1`.
 
 1. From the left navigation, go to **Deployments**.
 2. Click on **Create Deployment +**.
-3. Choose the **Advanced** view and provide the following parameters:
+3. Provide the following parameters:
     - **Name**: `orders-service`
-    - **Labels**: add labels `app` and `example` and set their values to `orders-service`
     - **Containers**: enter Docker image `eu.gcr.io/kyma-project/develop/orders-service:68a58069`  
   
-    _Optionally_, to save resources, modify these parameters:
+    _Optionally_, to save resources, go to the **Advanced** view and modify these parameters:
     - **Memory requests**: `10Mi`
     - **Memory limits**: `32Mi`
     - **CPU requests (m)**: `16m`
@@ -212,9 +211,8 @@ EOF
   Kyma Dashboard
   </summary>
 
-1. Using the left navigation, go to **Discovery and Network** > **Services** and select your Service.
-2. In your Services's view, click on **Create API Rule +**.
-3. Provide the **Name** (`orders-service`) and **Subdomain** (`orders-service`) and click **Create**.
+1. In your Services's view, click on **Create API Rule +**.
+2. Provide the **Name** (`orders-service`) and **Subdomain** (`orders-service`) and click **Create**.
 
 > **NOTE:** Alternatively, from the left navigation go to **Discovery and Network** > **API Rules**, click on **Create API Rule +**, and continue with step 2, selecting the appropriate **Service** from the dropdown menu.
   </details>

--- a/docs/02-get-started/03-deploy-expose-microservice.md
+++ b/docs/02-get-started/03-deploy-expose-microservice.md
@@ -11,6 +11,27 @@ First, let's create a Deployment that provides the microservice definition and l
 
 <div tabs name="Create a microservice Deployment" group="deploy-expose-microservice">
   <details open>
+  <summary label="Kyma Dashboard">
+  Kyma Dashboard
+  </summary>
+
+1. From the left navigation, go to **Deployments**.
+2. Click on **Create Deployment +**.
+3. Provide the following parameters:
+    - **Name**: `orders-service`
+    - **Containers**: enter Docker image `eu.gcr.io/kyma-project/develop/orders-service:68a58069`  
+  
+    _Optionally_, to save resources, go to the **Advanced** view and modify these parameters:
+    - **Memory requests**: `10Mi`
+    - **Memory limits**: `32Mi`
+    - **CPU requests (m)**: `16m`
+    - **CPU limits (m)**: `20m`  
+  
+4. Click **Create**.
+
+The operation was successful if you can see `1/1` Pods running in the Deployment's view.
+  </details>
+  <details>
   <summary label="kubectl">
   kubectl
   </summary>
@@ -68,27 +89,6 @@ The operation was successful if the returned number of **readyReplicas** is `1`.
 > **NOTE:** You might need to wait a few seconds for the replica to be ready and return the status.
 
   </details>
-  <details>
-  <summary label="Kyma Dashboard">
-  Kyma Dashboard
-  </summary>
-
-1. From the left navigation, go to **Deployments**.
-2. Click on **Create Deployment +**.
-3. Provide the following parameters:
-    - **Name**: `orders-service`
-    - **Containers**: enter Docker image `eu.gcr.io/kyma-project/develop/orders-service:68a58069`  
-  
-    _Optionally_, to save resources, go to the **Advanced** view and modify these parameters:
-    - **Memory requests**: `10Mi`
-    - **Memory limits**: `32Mi`
-    - **CPU requests (m)**: `16m`
-    - **CPU limits (m)**: `20m`  
-  
-4. Click **Create**.
-
-The operation was successful if you can see `1/1` Pods running in the Deployment's view.
-  </details>
 </div>
 
 ### Create the Service
@@ -97,6 +97,31 @@ Now that we have the Deployment, let's deploy the Kubernetes [Service](https://k
 
 <div tabs name="Create a Service" group="deploy-expose-microservice">
   <details open>
+  <summary label="Kyma Dashboard">
+  Kyma Dashboard
+  </summary>
+
+1. From the left navigation, go to **Discovery and Network > Services**.
+2. Click on **Create Service +**.
+3. In the **Create Service** view, paste the following values to your YAML file:  
+
+   ```yaml
+   apiVersion: v1
+   kind: Service
+   metadata:
+     name: orders-service
+   spec:
+     selector:
+       app: orders-service
+     ports:
+       - protocol: TCP
+         port: 80
+         targetPort: 8080
+    ```
+
+4. Click **Create**. 
+  </details>
+  <details>
   <summary label="kubectl">
   kubectl
   </summary>
@@ -135,31 +160,6 @@ kubectl get service orders-service -o=jsonpath="{.metadata.uid}"
 The operation was successful if the command returns the **uid** of your Service.
 
   </details>
-  <details>
-  <summary label="Kyma Dashboard">
-  Kyma Dashboard
-  </summary>
-
-1. From the left navigation, go to **Discovery and Network > Services**.
-2. Click on **Create Service +**.
-3. In the **Create Service** view, paste the following values to your YAML file:  
-
-   ```yaml
-   apiVersion: v1
-   kind: Service
-   metadata:
-     name: orders-service
-   spec:
-     selector:
-       app: orders-service
-     ports:
-       - protocol: TCP
-         port: 80
-         targetPort: 8080
-    ```
-
-4. Click **Create**. 
-  </details>
 </div>
 
 ## Expose the microservice
@@ -172,6 +172,16 @@ To expose our microservice, we must create an [APIRule](../05-technical-referenc
 
 <div tabs name="Expose the microservice" group="deploy-expose-microservice">
   <details open>
+  <summary label="Kyma Dashboard">
+  Kyma Dashboard
+  </summary>
+
+1. In your Services's view, click on **Create API Rule +**.
+2. Provide the **Name** (`orders-service`) and **Subdomain** (`orders-service`) and click **Create**.
+
+> **NOTE:** Alternatively, from the left navigation go to **Discovery and Network** > **API Rules**, click on **Create API Rule +**, and continue with step 2, selecting the appropriate **Service** from the dropdown menu.
+  </details>
+  <details>
   <summary label="kubectl">
   kubectl
   </summary>
@@ -204,16 +214,6 @@ EOF
 ```
 
   </details>
-  <details>
-  <summary label="Kyma Dashboard">
-  Kyma Dashboard
-  </summary>
-
-1. In your Services's view, click on **Create API Rule +**.
-2. Provide the **Name** (`orders-service`) and **Subdomain** (`orders-service`) and click **Create**.
-
-> **NOTE:** Alternatively, from the left navigation go to **Discovery and Network** > **API Rules**, click on **Create API Rule +**, and continue with step 2, selecting the appropriate **Service** from the dropdown menu.
-  </details>
 </div>
 
 ### Verify the microservice exposure
@@ -222,6 +222,19 @@ Now let's check that the microservice has been exposed successfully.
 
 <div tabs name="Verify microservice exposure" group="deploy-expose-microservice">
   <details open>
+  <summary label="Kyma Dashboard">
+  Kyma Dashboard
+  </summary>
+
+1. From your Services's view, get the APIRule's **Host**.
+
+   > **NOTE:** Alternatively, from the left navigation go to **API Rules** and get the **Host** URL from there.
+
+2. Paste this **Host** in your browser and add the `/orders` suffix to the end of it, like this: `{HOST}/orders`. Open it.
+
+The operation was successful if the page shows the (possibly empty `[]`) list of orders.
+  </details>
+  <details>
   <summary label="kubectl">
   kubectl
   </summary>
@@ -234,18 +247,5 @@ curl https://orders-service.$CLUSTER_DOMAIN/orders
 
 The operation was successful if the command returns the (possibly empty `[]`) list of orders.
 
-  </details>
-  <details>
-  <summary label="Kyma Dashboard">
-  Kyma Dashboard
-  </summary>
-
-1. From your Services's view, get the APIRule's **Host**.
-
-   > **NOTE:** Alternatively, from the left navigation go to **API Rules** and get the **Host** URL from there.
-
-2. Paste this **Host** in your browser and add the `/orders` suffix to the end of it, like this: `{HOST}/orders`. Open it.
-
-The operation was successful if the page shows the (possibly empty `[]`) list of orders.
   </details>
 </div>

--- a/docs/02-get-started/03-deploy-expose-microservice.md
+++ b/docs/02-get-started/03-deploy-expose-microservice.md
@@ -87,7 +87,7 @@ The operation was successful if the returned number of **readyReplicas** is `1`.
   
 4. Click **Create**.
 
-The operation was successful if the Pod **Status** for the Deployment is `RUNNING`.
+The operation was successful if you can see `1/1` Pods running in the Deployment's view.
   </details>
 </div>
 

--- a/docs/02-get-started/04-trigger-workload-with-event.md
+++ b/docs/02-get-started/04-trigger-workload-with-event.md
@@ -11,11 +11,32 @@ First, create a sample Function that prints out the received event to console:
 
 <div tabs name="Deploy a Function" group="trigger-workload">
   <details open>
+  <summary label="Kyma Dashboard">
+  Kyma Dashboard
+  </summary>
+
+1. Go to **Namespaces** and select the default Namespace.
+2. Go to **Workloads** > **Functions** and click **Create Function +**.
+3. Name the Function `lastorder` and click **Create**.
+4. In the inline editor for the Function, replace its source with the following code:
+    ```js
+    module.exports = {
+      main: async function (event, context) {
+        console.log("Received event:", event.data);
+        return;
+      } 
+    }
+    ```
+5. Save your changes.
+6. Wait a few seconds for the Function to have status `RUNNING`.
+
+  </details>
+  <details>
   <summary label="kubectl">
   kubectl
   </summary>
-  
-  Run:
+
+Run:
 
 ```bash
 cat <<EOF | kubectl apply -f -
@@ -48,34 +69,13 @@ The Function was created successfully if the command returns this message:
 function.serverless.kyma-project.io/lastorder created
 ```
 
-Wait a few seconds for the Function to have status `RUNNING`. To check the Function status, run: 
+Wait a few seconds for the Function to have status `RUNNING`. To check the Function status, run:
 
 ```bash
 kubectl get functions -n default lastorder
 ```
 
 > **NOTE:** You might need to wait a few seconds for the Function to be ready.
-
-  </details>
-  <details>
-  <summary label="Kyma Dashboard">
-  Kyma Dashboard
-  </summary>
-
-1. Go to **Namespaces** and select the default Namespace.
-2. Go to **Workloads** > **Functions** and click **Create Function +**.
-3. Name the Function `lastorder` and click **Create**.
-4. In the inline editor for the Function, replace its source with the following code:
-    ```js
-    module.exports = {
-      main: async function (event, context) {
-        console.log("Received event:", event.data);
-        return;
-      } 
-    }
-    ```
-5. Save your changes.
-6. Wait a few seconds for the Function to have status `RUNNING`.
 
   </details>
 </div>
@@ -87,11 +87,29 @@ All the published events of this type are then forwarded to an HTTP endpoint cal
 
 <div tabs name="Create a Subscription" group="trigger-workload">
   <details open>
+  <summary label="Kyma Dashboard">
+  Kyma Dashboard
+  </summary>
+
+1. In your Function's view, go to **Configuration** and click **Create Subscription+**.
+2. Provide the following parameters:
+   - **Subscription name**: `lastorder-sub`
+   - **Application name**: `myapp`
+   - **Event name**: `order.received`
+   - **Event version**: `v1`
+
+   - **Event type** is generated automatically. For this example, it's `sap.kyma.custom.myapp.order.received.v1`.
+
+3. Click **Create**.
+4. Wait a few seconds for the Subscription to have status `READY`.
+
+  </details>
+  <details>
   <summary label="kubectl">
   kubectl
   </summary>
 
-Run: 
+Run:
 ```bash
 cat <<EOF | kubectl apply -f -
    apiVersion: eventing.kyma-project.io/v1alpha1
@@ -120,24 +138,6 @@ kubectl get subscriptions lastorder-sub -o=jsonpath="{.status.ready}"
 ```
 
 The operation was successful if the returned status says `true`.
-
-  </details>
-  <details>
-  <summary label="Kyma Dashboard">
-  Kyma Dashboard
-  </summary>
-
-1. In your Function's view, go to **Configuration** and click **Create Subscription+**.
-2. Provide the following parameters:
-   - **Subscription name**: `lastorder-sub`
-   - **Application name**: `myapp`
-   - **Event name**: `order.received`
-   - **Event version**: `v1`
-
-   - **Event type** is generated automatically. For this example, it's `sap.kyma.custom.myapp.order.received.v1`.
-
-3. Click **Create**.
-4. Wait a few seconds for the Subscription to have status `READY`.
 
   </details>
 </div>
@@ -194,6 +194,20 @@ To verify that the event was properly delivered, check the logs of the Function:
 
 <div tabs name="Verify the event delivery" group="trigger-workload">
   <details open>
+  <summary label="Kyma Dashboard">
+  Kyma Dashboard
+  </summary>
+
+1. In Kyma Dashboard, return to the view of your `lastorder` Function.
+2. Go to **Code** and find the **Replicas of the Function** section.
+3. Click on **View Logs**.
+4. You see the received event in the logs:
+   ```
+   Received event: { orderCode: '3211213' }
+   ```
+
+  </details>
+  <details>
   <summary label="kubectl">
   kubectl
   </summary>
@@ -211,20 +225,6 @@ You see the received event in the logs:
 ```
 Received event: { orderCode: '3211213' }
 ```
-
-  </details>
-  <details>
-  <summary label="Kyma Dashboard">
-  Kyma Dashboard
-  </summary>
-
-1. In Kyma Dashboard, return to the view of your `lastorder` Function.
-2. Go to **Code** and find the **Replicas of the Function** section.
-3. Click on **View Logs**.
-4. You see the received event in the logs:
-   ```
-   Received event: { orderCode: '3211213' }
-   ```
 
   </details>
 </div>

--- a/docs/02-get-started/04-trigger-workload-with-event.md
+++ b/docs/02-get-started/04-trigger-workload-with-event.md
@@ -13,27 +13,6 @@ First, create a sample Function that prints out the received event to console:
 
 <div tabs name="Deploy a Function" group="trigger-workload">
   <details open>
-  <summary label="Kyma Dashboard">
-  Kyma Dashboard
-  </summary>
-
-1. Go to **Namespaces** and select the default Namespace.
-2. Go to **Workloads** > **Functions** and click **Create Function +**.
-3. Name the Function `lastorder` and click **Create**.
-4. In the inline editor for the Function, replace its source with the following code:
-    ```js
-    module.exports = {
-      main: async function (event, context) {
-        console.log("Received event:", event.data);
-        return;
-      } 
-    }
-    ```
-5. Save your changes.
-6. Wait a few seconds for the Function to have status `RUNNING`.
-
-  </details>
-  <details>
   <summary label="kubectl">
   kubectl
   </summary>
@@ -80,6 +59,27 @@ kubectl get functions -n default lastorder
 > **NOTE:** You might need to wait a few seconds for the Function to be ready.
 
   </details>
+  <details>
+  <summary label="Kyma Dashboard">
+  Kyma Dashboard
+  </summary>
+
+1. Go to **Namespaces** and select the default Namespace.
+2. Go to **Workloads** > **Functions** and click **Create Function +**.
+3. Name the Function `lastorder` and click **Create**.
+4. In the inline editor for the Function, replace its source with the following code:
+    ```js
+    module.exports = {
+      main: async function (event, context) {
+        console.log("Received event:", event.data);
+        return;
+      } 
+    }
+    ```
+5. Save your changes.
+6. Wait a few seconds for the Function to have status `RUNNING`.
+
+  </details>
 </div>
 
 ## Create a Subscription
@@ -89,24 +89,6 @@ All the published events of this type are then forwarded to an HTTP endpoint cal
 
 <div tabs name="Create a Subscription" group="trigger-workload">
   <details open>
-  <summary label="Kyma Dashboard">
-  Kyma Dashboard
-  </summary>
-
-1. In your Function's view, go to **Configuration** and click **Create Subscription+**.
-2. Provide the following parameters:
-   - **Subscription name**: `lastorder-sub`
-   - **Application name**: `myapp`
-   - **Event name**: `order.received`
-   - **Event version**: `v1`
-
-   - **Event type** is generated automatically. For this example, it's `sap.kyma.custom.myapp.order.received.v1`.
-
-3. Click **Create**.
-4. Wait a few seconds for the Subscription to have status `READY`.
-
-  </details>
-  <details>
   <summary label="kubectl">
   kubectl
   </summary>
@@ -140,6 +122,24 @@ kubectl get subscriptions lastorder-sub -o=jsonpath="{.status.ready}"
 ```
 
 The operation was successful if the returned status says `true`.
+
+  </details>
+  <details>
+  <summary label="Kyma Dashboard">
+  Kyma Dashboard
+  </summary>
+
+1. In your Function's view, go to **Configuration** and click **Create Subscription+**.
+2. Provide the following parameters:
+   - **Subscription name**: `lastorder-sub`
+   - **Application name**: `myapp`
+   - **Event name**: `order.received`
+   - **Event version**: `v1`
+
+   - **Event type** is generated automatically. For this example, it's `sap.kyma.custom.myapp.order.received.v1`.
+
+3. Click **Create**.
+4. Wait a few seconds for the Subscription to have status `READY`.
 
   </details>
 </div>
@@ -196,20 +196,6 @@ To verify that the event was properly delivered, check the logs of the Function:
 
 <div tabs name="Verify the event delivery" group="trigger-workload">
   <details open>
-  <summary label="Kyma Dashboard">
-  Kyma Dashboard
-  </summary>
-
-1. In Kyma Dashboard, return to the view of your `lastorder` Function.
-2. Go to **Code** and find the **Replicas of the Function** section.
-3. Click on **View Logs**.
-4. You see the received event in the logs:
-   ```
-   Received event: { orderCode: '3211213' }
-   ```
-
-</details>
-  <details>
   <summary label="kubectl">
   kubectl
   </summary>
@@ -227,6 +213,20 @@ You see the received event in the logs:
 ```
 Received event: { orderCode: '3211213' }
 ```
+
+  </details>
+  <details>
+  <summary label="Kyma Dashboard">
+  Kyma Dashboard
+  </summary>
+
+1. In Kyma Dashboard, return to the view of your `lastorder` Function.
+2. Go to **Code** and find the **Replicas of the Function** section.
+3. Click on **View Logs**.
+4. You see the received event in the logs:
+   ```
+   Received event: { orderCode: '3211213' }
+   ```
 
   </details>
 </div>

--- a/docs/02-get-started/04-trigger-workload-with-event.md
+++ b/docs/02-get-started/04-trigger-workload-with-event.md
@@ -9,8 +9,6 @@ Now it's time to actually use an event to trigger a workload.
 
 First, create a sample Function that prints out the received event to console:
 
->**NOTE:** Read about [Istio sidecars in Kyma and why you want them](../01-overview/main-areas/service-mesh/smsh-03-istio-sidecars-in-kyma.md). Then, check how to [enable automatic Istio sidecar proxy injection](../04-operation-guides/operations/smsh-01-istio-enable-sidecar-injection.md). For more details, see [Default Istio setup in Kyma](../01-overview/main-areas/service-mesh/smsh-02-default-istio-setup-in-kyma.md).
-
 <div tabs name="Deploy a Function" group="trigger-workload">
   <details open>
   <summary label="kubectl">

--- a/docs/02-get-started/04-trigger-workload-with-event.md
+++ b/docs/02-get-started/04-trigger-workload-with-event.md
@@ -44,13 +44,13 @@ cat <<EOF | kubectl apply -f -
 EOF
 ```
 
-If the resources were created successfully, the command returns this message:
+The Function was created successfully if the command returns this message:
 
 ```bash
 function.serverless.kyma-project.io/lastorder created
 ```
 
-To check the Function status, run: 
+Wait a few seconds for the Function to have status `RUNNING`. To check the Function status, run: 
 
 ```bash
 kubectl get functions -n default lastorder
@@ -148,7 +148,7 @@ The operation was successful if the returned status says `true`.
 
 We created the `lastorder` Function and subscribed to the `order.received.v1` event by creating a Subscription CR. Now it's time to publish your event and trigger the Function. In this example, we'll port-forward the Kyma Eventing Service to localhost. 
 
-1. Port-forward the Kyma Eventing Service to localhost. We will use port `3000`. Run: 
+1. Port-forward the Kyma Eventing Service to localhost. We will use port `3000`. In your terminal, run: 
    ```bash
    kubectl -n kyma-system port-forward service/eventing-event-publisher-proxy 3000:80
    ```

--- a/docs/02-get-started/04-trigger-workload-with-event.md
+++ b/docs/02-get-started/04-trigger-workload-with-event.md
@@ -5,18 +5,6 @@ title: Trigger a workload with an event
 We already know how to create and expose a workload ([Function](02-deploy-expose-function.md) and [microservice](03-deploy-expose-microservice.md)). 
 Now it's time to actually use an event to trigger a workload.
 
-## Prerequisites
-
-1. Provision a [Kyma Cluster](01-quick-install.md).
-2. (Optional) Deploy [Kyma Dashboard](../01-overview/main-areas/ui/ui-01-gui.md) on the Kyma cluster using the following command. Alternatively, you can also use `kubectl` CLI.
-   ```bash
-   kyma dashboard
-   ```
-3. (Optional) Install [CloudEvents Conformance Tool](https://github.com/cloudevents/conformance) for publishing events. Alternatively, you can also use `curl` to publish events.
-   ```bash
-   go install github.com/cloudevents/conformance/cmd/cloudevents@latest
-   ```
-
 ## Create a Function
 
 First, create a sample Function that prints out the received event to console:
@@ -105,9 +93,8 @@ All the published events of this type are then forwarded to an HTTP endpoint cal
   Kyma Dashboard
   </summary>
 
-1. In Kyma Dashboard, go to the view of your Function `lastorder`.
-2. Go to **Configuration** > **Create Subscription+**.
-3. Provide the following parameters:
+1. In your Function's view, go to **Configuration** and click **Create Subscription+**.
+2. Provide the following parameters:
    - **Subscription name**: `lastorder-sub`
    - **Application name**: `myapp`
    - **Event name**: `order.received`
@@ -115,8 +102,8 @@ All the published events of this type are then forwarded to an HTTP endpoint cal
 
    - **Event type** is generated automatically. For this example, it's `sap.kyma.custom.myapp.order.received.v1`.
 
-4. Click **Create**.
-5. Wait a few seconds for the Subscription to have status `READY`.
+3. Click **Create**.
+4. Wait a few seconds for the Subscription to have status `READY`.
 
   </details>
   <details>
@@ -229,8 +216,8 @@ To verify that the event was properly delivered, check the logs of the Function:
 Run: 
 
 ```bash
-kubectl logs -f -n default \
-  $(kubectl get pod \
+kubectl logs -n default \
+  $(kubectl get pod -n default \
     --field-selector=status.phase==Running \
     -l serverless.kyma-project.io/function-name=lastorder \
     -o jsonpath="{.items[0].metadata.name}")

--- a/docs/02-get-started/04-trigger-workload-with-event.md
+++ b/docs/02-get-started/04-trigger-workload-with-event.md
@@ -156,22 +156,6 @@ We created the `lastorder` Function and subscribed to the `order.received.v1` ev
 
 <div tabs name="Publish an event" group="trigger-workload">
   <details open>
-  <summary label="CloudEvents Conformance Tool">
-  CloudEvents Conformance Tool
-  </summary>
-
-   ```bash
-   cloudevents send http://localhost:3000/publish \
-      --type sap.kyma.custom.myapp.order.received.v1 \
-      --id 759815c3-b142-48f2-bf18-c6502dc0998f \
-      --source myapp \
-      --datacontenttype application/json \
-      --data "{\"orderCode\":\"3211213\"}" \
-      --yaml
-   ```
-
-  </details>
-  <details>
   <summary label="curl">
   curl
   </summary>
@@ -187,6 +171,22 @@ We created the `lastorder` Function and subscribed to the `order.received.v1` ev
         -d "{\"orderCode\":\"3211213\"}" \
         http://localhost:3000/publish
    ```
+  </details>
+  <details>
+  <summary label="CloudEvents Conformance Tool">
+  CloudEvents Conformance Tool
+  </summary>
+
+   ```bash
+   cloudevents send http://localhost:3000/publish \
+      --type sap.kyma.custom.myapp.order.received.v1 \
+      --id 759815c3-b142-48f2-bf18-c6502dc0998f \
+      --source myapp \
+      --datacontenttype application/json \
+      --data "{\"orderCode\":\"3211213\"}" \
+      --yaml
+   ```
+
   </details>
 </div>
 

--- a/docs/02-get-started/README.md
+++ b/docs/02-get-started/README.md
@@ -13,7 +13,15 @@ All the steps are performed in the `default` Namespace.
 - [curl](https://github.com/curl/curl)
 - [k3d](https://k3d.io) (v5.0.0 or higher with [a Kubernetes version supported by Kyma](../04-operation-guides/operations/02-install-kyma.md))
 - [Kyma CLI](../04-operation-guides/operations/01-install-kyma-CLI.md)
-- Minimum Docker resources: 4 CPUs and 8 GB RAM (learn how to adjust the values on [Mac](https://docs.docker.com/desktop/settings/mac/#resources), [Windows](https://docs.docker.com/desktop/settings/windows/#resources), or [Linux](https://docs.docker.com/desktop/settings/linux/#resources)).
+- Minimum Docker resources: 4 CPUs and 8 GB RAM 
+  > **NOTE:** Learn how to adjust these Docker values on [Mac](https://docs.docker.com/desktop/settings/mac/#resources), [Windows](https://docs.docker.com/desktop/settings/windows/#resources), or [Linux](https://docs.docker.com/desktop/settings/linux/#resources).
+- (Optional*) [CloudEvents Conformance Tool](https://github.com/cloudevents/conformance) for [triggering workloads with events](./04-trigger-workload-with-event.md)
+   ```bash
+   go install github.com/cloudevents/conformance/cmd/cloudevents@latest
+   ```
+  
+    Alternatively, you can just use `curl` to publish events.
+
 
 ## Steps
 

--- a/docs/02-get-started/README.md
+++ b/docs/02-get-started/README.md
@@ -21,8 +21,8 @@ All the steps are performed in the `default` Namespace.
    ```
   
     Alternatively, you can just use `curl` to publish events.
-
->**NOTE:** Read about [Istio sidecars in Kyma and why you want them](../01-overview/main-areas/service-mesh/smsh-03-istio-sidecars-in-kyma.md). Then, check how to [enable automatic Istio sidecar proxy injection](../04-operation-guides/operations/smsh-01-istio-enable-sidecar-injection.md). For more details, see [Default Istio setup in Kyma](../01-overview/main-areas/service-mesh/smsh-02-default-istio-setup-in-kyma.md).
+- Istio sidecar injection enabled in the `default` Namespace
+  >**NOTE:** Read about [Istio sidecars in Kyma and why you want them](../01-overview/main-areas/service-mesh/smsh-03-istio-sidecars-in-kyma.md). Then, check how to [enable automatic Istio sidecar proxy injection](../04-operation-guides/operations/smsh-01-istio-enable-sidecar-injection.md). For more details, see [Default Istio setup in Kyma](../01-overview/main-areas/service-mesh/smsh-02-default-istio-setup-in-kyma.md).
 
 ## Steps
 

--- a/docs/02-get-started/README.md
+++ b/docs/02-get-started/README.md
@@ -22,6 +22,7 @@ All the steps are performed in the `default` Namespace.
   
     Alternatively, you can just use `curl` to publish events.
 
+>**NOTE:** Read about [Istio sidecars in Kyma and why you want them](../01-overview/main-areas/service-mesh/smsh-03-istio-sidecars-in-kyma.md). Then, check how to [enable automatic Istio sidecar proxy injection](../04-operation-guides/operations/smsh-01-istio-enable-sidecar-injection.md). For more details, see [Default Istio setup in Kyma](../01-overview/main-areas/service-mesh/smsh-02-default-istio-setup-in-kyma.md).
 
 ## Steps
 

--- a/docs/02-get-started/README.md
+++ b/docs/02-get-started/README.md
@@ -15,7 +15,7 @@ All the steps are performed in the `default` Namespace.
 - [Kyma CLI](../04-operation-guides/operations/01-install-kyma-CLI.md)
 - Minimum Docker resources: 4 CPUs and 8 GB RAM 
   > **NOTE:** Learn how to adjust these Docker values on [Mac](https://docs.docker.com/desktop/settings/mac/#resources), [Windows](https://docs.docker.com/desktop/settings/windows/#resources), or [Linux](https://docs.docker.com/desktop/settings/linux/#resources).
-- (Optional*) [CloudEvents Conformance Tool](https://github.com/cloudevents/conformance) for [triggering workloads with events](./04-trigger-workload-with-event.md)
+- (Optional) [CloudEvents Conformance Tool](https://github.com/cloudevents/conformance) for [triggering workloads with events](./04-trigger-workload-with-event.md)
    ```bash
    go install github.com/cloudevents/conformance/cmd/cloudevents@latest
    ```

--- a/docs/03-tutorials/00-eventing/README.md
+++ b/docs/03-tutorials/00-eventing/README.md
@@ -4,7 +4,7 @@ title: Eventing - tutorials
 
 Browse the tutorials for Eventing to learn how to use it step-by-step in different scenarios.
 
-# Prerequisites
+## Prerequisites
 
 To perform the steps described in the Eventing tutorials, you need the following: 
 

--- a/docs/03-tutorials/00-eventing/README.md
+++ b/docs/03-tutorials/00-eventing/README.md
@@ -3,3 +3,19 @@ title: Eventing - tutorials
 ---
 
 Browse the tutorials for Eventing to learn how to use it step-by-step in different scenarios.
+
+# Prerequisites
+
+To perform the steps described in the Eventing tutorials, you need the following: 
+
+1. [Kyma cluster provisioned](../../04-operation-guides/operations/02-install-kyma.md).
+2. (Optional) [Kyma Dashboard](../../01-overview/main-areas/ui/ui-01-gui.md) deployed on the Kyma cluster. To access the Dashboard, run: 
+   ```bash
+   kyma dashboard
+   ```
+   Alternatively, you can just use the `kubectl` CLI instead.
+3. (Optional) [CloudEvents Conformance Tool](https://github.com/cloudevents/conformance) for publishing events. 
+   ```bash
+   go install github.com/cloudevents/conformance/cmd/cloudevents@latest
+   ```
+   Alternatively, you can just use `curl` to publish events.

--- a/docs/03-tutorials/00-eventing/evnt-02-subs-with-multiple-filters.md
+++ b/docs/03-tutorials/00-eventing/evnt-02-subs-with-multiple-filters.md
@@ -8,7 +8,7 @@ The [Subscription](../../05-technical-reference/00-custom-resources/evnt-01-subs
 
 >**NOTE:** Read about [Istio sidecars in Kyma and why you want them](../../01-overview/main-areas/service-mesh/smsh-03-istio-sidecars-in-kyma.md). Then, check how to [enable automatic Istio sidecar proxy injection](../../04-operation-guides/operations/smsh-01-istio-enable-sidecar-injection.md). For more details, see [Default Istio setup in Kyma](../../01-overview/main-areas/service-mesh/smsh-02-default-istio-setup-in-kyma.md).
 
-1. Follow the [prerequisites steps](./README.md#prerequisites) for the Eventing tutorials.
+1. Follow the [Prerequisites steps](README.md#prerequisites) for the Eventing tutorials.
 2. [Create a Function](../../02-get-started/04-trigger-workload-with-event.md#create-a-function).
 
 ## Create a Subscription with Multiple Filters

--- a/docs/03-tutorials/00-eventing/evnt-02-subs-with-multiple-filters.md
+++ b/docs/03-tutorials/00-eventing/evnt-02-subs-with-multiple-filters.md
@@ -8,7 +8,7 @@ The [Subscription](../../05-technical-reference/00-custom-resources/evnt-01-subs
 
 >**NOTE:** Read about [Istio sidecars in Kyma and why you want them](../../01-overview/main-areas/service-mesh/smsh-03-istio-sidecars-in-kyma.md). Then, check how to [enable automatic Istio sidecar proxy injection](../../04-operation-guides/operations/smsh-01-istio-enable-sidecar-injection.md). For more details, see [Default Istio setup in Kyma](../../01-overview/main-areas/service-mesh/smsh-02-default-istio-setup-in-kyma.md).
 
-1. Follow the [Prerequisites steps](README.md#prerequisites) for the Eventing tutorials.
+1. Follow the [Prerequisites steps](../#prerequisites) for the Eventing tutorials.
 2. [Create a Function](../../02-get-started/04-trigger-workload-with-event.md#create-a-function).
 
 ## Create a Subscription with Multiple Filters

--- a/docs/03-tutorials/00-eventing/evnt-02-subs-with-multiple-filters.md
+++ b/docs/03-tutorials/00-eventing/evnt-02-subs-with-multiple-filters.md
@@ -8,7 +8,7 @@ The [Subscription](../../05-technical-reference/00-custom-resources/evnt-01-subs
 
 >**NOTE:** Read about [Istio sidecars in Kyma and why you want them](../../01-overview/main-areas/service-mesh/smsh-03-istio-sidecars-in-kyma.md). Then, check how to [enable automatic Istio sidecar proxy injection](../../04-operation-guides/operations/smsh-01-istio-enable-sidecar-injection.md). For more details, see [Default Istio setup in Kyma](../../01-overview/main-areas/service-mesh/smsh-02-default-istio-setup-in-kyma.md).
 
-1. Follow the [Prerequisites steps](../#prerequisites) for the Eventing tutorials.
+1. Follow the [Prerequisites steps](./) for the Eventing tutorials.
 2. [Create a Function](../../02-get-started/04-trigger-workload-with-event.md#create-a-function).
 
 ## Create a Subscription with Multiple Filters

--- a/docs/03-tutorials/00-eventing/evnt-02-subs-with-multiple-filters.md
+++ b/docs/03-tutorials/00-eventing/evnt-02-subs-with-multiple-filters.md
@@ -8,12 +8,12 @@ The [Subscription](../../05-technical-reference/00-custom-resources/evnt-01-subs
 
 >**NOTE:** Read about [Istio sidecars in Kyma and why you want them](../../01-overview/main-areas/service-mesh/smsh-03-istio-sidecars-in-kyma.md). Then, check how to [enable automatic Istio sidecar proxy injection](../../04-operation-guides/operations/smsh-01-istio-enable-sidecar-injection.md). For more details, see [Default Istio setup in Kyma](../../01-overview/main-areas/service-mesh/smsh-02-default-istio-setup-in-kyma.md).
 
-1. Follow the [prerequisites steps](../../02-get-started/04-trigger-workload-with-event.md#prerequisites) in the Getting Started guide.
-2. Create a Function by following the [instructions](../../02-get-started/04-trigger-workload-with-event.md#create-a-function) in the Getting Started guide.
+1. Follow the [prerequisites steps](./README.md#prerequisites) for the Eventing tutorials.
+2. [Create a Function](../../02-get-started/04-trigger-workload-with-event.md#create-a-function).
 
 ## Create a Subscription with Multiple Filters
 
-Next, to subscribe to multiple events, you need a [Subscription](../../05-technical-reference/00-custom-resources/evnt-01-subscription.md) custom resource. In the following example, you learn how to subscribe to events of two types: `order.received.v1` and `order.changed.v1`.
+To subscribe to multiple events, you need a [Subscription](../../05-technical-reference/00-custom-resources/evnt-01-subscription.md) custom resource. In the following example, you learn how to subscribe to events of two types: `order.received.v1` and `order.changed.v1`.
 
 <div tabs name="Create a Subscription" group="create-subscription">
   <details open>

--- a/docs/03-tutorials/00-eventing/evnt-03-type-cleanup.md
+++ b/docs/03-tutorials/00-eventing/evnt-03-type-cleanup.md
@@ -9,7 +9,7 @@ You learn how Eventing behaves when you create a [Subscription](../../05-technic
 
 >**NOTE:** Read about [Istio sidecars in Kyma and why you want them](../../01-overview/main-areas/service-mesh/smsh-03-istio-sidecars-in-kyma.md). Then, check how to [enable automatic Istio sidecar proxy injection](../../04-operation-guides/operations/smsh-01-istio-enable-sidecar-injection.md). For more details, see [Default Istio setup in Kyma](../../01-overview/main-areas/service-mesh/smsh-02-default-istio-setup-in-kyma.md).
 
-1. Follow the [Prerequisites steps](README.md#prerequisites) for the Eventing tutorials.
+1. Follow the [Prerequisites steps](../#prerequisites) for the Eventing tutorials.
 2. [Create a Function](../../02-get-started/04-trigger-workload-with-event.md#create-a-function).
 3. For this tutorial, instead of the default code sample, replace the Function source with the following code:
 

--- a/docs/03-tutorials/00-eventing/evnt-03-type-cleanup.md
+++ b/docs/03-tutorials/00-eventing/evnt-03-type-cleanup.md
@@ -9,7 +9,7 @@ You learn how Eventing behaves when you create a [Subscription](../../05-technic
 
 >**NOTE:** Read about [Istio sidecars in Kyma and why you want them](../../01-overview/main-areas/service-mesh/smsh-03-istio-sidecars-in-kyma.md). Then, check how to [enable automatic Istio sidecar proxy injection](../../04-operation-guides/operations/smsh-01-istio-enable-sidecar-injection.md). For more details, see [Default Istio setup in Kyma](../../01-overview/main-areas/service-mesh/smsh-02-default-istio-setup-in-kyma.md).
 
-1. Follow the [prerequisites steps](./README.md#prerequisites) for the Eventing tutorials.
+1. Follow the [Prerequisites steps](README.md#prerequisites) for the Eventing tutorials.
 2. [Create a Function](../../02-get-started/04-trigger-workload-with-event.md#create-a-function).
 3. For this tutorial, instead of the default code sample, replace the Function source with the following code:
 

--- a/docs/03-tutorials/00-eventing/evnt-03-type-cleanup.md
+++ b/docs/03-tutorials/00-eventing/evnt-03-type-cleanup.md
@@ -9,8 +9,8 @@ You learn how Eventing behaves when you create a [Subscription](../../05-technic
 
 >**NOTE:** Read about [Istio sidecars in Kyma and why you want them](../../01-overview/main-areas/service-mesh/smsh-03-istio-sidecars-in-kyma.md). Then, check how to [enable automatic Istio sidecar proxy injection](../../04-operation-guides/operations/smsh-01-istio-enable-sidecar-injection.md). For more details, see [Default Istio setup in Kyma](../../01-overview/main-areas/service-mesh/smsh-02-default-istio-setup-in-kyma.md).
 
-1. Follow the [prerequisites steps](../../02-get-started/04-trigger-workload-with-event.md#prerequisites) in the Getting Started guide.
-2. Create a Function by following the [instructions](../../02-get-started/04-trigger-workload-with-event.md#create-a-function) in the Getting Started guide.
+1. Follow the [prerequisites steps](./README.md#prerequisites) for the Eventing tutorials.
+2. [Create a Function](../../02-get-started/04-trigger-workload-with-event.md#create-a-function).
 3. For this tutorial, instead of the default code sample, replace the Function source with the following code:
 
    <div tabs name="Deploy a Function" group="create-workload">
@@ -64,7 +64,7 @@ You learn how Eventing behaves when you create a [Subscription](../../05-technic
 
 ## Create a Subscription with Event type consisting of alphanumeric characters
 
-Next, create a [Subscription](../../05-technical-reference/00-custom-resources/evnt-01-subscription.md) custom resource and subscribe for events of the type: `order.payment-success.v1`. Note that `order.payment-success.v1` contains a non-alphanumeric character, the hyphen `-`.
+Create a [Subscription](../../05-technical-reference/00-custom-resources/evnt-01-subscription.md) custom resource and subscribe for events of the type: `order.payment-success.v1`. Note that `order.payment-success.v1` contains a non-alphanumeric character, the hyphen `-`.
 
 <div tabs name="Create a Subscription" group="create-subscription">
   <details open>

--- a/docs/03-tutorials/00-eventing/evnt-03-type-cleanup.md
+++ b/docs/03-tutorials/00-eventing/evnt-03-type-cleanup.md
@@ -9,7 +9,7 @@ You learn how Eventing behaves when you create a [Subscription](../../05-technic
 
 >**NOTE:** Read about [Istio sidecars in Kyma and why you want them](../../01-overview/main-areas/service-mesh/smsh-03-istio-sidecars-in-kyma.md). Then, check how to [enable automatic Istio sidecar proxy injection](../../04-operation-guides/operations/smsh-01-istio-enable-sidecar-injection.md). For more details, see [Default Istio setup in Kyma](../../01-overview/main-areas/service-mesh/smsh-02-default-istio-setup-in-kyma.md).
 
-1. Follow the [Prerequisites steps](../#prerequisites) for the Eventing tutorials.
+1. Follow the [Prerequisites steps](./) for the Eventing tutorials.
 2. [Create a Function](../../02-get-started/04-trigger-workload-with-event.md#create-a-function).
 3. For this tutorial, instead of the default code sample, replace the Function source with the following code:
 

--- a/docs/03-tutorials/00-eventing/evnt-04-change-max-in-flight-in-sub.md
+++ b/docs/03-tutorials/00-eventing/evnt-04-change-max-in-flight-in-sub.md
@@ -9,7 +9,7 @@ The "in-flight messages" config defines the number of events that Kyma Eventing 
 
 >**NOTE:** Read about [Istio sidecars in Kyma and why you want them](../../01-overview/main-areas/service-mesh/smsh-03-istio-sidecars-in-kyma.md). Then, check how to [enable automatic Istio sidecar proxy injection](../../04-operation-guides/operations/smsh-01-istio-enable-sidecar-injection.md). For more details, see [Default Istio setup in Kyma](../../01-overview/main-areas/service-mesh/smsh-02-default-istio-setup-in-kyma.md).
 
-1. Follow the [Prerequisites steps](../#prerequisites) for the Eventing tutorials.
+1. Follow the [Prerequisites steps](./) for the Eventing tutorials.
 2. [Create a Function](../../02-get-started/04-trigger-workload-with-event.md#create-a-function).
 3. For this tutorial, instead of the default code sample, replace the Function source with the following code. To simulate prolonged event processing, the Function waits for 5 seconds before returning the response.
 

--- a/docs/03-tutorials/00-eventing/evnt-04-change-max-in-flight-in-sub.md
+++ b/docs/03-tutorials/00-eventing/evnt-04-change-max-in-flight-in-sub.md
@@ -9,7 +9,7 @@ The "in-flight messages" config defines the number of events that Kyma Eventing 
 
 >**NOTE:** Read about [Istio sidecars in Kyma and why you want them](../../01-overview/main-areas/service-mesh/smsh-03-istio-sidecars-in-kyma.md). Then, check how to [enable automatic Istio sidecar proxy injection](../../04-operation-guides/operations/smsh-01-istio-enable-sidecar-injection.md). For more details, see [Default Istio setup in Kyma](../../01-overview/main-areas/service-mesh/smsh-02-default-istio-setup-in-kyma.md).
 
-1. Follow the [prerequisites steps](./README.md#prerequisites) for the Eventing tutorials.
+1. Follow the [Prerequisites steps](README.md#prerequisites) for the Eventing tutorials.
 2. [Create a Function](../../02-get-started/04-trigger-workload-with-event.md#create-a-function).
 3. For this tutorial, instead of the default code sample, replace the Function source with the following code. To simulate prolonged event processing, the Function waits for 5 seconds before returning the response.
 

--- a/docs/03-tutorials/00-eventing/evnt-04-change-max-in-flight-in-sub.md
+++ b/docs/03-tutorials/00-eventing/evnt-04-change-max-in-flight-in-sub.md
@@ -9,7 +9,7 @@ The "in-flight messages" config defines the number of events that Kyma Eventing 
 
 >**NOTE:** Read about [Istio sidecars in Kyma and why you want them](../../01-overview/main-areas/service-mesh/smsh-03-istio-sidecars-in-kyma.md). Then, check how to [enable automatic Istio sidecar proxy injection](../../04-operation-guides/operations/smsh-01-istio-enable-sidecar-injection.md). For more details, see [Default Istio setup in Kyma](../../01-overview/main-areas/service-mesh/smsh-02-default-istio-setup-in-kyma.md).
 
-1. Follow the [Prerequisites steps](README.md#prerequisites) for the Eventing tutorials.
+1. Follow the [Prerequisites steps](../#prerequisites) for the Eventing tutorials.
 2. [Create a Function](../../02-get-started/04-trigger-workload-with-event.md#create-a-function).
 3. For this tutorial, instead of the default code sample, replace the Function source with the following code. To simulate prolonged event processing, the Function waits for 5 seconds before returning the response.
 

--- a/docs/03-tutorials/00-eventing/evnt-04-change-max-in-flight-in-sub.md
+++ b/docs/03-tutorials/00-eventing/evnt-04-change-max-in-flight-in-sub.md
@@ -9,8 +9,8 @@ The "in-flight messages" config defines the number of events that Kyma Eventing 
 
 >**NOTE:** Read about [Istio sidecars in Kyma and why you want them](../../01-overview/main-areas/service-mesh/smsh-03-istio-sidecars-in-kyma.md). Then, check how to [enable automatic Istio sidecar proxy injection](../../04-operation-guides/operations/smsh-01-istio-enable-sidecar-injection.md). For more details, see [Default Istio setup in Kyma](../../01-overview/main-areas/service-mesh/smsh-02-default-istio-setup-in-kyma.md).
 
-1. Follow the [prerequisites steps](../../02-get-started/04-trigger-workload-with-event.md#prerequisites) in the Getting Started guide.
-2. Create a Function by following the [instructions](../../02-get-started/04-trigger-workload-with-event.md#create-a-function) in the Getting Started guide.
+1. Follow the [prerequisites steps](./README.md#prerequisites) for the Eventing tutorials.
+2. [Create a Function](../../02-get-started/04-trigger-workload-with-event.md#create-a-function).
 3. For this tutorial, instead of the default code sample, replace the Function source with the following code. To simulate prolonged event processing, the Function waits for 5 seconds before returning the response.
 
    <div tabs name="Deploy a Function" group="create-workload">
@@ -70,7 +70,7 @@ The "in-flight messages" config defines the number of events that Kyma Eventing 
 
 ## Create a Subscription with Max-In-Flight config
 
-Next, create a [Subscription](../../05-technical-reference/00-custom-resources/evnt-01-subscription.md) custom resource. Subscribe for events of the type: `order.received.v1` and set the `maxInFlightMessages` to `5`, so that Kyma Eventing forwards maximum 5 events in parallel to the sink without waiting for a response.
+Create a [Subscription](../../05-technical-reference/00-custom-resources/evnt-01-subscription.md) custom resource. Subscribe for events of the type: `order.received.v1` and set the `maxInFlightMessages` to `5`, so that Kyma Eventing forwards maximum 5 events in parallel to the sink without waiting for a response.
 
 <div tabs name="Create a Subscription" group="create-subscription">
   <details open>

--- a/docs/03-tutorials/00-eventing/evnt-05-send-legacy-events.md
+++ b/docs/03-tutorials/00-eventing/evnt-05-send-legacy-events.md
@@ -10,12 +10,12 @@ Kyma Eventing also supports sending and receiving of legacy events. In this tuto
 
 >**NOTE:** Read about [Istio sidecars in Kyma and why you want them](../../01-overview/main-areas/service-mesh/smsh-03-istio-sidecars-in-kyma.md). Then, check how to [enable automatic Istio sidecar proxy injection](../../04-operation-guides/operations/smsh-01-istio-enable-sidecar-injection.md). For more details, see [Default Istio setup in Kyma](../../01-overview/main-areas/service-mesh/smsh-02-default-istio-setup-in-kyma.md).
 
-1. Follow the [prerequisites steps](../../02-get-started/04-trigger-workload-with-event.md#prerequisites) in the Getting Started guide.
-2. Create a Function by following the [instructions](../../02-get-started/04-trigger-workload-with-event.md#create-a-function) in the Getting Started guide.
+1. Follow the [prerequisites steps](./README.md#prerequisites) for the Eventing tutorials.
+2. [Create a Function](../../02-get-started/04-trigger-workload-with-event.md#create-a-function).
 
 ## Create a Subscription
 
-Next, to subscribe to events, we need a [Subscription](../../05-technical-reference/00-custom-resources/evnt-01-subscription.md) custom resource. We're going to subscribe to events of the type `order.received.v1`.
+To subscribe to events, we need a [Subscription](../../05-technical-reference/00-custom-resources/evnt-01-subscription.md) custom resource. We're going to subscribe to events of the type `order.received.v1`.
 
 <div tabs name="Create a Subscription" group="trigger-workload">
   <details open>

--- a/docs/03-tutorials/00-eventing/evnt-05-send-legacy-events.md
+++ b/docs/03-tutorials/00-eventing/evnt-05-send-legacy-events.md
@@ -10,7 +10,7 @@ Kyma Eventing also supports sending and receiving of legacy events. In this tuto
 
 >**NOTE:** Read about [Istio sidecars in Kyma and why you want them](../../01-overview/main-areas/service-mesh/smsh-03-istio-sidecars-in-kyma.md). Then, check how to [enable automatic Istio sidecar proxy injection](../../04-operation-guides/operations/smsh-01-istio-enable-sidecar-injection.md). For more details, see [Default Istio setup in Kyma](../../01-overview/main-areas/service-mesh/smsh-02-default-istio-setup-in-kyma.md).
 
-1. Follow the [Prerequisites steps](../#prerequisites) for the Eventing tutorials.
+1. Follow the [Prerequisites steps](./) for the Eventing tutorials.
 2. [Create a Function](../../02-get-started/04-trigger-workload-with-event.md#create-a-function).
 
 ## Create a Subscription

--- a/docs/03-tutorials/00-eventing/evnt-05-send-legacy-events.md
+++ b/docs/03-tutorials/00-eventing/evnt-05-send-legacy-events.md
@@ -10,7 +10,7 @@ Kyma Eventing also supports sending and receiving of legacy events. In this tuto
 
 >**NOTE:** Read about [Istio sidecars in Kyma and why you want them](../../01-overview/main-areas/service-mesh/smsh-03-istio-sidecars-in-kyma.md). Then, check how to [enable automatic Istio sidecar proxy injection](../../04-operation-guides/operations/smsh-01-istio-enable-sidecar-injection.md). For more details, see [Default Istio setup in Kyma](../../01-overview/main-areas/service-mesh/smsh-02-default-istio-setup-in-kyma.md).
 
-1. Follow the [prerequisites steps](./README.md#prerequisites) for the Eventing tutorials.
+1. Follow the [Prerequisites steps](README.md#prerequisites) for the Eventing tutorials.
 2. [Create a Function](../../02-get-started/04-trigger-workload-with-event.md#create-a-function).
 
 ## Create a Subscription

--- a/docs/03-tutorials/00-eventing/evnt-05-send-legacy-events.md
+++ b/docs/03-tutorials/00-eventing/evnt-05-send-legacy-events.md
@@ -10,7 +10,7 @@ Kyma Eventing also supports sending and receiving of legacy events. In this tuto
 
 >**NOTE:** Read about [Istio sidecars in Kyma and why you want them](../../01-overview/main-areas/service-mesh/smsh-03-istio-sidecars-in-kyma.md). Then, check how to [enable automatic Istio sidecar proxy injection](../../04-operation-guides/operations/smsh-01-istio-enable-sidecar-injection.md). For more details, see [Default Istio setup in Kyma](../../01-overview/main-areas/service-mesh/smsh-02-default-istio-setup-in-kyma.md).
 
-1. Follow the [Prerequisites steps](README.md#prerequisites) for the Eventing tutorials.
+1. Follow the [Prerequisites steps](../#prerequisites) for the Eventing tutorials.
 2. [Create a Function](../../02-get-started/04-trigger-workload-with-event.md#create-a-function).
 
 ## Create a Subscription


### PR DESCRIPTION
**Description**

While testing the Get Started guides, it was discovered that the kubectl command to verify event delivery was incomplete  which resulted in a not-so-obvious error when a Namespace other than default was used. This PR fixes that and refines the guides to keep them simple as an entry point for newbies. 

Changes proposed in this pull request:

- Remove obsolete prerequisites from [Trigger a Function with an event](https://kyma-project.io/docs/kyma/2.6/02-get-started/04-trigger-workload-with-event/), and move additional prerequisites to the [initial document](https://kyma-project.io/docs/kyma/2.6/02-get-started/)
- Remove obsolete steps
- Fix the [kubectl command to verify event delivery](https://kyma-project.io/docs/kyma/2.6/02-get-started/04-trigger-workload-with-event/#verify-the-event-delivery) by specifying a Namespace
- Tidy up the prerequisites for Eventing tutorials to fix broken links (Eventing tutorials have been using the GSG prerequisites instead of their own) 

**Related issue(s)**
#15129 
