### PR TITLE
Remove compass-system namespace by default in LogPipelines

### DIFF
--- a/components/telemetry-operator/internal/fluentbit/config/builder/config_builder_test.go
+++ b/components/telemetry-operator/internal/fluentbit/config/builder/config_builder_test.go
@@ -83,7 +83,7 @@ func TestMergeSectionsConfig(t *testing.T) {
     emitter_mem_buf_limit 10M
     emitter_name          foo
     emitter_storage.type  filesystem
-    rule                  $kubernetes['namespace_name'] "^(?!kyma-system$|kyma-integration$|kube-system$|istio-system$).*" foo.$TAG true
+    rule                  $kubernetes['namespace_name'] "^(?!kyma-system$|kyma-integration$|kube-system$|istio-system$|compass-system$).*" foo.$TAG true
 
 [FILTER]
     name   record_modifier

--- a/components/telemetry-operator/internal/fluentbit/config/builder/rewritetag_filter.go
+++ b/components/telemetry-operator/internal/fluentbit/config/builder/rewritetag_filter.go
@@ -8,7 +8,7 @@ import (
 )
 
 func systemNamespaces() []string {
-	return []string{"kyma-system", "kyma-integration", "kube-system", "istio-system"}
+	return []string{"kyma-system", "kyma-integration", "kube-system", "istio-system", "compass-system"}
 }
 
 // CreateRewriteTagFilter creates the Fluent Bit Rewrite Tag Filter section

--- a/components/telemetry-operator/internal/fluentbit/config/builder/rewritetag_filter_test.go
+++ b/components/telemetry-operator/internal/fluentbit/config/builder/rewritetag_filter_test.go
@@ -101,7 +101,7 @@ func TestCreateRewriteTagFilterIncludeContainers(t *testing.T) {
     emitter_name          logpipeline1
     emitter_storage.type  filesystem
     rule                  $kubernetes['container_name'] "^(container1|container2)$" logpipeline1.$TAG true
-    rule                  $kubernetes['namespace_name'] "^(?!kyma-system$|kyma-integration$|kube-system$|istio-system$).*" logpipeline1.$TAG true
+    rule                  $kubernetes['namespace_name'] "^(?!kyma-system$|kyma-integration$|kube-system$|istio-system$|compass-system$).*" logpipeline1.$TAG true
 
 `
 	actual := createRewriteTagFilterSection(logPipeline, pipelineConfig)
@@ -134,7 +134,7 @@ func TestCreateRewriteTagFilterExcludeContainers(t *testing.T) {
     emitter_name          logpipeline1
     emitter_storage.type  filesystem
     rule                  $kubernetes['container_name'] "^(?!container1$|container2$).*" logpipeline1.$TAG true
-    rule                  $kubernetes['namespace_name'] "^(?!kyma-system$|kyma-integration$|kube-system$|istio-system$).*" logpipeline1.$TAG true
+    rule                  $kubernetes['namespace_name'] "^(?!kyma-system$|kyma-integration$|kube-system$|istio-system$|compass-system$).*" logpipeline1.$TAG true
 
 `
 	actual := createRewriteTagFilterSection(logPipeline, pipelineConfig)

--- a/components/telemetry-operator/webhook/dryrun/testdata/expected/pipelines/dynamic/logpipeline-1.conf
+++ b/components/telemetry-operator/webhook/dryrun/testdata/expected/pipelines/dynamic/logpipeline-1.conf
@@ -4,7 +4,7 @@
     emitter_mem_buf_limit 10M
     emitter_name          logpipeline-1
     emitter_storage.type  filesystem
-    rule                  $kubernetes['namespace_name'] "^(?!kyma-system$|kyma-integration$|kube-system$|istio-system$).*" logpipeline-1.$TAG true
+    rule                  $kubernetes['namespace_name'] "^(?!kyma-system$|kyma-integration$|kube-system$|istio-system$|compass-system$).*" logpipeline-1.$TAG true
 
 [FILTER]
     name   record_modifier

--- a/resources/telemetry/values.yaml
+++ b/resources/telemetry/values.yaml
@@ -7,7 +7,7 @@ global:
       version: "PR-15382"
     telemetry_operator:
       name: "telemetry-operator"
-      version: "PR-15415"
+      version: "PR-15487"
     fluent_bit:
       name: "fluent-bit"
       version: "1.9.7-248e790f"


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- Add compass-system to list of system namespaces to be excluded by default form log shipping

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
