### PR TITLE
increase the fluent-bit memory limits for pods generating lots of logs

### DIFF
--- a/resources/telemetry/profile-production.yaml
+++ b/resources/telemetry/profile-production.yaml
@@ -5,4 +5,5 @@ fluent-bit:
     requests:
       cpu: 100m
     limits:
-      cpu: 800m
+      cpu: "1"
+      memory: 512Mi


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- For the case when pods are generating lots of logs current limits might not be enough so increase it.

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
