### PR TITLE
Cherry-pick the log in EPP which exposes the event to Release 2.6

### DIFF
--- a/components/event-publisher-proxy/pkg/sender/jetstream.go
+++ b/components/event-publisher-proxy/pkg/sender/jetstream.go
@@ -74,7 +74,6 @@ func (s *JetstreamMessageSender) Send(_ context.Context, event *event.Event) (in
 	}
 
 	// send the event
-	s.namedLogger().Infof("Sending event:%v to backend, stream name:%s", event, s.envCfg.JSStreamName)
 	_, err = jsCtx.PublishMsg(msg)
 	if err != nil {
 		s.namedLogger().Errorw("Cannot send event to backend", "error", err)

--- a/resources/eventing/values.yaml
+++ b/resources/eventing/values.yaml
@@ -9,7 +9,7 @@ global:
       pullPolicy: "IfNotPresent"
     publisher_proxy:
       name: event-publisher-proxy
-      version: 26d1279e
+      version: PR-15209
     nats:
       name: nats
       version: 2.8.4-alpine

--- a/resources/eventing/values.yaml
+++ b/resources/eventing/values.yaml
@@ -9,7 +9,7 @@ global:
       pullPolicy: "IfNotPresent"
     publisher_proxy:
       name: event-publisher-proxy
-      version: PR-15209
+      version: f12f8b58
     nats:
       name: nats
       version: 2.8.4-alpine


### PR DESCRIPTION

**Description**

Cherry-pick the changes from: https://github.com/kyma-project/kyma/pull/15209
