### PR TITLE
Bump Istio charts to Istio 1.14.4 (#15496)

### DIFF
--- a/resources/istio-resources/files/dashboards/control-plane.json
+++ b/resources/istio-resources/files/dashboards/control-plane.json
@@ -12,7 +12,7 @@
       }
     ]
   },
-  "description": "Istio Control Plane Dashboard version 1.14.3",
+  "description": "Istio Control Plane Dashboard version 1.14.4",
   "editable": false,
   "gnetId": 7645,
   "graphTooltip": 1,

--- a/resources/istio-resources/files/dashboards/mesh.json
+++ b/resources/istio-resources/files/dashboards/mesh.json
@@ -12,7 +12,7 @@
       }
     ]
   },
-  "description": "Istio Mesh Dashboard version 1.14.3",
+  "description": "Istio Mesh Dashboard version 1.14.4",
   "editable": false,
   "gnetId": 7639,
   "graphTooltip": 0,

--- a/resources/istio-resources/files/dashboards/performance.json
+++ b/resources/istio-resources/files/dashboards/performance.json
@@ -12,7 +12,7 @@
       }
     ]
   },
-  "description": "Istio Performance Dashboard version 1.14.3",
+  "description": "Istio Performance Dashboard version 1.14.4",
   "editable": false,
   "gnetId": 11829,
   "graphTooltip": 0,

--- a/resources/istio-resources/files/dashboards/service.json
+++ b/resources/istio-resources/files/dashboards/service.json
@@ -12,7 +12,7 @@
       }
     ]
   },
-  "description": "Istio Service Dashboard version 1.14.3",
+  "description": "Istio Service Dashboard version 1.14.4",
   "editable": false,
   "gnetId": 7636,
   "graphTooltip": 0,

--- a/resources/istio-resources/files/dashboards/workload.json
+++ b/resources/istio-resources/files/dashboards/workload.json
@@ -12,7 +12,7 @@
       }
     ]
   },
-  "description": "Istio Workload Dashboard version 1.14.3",
+  "description": "Istio Workload Dashboard version 1.14.4",
   "editable": false,
   "gnetId": 7630,
   "graphTooltip": 0,

--- a/resources/istio/Chart.yaml
+++ b/resources/istio/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: istio
-version: 1.14.3
-appVersion: 1.14.3
+version: 1.14.4
+appVersion: 1.14.4
 tillerVersion: ">=2.7.2-0"
 description: Kyma 2.0 Helm chart for Istio Operator resource
 keywords:

--- a/resources/istio/values.yaml
+++ b/resources/istio/values.yaml
@@ -134,12 +134,12 @@ global:
     # these definitions aren't used by the chart, but they are required by external tool for list generation
     istio_proxyv2:
       name: "proxyv2"
-      version: "1.14.3-distroless"
+      version: "1.14.4-distroless"
       directory: "external/istio"
       containerRegistryPath: "eu.gcr.io/kyma-project"
     istio_pilot:
       name: "pilot"
-      version: "1.14.3-distroless"
+      version: "1.14.4-distroless"
       directory: "external/istio"
       containerRegistryPath: "eu.gcr.io/kyma-project"
   tracing:


### PR DESCRIPTION
* Bump istio to 1.14.4

Reasons:
[Protecode-SKR/kyma-project_external_istio_proxyv2.tar/golang-runtime:1.18.4:CVE-2022-27664](https://github.tools.sap/kyma/security-scans/issues/21359)