### PR TITLE
Improve the NATS JetStream Subscription/Consumer logic

### DIFF
--- a/components/eventing-controller/cmd/eventing-controller/main.go
+++ b/components/eventing-controller/cmd/eventing-controller/main.go
@@ -112,7 +112,5 @@ func main() {
 	}
 
 	// unsubscribe on NATS before shutdown
-	if err := natsSubMgr.UnsubscribeAll(); err != nil {
-		log.Fatalf("Failed to unsubscribe on NATS Server, err: %v", err)
-	}
+	natsSubMgr.UnsubscribeAll()
 }

--- a/components/eventing-controller/cmd/eventing-controller/main.go
+++ b/components/eventing-controller/cmd/eventing-controller/main.go
@@ -110,4 +110,9 @@ func main() {
 	if err := mgr.Start(ctrl.SetupSignalHandler()); err != nil {
 		setupLogger.Fatalw("Failed to start controller manager", "error", err)
 	}
+
+	// unsubscribe on NATS before shutdown
+	if err := natsSubMgr.UnsubscribeAll(); err != nil {
+		log.Fatalf("Failed to unsubscribe on NATS Server, err: %v", err)
+	}
 }

--- a/components/eventing-controller/controllers/backend/reconciler_test.go
+++ b/components/eventing-controller/controllers/backend/reconciler_test.go
@@ -855,8 +855,8 @@ func (t *SubMgrMock) Stop(runCleanup bool) error {
 	}
 	return t.stopErr
 }
