### PR TITLE
Fix for cleanup in makefiles for application-connector component tests

### DIFF
--- a/tests/components/application-connector/Makefile.test-application-conn-validator
+++ b/tests/components/application-connector/Makefile.test-application-conn-validator
@@ -3,6 +3,7 @@ GOPATH ?= $(shell go env GOPATH)
 
 VALIDATOR_TEST_IMAGE = "$(DOCKER_PUSH_REPOSITORY)$(DOCKER_PUSH_DIRECTORY)/connectivity-validator-test:$(DOCKER_TAG)"
 TEST_TIMEOUT = "3m"
+MAKEFILE_NAME=Makefile.test-application-conn-validator
 
 .PHONY: test clean
 .PHONY: patch-for-validator-test unpatch-after-validator-test test-validator test-validator-debug validator-create-resources clean-validator-test publish-validator-test
@@ -21,11 +22,11 @@ test-validator: patch-for-validator-test validator-create-resources
 	if kubectl wait --for=condition=complete --timeout=$(TEST_TIMEOUT) -n $(NAMESPACE) job/application-connectivity-validator-test; then \
 	echo "Success! Results:"; \
 	./scripts/check-pod-logs.sh application-connectivity-validator-test; \
-	$(MAKE) clean-validator-test; \
+	$(MAKE) clean-validator-test -f $(MAKEFILE_NAME); \
 	else \
 	echo "Tests failed! Results:"; \
 	./scripts/check-pod-logs.sh application-connectivity-validator-test; \
-	$(MAKE) clean-validator-test; \
+	$(MAKE) clean-validator-test -f $(MAKEFILE_NAME); \
 	exit 1; \
 	fi
 

--- a/tests/components/application-connector/Makefile.test-application-gateway
+++ b/tests/components/application-connector/Makefile.test-application-gateway
@@ -4,6 +4,7 @@ GOPATH ?= $(shell go env GOPATH)
 MOCK_SERVICE_NAME="mock-application"
 APP_URL = "$(MOCK_SERVICE_NAME).$(NAMESPACE).svc.cluster.local"
 TEST_TIMEOUT = "3m"
+MAKEFILE_NAME=Makefile.test-application-gateway
 
 .PHONY: test clean
 .PHONY: test-gateway test-gateway-debug clean-gateway-test disable-sidecar-for-mtls-test enable-sidecar-after-mtls-test generate-certs
@@ -15,11 +16,11 @@ test-gateway: disable-sidecar-for-mtls-test generate-certs create-resources
 	if kubectl wait --for=condition=complete --timeout=$(TEST_TIMEOUT) -n $(NAMESPACE) job/application-gateway-test; then \
 	echo "Success! Results:"; \
 	./scripts/check-pod-logs.sh application-gateway-test; \
-	$(MAKE) clean-gateway-test; \
+	$(MAKE) clean-gateway-test -f $(MAKEFILE_NAME); \
 	else \
 	echo "Tests failed! Results:"; \
 	./scripts/check-pod-logs.sh application-gateway-test; \
-	$(MAKE) clean-gateway-test; \
+	$(MAKE) clean-gateway-test -f $(MAKEFILE_NAME); \
 	exit 1; \
 	fi
 


### PR DESCRIPTION
After latest changes in makefiles the cleanup command was not called properly. 

This PR should fix this problem 