### PR TITLE
Add the omitted parameter to the command description

### DIFF
--- a/docs/03-tutorials/00-application-connectivity/ac-05-call-registered-service-from-kyma.md
+++ b/docs/03-tutorials/00-application-connectivity/ac-05-call-registered-service-from-kyma.md
@@ -9,7 +9,7 @@ This guide shows how to call a registered external service from Kyma using a sim
 - A [registered external service](./ac-03-register-manage-services.md)
 - Your [service display name exported](./ac-03-register-manage-services.md#prerequisites) as an environment variable
 - Your [Application name exported](ac-01-create-application.md#prerequisites) as an environment variable
-- Your desired Namespace, cluster domain, and the name for your Function exported as environment variables
+- Your desired Namespace, cluster domain, and the names for your Function and APIRule exported as environment variables
   ```bash
   export NAMESPACE=default
   export CLUSTER_DOMAIN=local.kyma.dev


### PR DESCRIPTION
**Description**

The [Call a registered external service from Kyma](https://kyma-project.io/docs/kyma/2.6/03-tutorials/00-application-connectivity/ac-05-call-registered-service-from-kyma/) tutorial was edited and more parameters were added to the command in Prerequisites, but not all were listed in its description. This PR is fixing that. 

Changes proposed in this pull request:

- Add omitted parameters from the command to the command's description

**Related issue(s)**
#15262 