-func (t *SubMgrMock) UnsubscribeAll() error {
-	return nil
+
+func (t *SubMgrMock) UnsubscribeAll() {
 }
 
 func (t *SubMgrMock) resetState() {

--- a/components/eventing-controller/controllers/backend/reconciler_test.go
+++ b/components/eventing-controller/controllers/backend/reconciler_test.go
@@ -855,6 +855,9 @@ func (t *SubMgrMock) Stop(runCleanup bool) error {
 	}
 	return t.stopErr
 }
+func (t *SubMgrMock) UnsubscribeAll() error {
+	return nil
+}
 
 func (t *SubMgrMock) resetState() {
 	t.startErr = nil

--- a/components/eventing-controller/pkg/backend/mocks/JetStreamBackend.go
+++ b/components/eventing-controller/pkg/backend/mocks/JetStreamBackend.go
@@ -72,3 +72,8 @@ func (_m *JetStreamBackend) SyncSubscription(subscription *v1alpha1.Subscription
 
 	return r0
 }
+
+// UnsubscribeOnNats provides a mock function with given fields:
+func (_m *JetStreamBackend) UnsubscribeOnNats() {
+	_m.Called()
+}

--- a/components/eventing-controller/pkg/backend/nats/jetstream/jetstream_test.go
+++ b/components/eventing-controller/pkg/backend/nats/jetstream/jetstream_test.go
@@ -8,7 +8,7 @@ import (
 	"testing"
 	"time"
 
-	testing2 "github.com/kyma-project/kyma/components/eventing-controller/controllers/subscription/testing"
+	subscriptiontesting "github.com/kyma-project/kyma/components/eventing-controller/controllers/subscription/testing"
 
 	kymalogger "github.com/kyma-project/kyma/common/logging/logger"
 	"github.com/nats-io/nats-server/v2/server"
@@ -1479,8 +1479,9 @@ func TestSubscriptionSubjectIdentifierNamespacedName(t *testing.T) {
 	}
 }
 
-// Test_CreatingConsumer tests the creation of the valid consumer on NATS server
-func Test_CreatingConsumer(t *testing.T) {
+// Test_SyncSubscription tests the creation of the valid consumer on NATS server.
+// It also sends events to check if the consumer/subscription logic works.
+func Test_SyncSubscription(t *testing.T) {
 	// given
 	testEnvironment := setupTestEnvironment(t)
 	jsBackend := testEnvironment.jsBackend
@@ -1494,7 +1495,7 @@ func Test_CreatingConsumer(t *testing.T) {
 	require.True(t, subscriber.IsRunning())
 
 	// create a new Subscription
-	cleanEventTypes := []string{testing2.NewCleanEventType("0")}
+	cleanEventTypes := []string{subscriptiontesting.NewCleanEventType("0")}
 	defaultSubsConfig := env.DefaultSubscriptionConfig{MaxInFlightMessages: 10}
 	sub := evtesting.NewSubscription("sub", "foo",
 		evtesting.WithNotCleanFilter(),
@@ -1539,7 +1540,7 @@ func Test_CreatingConsumer(t *testing.T) {
 	require.NoError(t, SendEventToJetStream(jsBackend, ev2data))
 	require.NoError(t, subscriber.CheckEvent(expectedEv2Data))
 
-	// unsubscribe from topic, this will keep the consumer, but remove the NATS Subscription
+	// unsubscribe from subject, this will keep the consumer, but remove the NATS Subscription
 	for key, sub := range jsBackend.subscriptions {
 		require.NoError(t, sub.Unsubscribe())
 		delete(jsBackend.subscriptions, key)

--- a/components/eventing-controller/pkg/backend/nats/jetstream/jetstream_test.go
+++ b/components/eventing-controller/pkg/backend/nats/jetstream/jetstream_test.go
@@ -8,6 +8,8 @@ import (
 	"testing"
 	"time"
 
+	testing2 "github.com/kyma-project/kyma/components/eventing-controller/controllers/subscription/testing"
+
 	kymalogger "github.com/kyma-project/kyma/common/logging/logger"
 	"github.com/nats-io/nats-server/v2/server"
 	"github.com/nats-io/nats.go"
@@ -1475,4 +1477,84 @@ func TestSubscriptionSubjectIdentifierNamespacedName(t *testing.T) {
 			assert.Equal(t, tc.wantNamespacedName, tc.givenIdentifier.NamespacedName())
 		})
 	}
+}
+
+// Test_CreatingConsumer tests the creation of the valid consumer on NATS server
+func Test_CreatingConsumer(t *testing.T) {
+	// given
+	testEnvironment := setupTestEnvironment(t)
+	jsBackend := testEnvironment.jsBackend
+	defer testEnvironment.natsServer.Shutdown()
+	defer testEnvironment.jsClient.natsConn.Close()
+	initErr := jsBackend.Initialize(nil)
+	require.NoError(t, initErr)
+
+	// create New Subscriber
+	subscriber := evtesting.NewSubscriber()
+	require.True(t, subscriber.IsRunning())
+
+	// create a new Subscription
+	cleanEventTypes := []string{testing2.NewCleanEventType("0")}
+	defaultSubsConfig := env.DefaultSubscriptionConfig{MaxInFlightMessages: 10}
+	sub := evtesting.NewSubscription("sub", "foo",
+		evtesting.WithNotCleanFilter(),
+		evtesting.WithSinkURL(subscriber.SinkURL),
+		evtesting.WithStatusConfig(defaultSubsConfig),
+		evtesting.WithStatusCleanEventTypes(cleanEventTypes),
+	)
+	require.NoError(t, addJSCleanEventTypesToStatus(sub, testEnvironment.cleaner))
+
+	// init the required strings
+	jsSubject := jsBackend.GetJetstreamSubject(sub.Status.CleanEventTypes[0])
+	jsSubKey := NewSubscriptionSubjectIdentifier(sub, jsSubject)
+
+	// no consumer resources yet
+	assert.Empty(t, jsBackend.subscriptions)
+	consumerInfo, _ := jsBackend.jsCtx.ConsumerInfo(defaultStreamName, jsSubKey.ConsumerName())
+	assert.Nil(t, consumerInfo)
+
+	// send an event, which should not be dispatched, because there is no consumer yet
+	ev2data := "newsampledata"
+	require.NoError(t, SendEventToJetStream(jsBackend, ev2data))
+	expectedEv2Data := fmt.Sprintf("\"%s\"", ev2data)
+	require.Error(t, subscriber.CheckEvent(expectedEv2Data))
+	info, err := jsBackend.jsCtx.StreamInfo(defaultStreamName)
+	require.NoError(t, err)
+	require.Equal(t, info.State.Consumers, 0)
+
+	// when
+	require.NoError(t, jsBackend.SyncSubscription(sub))
+
+	// then
+	// the expected consumer should have been created
+	consumerInfo, _ = jsBackend.jsCtx.ConsumerInfo(defaultStreamName, jsSubKey.ConsumerName())
+	require.NotNil(t, consumerInfo)
+	require.Equal(t, consumerInfo.Name, jsSubKey.ConsumerName())
+	require.Equal(t, len(jsBackend.subscriptions), 1)
+	info, err = jsBackend.jsCtx.StreamInfo(defaultStreamName)
+	require.NoError(t, err)
+	require.Equal(t, info.State.Consumers, 1)
+
+	// send the event again, which should be dispatched
+	require.NoError(t, SendEventToJetStream(jsBackend, ev2data))
+	require.NoError(t, subscriber.CheckEvent(expectedEv2Data))
+
+	// unsubscribe from topic, this will keep the consumer, but remove the NATS Subscription
+	for key, sub := range jsBackend.subscriptions {
+		require.NoError(t, sub.Unsubscribe())
+		delete(jsBackend.subscriptions, key)
+	}
+
+	// change the event name
+	ev2data = "newsampledata2"
+	expectedEv2Data = fmt.Sprintf("\"%s\"", ev2data)
+	require.NoError(t, SendEventToJetStream(jsBackend, ev2data))
+
+	// this should resubscribe to existing consumer
+	require.NoError(t, jsBackend.SyncSubscription(sub))
+
+	// the same event should be redelivered
+	require.Eventually(t, func() bool {
+		return subscriber.CheckEvent(expectedEv2Data) == nil
+	}, 60*time.Second, 5*time.Second)
 }

--- a/components/eventing-controller/pkg/backend/nats/jetstream/jetstream_util.go
+++ b/components/eventing-controller/pkg/backend/nats/jetstream/jetstream_util.go
@@ -55,3 +55,20 @@ func toJetStreamConsumerDeliverPolicyOptOrDefault(deliverPolicy string) nats.Sub
 	}
 	return nats.DeliverNew()
 }
+
+// toJetStreamConsumerDeliverPolicy returns a nats.DeliverPolicy based on the given deliver policy string value.
+// It returns "DeliverNew" as the default nats.DeliverPolicy, if the given deliver policy value is not supported.
+// Supported deliver policy values are ("all", "last", "last_per_subject" and "new").
+func toJetStreamConsumerDeliverPolicy(deliverPolicy string) nats.DeliverPolicy {
+	switch deliverPolicy {
+	case ConsumerDeliverPolicyAll:
+		return nats.DeliverAllPolicy
+	case ConsumerDeliverPolicyLast:
+		return nats.DeliverLastPolicy
+	case ConsumerDeliverPolicyLastPerSubject:
+		return nats.DeliverLastPerSubjectPolicy
+	case ConsumerDeliverPolicyNew:
+		return nats.DeliverNewPolicy
+	}
+	return nats.DeliverNewPolicy
+}

--- a/components/eventing-controller/pkg/subscriptionmanager/beb/beb.go
+++ b/components/eventing-controller/pkg/subscriptionmanager/beb/beb.go
@@ -73,6 +73,11 @@ func NewSubscriptionManager(restCfg *rest.Config, metricsAddr string, resyncPeri
 	}
 }
 
+// UnsubscribeAll the subscriptionmanager.Manager interface.
+func (c *SubscriptionManager) UnsubscribeAll() error {
+	return nil
+}
+
 // Init implements the subscriptionmanager.Manager interface.
 func (c *SubscriptionManager) Init(mgr manager.Manager) error {
 	if len(c.envCfg.Domain) == 0 {

--- a/components/eventing-controller/pkg/subscriptionmanager/beb/beb.go
+++ b/components/eventing-controller/pkg/subscriptionmanager/beb/beb.go
@@ -74,8 +74,7 @@ func NewSubscriptionManager(restCfg *rest.Config, metricsAddr string, resyncPeri
 }
 
 // UnsubscribeAll the subscriptionmanager.Manager interface.
-func (c *SubscriptionManager) UnsubscribeAll() error {
-	return nil
+func (c *SubscriptionManager) UnsubscribeAll() {
 }
 
 // Init implements the subscriptionmanager.Manager interface.

--- a/components/eventing-controller/pkg/subscriptionmanager/jetstream/jetstream.go
+++ b/components/eventing-controller/pkg/subscriptionmanager/jetstream/jetstream.go
@@ -66,9 +66,8 @@ func NewSubscriptionManager(restCfg *rest.Config, natsConfig env.NatsConfig, met
 	}
 }
 
-func (sm *SubscriptionManager) UnsubscribeAll() error {
+func (sm *SubscriptionManager) UnsubscribeAll() {
 	sm.backend.UnsubscribeOnNats()
-	return nil
 }
 
 // Init initialize the JetStream subscription manager.

--- a/components/eventing-controller/pkg/subscriptionmanager/jetstream/jetstream.go
+++ b/components/eventing-controller/pkg/subscriptionmanager/jetstream/jetstream.go
@@ -66,6 +66,11 @@ func NewSubscriptionManager(restCfg *rest.Config, natsConfig env.NatsConfig, met
 	}
 }
 
+func (sm *SubscriptionManager) UnsubscribeAll() error {
+	sm.backend.UnsubscribeOnNats()
+	return nil
+}
+
 // Init initialize the JetStream subscription manager.
 func (sm *SubscriptionManager) Init(mgr manager.Manager) error {
 	if len(sm.envCfg.URL) == 0 {

--- a/components/eventing-controller/pkg/subscriptionmanager/manager.go
+++ b/components/eventing-controller/pkg/subscriptionmanager/manager.go
@@ -18,4 +18,7 @@ type Manager interface {
 
 	// Stop tells the subscription manager instance to shut down and clean-up.
 	Stop(runCleanup bool) error
+
+	// UnsubscribeAll removes all the subscriptions on the backend side
+	UnsubscribeAll() error
 }

--- a/components/eventing-controller/pkg/subscriptionmanager/manager.go
+++ b/components/eventing-controller/pkg/subscriptionmanager/manager.go
@@ -19,6 +19,6 @@ type Manager interface {
 	// Stop tells the subscription manager instance to shut down and clean-up.
 	Stop(runCleanup bool) error
 
-	// UnsubscribeAll removes all the subscriptions on the backend side
-	UnsubscribeAll() error
+	// UnsubscribeAll removes all the subscriptions on the backend side.
+	UnsubscribeAll()
 }

--- a/components/eventing-controller/pkg/subscriptionmanager/nats/nats.go
+++ b/components/eventing-controller/pkg/subscriptionmanager/nats/nats.go
@@ -105,8 +105,7 @@ func (c *SubscriptionManager) Start(defaultSubsConfig env.DefaultSubscriptionCon
 }
 
 // UnsubscribeAll the subscriptionmanager.Manager interface.
-func (c *SubscriptionManager) UnsubscribeAll() error {
-	return nil
+func (c *SubscriptionManager) UnsubscribeAll() {
 }
 
 // Stop implements the subscriptionmanager.Manager interface and stops the NATS subscription manager.

--- a/components/eventing-controller/pkg/subscriptionmanager/nats/nats.go
+++ b/components/eventing-controller/pkg/subscriptionmanager/nats/nats.go
@@ -104,6 +104,11 @@ func (c *SubscriptionManager) Start(defaultSubsConfig env.DefaultSubscriptionCon
 	return nil
 }
 
+// UnsubscribeAll the subscriptionmanager.Manager interface.
+func (c *SubscriptionManager) UnsubscribeAll() error {
+	return nil
+}
+
 // Stop implements the subscriptionmanager.Manager interface and stops the NATS subscription manager.
 // It cleans up the subscriptions on NATS, if the runCleanup flag is true.
 func (c *SubscriptionManager) Stop(runCleanup bool) error {

--- a/resources/eventing/values.yaml
+++ b/resources/eventing/values.yaml
@@ -5,7 +5,7 @@ global:
   images:
     eventing_controller:
       name: eventing-controller
-      version: PR-15331
+      version: PR-15295
       pullPolicy: "IfNotPresent"
     publisher_proxy:
       name: event-publisher-proxy

--- a/tests/fast-integration/eventing-test/eventing-test-prep.js
+++ b/tests/fast-integration/eventing-test/eventing-test-prep.js
@@ -32,7 +32,7 @@ const {
   info,
   error,
   debug,
-  createEventingBackendK8sSecret,
+  createEventingBackendK8sSecret, printAllSubscriptions, printEventingControllerLogs, printEventingPublisherProxyLogs,
 } = require('../utils');
 const {
   addScenarioInCompass,
@@ -116,6 +116,9 @@ describe('Eventing tests preparation', function() {
   afterEach(async function() {
     // if the test preparation failed, perform the cleanup
     if (this.currentTest.state === 'failed') {
+      await printAllSubscriptions(testNamespace);
+      await printEventingControllerLogs();
+      await printEventingPublisherProxyLogs();
       await cleanupTestingResources();
     }
   });


### PR DESCRIPTION
**Description**

The error from [this issue](https://github.com/kyma-project/kyma/issues/15215) happens during the upgrade. The first 10 seconds after the controller connects to the NATS server, we try to subscribe to the topics again. We have a map, which reflects the NATS subscription in our controller. This is only in-memory, so after controller gets restarted we need to populate this map again. Our current code does that by resubscribing the the same topic, which causes the `consumer is already bound to a subscription` error. 

This PR tries to get improve our consumer/subscribing logic. 

**Changes proposed in this pull request**:

Since we store the NATS-Subscriptions in the controller in-memory and there is currently no way to fetch the NATS subscriptions from the server, let's unsubscribe all the NATS subs before the controller shuts down. Currently we subscribe in NATS backend by using the `Subscribe` method, this also creates a consumer for us. This means that unsubscribing before the shutdown will delete als the consumer and hence the interest in the topic. This can cause event loss. 

In order to fix that we need to create a consumer manually and then propagate it to the `Subscribe` method. That will keep the consumer even after the `Unsubscribe`-call

**Code changes**:
- create a consumer manually if it doesn't exist on NATS Server
- Subscribe to the manually created consumer by binding to it (this will first try to bind the subscription to the consumer instead of creating a new one)
- add a test

**Open tasks**
- [ ] https://github.com/kyma-project/kyma/pull/15447/files#r969253673

**Related issues**
https://github.com/kyma-project/kyma/issues/15093
