### PR TITLE
Disable health-check on fb pod and enable metrics

### DIFF
--- a/resources/telemetry/charts/fluent-bit/values.yaml
+++ b/resources/telemetry/charts/fluent-bit/values.yaml
@@ -356,8 +356,8 @@ config:
         HTTP_Server On
         HTTP_Listen 0.0.0.0
         HTTP_Port {{ .Values.metricsPort }}
-        Health_Check On
         storage.path /data/flb-storage/
+        storage.metrics on
 
   ## https://docs.fluentbit.io/manual/pipeline/inputs
   inputs: |


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- Sometimes there can be a case that loki rejects logs because they exceed its ingestion limit. This usually happens when we have pods producing lots of logs. When fluent-bit see lots of logs being rejected it would mark the fluent-bit pod unhelathy. More info [here](https://docs.fluentbit.io/manual/administration/monitoring#health-check-for-fluent-bit). To avoid marking fluent-bit unhealthy because of external output not behaving properly disable the health check

- We are using bunch of filters it would be interesting to see memory consumption of each of them and thus allow easy debugging so enable storage metrics. 

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
