### PR TITLE
[Telemetry operator] Add telemetry_all_logpipelines gauge

### DIFF
--- a/components/telemetry-operator/controller/logpipeline/controller.go
+++ b/components/telemetry-operator/controller/logpipeline/controller.go
@@ -222,13 +222,13 @@ func (r *Reconciler) updateMetrics(allPipelines *telemetryv1alpha1.LogPipelineLi
 }
 
 // syncUnsupportedPluginsTotal checks if any LogPipeline defines a unsupported Filter or Output.
-func countUnsupportedPluginUsages(logPipelines *telemetryv1alpha1.LogPipelineList) int {
+func countUnsupportedPluginUsages(pipelines *telemetryv1alpha1.LogPipelineList) int {
 	count := 0
-	for _, l := range logPipelines.Items {
-		if !l.DeletionTimestamp.IsZero() {
+	for i := range pipelines.Items {
+		if !pipelines.Items[i].DeletionTimestamp.IsZero() {
 			continue
 		}
-		if usesUnsupportedPlugin(&l) {
+		if usesUnsupportedPlugin(&pipelines.Items[i]) {
 			count++
 		}
 	}

--- a/components/telemetry-operator/controller/logpipeline/controller.go
+++ b/components/telemetry-operator/controller/logpipeline/controller.go
@@ -101,10 +101,6 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 		log.Error(err, "Failed to get all log pipelines")
 		return ctrl.Result{Requeue: controller.ShouldRetryOn(err)}, err
 	}
-	log.Info("ALL PIPELINES")
-	for _, p := range allPipelines.Items {
-		log.Info(fmt.Sprintf("%s: %v", p.Name, p.DeletionTimestamp))
-	}
 	r.updateMetrics(&allPipelines)
 
 	var logPipeline telemetryv1alpha1.LogPipeline

--- a/components/telemetry-operator/controller/logpipeline/controller.go
+++ b/components/telemetry-operator/controller/logpipeline/controller.go
@@ -101,7 +101,10 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 		log.Error(err, "Failed to get all log pipelines")
 		return ctrl.Result{Requeue: controller.ShouldRetryOn(err)}, err
 	}
-	log.Info(fmt.Sprintf("TEST: %#v", allPipelines.Items))
+	log.Info("ALL PIPELINES")
+	for _, p := range allPipelines.Items {
+		log.Info(fmt.Sprintf("%s: %v", p.Name, p.DeletionTimestamp))
+	}
 	r.updateMetrics(&allPipelines)
 
 	var logPipeline telemetryv1alpha1.LogPipeline

--- a/components/telemetry-operator/controller/logpipeline/controller.go
+++ b/components/telemetry-operator/controller/logpipeline/controller.go
@@ -104,7 +104,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 			telemetryv1alpha1.SecretsNotPresent,
 			telemetryv1alpha1.LogPipelinePending,
 		)
-		pipeLineUnsupported := IsUnsupported(logPipeline)
+		pipeLineUnsupported := isUnsupported(logPipeline)
 		if err := r.updateLogPipelineStatus(ctx, req.NamespacedName, condition, pipeLineUnsupported); err != nil {
 			return ctrl.Result{Requeue: controller.ShouldRetryOn(err)}, nil
 		}
@@ -112,7 +112,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 		return ctrl.Result{RequeueAfter: controller.RequeueTime}, nil
 	}
 
-	changed, err := r.syncer.SyncAll(ctx, &logPipeline)
+	changed, err := r.syncer.syncAll(ctx, &logPipeline)
 	if err != nil {
 		return ctrl.Result{Requeue: controller.ShouldRetryOn(err)}, nil
 	}
@@ -136,7 +136,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 			telemetryv1alpha1.FluentBitDSRestartedReason,
 			telemetryv1alpha1.LogPipelinePending,
 		)
-		pipeLineUnsupported := IsUnsupported(logPipeline)
+		pipeLineUnsupported := isUnsupported(logPipeline)
 		if err = r.updateLogPipelineStatus(ctx, req.NamespacedName, condition, pipeLineUnsupported); err != nil {
 			return ctrl.Result{RequeueAfter: controller.RequeueTime}, err
 		}
