### PR TITLE
disabled telemetry busola extension

### DIFF
--- a/resources/telemetry/charts/operator/templates/logparser_busola_extension_cm.yaml
+++ b/resources/telemetry/charts/operator/templates/logparser_busola_extension_cm.yaml
@@ -7,6 +7,7 @@ metadata:
     busola.io/extension: resource
     busola.io/extension-version: "0.5"
   name: logparsers.telemetry.kyma-project.io
+  namespace: kube-public
 data:
   details: |-
     {

--- a/resources/telemetry/charts/operator/templates/logpipeline_busola_extension_cm.yaml
+++ b/resources/telemetry/charts/operator/templates/logpipeline_busola_extension_cm.yaml
@@ -7,6 +7,7 @@ metadata:
     busola.io/extension: resource
     busola.io/extension-version: "0.5"
   name: logpipelines.telemetry.kyma-project.io
+  namespace: kube-public
 data:
   details: |-
     {

--- a/resources/telemetry/charts/operator/values.yaml
+++ b/resources/telemetry/charts/operator/values.yaml
@@ -102,4 +102,4 @@ tolerations: []
 affinity: {}
 
 dashboardExtension:
-  enabled: true
+  enabled: false


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

The custom plugins in the LogPipeline configuration require clear indicators that it will turn a pipeline into an unsupported mode. We should wait till the description feature is ready and see how that will look like till we activate the extension

Changes proposed in this pull request:

- Disable the extension feature for now
- Moved the configmaps to the kube-public namespace as recommended by the busola team
- ...

**Related issue(s)**
https://github.com/kyma-project/kyma/issues/15204
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
