### PR TITLE
Clone the fast-integration-tests version which is compatible with the given Kyma version

### DIFF
--- a/tests/fast-integration/image/Dockerfile
+++ b/tests/fast-integration/image/Dockerfile
@@ -1,5 +1,6 @@
 FROM node:14.20.0-alpine3.16
 
+ENV KYMA_VERSION=main
 ENV FIT_MAKE_TARGET=ci-skr
 
 SHELL ["/bin/ash", "-o", "pipefail", "-c"]

--- a/tests/fast-integration/image/clone-and-run-fit.sh
+++ b/tests/fast-integration/image/clone-and-run-fit.sh
@@ -2,8 +2,13 @@
 
 set -ex
 
-# Clone the Kyma fast-integration tests and run the given make target
+# Set the KYMA_VERSION to the git branch corresponding to the given release tag.
+# For example: The "release-2.6" is the git branch corresponding to the "2.6.0" tag.
+if [[ -n $KYMA_VERSION && $KYMA_VERSION != "main" && $KYMA_VERSION != "latest" ]]; then
+  KYMA_VERSION=$(echo "$KYMA_VERSION" | awk -F '.' '{str = sprintf("release-%s.%s", $1, $2)} END {print str}')
+fi
 
-git clone https://github.com/kyma-project/kyma /kyma
+# Clone the Kyma fast-integration tests and run the given make target with the given KYMA_VERSION.
+git clone --depth 1 --branch "$KYMA_VERSION" https://github.com/kyma-project/kyma /kyma
 cd /kyma/tests/fast-integration
 make "$FIT_MAKE_TARGET"


### PR DESCRIPTION
**Description**

Cherry-pick:
- Clone the fast-integration-tests version which is compatible with the given Kyma version https://github.com/kyma-project/kyma/commit/3146d8fb9ea1669609a2a19d292db2a9a4c6ffc4.