@@ -161,7 +161,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 			telemetryv1alpha1.FluentBitDSRestartCompletedReason,
 			telemetryv1alpha1.LogPipelineRunning,
 		)
-		pipeLineUnsupported := IsUnsupported(logPipeline)
+		pipeLineUnsupported := isUnsupported(logPipeline)
 
 		if err = r.updateLogPipelineStatus(ctx, req.NamespacedName, condition, pipeLineUnsupported); err != nil {
 			return ctrl.Result{RequeueAfter: controller.RequeueTime}, err

--- a/components/telemetry-operator/controller/logpipeline/controller.go
+++ b/components/telemetry-operator/controller/logpipeline/controller.go
@@ -101,6 +101,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 		log.Error(err, "Failed to get all log pipelines")
 		return ctrl.Result{Requeue: controller.ShouldRetryOn(err)}, err
 	}
+	log.Info(fmt.Sprintf("TEST: %#v", allPipelines.Items))
 	r.updateMetrics(&allPipelines)
 
 	var logPipeline telemetryv1alpha1.LogPipeline

--- a/components/telemetry-operator/controller/logpipeline/controller.go
+++ b/components/telemetry-operator/controller/logpipeline/controller.go
@@ -96,19 +96,19 @@ func (r *Reconciler) SetupWithManager(mgr ctrl.Manager) error {
 func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	log := logf.FromContext(ctx)
 
-	var logPipeline telemetryv1alpha1.LogPipeline
-	if err := r.Get(ctx, req.NamespacedName, &logPipeline); err != nil {
-		log.Info("Ignoring deleted LogPipeline")
-		// Ignore not-found errors since we can get them on deleted requests
-		return ctrl.Result{}, client.IgnoreNotFound(err)
-	}
-
 	var allPipelines telemetryv1alpha1.LogPipelineList
 	if err := r.List(ctx, &allPipelines); err != nil {
 		log.Error(err, "Failed to get all log pipelines")
 		return ctrl.Result{Requeue: controller.ShouldRetryOn(err)}, err
 	}
 	r.updateMetrics(&allPipelines)
+
+	var logPipeline telemetryv1alpha1.LogPipeline
+	if err := r.Get(ctx, req.NamespacedName, &logPipeline); err != nil {
+		log.Info("Ignoring deleted LogPipeline")
+		// Ignore not-found errors since we can get them on deleted requests
+		return ctrl.Result{}, client.IgnoreNotFound(err)
+	}
 
 	secretsOK := r.syncer.secretHelper.ValidatePipelineSecretsExist(ctx, &logPipeline)
 	if !secretsOK {

--- a/components/telemetry-operator/controller/logpipeline/controller_test.go
+++ b/components/telemetry-operator/controller/logpipeline/controller_test.go
@@ -318,6 +318,21 @@ var _ = Describe("LogPipeline controller", func() {
 				}
 				return int(fluentBitDaemonSet.Generation)
 			}, timeout, interval).Should(Equal(2))
+
+			// All log pipeline gauge should be updated after deletion
+			Eventually(func() float64 {
+				resp, err := http.Get("http://localhost:8080/metrics")
+				if err != nil {
+					return 0
+				}
+				var parser expfmt.TextParser
+				mf, err := parser.TextToMetricFamilies(resp.Body)
+				if err != nil {
+					return 0
+				}
+
+				return *mf["telemetry_all_logpipelines"].Metric[0].Gauge.Value
+			}, timeout, interval).Should(Equal(0.0))
 		})
 	})
 })

--- a/components/telemetry-operator/controller/logpipeline/controller_test.go
+++ b/components/telemetry-operator/controller/logpipeline/controller_test.go
@@ -333,6 +333,21 @@ var _ = Describe("LogPipeline controller", func() {
 
 				return *mf["telemetry_all_logpipelines"].Metric[0].Gauge.Value
 			}, timeout, interval).Should(Equal(0.0))
