### PR TITLE
Improve the command for getting logs of the event sink in the getting started guides

### DIFF
--- a/docs/02-get-started/04-trigger-workload-with-event.md
+++ b/docs/02-get-started/04-trigger-workload-with-event.md
@@ -214,11 +214,7 @@ To verify that the event was properly delivered, check the logs of the Function:
 Run: 
 
 ```bash
-kubectl logs -n default \
-  $(kubectl get pod -n default \
-    --field-selector=status.phase==Running \
-    -l serverless.kyma-project.io/function-name=lastorder \
-    -o jsonpath="{.items[0].metadata.name}")
+kubectl logs -n default -l serverless.kyma-project.io/function-name=lastorder,serverless.kyma-project.io/resource=deployment -c function
 ```
 
 You see the received event in the logs:

--- a/docs/02-get-started/04-trigger-workload-with-event.md
+++ b/docs/02-get-started/04-trigger-workload-with-event.md
@@ -214,7 +214,10 @@ To verify that the event was properly delivered, check the logs of the Function:
 Run: 
 
 ```bash
-kubectl logs -n default -l serverless.kyma-project.io/function-name=lastorder,serverless.kyma-project.io/resource=deployment -c function
+kubectl logs \
+  -n default \
+  -l serverless.kyma-project.io/function-name=lastorder,serverless.kyma-project.io/resource=deployment \
+  -c function
 ```
 
 You see the received event in the logs:


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- Improve the command for **getting logs** of the **event sink** in the _getting started guides_.
  - The command is a **1-liner** and the **advantage** is that if the pod is not found, the **error message** is **less confusing** for the user.


Before:
```shell
$ kubectl logs -f -n gsg-ns \
  $(kubectl get pod -n default \
    --field-selector=status.phase==Running \
    -l serverless.kyma-project.io/function-name=lastorder \
    -o jsonpath="{.items[0].metadata.name}")
error: error executing jsonpath "{.items[0].metadata.name}": Error executing template: array index out of bounds: index 0, length 0. Printing more information for debugging the template:
        template was:
                {.items[0].metadata.name}
        object given to jsonpath engine was:
                map[string]interface {}{"apiVersion":"v1", "items":[]interface {}{}, "kind":"List", "metadata":map[string]interface {}{"resourceVersion":""}}


error: expected 'logs [-f] [-p] (POD | TYPE/NAME) [-c CONTAINER]'.
POD or TYPE/NAME is a required argument for the logs command
See 'kubectl logs -h' for help and examples
```

After:
```shell
$ kubectl logs -l serverless.kyma-project.io/function-name=lastorder10,serverless.kyma-project.io/resource=deployment -n gsg-ns -c function
No resources found in gsg-ns namespace.
```

IMHO, the error message for the case that the function is not found, is less confusing.

> **NOTE:** The label `serverless.kyma-project.io/resource=deployment` is stable (it is used to separate the build pod from the actual function pod) and will not be removed in the foreseen future by the kyma serverless team. Therefore it is safe to use.

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
