### PR TITLE
Adjust telemetry-operator memory limit

### DIFF
--- a/resources/telemetry/charts/operator/values.yaml
+++ b/resources/telemetry/charts/operator/values.yaml
@@ -43,7 +43,7 @@ readinessProbe:
 resources:
   limits:
     cpu: 100m
-    memory: 100Mi
+    memory: 256Mi
   requests:
     cpu: 5m
     memory: 20Mi


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Increase limits to avoid OOMKilled telemetry-operator pods that we have seen on some clusters.

Changes proposed in this pull request:

- Increase telemetry-operator memory limit to 256Mi

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