+
+			// Unsupported log pipeline gauge should be updated after deletion
+			Eventually(func() float64 {
+				resp, err := http.Get("http://localhost:8080/metrics")
+				if err != nil {
+					return 0
+				}
+				var parser expfmt.TextParser
+				mf, err := parser.TextToMetricFamilies(resp.Body)
+				if err != nil {
+					return 0
+				}
+
+				return *mf["telemetry_unsupported_logpipelines"].Metric[0].Gauge.Value
+			}, timeout, interval).Should(Equal(0.0))
 		})
 	})
 })

--- a/components/telemetry-operator/controller/logpipeline/sync.go
+++ b/components/telemetry-operator/controller/logpipeline/sync.go
@@ -167,7 +167,7 @@ func (s *syncer) syncVariables(ctx context.Context, logPipelines *telemetryv1alp
 
 	for i := range logPipelines.Items {
 		for _, field := range lookupSecretRefFields(&logPipelines.Items[i]) {
-			err := s.secretHelper.CopySecretData(ctx, *&field.secretKeyRef, field.targetSecretKey, newSecret.Data)
+			err := s.secretHelper.CopySecretData(ctx, field.secretKeyRef, field.targetSecretKey, newSecret.Data)
 			if err != nil {
 				log.Error(err, "unable to find secret for http host")
 				return false, err

--- a/components/telemetry-operator/controller/logpipeline/sync.go
+++ b/components/telemetry-operator/controller/logpipeline/sync.go
@@ -40,7 +40,7 @@ func newSyncer(
 	return &s
 }
 
-func (s *syncer) SyncAll(ctx context.Context, logPipeline *telemetryv1alpha1.LogPipeline) (bool, error) {
+func (s *syncer) syncAll(ctx context.Context, logPipeline *telemetryv1alpha1.LogPipeline) (bool, error) {
 	log := logf.FromContext(ctx)
 
 	sectionsChanged, err := s.syncSectionsConfigMap(ctx, logPipeline)
@@ -204,7 +204,7 @@ func (s *syncer) syncUnsupportedPluginsTotal(logPipelines *telemetryv1alpha1.Log
 		if !l.DeletionTimestamp.IsZero() {
 			continue
 		}
-		if IsUnsupported(l) {
+		if isUnsupported(l) {
 			unsupportedPluginsTotal++
 		}
 	}
@@ -212,7 +212,7 @@ func (s *syncer) syncUnsupportedPluginsTotal(logPipelines *telemetryv1alpha1.Log
 	s.unsupportedPluginsTotal = unsupportedPluginsTotal
 }
 
-func IsUnsupported(pipeline telemetryv1alpha1.LogPipeline) bool {
+func isUnsupported(pipeline telemetryv1alpha1.LogPipeline) bool {
 	if pipeline.Spec.Output.Custom != "" {
 		return true
 	}

--- a/components/telemetry-operator/controller/logpipeline/sync.go
+++ b/components/telemetry-operator/controller/logpipeline/sync.go
@@ -21,11 +21,9 @@ const (
 
 type syncer struct {
 	client.Client
-	config                  Config
-	enableUnsupportedPlugin bool
-	unsupportedPluginsTotal int
-	secretHelper            *secretHelper
-	k8sGetterOrCreator      *kubernetes.GetterOrCreator
+	config             Config
+	secretHelper       *secretHelper
+	k8sGetterOrCreator *kubernetes.GetterOrCreator
 }
 
 func newSyncer(
@@ -40,34 +38,26 @@ func newSyncer(
 	return &s
 }
 
-func (s *syncer) syncAll(ctx context.Context, logPipeline *telemetryv1alpha1.LogPipeline) (bool, error) {
+func (s *syncer) syncAll(ctx context.Context, newPipeline *telemetryv1alpha1.LogPipeline, allPipelines *telemetryv1alpha1.LogPipelineList) (bool, error) {
 	log := logf.FromContext(ctx)
 
-	sectionsChanged, err := s.syncSectionsConfigMap(ctx, logPipeline)
+	sectionsChanged, err := s.syncSectionsConfigMap(ctx, newPipeline)
 	if err != nil {
 		log.Error(err, "Failed to sync Sections ConfigMap")
 		return false, err
 	}
 
-	filesChanged, err := s.syncFilesConfigMap(ctx, logPipeline)
+	filesChanged, err := s.syncFilesConfigMap(ctx, newPipeline)
 	if err != nil {
 		log.Error(err, "Failed to sync mounted files")
 		return false, err
 	}
 
-	var logPipelines telemetryv1alpha1.LogPipelineList
-	err = s.List(ctx, &logPipelines)
-	if err != nil {
-		return false, err
-	}
-
-	variablesChanged, err := s.syncVariables(ctx, &logPipelines)
+	variablesChanged, err := s.syncVariables(ctx, allPipelines)
 	if err != nil {
 		log.Error(err, "Failed to sync variables")
 		return false, err
 	}
-
-	s.syncUnsupportedPluginsTotal(&logPipelines)
 
 	return sectionsChanged || filesChanged || variablesChanged, nil
 }
@@ -195,31 +185,4 @@ func (s *syncer) syncVariables(ctx context.Context, logPipelines *telemetryv1alp
 		return false, err
 	}
 	return secretHasChanged, nil
-}
-
-// syncUnsupportedPluginsTotal checks if any LogPipeline defines a unsupported Filter or Output.
-func (s *syncer) syncUnsupportedPluginsTotal(logPipelines *telemetryv1alpha1.LogPipelineList) {
-	unsupportedPluginsTotal := 0
-	for _, l := range logPipelines.Items {
-		if !l.DeletionTimestamp.IsZero() {
-			continue
-		}
-		if isUnsupported(l) {
-			unsupportedPluginsTotal++
-		}
-	}
-
-	s.unsupportedPluginsTotal = unsupportedPluginsTotal
-}
-
-func isUnsupported(pipeline telemetryv1alpha1.LogPipeline) bool {
-	if pipeline.Spec.Output.Custom != "" {
-		return true
-	}
-	for _, f := range pipeline.Spec.Filters {
-		if f.Custom != "" {
-			return true
-		}
-	}
-	return false
 }

--- a/components/telemetry-operator/controller/logpipeline/sync.go
+++ b/components/telemetry-operator/controller/logpipeline/sync.go
@@ -53,7 +53,7 @@ func (s *syncer) syncAll(ctx context.Context, newPipeline *telemetryv1alpha1.Log
 		return false, err
 	}
 
-	variablesChanged, err := s.syncVariables(ctx, allPipelines)
+	variablesChanged, err := s.syncReferencedSecrets(ctx, allPipelines)
 	if err != nil {
 		log.Error(err, "Failed to sync variables")
 		return false, err
@@ -154,8 +154,8 @@ func (s *syncer) syncFilesConfigMap(ctx context.Context, logPipeline *telemetryv
 	return changed, nil
 }
 
-// syncVariables copies referenced secrets to global Fluent Bit environment secret.
-func (s *syncer) syncVariables(ctx context.Context, logPipelines *telemetryv1alpha1.LogPipelineList) (bool, error) {
+// syncReferencedSecrets copies referenced secrets to global Fluent Bit environment secret.
+func (s *syncer) syncReferencedSecrets(ctx context.Context, logPipelines *telemetryv1alpha1.LogPipelineList) (bool, error) {
 	log := logf.FromContext(ctx)
 	oldSecret, err := s.k8sGetterOrCreator.Secret(ctx, s.config.EnvSecret)
 	if err != nil {

--- a/components/telemetry-operator/controller/logpipeline/sync_test.go
+++ b/components/telemetry-operator/controller/logpipeline/sync_test.go
@@ -46,31 +46,6 @@ func TestSyncFilesConfigMapErrorClientErrorReturnsError(t *testing.T) {
 	require.Equal(t, result, false)
 }
 
-func TestUnsupportedTotal(t *testing.T) {
-	l1OpCustom := `Name  foo
-Alias  bar`
-	l2FilterCustom1 := telemetryv1alpha1.Filter{
-		Custom: `Name  filter1`,
-	}
-	l2FilterCustom2 := telemetryv1alpha1.Filter{
-		Custom: `Name  filter2`,
-	}
-	l1 := telemetryv1alpha1.LogPipeline{
-		ObjectMeta: metav1.ObjectMeta{Name: "l1"},
-		Spec:       telemetryv1alpha1.LogPipelineSpec{Output: telemetryv1alpha1.Output{Custom: l1OpCustom}},
-	}
-	l2 := telemetryv1alpha1.LogPipeline{
-		ObjectMeta: metav1.ObjectMeta{Name: "l2"},
-		Spec:       telemetryv1alpha1.LogPipelineSpec{Filters: []telemetryv1alpha1.Filter{l2FilterCustom1, l2FilterCustom2}},
-	}
-	logPipelines := &telemetryv1alpha1.LogPipelineList{Items: []telemetryv1alpha1.LogPipeline{l1, l2}}
-
-	mockClient := &mocks.Client{}
-	sut := newSyncer(mockClient, testConfig)
-	sut.syncUnsupportedPluginsTotal(logPipelines)
-	require.Equal(t, 2, sut.unsupportedPluginsTotal)
-}
-
 func TestSyncVariablesFromHttpOutput(t *testing.T) {
 	s := scheme.Scheme
 	err := telemetryv1alpha1.AddToScheme(s)

--- a/components/telemetry-operator/controller/logpipeline/sync_test.go
+++ b/components/telemetry-operator/controller/logpipeline/sync_test.go
@@ -88,7 +88,7 @@ func TestSyncVariablesFromHttpOutput(t *testing.T) {
 	mockClient := fake.NewClientBuilder().WithScheme(s).WithObjects(&referencedSecret).Build()
 
 	sut := newSyncer(mockClient, testConfig)
-	restartRequired, err := sut.syncVariables(context.Background(), &logPipelines)
+	restartRequired, err := sut.syncReferencedSecrets(context.Background(), &logPipelines)
 	require.NoError(t, err)
 	require.True(t, restartRequired)
 

--- a/resources/telemetry/charts/operator/values.yaml
+++ b/resources/telemetry/charts/operator/values.yaml
@@ -77,7 +77,7 @@ serviceMonitor:
       keyFile: /etc/prometheus/secrets/istio.default/key.pem
     metricRelabelings:
      - action: keep
-       regex: ^(go_gc_duration_seconds|go_goroutines|go_memstats_alloc_bytes|go_memstats_heap_alloc_bytes|go_memstats_heap_inuse_bytes|go_memstats_heap_sys_bytes|go_memstats_stack_inuse_bytes|go_threads|http_requests_total|process_cpu_seconds_total|process_max_fds|process_open_fds|process_resident_memory_bytes|process_start_time_seconds|process_virtual_memory_bytes|rest_client_requests_total|workqueue_adds_total|workqueue_depth|workqueue_queue_duration_seconds_bucket|telemetry_fluentbit_triggered_restarts_total)$
+       regex: ^(go_gc_duration_seconds|go_goroutines|go_memstats_alloc_bytes|go_memstats_heap_alloc_bytes|go_memstats_heap_inuse_bytes|go_memstats_heap_sys_bytes|go_memstats_stack_inuse_bytes|go_threads|http_requests_total|process_cpu_seconds_total|process_max_fds|process_open_fds|process_resident_memory_bytes|process_start_time_seconds|process_virtual_memory_bytes|rest_client_requests_total|workqueue_adds_total|workqueue_depth|workqueue_queue_duration_seconds_bucket|telemetry_fluentbit_triggered_restarts_total|telemetry_all_logpipelines|telemetry_unsupported_logpipelines)$
        sourceLabels: [ __name__ ]
 
 logProcessor: fluent-bit

--- a/resources/telemetry/values.yaml
+++ b/resources/telemetry/values.yaml
@@ -7,7 +7,7 @@ global:
       version: "193e0058"
     telemetry_operator:
       name: "telemetry-operator"
-      version: "PR-15336"
+      version: "PR-15375"
     fluent_bit:
       name: "fluent-bit"
       version: "1.9.7-248e790f"


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- Add `telemetry_all_logpipelines ` gauge to count the current number of log pipelines
- Rename `telemetry_plugins_unsupported_total ` to `telemetry_unsupported_logpipelines `. The `_total` ending should be only used with counters: https://www.robustperception.io/on-the-naming-of-things/.
- Lift metric updating from the syncer to the controller itself
- Whitelist new metrics in the `servicemonitor`

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
