### PR TITLE
consistent naming in epp

### DIFF
--- a/components/event-publisher-proxy/cmd/event-publisher-proxy/beb/beb.go
+++ b/components/event-publisher-proxy/cmd/event-publisher-proxy/beb/beb.go
@@ -35,7 +35,7 @@ const (
 // Commander implements the Commander interface.
 type Commander struct {
 	cancel           context.CancelFunc
-	envCfg           *env.BebConfig
+	envCfg           *env.BEBConfig
 	logger           *logger.Logger
 	metricsCollector *metrics.Collector
 	opts             *options.Options
@@ -46,7 +46,7 @@ func NewCommander(opts *options.Options, metricsCollector *metrics.Collector, lo
 	return &Commander{
 		metricsCollector: metricsCollector,
 		logger:           logger,
-		envCfg:           new(env.BebConfig),
+		envCfg:           new(env.BEBConfig),
 		opts:             opts,
 	}
 }

--- a/components/event-publisher-proxy/cmd/event-publisher-proxy/beb/beb.go
+++ b/components/event-publisher-proxy/cmd/event-publisher-proxy/beb/beb.go
@@ -75,7 +75,7 @@ func (c *Commander) Start() error {
 	defer client.CloseIdleConnections()
 
 	// configure message sender
-	messageSender := sender.NewBebMessageSender(c.envCfg.EmsPublishURL, client)
+	messageSender := sender.NewBEBMessageSender(c.envCfg.EmsPublishURL, client)
 
 	// cluster config
 	k8sConfig := config.GetConfigOrDie()

--- a/components/event-publisher-proxy/cmd/event-publisher-proxy/main.go
+++ b/components/event-publisher-proxy/cmd/event-publisher-proxy/main.go
@@ -21,8 +21,8 @@ type Config struct {
 	// Backend used for Eventing. It could be "nats" or "beb".
 	Backend string `envconfig:"BACKEND" required:"true"`
 
-	// JetstreamModeEnabled indicates whether NATS backend will be used in default or jetstream mode.
-	JetstreamModeEnabled bool `envconfig:"ENABLE_JETSTREAM_BACKEND" default:"false"`
+	// JetStreamModeEnabled indicates whether NATS backend will be used in default or jetstream mode.
+	JetStreamModeEnabled bool `envconfig:"ENABLE_JETSTREAM_BACKEND" default:"false"`
 
 	// AppLogFormat defines the log format.
 	AppLogFormat string `envconfig:"APP_LOG_FORMAT" default:"json"`
@@ -62,7 +62,7 @@ func main() {
 			golog.Printf("Failed to flush logger, error: %v", err)
 		}
 	}()
-	setupLogger := logger.WithContext().With("backend", cfg.Backend, "jetstream mode", cfg.JetstreamModeEnabled)
+	setupLogger := logger.WithContext().With("backend", cfg.Backend, "jetstream mode", cfg.JetStreamModeEnabled)
 
 	// metrics collector
 	metricsCollector := metrics.NewCollector()
@@ -74,7 +74,7 @@ func main() {
 	case backendBEB:
 		commander = beb.NewCommander(opts, metricsCollector, logger)
 	case backendNATS:
-		commander = nats.NewCommander(opts, metricsCollector, logger, cfg.JetstreamModeEnabled)
+		commander = nats.NewCommander(opts, metricsCollector, logger, cfg.JetStreamModeEnabled)
 	default:
 		setupLogger.Fatalf("Invalid publisher backend: %v", cfg.Backend)
 	}

--- a/components/event-publisher-proxy/cmd/event-publisher-proxy/nats/nats.go
+++ b/components/event-publisher-proxy/cmd/event-publisher-proxy/nats/nats.go
@@ -89,7 +89,7 @@ func (c *Commander) Start() error {
 	if c.jetstreamMode {
 		messageSenderToNats = sender.NewJetstreamMessageSender(ctx, connection, c.envCfg, c.logger)
 	} else {
-		messageSenderToNats = sender.NewNatsMessageSender(ctx, connection, c.logger)
+		messageSenderToNats = sender.NewNATSMessageSender(ctx, connection, c.logger)
 	}
 
 	// cluster config

--- a/components/event-publisher-proxy/cmd/event-publisher-proxy/nats/nats.go
+++ b/components/event-publisher-proxy/cmd/event-publisher-proxy/nats/nats.go
@@ -87,7 +87,7 @@ func (c *Commander) Start() error {
 	// configure the message sender
 	var messageSenderToNATS sender.GenericSender
 	if c.jetstreamMode {
-		messageSenderToNATS = sender.NewJetstreamMessageSender(ctx, connection, c.envCfg, c.logger)
+		messageSenderToNATS = sender.NewJetStreamMessageSender(ctx, connection, c.envCfg, c.logger)
 	} else {
 		messageSenderToNATS = sender.NewNATSMessageSender(ctx, connection, c.logger)
 	}

--- a/components/event-publisher-proxy/cmd/event-publisher-proxy/nats/nats.go
+++ b/components/event-publisher-proxy/cmd/event-publisher-proxy/nats/nats.go
@@ -85,11 +85,11 @@ func (c *Commander) Start() error {
 	defer connection.Close()
 
 	// configure the message sender
-	var messageSenderToNats sender.GenericSender
+	var messageSenderToNATS sender.GenericSender
 	if c.jetstreamMode {
-		messageSenderToNats = sender.NewJetstreamMessageSender(ctx, connection, c.envCfg, c.logger)
+		messageSenderToNATS = sender.NewJetstreamMessageSender(ctx, connection, c.envCfg, c.logger)
 	} else {
-		messageSenderToNats = sender.NewNATSMessageSender(ctx, connection, c.logger)
+		messageSenderToNATS = sender.NewNATSMessageSender(ctx, connection, c.logger)
 	}
 
 	// cluster config
@@ -124,7 +124,7 @@ func (c *Commander) Start() error {
 	eventTypeCleaner := eventtype.NewCleaner(c.envCfg.EventTypePrefix, applicationLister, c.logger)
 
 	// start handler which blocks until it receives a shutdown signal
-	if err := nats.NewHandler(messageReceiver, &messageSenderToNats, c.envCfg.RequestTimeout, legacyTransformer, c.opts,
+	if err := nats.NewHandler(messageReceiver, &messageSenderToNATS, c.envCfg.RequestTimeout, legacyTransformer, c.opts,
 		subscribedProcessor, c.logger, c.metricsCollector, eventTypeCleaner).Start(ctx); err != nil {
 		return xerrors.Errorf("failed to start handler for %s : %v", natsCommanderName, err)
 	}

--- a/components/event-publisher-proxy/cmd/event-publisher-proxy/nats/nats.go
+++ b/components/event-publisher-proxy/cmd/event-publisher-proxy/nats/nats.go
@@ -38,7 +38,7 @@ type Commander struct {
 	cancel           context.CancelFunc
 	metricsCollector *metrics.Collector
 	logger           *logger.Logger
-	envCfg           *env.NatsConfig
+	envCfg           *env.NATSConfig
 	opts             *options.Options
 	jetstreamMode    bool
 }
@@ -46,7 +46,7 @@ type Commander struct {
 // NewCommander creates the Commander for publisher to NATS.
 func NewCommander(opts *options.Options, metricsCollector *metrics.Collector, logger *logger.Logger, jetstreamMode bool) *Commander {
 	return &Commander{
-		envCfg:           new(env.NatsConfig),
+		envCfg:           new(env.NATSConfig),
 		logger:           logger,
 		metricsCollector: metricsCollector,
 		opts:             opts,

--- a/components/event-publisher-proxy/pkg/env/beb_config.go
+++ b/components/event-publisher-proxy/pkg/env/beb_config.go
@@ -34,7 +34,7 @@ func (c *BEBConfig) ConfigureTransport(transport *http.Transport) {
 
 // String implements the fmt.Stringer interface
 func (c *BEBConfig) String() string {
-	return fmt.Sprintf("BebConfig{ Port: %v; TokenEndPoint: %v; EmsPublishURL: %v; "+
+	return fmt.Sprintf("BEBConfig{ Port: %v; TokenEndPoint: %v; EmsPublishURL: %v; "+
 		"MaxIdleConns: %v; MaxIdleConnsPerHost: %v; RequestTimeout: %v; BEBNamespace: %v; EventTypePrefix: %v }",
 		c.Port, c.TokenEndpoint, c.EmsPublishURL, c.MaxIdleConns, c.MaxIdleConnsPerHost, c.RequestTimeout, c.BEBNamespace, c.EventTypePrefix)
 }

--- a/components/event-publisher-proxy/pkg/env/beb_config.go
+++ b/components/event-publisher-proxy/pkg/env/beb_config.go
@@ -7,10 +7,10 @@ import (
 )
 
 // compile time check
-var _ fmt.Stringer = &BebConfig{}
+var _ fmt.Stringer = &BEBConfig{}
 
-// BebConfig represents the environment config for the Event Publisher to BEB.
-type BebConfig struct {
+// BEBConfig represents the environment config for the Event Publisher to BEB.
+type BEBConfig struct {
 	Port                int           `envconfig:"INGRESS_PORT" default:"8080"`
 	ClientID            string        `envconfig:"CLIENT_ID" required:"true"`
 	ClientSecret        string        `envconfig:"CLIENT_SECRET" required:"true"`
@@ -27,13 +27,13 @@ type BebConfig struct {
 }
 
 // ConfigureTransport receives an HTTP transport and configure its max idle connection properties.
-func (c *BebConfig) ConfigureTransport(transport *http.Transport) {
+func (c *BEBConfig) ConfigureTransport(transport *http.Transport) {
 	transport.MaxIdleConns = c.MaxIdleConns
 	transport.MaxIdleConnsPerHost = c.MaxIdleConnsPerHost
 }
 
 // String implements the fmt.Stringer interface
-func (c *BebConfig) String() string {
+func (c *BEBConfig) String() string {
 	return fmt.Sprintf("BebConfig{ Port: %v; TokenEndPoint: %v; EmsPublishURL: %v; "+
 		"MaxIdleConns: %v; MaxIdleConnsPerHost: %v; RequestTimeout: %v; BEBNamespace: %v; EventTypePrefix: %v }",
 		c.Port, c.TokenEndpoint, c.EmsPublishURL, c.MaxIdleConns, c.MaxIdleConnsPerHost, c.RequestTimeout, c.BEBNamespace, c.EventTypePrefix)

--- a/components/event-publisher-proxy/pkg/env/beb_config_test.go
+++ b/components/event-publisher-proxy/pkg/env/beb_config_test.go
@@ -14,7 +14,7 @@ func TestConfigureTransport(t *testing.T) {
 	)
 
 	transport := &http.Transport{}
-	cfg := BebConfig{MaxIdleConns: maxIdleConns, MaxIdleConnsPerHost: maxIdleConnsPerHost}
+	cfg := BEBConfig{MaxIdleConns: maxIdleConns, MaxIdleConnsPerHost: maxIdleConnsPerHost}
 	cfg.ConfigureTransport(transport)
 
 	if transport.MaxIdleConns != maxIdleConns {

--- a/components/event-publisher-proxy/pkg/env/nats_config.go
+++ b/components/event-publisher-proxy/pkg/env/nats_config.go
@@ -6,12 +6,12 @@ import (
 )
 
 // compile time check
-var _ fmt.Stringer = &NatsConfig{}
+var _ fmt.Stringer = &NATSConfig{}
 
 const JetStreamSubjectPrefix = "kyma"
 
-// NatsConfig represents the environment config for the Event Publisher to NATS.
-type NatsConfig struct {
+// NATSConfig represents the environment config for the Event Publisher to NATS.
+type NATSConfig struct {
 	Port                 int           `envconfig:"INGRESS_PORT" default:"8080"`
 	URL                  string        `envconfig:"NATS_URL" default:"nats.nats.svc.cluster.local"`
 	RetryOnFailedConnect bool          `envconfig:"RETRY_ON_FAILED_CONNECT" default:"true"`
@@ -30,7 +30,7 @@ type NatsConfig struct {
 }
 
 // ToConfig converts to a default BEB BEBConfig
-func (c *NatsConfig) ToConfig() *BEBConfig {
+func (c *NATSConfig) ToConfig() *BEBConfig {
 	cfg := &BEBConfig{
 		BEBNamespace:    c.LegacyNamespace,
 		EventTypePrefix: c.EventTypePrefix,
@@ -39,6 +39,6 @@ func (c *NatsConfig) ToConfig() *BEBConfig {
 }
 
 // String implements the fmt.Stringer interface
-func (c *NatsConfig) String() string {
+func (c *NATSConfig) String() string {
 	return fmt.Sprintf("%#v", c)
 }

--- a/components/event-publisher-proxy/pkg/env/nats_config.go
+++ b/components/event-publisher-proxy/pkg/env/nats_config.go
@@ -29,7 +29,7 @@ type NatsConfig struct {
 	JSStreamName string `envconfig:"JS_STREAM_NAME" default:"kyma"`
 }
 
-// ToConfig converts to a default BEB BebConfig
+// ToConfig converts to a default BEB BEBConfig
 func (c *NatsConfig) ToConfig() *BEBConfig {
 	cfg := &BEBConfig{
 		BEBNamespace:    c.LegacyNamespace,

--- a/components/event-publisher-proxy/pkg/env/nats_config.go
+++ b/components/event-publisher-proxy/pkg/env/nats_config.go
@@ -30,8 +30,8 @@ type NatsConfig struct {
 }
 
 // ToConfig converts to a default BEB BebConfig
-func (c *NatsConfig) ToConfig() *BebConfig {
-	cfg := &BebConfig{
+func (c *NatsConfig) ToConfig() *BEBConfig {
+	cfg := &BEBConfig{
 		BEBNamespace:    c.LegacyNamespace,
 		EventTypePrefix: c.EventTypePrefix,
 	}

--- a/components/event-publisher-proxy/pkg/env/nats_config.go
+++ b/components/event-publisher-proxy/pkg/env/nats_config.go
@@ -8,7 +8,7 @@ import (
 // compile time check
 var _ fmt.Stringer = &NatsConfig{}
 
-const JetstreamSubjectPrefix = "kyma"
+const JetStreamSubjectPrefix = "kyma"
 
 // NatsConfig represents the environment config for the Event Publisher to NATS.
 type NatsConfig struct {

--- a/components/event-publisher-proxy/pkg/handler/beb/handler.go
+++ b/components/event-publisher-proxy/pkg/handler/beb/handler.go
@@ -49,7 +49,7 @@ type Handler struct {
 	// Receiver receives incoming HTTP requests
 	Receiver *receiver.HTTPMessageReceiver
 	// Sender sends requests to the broker
-	Sender *sender.BebMessageSender
+	Sender *sender.BEBMessageSender
 	// Defaulter sets default values to incoming events
 	Defaulter cev2client.EventDefaulter
 	// LegacyTransformer handles transformations needed to handle legacy events
@@ -69,7 +69,7 @@ type Handler struct {
 }
 
 // NewHandler returns a new HTTP Handler instance.
-func NewHandler(receiver *receiver.HTTPMessageReceiver, sender *sender.BebMessageSender, requestTimeout time.Duration,
+func NewHandler(receiver *receiver.HTTPMessageReceiver, sender *sender.BEBMessageSender, requestTimeout time.Duration,
 	legacyTransformer *legacy.Transformer, opts *options.Options, subscribedProcessor *subscribed.Processor,
 	logger *logger.Logger, collector *metrics.Collector, eventTypeCleaner eventtype.Cleaner) *Handler {
 	return &Handler{

--- a/components/event-publisher-proxy/pkg/handler/beb/mock/mock.go
+++ b/components/event-publisher-proxy/pkg/handler/beb/mock/mock.go
@@ -129,7 +129,7 @@ func StartOrDie(ctx context.Context, t *testing.T, requestSize int, eventTypePre
 	defer client.CloseIdleConnections()
 
 	msgReceiver := receiver.NewHTTPMessageReceiver(mock.cfg.Port)
-	msgSender := sender.NewBebMessageSender(mock.cfg.EmsPublishURL, client)
+	msgSender := sender.NewBEBMessageSender(mock.cfg.EmsPublishURL, client)
 	msgHandlerOpts := &options.Options{MaxRequestSize: int64(requestSize)}
 	msgHandler := beb.NewHandler(
 		msgReceiver,

--- a/components/event-publisher-proxy/pkg/handler/beb/mock/mock.go
+++ b/components/event-publisher-proxy/pkg/handler/beb/mock/mock.go
@@ -47,8 +47,8 @@ const (
 	defaultEventsHTTP400Endpoint = "/events400"
 )
 
-// BebHandlerMock represents a mock for the beb.Handler.
-type BebHandlerMock struct {
+// BEBHandlerMock represents a mock for the beb.Handler.
+type BEBHandlerMock struct {
 	ctx                 context.Context
 	cfg                 *env.BEBConfig
 	logger              *logger.Logger
@@ -62,37 +62,37 @@ type BebHandlerMock struct {
 }
 
 // BebHandlerMockOpt represents a BebHandlerMock option.
-type BebHandlerMockOpt func(*BebHandlerMock)
+type BebHandlerMockOpt func(*BEBHandlerMock)
 
 // GetPort returns the port used by the BebHandlerMock.
-func (m *BebHandlerMock) GetPort() int {
+func (m *BEBHandlerMock) GetPort() int {
 	return m.cfg.Port
 }
 
 // GetMetricsCollector returns the metrics.Collector used by the BebHandlerMock.
-func (m *BebHandlerMock) GetMetricsCollector() *metrics.Collector {
+func (m *BEBHandlerMock) GetMetricsCollector() *metrics.Collector {
 	return m.collector
 }
 
 // Close closes the testing.MockServer used by the BebHandlerMock.
-func (m *BebHandlerMock) Close() {
+func (m *BEBHandlerMock) Close() {
 	m.mockServer.Close()
 }
 
 // GetLivenessEndpoint returns the liveness endpoint used by the BebHandlerMock.
-func (m *BebHandlerMock) GetLivenessEndpoint() string {
+func (m *BEBHandlerMock) GetLivenessEndpoint() string {
 	return m.livenessEndpoint
 }
 
 // GetReadinessEndpoint returns the readiness endpoint used by the BebHandlerMock.
-func (m *BebHandlerMock) GetReadinessEndpoint() string {
+func (m *BEBHandlerMock) GetReadinessEndpoint() string {
 	return m.readinessEndpoint
 }
 
 // StartOrDie starts a new BebHandlerMock instance or die if a precondition fails.
 // Preconditions: 1) beb.Handler started without errors.
 func StartOrDie(ctx context.Context, t *testing.T, requestSize int, eventTypePrefix, eventsEndpoint string,
-	requestTimeout, serverResponseTime time.Duration, opts ...BebHandlerMockOpt) *BebHandlerMock {
+	requestTimeout, serverResponseTime time.Duration, opts ...BebHandlerMockOpt) *BEBHandlerMock {
 	mockServer := testingutils.NewMockServer(testingutils.WithResponseTime(serverResponseTime))
 	mockServer.Start(t, defaultTokenEndpoint, defaultEventsEndpoint, defaultEventsHTTP400Endpoint)
 
@@ -108,7 +108,7 @@ func StartOrDie(ctx context.Context, t *testing.T, requestSize int, eventTypePre
 	mockedLogger, err := logger.New("json", "info")
 	require.NoError(t, err)
 
-	mock := &BebHandlerMock{
+	mock := &BEBHandlerMock{
 		ctx:                 ctx,
 		cfg:                 cfg,
 		logger:              mockedLogger,
@@ -187,14 +187,14 @@ func extractEventTypeFromRequest(r *http.Request) (string, error) {
 
 // WithEventTypePrefix returns BebHandlerMockOpt which sets the eventTypePrefix for the given BebHandlerMock.
 func WithEventTypePrefix(eventTypePrefix string) BebHandlerMockOpt {
-	return func(m *BebHandlerMock) {
+	return func(m *BEBHandlerMock) {
 		m.cfg.EventTypePrefix = eventTypePrefix
 	}
 }
 
 // WithApplication returns BebHandlerMockOpt which sets the subscribed.Processor for the given BebHandlerMock.
 func WithApplication(applicationNameToCreate, applicationNameToValidate string) BebHandlerMockOpt {
-	return func(m *BebHandlerMock) {
+	return func(m *BEBHandlerMock) {
 		applicationLister := handlertest.NewApplicationListerOrDie(m.ctx, applicationNameToCreate)
 		m.legacyTransformer = legacy.NewTransformer(m.cfg.BEBNamespace, m.cfg.EventTypePrefix, applicationLister)
 		validator := validateEventTypeContainsApplicationName(applicationNameToValidate)
@@ -205,7 +205,7 @@ func WithApplication(applicationNameToCreate, applicationNameToValidate string) 
 
 // WithSubscription returns BebHandlerMockOpt which sets the subscribed.Processor for the given BebHandlerMock.
 func WithSubscription(scheme *runtime.Scheme, subscription *eventingv1alpha1.Subscription) BebHandlerMockOpt {
-	return func(m *BebHandlerMock) {
+	return func(m *BEBHandlerMock) {
 		dynamicClient := dynamicfake.NewSimpleDynamicClient(scheme, subscription)
 		informerFactory := dynamicinformer.NewFilteredDynamicSharedInformerFactory(dynamicClient, time.Second, v1.NamespaceAll, nil)
 		genericInformer := informerFactory.ForResource(subscribed.GVR)

--- a/components/event-publisher-proxy/pkg/handler/beb/mock/mock.go
+++ b/components/event-publisher-proxy/pkg/handler/beb/mock/mock.go
@@ -61,8 +61,8 @@ type BEBHandlerMock struct {
 	eventTypeCleaner    eventtype.Cleaner
 }
 
-// BebHandlerMockOpt represents a BebHandlerMock option.
-type BebHandlerMockOpt func(*BEBHandlerMock)
+// BEBHandlerMockOpt represents a BebHandlerMock option.
+type BEBHandlerMockOpt func(*BEBHandlerMock)
 
 // GetPort returns the port used by the BebHandlerMock.
 func (m *BEBHandlerMock) GetPort() int {
@@ -92,7 +92,7 @@ func (m *BEBHandlerMock) GetReadinessEndpoint() string {
 // StartOrDie starts a new BebHandlerMock instance or die if a precondition fails.
 // Preconditions: 1) beb.Handler started without errors.
 func StartOrDie(ctx context.Context, t *testing.T, requestSize int, eventTypePrefix, eventsEndpoint string,
-	requestTimeout, serverResponseTime time.Duration, opts ...BebHandlerMockOpt) *BEBHandlerMock {
+	requestTimeout, serverResponseTime time.Duration, opts ...BEBHandlerMockOpt) *BEBHandlerMock {
 	mockServer := testingutils.NewMockServer(testingutils.WithResponseTime(serverResponseTime))
 	mockServer.Start(t, defaultTokenEndpoint, defaultEventsEndpoint, defaultEventsHTTP400Endpoint)
 
@@ -186,14 +186,14 @@ func extractEventTypeFromRequest(r *http.Request) (string, error) {
 }
 
 // WithEventTypePrefix returns BebHandlerMockOpt which sets the eventTypePrefix for the given BebHandlerMock.
-func WithEventTypePrefix(eventTypePrefix string) BebHandlerMockOpt {
+func WithEventTypePrefix(eventTypePrefix string) BEBHandlerMockOpt {
 	return func(m *BEBHandlerMock) {
 		m.cfg.EventTypePrefix = eventTypePrefix
 	}
 }
 
 // WithApplication returns BebHandlerMockOpt which sets the subscribed.Processor for the given BebHandlerMock.
-func WithApplication(applicationNameToCreate, applicationNameToValidate string) BebHandlerMockOpt {
+func WithApplication(applicationNameToCreate, applicationNameToValidate string) BEBHandlerMockOpt {
 	return func(m *BEBHandlerMock) {
 		applicationLister := handlertest.NewApplicationListerOrDie(m.ctx, applicationNameToCreate)
 		m.legacyTransformer = legacy.NewTransformer(m.cfg.BEBNamespace, m.cfg.EventTypePrefix, applicationLister)
@@ -204,7 +204,7 @@ func WithApplication(applicationNameToCreate, applicationNameToValidate string) 
 }
 
 // WithSubscription returns BebHandlerMockOpt which sets the subscribed.Processor for the given BebHandlerMock.
-func WithSubscription(scheme *runtime.Scheme, subscription *eventingv1alpha1.Subscription) BebHandlerMockOpt {
+func WithSubscription(scheme *runtime.Scheme, subscription *eventingv1alpha1.Subscription) BEBHandlerMockOpt {
 	return func(m *BEBHandlerMock) {
 		dynamicClient := dynamicfake.NewSimpleDynamicClient(scheme, subscription)
 		informerFactory := dynamicinformer.NewFilteredDynamicSharedInformerFactory(dynamicClient, time.Second, v1.NamespaceAll, nil)

--- a/components/event-publisher-proxy/pkg/handler/beb/mock/mock.go
+++ b/components/event-publisher-proxy/pkg/handler/beb/mock/mock.go
@@ -50,7 +50,7 @@ const (
 // BebHandlerMock represents a mock for the beb.Handler.
 type BebHandlerMock struct {
 	ctx                 context.Context
-	cfg                 *env.BebConfig
+	cfg                 *env.BEBConfig
 	logger              *logger.Logger
 	collector           *metrics.Collector
 	livenessEndpoint    string

--- a/components/event-publisher-proxy/pkg/handler/beb/mock/mock.go
+++ b/components/event-publisher-proxy/pkg/handler/beb/mock/mock.go
@@ -61,35 +61,35 @@ type BEBHandlerMock struct {
 	eventTypeCleaner    eventtype.Cleaner
 }
 
-// BEBHandlerMockOpt represents a BebHandlerMock option.
+// BEBHandlerMockOpt represents a BEBHandlerMock option.
 type BEBHandlerMockOpt func(*BEBHandlerMock)
 
-// GetPort returns the port used by the BebHandlerMock.
+// GetPort returns the port used by the BEBHandlerMock.
 func (m *BEBHandlerMock) GetPort() int {
 	return m.cfg.Port
 }
 
-// GetMetricsCollector returns the metrics.Collector used by the BebHandlerMock.
+// GetMetricsCollector returns the metrics.Collector used by the BEBHandlerMock.
 func (m *BEBHandlerMock) GetMetricsCollector() *metrics.Collector {
 	return m.collector
 }
 
-// Close closes the testing.MockServer used by the BebHandlerMock.
+// Close closes the testing.MockServer used by the BEBHandlerMock.
 func (m *BEBHandlerMock) Close() {
 	m.mockServer.Close()
 }
 
-// GetLivenessEndpoint returns the liveness endpoint used by the BebHandlerMock.
+// GetLivenessEndpoint returns the liveness endpoint used by the BEBHandlerMock.
 func (m *BEBHandlerMock) GetLivenessEndpoint() string {
 	return m.livenessEndpoint
 }
 
-// GetReadinessEndpoint returns the readiness endpoint used by the BebHandlerMock.
+// GetReadinessEndpoint returns the readiness endpoint used by the BEBHandlerMock.
 func (m *BEBHandlerMock) GetReadinessEndpoint() string {
 	return m.readinessEndpoint
 }
 
-// StartOrDie starts a new BebHandlerMock instance or die if a precondition fails.
+// StartOrDie starts a new BEBHandlerMock instance or die if a precondition fails.
 // Preconditions: 1) beb.Handler started without errors.
 func StartOrDie(ctx context.Context, t *testing.T, requestSize int, eventTypePrefix, eventsEndpoint string,
 	requestTimeout, serverResponseTime time.Duration, opts ...BEBHandlerMockOpt) *BEBHandlerMock {
@@ -185,14 +185,14 @@ func extractEventTypeFromRequest(r *http.Request) (string, error) {
 	return eventType, nil
 }
 
-// WithEventTypePrefix returns BebHandlerMockOpt which sets the eventTypePrefix for the given BebHandlerMock.
+// WithEventTypePrefix returns BEBHandlerMockOpt which sets the eventTypePrefix for the given BEBHandlerMock.
 func WithEventTypePrefix(eventTypePrefix string) BEBHandlerMockOpt {
 	return func(m *BEBHandlerMock) {
 		m.cfg.EventTypePrefix = eventTypePrefix
 	}
 }
 
-// WithApplication returns BebHandlerMockOpt which sets the subscribed.Processor for the given BebHandlerMock.
+// WithApplication returns BEBHandlerMockOpt which sets the subscribed.Processor for the given BEBHandlerMock.
 func WithApplication(applicationNameToCreate, applicationNameToValidate string) BEBHandlerMockOpt {
 	return func(m *BEBHandlerMock) {
 		applicationLister := handlertest.NewApplicationListerOrDie(m.ctx, applicationNameToCreate)
@@ -203,7 +203,7 @@ func WithApplication(applicationNameToCreate, applicationNameToValidate string) 
 	}
 }
 
-// WithSubscription returns BebHandlerMockOpt which sets the subscribed.Processor for the given BebHandlerMock.
+// WithSubscription returns BEBHandlerMockOpt which sets the subscribed.Processor for the given BEBHandlerMock.
 func WithSubscription(scheme *runtime.Scheme, subscription *eventingv1alpha1.Subscription) BEBHandlerMockOpt {
 	return func(m *BEBHandlerMock) {
 		dynamicClient := dynamicfake.NewSimpleDynamicClient(scheme, subscription)

--- a/components/event-publisher-proxy/pkg/handler/nats/handler_health_test.go
+++ b/components/event-publisher-proxy/pkg/handler/nats/handler_health_test.go
@@ -36,7 +36,7 @@ func TestHandlerHealth(t *testing.T) {
 			// test in both default and jetstream NATS modes
 			for _, serverMode := range testingutils.NATSServerModes {
 				t.Run(serverMode.Name, func(t *testing.T) {
-					handlerMock := mock.StartOrDie(context.TODO(), t, mock.WithJetstream(serverMode.JetstreamEnabled))
+					handlerMock := mock.StartOrDie(context.TODO(), t, mock.WithJetstream(serverMode.JetStreamEnabled))
 					defer handlerMock.Stop()
 
 					if tc.givenNATSServerShutdown {

--- a/components/event-publisher-proxy/pkg/handler/nats/handler_health_test.go
+++ b/components/event-publisher-proxy/pkg/handler/nats/handler_health_test.go
@@ -40,7 +40,7 @@ func TestHandlerHealth(t *testing.T) {
 					defer handlerMock.Stop()
 
 					if tc.givenNATSServerShutdown {
-						handlerMock.ShutdownNatsServerAndWait()
+						handlerMock.ShutdownNATSServerAndWait()
 					}
 
 					testingutils.WaitForEndpointStatusCodeOrFail(handlerMock.GetLivenessEndpoint(), tc.wantLivenessStatusCode)

--- a/components/event-publisher-proxy/pkg/handler/nats/handler_health_test.go
+++ b/components/event-publisher-proxy/pkg/handler/nats/handler_health_test.go
@@ -36,7 +36,7 @@ func TestHandlerHealth(t *testing.T) {
 			// test in both default and jetstream NATS modes
 			for _, serverMode := range testingutils.NATSServerModes {
 				t.Run(serverMode.Name, func(t *testing.T) {
-					handlerMock := mock.StartOrDie(context.TODO(), t, mock.WithJetstream(serverMode.JetStreamEnabled))
+					handlerMock := mock.StartOrDie(context.TODO(), t, mock.WithJetStream(serverMode.JetStreamEnabled))
 					defer handlerMock.Stop()
 
 					if tc.givenNATSServerShutdown {

--- a/components/event-publisher-proxy/pkg/handler/nats/handler_health_test.go
+++ b/components/event-publisher-proxy/pkg/handler/nats/handler_health_test.go
@@ -12,19 +12,19 @@ import (
 func TestHandlerHealth(t *testing.T) {
 	testCases := []struct {
 		name                    string
-		givenNatsServerShutdown bool
+		givenNATSServerShutdown bool
 		wantLivenessStatusCode  int
 		wantReadinessStatusCode int
 	}{
 		{
 			name:                    "NATS handler is healthy",
-			givenNatsServerShutdown: false,
+			givenNATSServerShutdown: false,
 			wantLivenessStatusCode:  health.StatusCodeHealthy,
 			wantReadinessStatusCode: health.StatusCodeHealthy,
 		},
 		{
 			name:                    "NATS handler is unhealthy",
-			givenNatsServerShutdown: true,
+			givenNATSServerShutdown: true,
 			wantLivenessStatusCode:  health.StatusCodeHealthy,
 			wantReadinessStatusCode: health.StatusCodeNotHealthy,
 		},
@@ -39,7 +39,7 @@ func TestHandlerHealth(t *testing.T) {
 					handlerMock := mock.StartOrDie(context.TODO(), t, mock.WithJetstream(serverMode.JetstreamEnabled))
 					defer handlerMock.Stop()
 
-					if tc.givenNatsServerShutdown {
+					if tc.givenNATSServerShutdown {
 						handlerMock.ShutdownNatsServerAndWait()
 					}
 

--- a/components/event-publisher-proxy/pkg/handler/nats/handler_health_test.go
+++ b/components/event-publisher-proxy/pkg/handler/nats/handler_health_test.go
@@ -34,7 +34,7 @@ func TestHandlerHealth(t *testing.T) {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			// test in both default and jetstream NATS modes
-			for _, serverMode := range testingutils.NatsServerModes {
+			for _, serverMode := range testingutils.NATSServerModes {
 				t.Run(serverMode.Name, func(t *testing.T) {
 					handlerMock := mock.StartOrDie(context.TODO(), t, mock.WithJetstream(serverMode.JetstreamEnabled))
 					defer handlerMock.Stop()

--- a/components/event-publisher-proxy/pkg/handler/nats/handler_integration_test.go
+++ b/components/event-publisher-proxy/pkg/handler/nats/handler_integration_test.go
@@ -113,7 +113,7 @@ func TestHandlerForCloudEvents(t *testing.T) {
 						testCase := testCase
 						t.Run(testCase.Name, func(t *testing.T) {
 							// connect to nats
-							connection, err := testingutils.ConnectToNATSServer(handlerMock.GetNatsURL())
+							connection, err := testingutils.ConnectToNATSServer(handlerMock.GetNATSURL())
 							assert.Nil(t, err)
 							assert.NotNil(t, connection)
 							defer connection.Close()
@@ -234,7 +234,7 @@ func TestHandlerForLegacyEvents(t *testing.T) {
 						testCase := testCase
 						t.Run(testCase.Name, func(t *testing.T) {
 							// connect to nats
-							connection, err := testingutils.ConnectToNATSServer(handlerMock.GetNatsURL())
+							connection, err := testingutils.ConnectToNATSServer(handlerMock.GetNATSURL())
 							assert.Nil(t, err)
 							assert.NotNil(t, connection)
 							defer connection.Close()

--- a/components/event-publisher-proxy/pkg/handler/nats/handler_integration_test.go
+++ b/components/event-publisher-proxy/pkg/handler/nats/handler_integration_test.go
@@ -98,7 +98,7 @@ func TestHandlerForCloudEvents(t *testing.T) {
 			defer cancel()
 
 			// test in both default and jetstream NATS modes
-			for _, serverMode := range testingutils.NatsServerModes {
+			for _, serverMode := range testingutils.NATSServerModes {
 				t.Run(serverMode.Name, func(t *testing.T) {
 					handlerMock := mock.StartOrDie(ctx, t,
 						mock.WithEventTypePrefix(tc.givenEventTypePrefix),
@@ -219,7 +219,7 @@ func TestHandlerForLegacyEvents(t *testing.T) {
 			defer cancel()
 
 			// test in both default and jetstream NATS modes
-			for _, serverMode := range testingutils.NatsServerModes {
+			for _, serverMode := range testingutils.NATSServerModes {
 				t.Run(serverMode.Name, func(t *testing.T) {
 					handlerMock := mock.StartOrDie(ctx, t,
 						mock.WithEventTypePrefix(tc.givenEventTypePrefix),
@@ -305,7 +305,7 @@ func TestHandlerForSubscribedEndpoint(t *testing.T) {
 			)
 
 			// test in both default and jetstream NATS modes
-			for _, serverMode := range testingutils.NatsServerModes {
+			for _, serverMode := range testingutils.NATSServerModes {
 				t.Run(serverMode.Name, func(t *testing.T) {
 					handlerMock := mock.StartOrDie(ctx, t,
 						mock.WithEventTypePrefix(tc.givenEventTypePrefix),

--- a/components/event-publisher-proxy/pkg/handler/nats/handler_integration_test.go
+++ b/components/event-publisher-proxy/pkg/handler/nats/handler_integration_test.go
@@ -103,7 +103,7 @@ func TestHandlerForCloudEvents(t *testing.T) {
 					handlerMock := mock.StartOrDie(ctx, t,
 						mock.WithEventTypePrefix(tc.givenEventTypePrefix),
 						mock.WithApplication(tc.givenApplicationName),
-						mock.WithJetstream(serverMode.JetstreamEnabled),
+						mock.WithJetstream(serverMode.JetStreamEnabled),
 					)
 					defer handlerMock.Stop()
 
@@ -224,7 +224,7 @@ func TestHandlerForLegacyEvents(t *testing.T) {
 					handlerMock := mock.StartOrDie(ctx, t,
 						mock.WithEventTypePrefix(tc.givenEventTypePrefix),
 						mock.WithApplication(tc.givenApplicationName),
-						mock.WithJetstream(serverMode.JetstreamEnabled),
+						mock.WithJetstream(serverMode.JetStreamEnabled),
 					)
 					defer handlerMock.Stop()
 
@@ -311,7 +311,7 @@ func TestHandlerForSubscribedEndpoint(t *testing.T) {
 						mock.WithEventTypePrefix(tc.givenEventTypePrefix),
 						mock.WithSubscription(scheme, subscription),
 						mock.WithApplication(testingutils.ApplicationName),
-						mock.WithJetstream(serverMode.JetstreamEnabled),
+						mock.WithJetstream(serverMode.JetStreamEnabled),
 					)
 					defer handlerMock.Stop()
 

--- a/components/event-publisher-proxy/pkg/handler/nats/handler_integration_test.go
+++ b/components/event-publisher-proxy/pkg/handler/nats/handler_integration_test.go
@@ -113,7 +113,7 @@ func TestHandlerForCloudEvents(t *testing.T) {
 						testCase := testCase
 						t.Run(testCase.Name, func(t *testing.T) {
 							// connect to nats
-							connection, err := testingutils.ConnectToNatsServer(handlerMock.GetNatsURL())
+							connection, err := testingutils.ConnectToNATSServer(handlerMock.GetNatsURL())
 							assert.Nil(t, err)
 							assert.NotNil(t, connection)
 							defer connection.Close()
@@ -234,7 +234,7 @@ func TestHandlerForLegacyEvents(t *testing.T) {
 						testCase := testCase
 						t.Run(testCase.Name, func(t *testing.T) {
 							// connect to nats
-							connection, err := testingutils.ConnectToNatsServer(handlerMock.GetNatsURL())
+							connection, err := testingutils.ConnectToNATSServer(handlerMock.GetNatsURL())
 							assert.Nil(t, err)
 							assert.NotNil(t, connection)
 							defer connection.Close()

--- a/components/event-publisher-proxy/pkg/handler/nats/handler_integration_test.go
+++ b/components/event-publisher-proxy/pkg/handler/nats/handler_integration_test.go
@@ -103,7 +103,7 @@ func TestHandlerForCloudEvents(t *testing.T) {
 					handlerMock := mock.StartOrDie(ctx, t,
 						mock.WithEventTypePrefix(tc.givenEventTypePrefix),
 						mock.WithApplication(tc.givenApplicationName),
-						mock.WithJetstream(serverMode.JetStreamEnabled),
+						mock.WithJetStream(serverMode.JetStreamEnabled),
 					)
 					defer handlerMock.Stop()
 
@@ -224,7 +224,7 @@ func TestHandlerForLegacyEvents(t *testing.T) {
 					handlerMock := mock.StartOrDie(ctx, t,
 						mock.WithEventTypePrefix(tc.givenEventTypePrefix),
 						mock.WithApplication(tc.givenApplicationName),
-						mock.WithJetstream(serverMode.JetStreamEnabled),
+						mock.WithJetStream(serverMode.JetStreamEnabled),
 					)
 					defer handlerMock.Stop()
 
@@ -311,7 +311,7 @@ func TestHandlerForSubscribedEndpoint(t *testing.T) {
 						mock.WithEventTypePrefix(tc.givenEventTypePrefix),
 						mock.WithSubscription(scheme, subscription),
 						mock.WithApplication(testingutils.ApplicationName),
-						mock.WithJetstream(serverMode.JetStreamEnabled),
+						mock.WithJetStream(serverMode.JetStreamEnabled),
 					)
 					defer handlerMock.Stop()
 

--- a/components/event-publisher-proxy/pkg/handler/nats/handler_integration_test.go
+++ b/components/event-publisher-proxy/pkg/handler/nats/handler_integration_test.go
@@ -108,7 +108,7 @@ func TestHandlerForCloudEvents(t *testing.T) {
 					defer handlerMock.Stop()
 
 					// run the tests for publishing cloudevents
-					publishEndpoint := fmt.Sprintf("http://localhost:%d/publish", handlerMock.GetNatsConfig().Port)
+					publishEndpoint := fmt.Sprintf("http://localhost:%d/publish", handlerMock.GetNATSConfig().Port)
 					for _, testCase := range handlertest.TestCasesForCloudEvents {
 						testCase := testCase
 						t.Run(testCase.Name, func(t *testing.T) {
@@ -229,7 +229,7 @@ func TestHandlerForLegacyEvents(t *testing.T) {
 					defer handlerMock.Stop()
 
 					// run the tests for publishing legacy events
-					publishLegacyEndpoint := fmt.Sprintf("http://localhost:%d/%s/v1/events", handlerMock.GetNatsConfig().Port, tc.givenApplicationName)
+					publishLegacyEndpoint := fmt.Sprintf("http://localhost:%d/%s/v1/events", handlerMock.GetNATSConfig().Port, tc.givenApplicationName)
 					for _, testCase := range handlertest.TestCasesForLegacyEvents {
 						testCase := testCase
 						t.Run(testCase.Name, func(t *testing.T) {
@@ -319,7 +319,7 @@ func TestHandlerForSubscribedEndpoint(t *testing.T) {
 					for _, testCase := range handlertest.TestCasesForSubscribedEndpoint {
 						testCase := testCase
 						t.Run(testCase.Name, func(t *testing.T) {
-							subscribedURL := fmt.Sprintf(subscribedEndpointFormat, handlerMock.GetNatsConfig().Port, testCase.AppName)
+							subscribedURL := fmt.Sprintf(subscribedEndpointFormat, handlerMock.GetNATSConfig().Port, testCase.AppName)
 							resp, err := testingutils.QuerySubscribedEndpoint(subscribedURL)
 							require.NoError(t, err)
 							require.Equal(t, testCase.WantStatusCode, resp.StatusCode)

--- a/components/event-publisher-proxy/pkg/handler/nats/handler_integration_test.go
+++ b/components/event-publisher-proxy/pkg/handler/nats/handler_integration_test.go
@@ -121,7 +121,7 @@ func TestHandlerForCloudEvents(t *testing.T) {
 							// validator to check NATS received events
 							notify := make(chan bool)
 							defer close(notify)
-							validator := testingutils.ValidateNatsSubjectOrFail(t, tc.wantEventType, notify)
+							validator := testingutils.ValidateNATSSubjectOrFail(t, tc.wantEventType, notify)
 							testingutils.SubscribeToEventOrFail(t, connection, tc.wantEventType, validator)
 
 							body, headers := testCase.ProvideMessage(tc.wantEventType)
@@ -242,7 +242,7 @@ func TestHandlerForLegacyEvents(t *testing.T) {
 							// publish a message to NATS and validate it
 							notify := make(chan bool)
 							defer close(notify)
-							validator := testingutils.ValidateNatsSubjectOrFail(t, tc.wantEventType, notify)
+							validator := testingutils.ValidateNATSSubjectOrFail(t, tc.wantEventType, notify)
 							testingutils.SubscribeToEventOrFail(t, connection, tc.wantEventType, validator)
 
 							body, headers := testCase.ProvideMessage()

--- a/components/event-publisher-proxy/pkg/handler/nats/health_test.go
+++ b/components/event-publisher-proxy/pkg/handler/nats/health_test.go
@@ -50,7 +50,7 @@ func TestReadinessCheck(t *testing.T) {
 						}
 					}()
 
-					handlerMock := mock.StartOrDie(context.TODO(), t, mock.WithJetstream(serverMode.JetStreamEnabled))
+					handlerMock := mock.StartOrDie(context.TODO(), t, mock.WithJetStream(serverMode.JetStreamEnabled))
 					defer handlerMock.Stop()
 
 					var handler http.HandlerFunc

--- a/components/event-publisher-proxy/pkg/handler/nats/health_test.go
+++ b/components/event-publisher-proxy/pkg/handler/nats/health_test.go
@@ -50,7 +50,7 @@ func TestReadinessCheck(t *testing.T) {
 						}
 					}()
 
-					handlerMock := mock.StartOrDie(context.TODO(), t, mock.WithJetstream(serverMode.JetstreamEnabled))
+					handlerMock := mock.StartOrDie(context.TODO(), t, mock.WithJetstream(serverMode.JetStreamEnabled))
 					defer handlerMock.Stop()
 
 					var handler http.HandlerFunc

--- a/components/event-publisher-proxy/pkg/handler/nats/health_test.go
+++ b/components/event-publisher-proxy/pkg/handler/nats/health_test.go
@@ -41,7 +41,7 @@ func TestReadinessCheck(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 
 			// test in both default and jetstream NATS modes
-			for _, serverMode := range testingutils.NatsServerModes {
+			for _, serverMode := range testingutils.NATSServerModes {
 				t.Run(serverMode.Name, func(t *testing.T) {
 					defer func() {
 						r := recover()

--- a/components/event-publisher-proxy/pkg/handler/nats/mock/mock.go
+++ b/components/event-publisher-proxy/pkg/handler/nats/mock/mock.go
@@ -82,7 +82,7 @@ func StartOrDie(ctx context.Context, t *testing.T, opts ...NatsHandlerMockOpt) *
 
 	msgReceiver := receiver.NewHTTPMessageReceiver(mock.natsConfig.Port)
 
-	connection, err := testingutils.ConnectToNatsServer(mock.GetNatsURL())
+	connection, err := testingutils.ConnectToNATSServer(mock.GetNatsURL())
 	require.NoError(t, err)
 	mock.connection = connection
 

--- a/components/event-publisher-proxy/pkg/handler/nats/mock/mock.go
+++ b/components/event-publisher-proxy/pkg/handler/nats/mock/mock.go
@@ -68,7 +68,7 @@ func StartOrDie(ctx context.Context, t *testing.T, opts ...NatsHandlerMockOpt) *
 		livenessEndpoint:    fmt.Sprintf("http://localhost:%d%s", port, health.LivenessURI),
 		readinessEndpoint:   fmt.Sprintf("http://localhost:%d%s", port, health.ReadinessURI),
 		logger:              mockedLogger,
-		natsConfig:          newNatsConfig(port),
+		natsConfig:          newNATSConfig(port),
 		collector:           metrics.NewCollector(),
 		legacyTransformer:   &legacy.Transformer{},
 		subscribedProcessor: &subscribed.Processor{},
@@ -195,7 +195,7 @@ func WithJetstream(jsEnabled bool) NatsHandlerMockOpt {
 	}
 }
 
-func newNatsConfig(port int) *env.NATSConfig {
+func newNATSConfig(port int) *env.NATSConfig {
 	return &env.NATSConfig{
 		Port:            port,
 		LegacyNamespace: testingutils.MessagingNamespace,

--- a/components/event-publisher-proxy/pkg/handler/nats/mock/mock.go
+++ b/components/event-publisher-proxy/pkg/handler/nats/mock/mock.go
@@ -52,10 +52,10 @@ type NATSHandlerMock struct {
 	connection          *natsio.Conn
 }
 
-// NATSHandlerMockOpt represents a NatsHandlerMock option.
+// NATSHandlerMockOpt represents a NATSHandlerMock option.
 type NATSHandlerMockOpt func(*NATSHandlerMock)
 
-// StartOrDie starts a new NatsHandlerMock instance or die if a precondition fails.
+// StartOrDie starts a new NATSHandlerMock instance or die if a precondition fails.
 // Preconditions: 1) NATS connection and 2) nats.Handler started without errors.
 func StartOrDie(ctx context.Context, t *testing.T, opts ...NATSHandlerMockOpt) *NATSHandlerMock {
 	port := testingutils.GeneratePortOrDie()
@@ -108,56 +108,56 @@ func StartOrDie(ctx context.Context, t *testing.T, opts ...NATSHandlerMockOpt) *
 	return mock
 }
 
-// Stop closes the sender.NatsMessageSender connection and calls the NatsHandlerMock.ShutdownNatsServerAndWait.
+// Stop closes the sender.NATSMessageSender connection and calls the NATSHandlerMock.ShutdownNATSServerAndWait.
 func (m *NATSHandlerMock) Stop() {
 	m.connection.Close()
 	m.ShutdownNATSServerAndWait()
 }
 
-// ShutdownNATSServerAndWait shuts down the NATS server used by the NatsHandlerMock and waits for the shutdown.
+// ShutdownNATSServerAndWait shuts down the NATS server used by the NATSHandlerMock and waits for the shutdown.
 func (m *NATSHandlerMock) ShutdownNATSServerAndWait() {
 	m.natsServer.Shutdown()
 	m.natsServer.WaitForShutdown()
 }
 
-// GetNATSURL returns the NATS server URL used by the NatsHandlerMock.
+// GetNATSURL returns the NATS server URL used by the NATSHandlerMock.
 func (m *NATSHandlerMock) GetNATSURL() string {
 	return m.natsServer.ClientURL()
 }
 
-// GetLivenessEndpoint returns the liveness endpoint used by the NatsHandlerMock.
+// GetLivenessEndpoint returns the liveness endpoint used by the NATSHandlerMock.
 func (m *NATSHandlerMock) GetLivenessEndpoint() string {
 	return m.livenessEndpoint
 }
 
-// GetReadinessEndpoint returns the readiness endpoint used by the NatsHandlerMock.
+// GetReadinessEndpoint returns the readiness endpoint used by the NATSHandlerMock.
 func (m *NATSHandlerMock) GetReadinessEndpoint() string {
 	return m.readinessEndpoint
 }
 
-// GetHandler returns the nats.Handler used by the NatsHandlerMock.
+// GetHandler returns the nats.Handler used by the NATSHandlerMock.
 func (m *NATSHandlerMock) GetHandler() *nats.Handler {
 	return m.handler
 }
 
-// GetMetricsCollector returns the metrics.Collector used by the NatsHandlerMock.
+// GetMetricsCollector returns the metrics.Collector used by the NATSHandlerMock.
 func (m *NATSHandlerMock) GetMetricsCollector() *metrics.Collector {
 	return m.collector
 }
 
-// GetNATSConfig returns the env.NatsConfig used by the NatsHandlerMock.
+// GetNATSConfig returns the env.NATSConfig used by the NATSHandlerMock.
 func (m *NATSHandlerMock) GetNATSConfig() *env.NATSConfig {
 	return m.natsConfig
 }
 
-// WithEventTypePrefix returns NatsHandlerMockOpt which sets the eventTypePrefix for the given NatsHandlerMock.
+// WithEventTypePrefix returns NATSHandlerMockOpt which sets the eventTypePrefix for the given NATSHandlerMock.
 func WithEventTypePrefix(eventTypePrefix string) NATSHandlerMockOpt {
 	return func(m *NATSHandlerMock) {
 		m.eventTypePrefix = eventTypePrefix
 	}
 }
 
-// WithSubscription returns NatsHandlerMockOpt which sets the subscribed.Processor for the given NatsHandlerMock.
+// WithSubscription returns NATSHandlerMockOpt which sets the subscribed.Processor for the given NATSHandlerMock.
 func WithSubscription(scheme *runtime.Scheme, subscription *eventingv1alpha1.Subscription) NATSHandlerMockOpt {
 	return func(m *NATSHandlerMock) {
 		m.natsConfig.EventTypePrefix = m.eventTypePrefix
@@ -175,7 +175,7 @@ func WithSubscription(scheme *runtime.Scheme, subscription *eventingv1alpha1.Sub
 	}
 }
 
-// WithApplication returns NatsHandlerMockOpt which sets the legacy.Transformer for the given NatsHandlerMock.
+// WithApplication returns NATSHandlerMockOpt which sets the legacy.Transformer for the given NATSHandlerMock.
 func WithApplication(applicationName string) NATSHandlerMockOpt {
 	return func(m *NATSHandlerMock) {
 		applicationLister := handlertest.NewApplicationListerOrDie(m.ctx, applicationName)
@@ -188,7 +188,7 @@ func WithApplication(applicationName string) NATSHandlerMockOpt {
 	}
 }
 
-// WithJetstream returns NatsHandlerMockOpt which starts the NATS server in the jetstream mode for the given NatsHandlerMock.
+// WithJetstream returns NATSHandlerMockOpt which starts the NATS server in the jetstream mode for the given NATSHandlerMock.
 func WithJetstream(jsEnabled bool) NATSHandlerMockOpt {
 	return func(m *NATSHandlerMock) {
 		m.jetstreamMode = jsEnabled

--- a/components/event-publisher-proxy/pkg/handler/nats/mock/mock.go
+++ b/components/event-publisher-proxy/pkg/handler/nats/mock/mock.go
@@ -88,7 +88,7 @@ func StartOrDie(ctx context.Context, t *testing.T, opts ...NatsHandlerMockOpt) *
 
 	//nolint:gosimple
 	var msgSender sender.GenericSender
-	msgSender = sender.NewNatsMessageSender(ctx, mock.connection, mock.logger)
+	msgSender = sender.NewNATSMessageSender(ctx, mock.connection, mock.logger)
 
 	mock.handler = nats.NewHandler(
 		msgReceiver,

--- a/components/event-publisher-proxy/pkg/handler/nats/mock/mock.go
+++ b/components/event-publisher-proxy/pkg/handler/nats/mock/mock.go
@@ -78,7 +78,7 @@ func StartOrDie(ctx context.Context, t *testing.T, opts ...NatsHandlerMockOpt) *
 	for _, opt := range opts {
 		opt(mock)
 	}
-	mock.natsServer = testingutils.StartNatsServer(mock.jetstreamMode)
+	mock.natsServer = testingutils.StartNATSServer(mock.jetstreamMode)
 
 	msgReceiver := receiver.NewHTTPMessageReceiver(mock.natsConfig.Port)
 

--- a/components/event-publisher-proxy/pkg/handler/nats/mock/mock.go
+++ b/components/event-publisher-proxy/pkg/handler/nats/mock/mock.go
@@ -111,11 +111,11 @@ func StartOrDie(ctx context.Context, t *testing.T, opts ...NATSHandlerMockOpt) *
 // Stop closes the sender.NatsMessageSender connection and calls the NatsHandlerMock.ShutdownNatsServerAndWait.
 func (m *NATSHandlerMock) Stop() {
 	m.connection.Close()
-	m.ShutdownNatsServerAndWait()
+	m.ShutdownNATSServerAndWait()
 }
 
-// ShutdownNatsServerAndWait shuts down the NATS server used by the NatsHandlerMock and waits for the shutdown.
-func (m *NATSHandlerMock) ShutdownNatsServerAndWait() {
+// ShutdownNATSServerAndWait shuts down the NATS server used by the NatsHandlerMock and waits for the shutdown.
+func (m *NATSHandlerMock) ShutdownNATSServerAndWait() {
 	m.natsServer.Shutdown()
 	m.natsServer.WaitForShutdown()
 }

--- a/components/event-publisher-proxy/pkg/handler/nats/mock/mock.go
+++ b/components/event-publisher-proxy/pkg/handler/nats/mock/mock.go
@@ -188,8 +188,8 @@ func WithApplication(applicationName string) NATSHandlerMockOpt {
 	}
 }
 
-// WithJetstream returns NATSHandlerMockOpt which starts the NATS server in the jetstream mode for the given NATSHandlerMock.
-func WithJetstream(jsEnabled bool) NATSHandlerMockOpt {
+// WithJetStream returns NATSHandlerMockOpt which starts the NATS server in the jetstream mode for the given NATSHandlerMock.
+func WithJetStream(jsEnabled bool) NATSHandlerMockOpt {
 	return func(m *NATSHandlerMock) {
 		m.jetstreamMode = jsEnabled
 	}

--- a/components/event-publisher-proxy/pkg/handler/nats/mock/mock.go
+++ b/components/event-publisher-proxy/pkg/handler/nats/mock/mock.go
@@ -44,7 +44,7 @@ type NatsHandlerMock struct {
 	logger              *logger.Logger
 	natsServer          *server.Server
 	jetstreamMode       bool
-	natsConfig          *env.NatsConfig
+	natsConfig          *env.NATSConfig
 	collector           *metrics.Collector
 	legacyTransformer   *legacy.Transformer
 	subscribedProcessor *subscribed.Processor
@@ -146,7 +146,7 @@ func (m *NatsHandlerMock) GetMetricsCollector() *metrics.Collector {
 }
 
 // GetNatsConfig returns the env.NatsConfig used by the NatsHandlerMock.
-func (m *NatsHandlerMock) GetNatsConfig() *env.NatsConfig {
+func (m *NatsHandlerMock) GetNatsConfig() *env.NATSConfig {
 	return m.natsConfig
 }
 
@@ -195,8 +195,8 @@ func WithJetstream(jsEnabled bool) NatsHandlerMockOpt {
 	}
 }
 
-func newNatsConfig(port int) *env.NatsConfig {
-	return &env.NatsConfig{
+func newNatsConfig(port int) *env.NATSConfig {
+	return &env.NATSConfig{
 		Port:            port,
 		LegacyNamespace: testingutils.MessagingNamespace,
 		EventTypePrefix: testingutils.MessagingEventTypePrefix,

--- a/components/event-publisher-proxy/pkg/handler/nats/mock/mock.go
+++ b/components/event-publisher-proxy/pkg/handler/nats/mock/mock.go
@@ -52,12 +52,12 @@ type NATSHandlerMock struct {
 	connection          *natsio.Conn
 }
 
-// NatsHandlerMockOpt represents a NatsHandlerMock option.
-type NatsHandlerMockOpt func(*NATSHandlerMock)
+// NATSHandlerMockOpt represents a NatsHandlerMock option.
+type NATSHandlerMockOpt func(*NATSHandlerMock)
 
 // StartOrDie starts a new NatsHandlerMock instance or die if a precondition fails.
 // Preconditions: 1) NATS connection and 2) nats.Handler started without errors.
-func StartOrDie(ctx context.Context, t *testing.T, opts ...NatsHandlerMockOpt) *NATSHandlerMock {
+func StartOrDie(ctx context.Context, t *testing.T, opts ...NATSHandlerMockOpt) *NATSHandlerMock {
 	port := testingutils.GeneratePortOrDie()
 
 	mockedLogger, err := logger.New("json", "info")
@@ -151,14 +151,14 @@ func (m *NATSHandlerMock) GetNatsConfig() *env.NATSConfig {
 }
 
 // WithEventTypePrefix returns NatsHandlerMockOpt which sets the eventTypePrefix for the given NatsHandlerMock.
-func WithEventTypePrefix(eventTypePrefix string) NatsHandlerMockOpt {
+func WithEventTypePrefix(eventTypePrefix string) NATSHandlerMockOpt {
 	return func(m *NATSHandlerMock) {
 		m.eventTypePrefix = eventTypePrefix
 	}
 }
 
 // WithSubscription returns NatsHandlerMockOpt which sets the subscribed.Processor for the given NatsHandlerMock.
-func WithSubscription(scheme *runtime.Scheme, subscription *eventingv1alpha1.Subscription) NatsHandlerMockOpt {
+func WithSubscription(scheme *runtime.Scheme, subscription *eventingv1alpha1.Subscription) NATSHandlerMockOpt {
 	return func(m *NATSHandlerMock) {
 		m.natsConfig.EventTypePrefix = m.eventTypePrefix
 		dynamicTestClient := dynamicfake.NewSimpleDynamicClient(scheme, subscription)
@@ -176,7 +176,7 @@ func WithSubscription(scheme *runtime.Scheme, subscription *eventingv1alpha1.Sub
 }
 
 // WithApplication returns NatsHandlerMockOpt which sets the legacy.Transformer for the given NatsHandlerMock.
-func WithApplication(applicationName string) NatsHandlerMockOpt {
+func WithApplication(applicationName string) NATSHandlerMockOpt {
 	return func(m *NATSHandlerMock) {
 		applicationLister := handlertest.NewApplicationListerOrDie(m.ctx, applicationName)
 		m.legacyTransformer = legacy.NewTransformer(
@@ -189,7 +189,7 @@ func WithApplication(applicationName string) NatsHandlerMockOpt {
 }
 
 // WithJetstream returns NatsHandlerMockOpt which starts the NATS server in the jetstream mode for the given NatsHandlerMock.
-func WithJetstream(jsEnabled bool) NatsHandlerMockOpt {
+func WithJetstream(jsEnabled bool) NATSHandlerMockOpt {
 	return func(m *NATSHandlerMock) {
 		m.jetstreamMode = jsEnabled
 	}

--- a/components/event-publisher-proxy/pkg/handler/nats/mock/mock.go
+++ b/components/event-publisher-proxy/pkg/handler/nats/mock/mock.go
@@ -34,8 +34,8 @@ import (
 	eventingv1alpha1 "github.com/kyma-project/kyma/components/eventing-controller/api/v1alpha1"
 )
 
-// NatsHandlerMock represents a mock for the nats.Handler.
-type NatsHandlerMock struct {
+// NATSHandlerMock represents a mock for the nats.Handler.
+type NATSHandlerMock struct {
 	ctx                 context.Context
 	handler             *nats.Handler
 	livenessEndpoint    string
@@ -53,17 +53,17 @@ type NatsHandlerMock struct {
 }
 
 // NatsHandlerMockOpt represents a NatsHandlerMock option.
-type NatsHandlerMockOpt func(*NatsHandlerMock)
+type NatsHandlerMockOpt func(*NATSHandlerMock)
 
 // StartOrDie starts a new NatsHandlerMock instance or die if a precondition fails.
 // Preconditions: 1) NATS connection and 2) nats.Handler started without errors.
-func StartOrDie(ctx context.Context, t *testing.T, opts ...NatsHandlerMockOpt) *NatsHandlerMock {
+func StartOrDie(ctx context.Context, t *testing.T, opts ...NatsHandlerMockOpt) *NATSHandlerMock {
 	port := testingutils.GeneratePortOrDie()
 
 	mockedLogger, err := logger.New("json", "info")
 	require.NoError(t, err)
 
-	mock := &NatsHandlerMock{
+	mock := &NATSHandlerMock{
 		ctx:                 ctx,
 		livenessEndpoint:    fmt.Sprintf("http://localhost:%d%s", port, health.LivenessURI),
 		readinessEndpoint:   fmt.Sprintf("http://localhost:%d%s", port, health.ReadinessURI),
@@ -109,57 +109,57 @@ func StartOrDie(ctx context.Context, t *testing.T, opts ...NatsHandlerMockOpt) *
 }
 
 // Stop closes the sender.NatsMessageSender connection and calls the NatsHandlerMock.ShutdownNatsServerAndWait.
-func (m *NatsHandlerMock) Stop() {
+func (m *NATSHandlerMock) Stop() {
 	m.connection.Close()
 	m.ShutdownNatsServerAndWait()
 }
 
 // ShutdownNatsServerAndWait shuts down the NATS server used by the NatsHandlerMock and waits for the shutdown.
-func (m *NatsHandlerMock) ShutdownNatsServerAndWait() {
+func (m *NATSHandlerMock) ShutdownNatsServerAndWait() {
 	m.natsServer.Shutdown()
 	m.natsServer.WaitForShutdown()
 }
 
 // GetNatsURL returns the NATS server URL used by the NatsHandlerMock.
-func (m *NatsHandlerMock) GetNatsURL() string {
+func (m *NATSHandlerMock) GetNatsURL() string {
 	return m.natsServer.ClientURL()
 }
 
 // GetLivenessEndpoint returns the liveness endpoint used by the NatsHandlerMock.
-func (m *NatsHandlerMock) GetLivenessEndpoint() string {
+func (m *NATSHandlerMock) GetLivenessEndpoint() string {
 	return m.livenessEndpoint
 }
 
 // GetReadinessEndpoint returns the readiness endpoint used by the NatsHandlerMock.
-func (m *NatsHandlerMock) GetReadinessEndpoint() string {
+func (m *NATSHandlerMock) GetReadinessEndpoint() string {
 	return m.readinessEndpoint
 }
 
 // GetHandler returns the nats.Handler used by the NatsHandlerMock.
-func (m *NatsHandlerMock) GetHandler() *nats.Handler {
+func (m *NATSHandlerMock) GetHandler() *nats.Handler {
 	return m.handler
 }
 
 // GetMetricsCollector returns the metrics.Collector used by the NatsHandlerMock.
-func (m *NatsHandlerMock) GetMetricsCollector() *metrics.Collector {
+func (m *NATSHandlerMock) GetMetricsCollector() *metrics.Collector {
 	return m.collector
 }
 
 // GetNatsConfig returns the env.NatsConfig used by the NatsHandlerMock.
-func (m *NatsHandlerMock) GetNatsConfig() *env.NATSConfig {
+func (m *NATSHandlerMock) GetNatsConfig() *env.NATSConfig {
 	return m.natsConfig
 }
 
 // WithEventTypePrefix returns NatsHandlerMockOpt which sets the eventTypePrefix for the given NatsHandlerMock.
 func WithEventTypePrefix(eventTypePrefix string) NatsHandlerMockOpt {
-	return func(m *NatsHandlerMock) {
+	return func(m *NATSHandlerMock) {
 		m.eventTypePrefix = eventTypePrefix
 	}
 }
 
 // WithSubscription returns NatsHandlerMockOpt which sets the subscribed.Processor for the given NatsHandlerMock.
 func WithSubscription(scheme *runtime.Scheme, subscription *eventingv1alpha1.Subscription) NatsHandlerMockOpt {
-	return func(m *NatsHandlerMock) {
+	return func(m *NATSHandlerMock) {
 		m.natsConfig.EventTypePrefix = m.eventTypePrefix
 		dynamicTestClient := dynamicfake.NewSimpleDynamicClient(scheme, subscription)
 		dFilteredSharedInfFactory := dynamicinformer.NewFilteredDynamicSharedInformerFactory(dynamicTestClient, 10*time.Second, v1.NamespaceAll, nil)
@@ -177,7 +177,7 @@ func WithSubscription(scheme *runtime.Scheme, subscription *eventingv1alpha1.Sub
 
 // WithApplication returns NatsHandlerMockOpt which sets the legacy.Transformer for the given NatsHandlerMock.
 func WithApplication(applicationName string) NatsHandlerMockOpt {
-	return func(m *NatsHandlerMock) {
+	return func(m *NATSHandlerMock) {
 		applicationLister := handlertest.NewApplicationListerOrDie(m.ctx, applicationName)
 		m.legacyTransformer = legacy.NewTransformer(
 			m.natsConfig.ToConfig().BEBNamespace,
@@ -190,7 +190,7 @@ func WithApplication(applicationName string) NatsHandlerMockOpt {
 
 // WithJetstream returns NatsHandlerMockOpt which starts the NATS server in the jetstream mode for the given NatsHandlerMock.
 func WithJetstream(jsEnabled bool) NatsHandlerMockOpt {
-	return func(m *NatsHandlerMock) {
+	return func(m *NATSHandlerMock) {
 		m.jetstreamMode = jsEnabled
 	}
 }

--- a/components/event-publisher-proxy/pkg/handler/nats/mock/mock.go
+++ b/components/event-publisher-proxy/pkg/handler/nats/mock/mock.go
@@ -145,8 +145,8 @@ func (m *NATSHandlerMock) GetMetricsCollector() *metrics.Collector {
 	return m.collector
 }
 
-// GetNatsConfig returns the env.NatsConfig used by the NatsHandlerMock.
-func (m *NATSHandlerMock) GetNatsConfig() *env.NATSConfig {
+// GetNATSConfig returns the env.NatsConfig used by the NatsHandlerMock.
+func (m *NATSHandlerMock) GetNATSConfig() *env.NATSConfig {
 	return m.natsConfig
 }
 

--- a/components/event-publisher-proxy/pkg/handler/nats/mock/mock.go
+++ b/components/event-publisher-proxy/pkg/handler/nats/mock/mock.go
@@ -82,7 +82,7 @@ func StartOrDie(ctx context.Context, t *testing.T, opts ...NATSHandlerMockOpt) *
 
 	msgReceiver := receiver.NewHTTPMessageReceiver(mock.natsConfig.Port)
 
-	connection, err := testingutils.ConnectToNATSServer(mock.GetNatsURL())
+	connection, err := testingutils.ConnectToNATSServer(mock.GetNATSURL())
 	require.NoError(t, err)
 	mock.connection = connection
 
@@ -120,8 +120,8 @@ func (m *NATSHandlerMock) ShutdownNATSServerAndWait() {
 	m.natsServer.WaitForShutdown()
 }
 
-// GetNatsURL returns the NATS server URL used by the NatsHandlerMock.
-func (m *NATSHandlerMock) GetNatsURL() string {
+// GetNATSURL returns the NATS server URL used by the NatsHandlerMock.
+func (m *NATSHandlerMock) GetNATSURL() string {
 	return m.natsServer.ClientURL()
 }
 

--- a/components/event-publisher-proxy/pkg/legacy-events/legacy_test.go
+++ b/components/event-publisher-proxy/pkg/legacy-events/legacy_test.go
@@ -162,16 +162,16 @@ func TestConvertPublishRequestToCloudEvent(t *testing.T) {
 		},
 	}
 
-	wantBebNs := MessagingNamespace
+	wantBEBNamespace := MessagingNamespace
 	wantEventID := givenEventID
 	wantEventType := formatEventType(givenEventTypePrefix, givenApplicationName, eventTypeMultiSegmentCombined, givenLegacyEventVersion)
 	wantTimeNowFormatted, _ := time.Parse(time.RFC3339, givenTimeNow)
 	wantDataContentType := internal.ContentTypeApplicationJSON
 
-	legacyTransformer := NewTransformer(wantBebNs, givenEventTypePrefix, nil)
+	legacyTransformer := NewTransformer(wantBEBNamespace, givenEventTypePrefix, nil)
 	gotEvent, err := legacyTransformer.convertPublishRequestToCloudEvent(givenApplicationName, givenPublishReqParams)
 	require.NoError(t, err)
-	assert.Equal(t, wantBebNs, gotEvent.Context.GetSource())
+	assert.Equal(t, wantBEBNamespace, gotEvent.Context.GetSource())
 	assert.Equal(t, wantEventID, gotEvent.Context.GetID())
 	assert.Equal(t, wantEventType, gotEvent.Context.GetType())
 	assert.Equal(t, wantTimeNowFormatted, gotEvent.Context.GetTime())

--- a/components/event-publisher-proxy/pkg/nats/connect_test.go
+++ b/components/event-publisher-proxy/pkg/nats/connect_test.go
@@ -37,7 +37,7 @@ func TestConnect(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 
 			// test in both default and jetstream NATS modes
-			for _, serverMode := range publishertesting.NatsServerModes {
+			for _, serverMode := range publishertesting.NATSServerModes {
 				t.Run(serverMode.Name, func(t *testing.T) {
 					tc := tc
 					// given

--- a/components/event-publisher-proxy/pkg/nats/connect_test.go
+++ b/components/event-publisher-proxy/pkg/nats/connect_test.go
@@ -41,7 +41,7 @@ func TestConnect(t *testing.T) {
 				t.Run(serverMode.Name, func(t *testing.T) {
 					tc := tc
 					// given
-					natsServer := publishertesting.StartNatsServer(serverMode.JetstreamEnabled)
+					natsServer := publishertesting.StartNATSServer(serverMode.JetstreamEnabled)
 					assert.NotNil(t, natsServer)
 					defer natsServer.Shutdown()
 

--- a/components/event-publisher-proxy/pkg/nats/connect_test.go
+++ b/components/event-publisher-proxy/pkg/nats/connect_test.go
@@ -41,7 +41,7 @@ func TestConnect(t *testing.T) {
 				t.Run(serverMode.Name, func(t *testing.T) {
 					tc := tc
 					// given
-					natsServer := publishertesting.StartNATSServer(serverMode.JetstreamEnabled)
+					natsServer := publishertesting.StartNATSServer(serverMode.JetStreamEnabled)
 					assert.NotNil(t, natsServer)
 					defer natsServer.Shutdown()
 

--- a/components/event-publisher-proxy/pkg/oauth/client.go
+++ b/components/event-publisher-proxy/pkg/oauth/client.go
@@ -12,7 +12,7 @@ import (
 )
 
 // NewClient returns a new HTTP client which have nested transports for handling oauth2 security, HTTP connection pooling, and tracing.
-func NewClient(ctx context.Context, cfg *env.BebConfig) *http.Client {
+func NewClient(ctx context.Context, cfg *env.BEBConfig) *http.Client {
 	// configure auth client
 	config := Config(cfg)
 	client := config.Client(ctx)

--- a/components/event-publisher-proxy/pkg/oauth/client_test.go
+++ b/components/event-publisher-proxy/pkg/oauth/client_test.go
@@ -22,7 +22,7 @@ func TestNewClient(t *testing.T) {
 		maxIdleConnsPerHost = 200
 	)
 
-	client := NewClient(context.Background(), &env.BebConfig{MaxIdleConns: maxIdleConns, MaxIdleConnsPerHost: maxIdleConnsPerHost})
+	client := NewClient(context.Background(), &env.BEBConfig{MaxIdleConns: maxIdleConns, MaxIdleConnsPerHost: maxIdleConnsPerHost})
 	defer client.CloseIdleConnections()
 
 	ocTransport, ok := client.Transport.(*ochttp.Transport)

--- a/components/event-publisher-proxy/pkg/oauth/config.go
+++ b/components/event-publisher-proxy/pkg/oauth/config.go
@@ -7,7 +7,7 @@ import (
 )
 
 // Config returns a new oauth2 client credentials config instance.
-func Config(cfg *env.BebConfig) clientcredentials.Config {
+func Config(cfg *env.BEBConfig) clientcredentials.Config {
 	return clientcredentials.Config{
 		ClientID:     cfg.ClientID,
 		ClientSecret: cfg.ClientSecret,

--- a/components/event-publisher-proxy/pkg/oauth/config_test.go
+++ b/components/event-publisher-proxy/pkg/oauth/config_test.go
@@ -9,7 +9,7 @@ import (
 func TestConfig(t *testing.T) {
 	t.Parallel()
 
-	cfg := &env.BebConfig{ClientID: "someID", ClientSecret: "someSecret", TokenEndpoint: "someEndpoint"}
+	cfg := &env.BEBConfig{ClientID: "someID", ClientSecret: "someSecret", TokenEndpoint: "someEndpoint"}
 	conf := Config(cfg)
 
 	if cfg.ClientID != conf.ClientID {

--- a/components/event-publisher-proxy/pkg/sender/beb.go
+++ b/components/event-publisher-proxy/pkg/sender/beb.go
@@ -5,23 +5,23 @@ import (
 	"net/http"
 )
 
-// BebMessageSender is responsible for sending messages over HTTP.
-type BebMessageSender struct {
+// BEBMessageSender is responsible for sending messages over HTTP.
+type BEBMessageSender struct {
 	Client *http.Client
 	Target string
 }
 
 // NewBEBMessageSender returns a new BebMessageSender instance with the given target and client.
-func NewBEBMessageSender(target string, client *http.Client) *BebMessageSender {
-	return &BebMessageSender{Client: client, Target: target}
+func NewBEBMessageSender(target string, client *http.Client) *BEBMessageSender {
+	return &BEBMessageSender{Client: client, Target: target}
 }
 
 // NewRequestWithTarget returns a new HTTP POST request with the given context and target.
-func (s *BebMessageSender) NewRequestWithTarget(ctx context.Context, target string) (*http.Request, error) {
+func (s *BEBMessageSender) NewRequestWithTarget(ctx context.Context, target string) (*http.Request, error) {
 	return http.NewRequestWithContext(ctx, http.MethodPost, target, nil)
 }
 
 // Send sends the given HTTP request and returns the HTTP response back.
-func (s *BebMessageSender) Send(req *http.Request) (*http.Response, error) {
+func (s *BEBMessageSender) Send(req *http.Request) (*http.Response, error) {
 	return s.Client.Do(req)
 }

--- a/components/event-publisher-proxy/pkg/sender/beb.go
+++ b/components/event-publisher-proxy/pkg/sender/beb.go
@@ -11,8 +11,8 @@ type BebMessageSender struct {
 	Target string
 }
 
-// NewBebMessageSender returns a new BebMessageSender instance with the given target and client.
-func NewBebMessageSender(target string, client *http.Client) *BebMessageSender {
+// NewBEBMessageSender returns a new BebMessageSender instance with the given target and client.
+func NewBEBMessageSender(target string, client *http.Client) *BebMessageSender {
 	return &BebMessageSender{Client: client, Target: target}
 }
 

--- a/components/event-publisher-proxy/pkg/sender/beb.go
+++ b/components/event-publisher-proxy/pkg/sender/beb.go
@@ -11,7 +11,7 @@ type BEBMessageSender struct {
 	Target string
 }
 
-// NewBEBMessageSender returns a new BebMessageSender instance with the given target and client.
+// NewBEBMessageSender returns a new BEBMessageSender instance with the given target and client.
 func NewBEBMessageSender(target string, client *http.Client) *BEBMessageSender {
 	return &BEBMessageSender{Client: client, Target: target}
 }

--- a/components/event-publisher-proxy/pkg/sender/beb_test.go
+++ b/components/event-publisher-proxy/pkg/sender/beb_test.go
@@ -28,7 +28,7 @@ func TestNewHttpMessageSender(t *testing.T) {
 	client := oauth.NewClient(context.Background(), &env.BEBConfig{})
 	defer client.CloseIdleConnections()
 
-	msgSender := NewBebMessageSender(eventsEndpoint, client)
+	msgSender := NewBEBMessageSender(eventsEndpoint, client)
 	if msgSender.Target != eventsEndpoint {
 		t.Errorf("Message sender target is misconfigured want: %s but got: %s", eventsEndpoint, msgSender.Target)
 	}
@@ -43,7 +43,7 @@ func TestNewRequestWithTarget(t *testing.T) {
 	client := oauth.NewClient(context.Background(), &env.BEBConfig{MaxIdleConns: maxIdleConns, MaxIdleConnsPerHost: maxIdleConnsPerHost})
 	defer client.CloseIdleConnections()
 
-	msgSender := NewBebMessageSender(eventsEndpoint, client)
+	msgSender := NewBEBMessageSender(eventsEndpoint, client)
 
 	type ctxKey struct{}
 	const ctxValue = "testValue"
@@ -91,7 +91,7 @@ func TestSend(t *testing.T) {
 	client := oauth.NewClient(ctx, cfg)
 	defer client.CloseIdleConnections()
 
-	msgSender := NewBebMessageSender(emsCEURL, client)
+	msgSender := NewBEBMessageSender(emsCEURL, client)
 
 	request, err := msgSender.NewRequestWithTarget(ctx, msgSender.Target)
 	if err != nil {

--- a/components/event-publisher-proxy/pkg/sender/beb_test.go
+++ b/components/event-publisher-proxy/pkg/sender/beb_test.go
@@ -25,7 +25,7 @@ const (
 func TestNewHttpMessageSender(t *testing.T) {
 	t.Parallel()
 
-	client := oauth.NewClient(context.Background(), &env.BebConfig{})
+	client := oauth.NewClient(context.Background(), &env.BEBConfig{})
 	defer client.CloseIdleConnections()
 
 	msgSender := NewBebMessageSender(eventsEndpoint, client)
@@ -40,7 +40,7 @@ func TestNewHttpMessageSender(t *testing.T) {
 func TestNewRequestWithTarget(t *testing.T) {
 	t.Parallel()
 
-	client := oauth.NewClient(context.Background(), &env.BebConfig{MaxIdleConns: maxIdleConns, MaxIdleConnsPerHost: maxIdleConnsPerHost})
+	client := oauth.NewClient(context.Background(), &env.BEBConfig{MaxIdleConns: maxIdleConns, MaxIdleConnsPerHost: maxIdleConnsPerHost})
 	defer client.CloseIdleConnections()
 
 	msgSender := NewBebMessageSender(eventsEndpoint, client)

--- a/components/event-publisher-proxy/pkg/sender/jetstream.go
+++ b/components/event-publisher-proxy/pkg/sender/jetstream.go
@@ -34,8 +34,8 @@ type JetstreamMessageSender struct {
 	envCfg     *env.NATSConfig
 }
 
-// NewJetstreamMessageSender returns a new NewJetstreamMessageSender instance with the given nats connection.
-func NewJetstreamMessageSender(ctx context.Context, connection *nats.Conn, envCfg *env.NATSConfig, logger *logger.Logger) *JetstreamMessageSender {
+// NewJetStreamMessageSender returns a new NewJetStreamMessageSender instance with the given nats connection.
+func NewJetStreamMessageSender(ctx context.Context, connection *nats.Conn, envCfg *env.NATSConfig, logger *logger.Logger) *JetstreamMessageSender {
 	return &JetstreamMessageSender{ctx: ctx, connection: connection, envCfg: envCfg, logger: logger}
 }
 

--- a/components/event-publisher-proxy/pkg/sender/jetstream.go
+++ b/components/event-publisher-proxy/pkg/sender/jetstream.go
@@ -44,16 +44,16 @@ func (s *JetStreamMessageSender) URL() string {
 	return s.connection.ConnectedUrl()
 }
 
-// ConnectionStatus returns nats.Status for the NATS connection used by the JetstreamMessageSender.
+// ConnectionStatus returns nats.Status for the NATS connection used by the JetStreamMessageSender.
 func (s *JetStreamMessageSender) ConnectionStatus() nats.Status {
 	return s.connection.Status()
 }
 
-// Send dispatches the event to the NATS backend in Jetstream mode.
+// Send dispatches the event to the NATS backend in JetStream mode.
 // If the NATS connection is not open, it returns an error.
 func (s *JetStreamMessageSender) Send(_ context.Context, event *event.Event) (int, error) {
 	if s.ConnectionStatus() != nats.CONNECTED {
-		return http.StatusBadGateway, errors.New("connection status: no connection to NATS Jetstream server")
+		return http.StatusBadGateway, errors.New("connection status: no connection to NATS JetStream server")
 	}
 	// ensure the stream exists
 	streamExists, err := s.streamExists(s.connection)

--- a/components/event-publisher-proxy/pkg/sender/jetstream.go
+++ b/components/event-publisher-proxy/pkg/sender/jetstream.go
@@ -31,11 +31,11 @@ type JetstreamMessageSender struct {
 	ctx        context.Context
 	logger     *logger.Logger
 	connection *nats.Conn
-	envCfg     *env.NatsConfig
+	envCfg     *env.NATSConfig
 }
 
 // NewJetstreamMessageSender returns a new NewJetstreamMessageSender instance with the given nats connection.
-func NewJetstreamMessageSender(ctx context.Context, connection *nats.Conn, envCfg *env.NatsConfig, logger *logger.Logger) *JetstreamMessageSender {
+func NewJetstreamMessageSender(ctx context.Context, connection *nats.Conn, envCfg *env.NATSConfig, logger *logger.Logger) *JetstreamMessageSender {
 	return &JetstreamMessageSender{ctx: ctx, connection: connection, envCfg: envCfg, logger: logger}
 }
 

--- a/components/event-publisher-proxy/pkg/sender/jetstream.go
+++ b/components/event-publisher-proxy/pkg/sender/jetstream.go
@@ -24,10 +24,10 @@ const (
 )
 
 // compile time check
-var _ GenericSender = &JetstreamMessageSender{}
+var _ GenericSender = &JetStreamMessageSender{}
 
-// JetstreamMessageSender is responsible for sending messages over HTTP.
-type JetstreamMessageSender struct {
+// JetStreamMessageSender is responsible for sending messages over HTTP.
+type JetStreamMessageSender struct {
 	ctx        context.Context
 	logger     *logger.Logger
 	connection *nats.Conn
@@ -35,23 +35,23 @@ type JetstreamMessageSender struct {
 }
 
 // NewJetStreamMessageSender returns a new NewJetStreamMessageSender instance with the given nats connection.
-func NewJetStreamMessageSender(ctx context.Context, connection *nats.Conn, envCfg *env.NATSConfig, logger *logger.Logger) *JetstreamMessageSender {
-	return &JetstreamMessageSender{ctx: ctx, connection: connection, envCfg: envCfg, logger: logger}
+func NewJetStreamMessageSender(ctx context.Context, connection *nats.Conn, envCfg *env.NATSConfig, logger *logger.Logger) *JetStreamMessageSender {
+	return &JetStreamMessageSender{ctx: ctx, connection: connection, envCfg: envCfg, logger: logger}
 }
 
 // URL returns the URL of the Sender's connection.
-func (s *JetstreamMessageSender) URL() string {
+func (s *JetStreamMessageSender) URL() string {
 	return s.connection.ConnectedUrl()
 }
 
 // ConnectionStatus returns nats.Status for the NATS connection used by the JetstreamMessageSender.
-func (s *JetstreamMessageSender) ConnectionStatus() nats.Status {
+func (s *JetStreamMessageSender) ConnectionStatus() nats.Status {
 	return s.connection.Status()
 }
 
 // Send dispatches the event to the NATS backend in Jetstream mode.
 // If the NATS connection is not open, it returns an error.
-func (s *JetstreamMessageSender) Send(_ context.Context, event *event.Event) (int, error) {
+func (s *JetStreamMessageSender) Send(_ context.Context, event *event.Event) (int, error) {
 	if s.ConnectionStatus() != nats.CONNECTED {
 		return http.StatusBadGateway, errors.New("connection status: no connection to NATS Jetstream server")
 	}
@@ -86,7 +86,7 @@ func (s *JetstreamMessageSender) Send(_ context.Context, event *event.Event) (in
 }
 
 // streamExists checks if the stream with the expected name exists.
-func (s *JetstreamMessageSender) streamExists(connection *nats.Conn) (bool, error) {
+func (s *JetStreamMessageSender) streamExists(connection *nats.Conn) (bool, error) {
 	jsCtx, err := connection.JetStream()
 	if err != nil {
 		return false, err
@@ -102,7 +102,7 @@ func (s *JetstreamMessageSender) streamExists(connection *nats.Conn) (bool, erro
 }
 
 // eventToNATSMsg translates cloud event into the NATS Msg.
-func (s *JetstreamMessageSender) eventToNATSMsg(event *event.Event) (*nats.Msg, error) {
+func (s *JetStreamMessageSender) eventToNATSMsg(event *event.Event) (*nats.Msg, error) {
 	header := make(nats.Header)
 	header.Set(internal.HeaderContentType, event.DataContentType())
 	header.Set(internal.CeSpecVersionHeader, event.SpecVersion())
@@ -123,10 +123,10 @@ func (s *JetstreamMessageSender) eventToNATSMsg(event *event.Event) (*nats.Msg, 
 }
 
 // getJsSubjectToPublish appends stream name to subject if needed.
-func (s *JetstreamMessageSender) getJsSubjectToPublish(subject string) string {
+func (s *JetStreamMessageSender) getJsSubjectToPublish(subject string) string {
 	return fmt.Sprintf("%s.%s", env.JetStreamSubjectPrefix, subject)
 }
 
-func (s *JetstreamMessageSender) namedLogger() *zap.SugaredLogger {
+func (s *JetStreamMessageSender) namedLogger() *zap.SugaredLogger {
 	return s.logger.WithContext().Named(jestreamHandlerName).With("backend", natsBackend, "jetstream enabled", true)
 }

--- a/components/event-publisher-proxy/pkg/sender/jetstream.go
+++ b/components/event-publisher-proxy/pkg/sender/jetstream.go
@@ -68,7 +68,7 @@ func (s *JetstreamMessageSender) Send(_ context.Context, event *event.Event) (in
 	if jsError != nil {
 		return http.StatusInternalServerError, jsError
 	}
-	msg, err := s.eventToNatsMsg(event)
+	msg, err := s.eventToNATSMsg(event)
 	if err != nil {
 		return http.StatusUnprocessableEntity, err
 	}
@@ -101,8 +101,8 @@ func (s *JetstreamMessageSender) streamExists(connection *nats.Conn) (bool, erro
 	return false, nats.ErrStreamNotFound
 }
 
-// eventToNatsMsg translates cloud event into the NATS Msg.
-func (s *JetstreamMessageSender) eventToNatsMsg(event *event.Event) (*nats.Msg, error) {
+// eventToNATSMsg translates cloud event into the NATS Msg.
+func (s *JetstreamMessageSender) eventToNATSMsg(event *event.Event) (*nats.Msg, error) {
 	header := make(nats.Header)
 	header.Set(internal.HeaderContentType, event.DataContentType())
 	header.Set(internal.CeSpecVersionHeader, event.SpecVersion())

--- a/components/event-publisher-proxy/pkg/sender/jetstream.go
+++ b/components/event-publisher-proxy/pkg/sender/jetstream.go
@@ -124,7 +124,7 @@ func (s *JetstreamMessageSender) eventToNatsMsg(event *event.Event) (*nats.Msg, 
 
 // getJsSubjectToPublish appends stream name to subject if needed.
 func (s *JetstreamMessageSender) getJsSubjectToPublish(subject string) string {
-	return fmt.Sprintf("%s.%s", env.JetstreamSubjectPrefix, subject)
+	return fmt.Sprintf("%s.%s", env.JetStreamSubjectPrefix, subject)
 }
 
 func (s *JetstreamMessageSender) namedLogger() *zap.SugaredLogger {

--- a/components/event-publisher-proxy/pkg/sender/jetstream_test.go
+++ b/components/event-publisher-proxy/pkg/sender/jetstream_test.go
@@ -157,7 +157,7 @@ type TestEnvironment struct {
 	Connection *nats.Conn
 	Config     *env.NATSConfig
 	Logger     *logger.Logger
-	Sender     *JetstreamMessageSender
+	Sender     *JetStreamMessageSender
 	Server     *server.Server
 	JsContext  *nats.JetStreamContext
 }
@@ -179,7 +179,7 @@ func setupTestEnvironment(t *testing.T) *TestEnvironment {
 	jsCtx, err := connection.JetStream()
 	require.NoError(t, err)
 
-	sender := &JetstreamMessageSender{
+	sender := &JetStreamMessageSender{
 		connection: connection,
 		envCfg:     natsConfig,
 		logger:     mockedLogger,

--- a/components/event-publisher-proxy/pkg/sender/jetstream_test.go
+++ b/components/event-publisher-proxy/pkg/sender/jetstream_test.go
@@ -27,27 +27,27 @@ func TestJetstreamMessageSender(t *testing.T) {
 	testCases := []struct {
 		name                      string
 		givenStream               bool
-		givenNatsConnectionClosed bool
+		givenNATSConnectionClosed bool
 		wantError                 bool
 		wantStatusCode            int
 	}{
 		{
 			name:                      "send in jetstream mode should not succeed if stream doesn't exist",
 			givenStream:               false,
-			givenNatsConnectionClosed: false,
+			givenNATSConnectionClosed: false,
 			wantError:                 true,
 			wantStatusCode:            http.StatusNotFound,
 		},
 		{
 			name:                      "send in jetstream mode should succeed if NATS connection is open and the stream exists",
 			givenStream:               true,
-			givenNatsConnectionClosed: false,
+			givenNATSConnectionClosed: false,
 			wantError:                 false,
 			wantStatusCode:            http.StatusNoContent,
 		},
 		{
 			name:                      "send in jetstream mode should fail if NATS connection is not open",
-			givenNatsConnectionClosed: true,
+			givenNATSConnectionClosed: true,
 			wantError:                 true,
 			wantStatusCode:            http.StatusBadGateway,
 		},
@@ -75,7 +75,7 @@ func TestJetstreamMessageSender(t *testing.T) {
 			ctx := context.Background()
 			sender := NewJetstreamMessageSender(context.Background(), connection, testEnv.Config, mockedLogger)
 
-			if tc.givenNatsConnectionClosed {
+			if tc.givenNATSConnectionClosed {
 				connection.Close()
 			}
 

--- a/components/event-publisher-proxy/pkg/sender/jetstream_test.go
+++ b/components/event-publisher-proxy/pkg/sender/jetstream_test.go
@@ -23,7 +23,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestJetstreamMessageSender(t *testing.T) {
+func TestJetStreamMessageSender(t *testing.T) {
 	testCases := []struct {
 		name                      string
 		givenStream               bool

--- a/components/event-publisher-proxy/pkg/sender/jetstream_test.go
+++ b/components/event-publisher-proxy/pkg/sender/jetstream_test.go
@@ -167,7 +167,7 @@ func setupTestEnvironment(t *testing.T) *TestEnvironment {
 	natsServer := testingutils.StartNATSServer(true)
 	require.NotNil(t, natsServer)
 
-	connection, err := testingutils.ConnectToNatsServer(natsServer.ClientURL())
+	connection, err := testingutils.ConnectToNATSServer(natsServer.ClientURL())
 	require.NotNil(t, connection)
 	require.NoError(t, err)
 

--- a/components/event-publisher-proxy/pkg/sender/jetstream_test.go
+++ b/components/event-publisher-proxy/pkg/sender/jetstream_test.go
@@ -164,7 +164,7 @@ type TestEnvironment struct {
 
 // setupTestEnvironment sets up the resources and mocks required for testing.
 func setupTestEnvironment(t *testing.T) *TestEnvironment {
-	natsServer := testingutils.StartNatsServer(true)
+	natsServer := testingutils.StartNATSServer(true)
 	require.NotNil(t, natsServer)
 
 	connection, err := testingutils.ConnectToNatsServer(natsServer.ClientURL())

--- a/components/event-publisher-proxy/pkg/sender/jetstream_test.go
+++ b/components/event-publisher-proxy/pkg/sender/jetstream_test.go
@@ -171,7 +171,7 @@ func setupTestEnvironment(t *testing.T) *TestEnvironment {
 	require.NotNil(t, connection)
 	require.NoError(t, err)
 
-	natsConfig := CreateNatsJsConfig(natsServer.ClientURL())
+	natsConfig := CreateNATSJsConfig(natsServer.ClientURL())
 
 	mockedLogger, err := logger.New("json", "info")
 	require.NoError(t, err)
@@ -227,7 +227,7 @@ func addStream(t *testing.T, connection *nats.Conn, config *nats.StreamConfig) {
 	assert.NoError(t, err)
 }
 
-func CreateNatsJsConfig(url string) *env.NATSConfig {
+func CreateNATSJsConfig(url string) *env.NATSConfig {
 	return &env.NATSConfig{
 		JSStreamName:  testingutils.StreamName,
 		URL:           url,

--- a/components/event-publisher-proxy/pkg/sender/jetstream_test.go
+++ b/components/event-publisher-proxy/pkg/sender/jetstream_test.go
@@ -155,7 +155,7 @@ func TestStreamExists(t *testing.T) {
 
 type TestEnvironment struct {
 	Connection *nats.Conn
-	Config     *env.NatsConfig
+	Config     *env.NATSConfig
 	Logger     *logger.Logger
 	Sender     *JetstreamMessageSender
 	Server     *server.Server
@@ -227,8 +227,8 @@ func addStream(t *testing.T, connection *nats.Conn, config *nats.StreamConfig) {
 	assert.NoError(t, err)
 }
 
-func CreateNatsJsConfig(url string) *env.NatsConfig {
-	return &env.NatsConfig{
+func CreateNatsJsConfig(url string) *env.NATSConfig {
+	return &env.NATSConfig{
 		JSStreamName:  testingutils.StreamName,
 		URL:           url,
 		ReconnectWait: time.Second,

--- a/components/event-publisher-proxy/pkg/sender/jetstream_test.go
+++ b/components/event-publisher-proxy/pkg/sender/jetstream_test.go
@@ -73,7 +73,7 @@ func TestJetStreamMessageSender(t *testing.T) {
 
 			// when
 			ctx := context.Background()
-			sender := NewJetstreamMessageSender(context.Background(), connection, testEnv.Config, mockedLogger)
+			sender := NewJetStreamMessageSender(context.Background(), connection, testEnv.Config, mockedLogger)
 
 			if tc.givenNATSConnectionClosed {
 				connection.Close()

--- a/components/event-publisher-proxy/pkg/sender/jetstream_test.go
+++ b/components/event-publisher-proxy/pkg/sender/jetstream_test.go
@@ -93,28 +93,28 @@ func TestStreamExists(t *testing.T) {
 	testCases := []struct {
 		name                      string
 		givenStream               bool
-		givenNatsConnectionClosed bool
+		givenNATSConnectionClosed bool
 		wantResult                bool
 		wantError                 error
 	}{
 		{
 			name:                      "Stream doesn't exist and should return false",
 			givenStream:               false,
-			givenNatsConnectionClosed: false,
+			givenNATSConnectionClosed: false,
 			wantResult:                false,
 			wantError:                 nats.ErrStreamNotFound,
 		},
 		{
 			name:                      "Stream exists and should return true",
 			givenStream:               true,
-			givenNatsConnectionClosed: false,
+			givenNATSConnectionClosed: false,
 			wantResult:                true,
 			wantError:                 nil,
 		},
 		{
 			name:                      "Connection closed and error should happen",
 			givenStream:               true,
-			givenNatsConnectionClosed: true,
+			givenNATSConnectionClosed: true,
 			wantResult:                false,
 			wantError:                 nats.ErrConnectionClosed,
 		},
@@ -137,7 +137,7 @@ func TestStreamExists(t *testing.T) {
 			}
 
 			// close the connection to provoke the error
-			if tc.givenNatsConnectionClosed {
+			if tc.givenNATSConnectionClosed {
 				connection.Close()
 			}
 

--- a/components/event-publisher-proxy/pkg/sender/jetstream_test.go
+++ b/components/event-publisher-proxy/pkg/sender/jetstream_test.go
@@ -213,7 +213,7 @@ func createCloudEvent(t *testing.T) *event.Event {
 func getStreamConfig() *nats.StreamConfig {
 	return &nats.StreamConfig{
 		Name:      testingutils.StreamName,
-		Subjects:  []string{fmt.Sprintf("%s.>", env.JetstreamSubjectPrefix)},
+		Subjects:  []string{fmt.Sprintf("%s.>", env.JetStreamSubjectPrefix)},
 		Storage:   nats.MemoryStorage,
 		Retention: nats.InterestPolicy,
 	}

--- a/components/event-publisher-proxy/pkg/sender/nats.go
+++ b/components/event-publisher-proxy/pkg/sender/nats.go
@@ -14,7 +14,7 @@ import (
 )
 
 // compile time check
-var _ GenericSender = &NatsMessageSender{}
+var _ GenericSender = &NATSMessageSender{}
 
 type GenericSender interface {
 	Send(context.Context, *event.Event) (int, error)
@@ -22,31 +22,31 @@ type GenericSender interface {
 	URL() string
 }
 
-// NatsMessageSender is responsible for sending messages over HTTP.
-type NatsMessageSender struct {
+// NATSMessageSender is responsible for sending messages over HTTP.
+type NATSMessageSender struct {
 	ctx        context.Context
 	logger     *logger.Logger
 	connection *nats.Conn
 }
 
 // NewNatsMessageSender returns a new NewNatsMessageSender instance with the given nats connection.
-func NewNatsMessageSender(ctx context.Context, connection *nats.Conn, logger *logger.Logger) *NatsMessageSender {
-	return &NatsMessageSender{ctx: ctx, connection: connection, logger: logger}
+func NewNatsMessageSender(ctx context.Context, connection *nats.Conn, logger *logger.Logger) *NATSMessageSender {
+	return &NATSMessageSender{ctx: ctx, connection: connection, logger: logger}
 }
 
 // URL returns the URL of the Sender's connection.
-func (s *NatsMessageSender) URL() string {
+func (s *NATSMessageSender) URL() string {
 	return s.connection.ConnectedUrl()
 }
 
 // ConnectionStatus returns nats.Status for the NATS connection used by the NatsMessageSender.
-func (s *NatsMessageSender) ConnectionStatus() nats.Status {
+func (s *NATSMessageSender) ConnectionStatus() nats.Status {
 	return s.connection.Status()
 }
 
 // Send dispatches the event.Event to NATS server.
 // If the NATS connection is not open, it returns an error.
-func (s *NatsMessageSender) Send(ctx context.Context, event *event.Event) (int, error) {
+func (s *NATSMessageSender) Send(ctx context.Context, event *event.Event) (int, error) {
 	if s.ConnectionStatus() != nats.CONNECTED {
 		return http.StatusBadGateway, errors.New("connection status: no connection to NATS server")
 	}

--- a/components/event-publisher-proxy/pkg/sender/nats.go
+++ b/components/event-publisher-proxy/pkg/sender/nats.go
@@ -29,8 +29,8 @@ type NATSMessageSender struct {
 	connection *nats.Conn
 }
 
-// NewNatsMessageSender returns a new NewNatsMessageSender instance with the given nats connection.
-func NewNatsMessageSender(ctx context.Context, connection *nats.Conn, logger *logger.Logger) *NATSMessageSender {
+// NewNATSMessageSender returns a new NewNATSMessageSender instance with the given nats connection.
+func NewNATSMessageSender(ctx context.Context, connection *nats.Conn, logger *logger.Logger) *NATSMessageSender {
 	return &NATSMessageSender{ctx: ctx, connection: connection, logger: logger}
 }
 

--- a/components/event-publisher-proxy/pkg/sender/nats.go
+++ b/components/event-publisher-proxy/pkg/sender/nats.go
@@ -39,7 +39,7 @@ func (s *NATSMessageSender) URL() string {
 	return s.connection.ConnectedUrl()
 }
 
-// ConnectionStatus returns nats.Status for the NATS connection used by the NatsMessageSender.
+// ConnectionStatus returns nats.Status for the NATS connection used by the NATSMessageSender.
 func (s *NATSMessageSender) ConnectionStatus() nats.Status {
 	return s.connection.Status()
 }

--- a/components/event-publisher-proxy/pkg/sender/nats_test.go
+++ b/components/event-publisher-proxy/pkg/sender/nats_test.go
@@ -20,19 +20,19 @@ func TestNATSMessageSender(t *testing.T) {
 
 	testCases := []struct {
 		name                      string
-		givenNatsConnectionClosed bool
+		givenNATSConnectionClosed bool
 		wantError                 bool
 		wantStatusCode            int
 	}{
 		{
 			name:                      "send should succeed if NATS connection is open",
-			givenNatsConnectionClosed: false,
+			givenNATSConnectionClosed: false,
 			wantError:                 false,
 			wantStatusCode:            http.StatusNoContent,
 		},
 		{
 			name:                      "send should fail if NATS connection is not open",
-			givenNatsConnectionClosed: true,
+			givenNATSConnectionClosed: true,
 			wantError:                 true,
 			wantStatusCode:            http.StatusBadGateway,
 		},
@@ -66,7 +66,7 @@ func TestNATSMessageSender(t *testing.T) {
 			ctx := context.Background()
 			sender := NewNATSMessageSender(context.Background(), connection, mockedLogger)
 
-			if tc.givenNatsConnectionClosed {
+			if tc.givenNATSConnectionClosed {
 				connection.Close()
 			}
 

--- a/components/event-publisher-proxy/pkg/sender/nats_test.go
+++ b/components/event-publisher-proxy/pkg/sender/nats_test.go
@@ -56,7 +56,7 @@ func TestNatsMessageSender(t *testing.T) {
 			defer func() { connection.Close() }()
 
 			receive := make(chan bool, 1)
-			validator := testingutils.ValidateNatsMessageDataOrFail(t, fmt.Sprintf(`"%s"`, testingutils.EventData), receive)
+			validator := testingutils.ValidateNATSMessageDataOrFail(t, fmt.Sprintf(`"%s"`, testingutils.EventData), receive)
 			testingutils.SubscribeToEventOrFail(t, connection, testingutils.CloudEventType, validator)
 
 			ce := createCloudEvent(t)

--- a/components/event-publisher-proxy/pkg/sender/nats_test.go
+++ b/components/event-publisher-proxy/pkg/sender/nats_test.go
@@ -42,7 +42,7 @@ func TestNatsMessageSender(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
-			natsServer := testingutils.StartNatsServer(false)
+			natsServer := testingutils.StartNATSServer(false)
 			assert.NotNil(t, natsServer)
 			defer natsServer.Shutdown()
 

--- a/components/event-publisher-proxy/pkg/sender/nats_test.go
+++ b/components/event-publisher-proxy/pkg/sender/nats_test.go
@@ -64,7 +64,7 @@ func TestNatsMessageSender(t *testing.T) {
 			mockedLogger, _ := logger.New("json", "info")
 
 			ctx := context.Background()
-			sender := NewNatsMessageSender(context.Background(), connection, mockedLogger)
+			sender := NewNATSMessageSender(context.Background(), connection, mockedLogger)
 
 			if tc.givenNatsConnectionClosed {
 				connection.Close()

--- a/components/event-publisher-proxy/pkg/sender/nats_test.go
+++ b/components/event-publisher-proxy/pkg/sender/nats_test.go
@@ -15,7 +15,7 @@ import (
 	testingutils "github.com/kyma-project/kyma/components/event-publisher-proxy/testing"
 )
 
-func TestNatsMessageSender(t *testing.T) {
+func TestNATSMessageSender(t *testing.T) {
 	t.Parallel()
 
 	testCases := []struct {

--- a/components/event-publisher-proxy/pkg/subscribed/processor.go
+++ b/components/event-publisher-proxy/pkg/subscribed/processor.go
@@ -16,7 +16,7 @@ const processorName = "processor"
 
 type Processor struct {
 	SubscriptionLister *cache.GenericLister
-	Config             *env.BebConfig
+	Config             *env.BEBConfig
 	Logger             *logger.Logger
 }
 

--- a/components/event-publisher-proxy/testing/env_config.go
+++ b/components/event-publisher-proxy/testing/env_config.go
@@ -6,48 +6,48 @@ import (
 	"github.com/kyma-project/kyma/components/event-publisher-proxy/pkg/env"
 )
 
-func NewEnvConfig(emsCEURL, authURL string, opts ...EnvConfigOption) *env.BebConfig {
-	envConfig := &env.BebConfig{Port: 8080, EmsPublishURL: emsCEURL, TokenEndpoint: authURL, RequestTimeout: time.Minute}
+func NewEnvConfig(emsCEURL, authURL string, opts ...EnvConfigOption) *env.BEBConfig {
+	envConfig := &env.BEBConfig{Port: 8080, EmsPublishURL: emsCEURL, TokenEndpoint: authURL, RequestTimeout: time.Minute}
 	for _, opt := range opts {
 		opt(envConfig)
 	}
 	return envConfig
 }
 
-type EnvConfigOption func(e *env.BebConfig)
+type EnvConfigOption func(e *env.BEBConfig)
 
 func WithPort(port int) EnvConfigOption {
-	return func(e *env.BebConfig) {
+	return func(e *env.BEBConfig) {
 		e.Port = port
 	}
 }
 
 func WithMaxIdleConns(maxIdleConns int) EnvConfigOption {
-	return func(e *env.BebConfig) {
+	return func(e *env.BEBConfig) {
 		e.MaxIdleConns = maxIdleConns
 	}
 }
 
 func WithMaxIdleConnsPerHost(maxIdleConnsPerHost int) EnvConfigOption {
-	return func(e *env.BebConfig) {
+	return func(e *env.BEBConfig) {
 		e.MaxIdleConnsPerHost = maxIdleConnsPerHost
 	}
 }
 
 func WithRequestTimeout(requestTimeout time.Duration) EnvConfigOption {
-	return func(e *env.BebConfig) {
+	return func(e *env.BEBConfig) {
 		e.RequestTimeout = requestTimeout
 	}
 }
 
 func WithBEBNamespace(bebNs string) EnvConfigOption {
-	return func(e *env.BebConfig) {
+	return func(e *env.BEBConfig) {
 		e.BEBNamespace = bebNs
 	}
 }
 
 func WithEventTypePrefix(eventTypePrefix string) EnvConfigOption {
-	return func(e *env.BebConfig) {
+	return func(e *env.BEBConfig) {
 		e.EventTypePrefix = eventTypePrefix
 	}
 }

--- a/components/event-publisher-proxy/testing/nats.go
+++ b/components/event-publisher-proxy/testing/nats.go
@@ -64,7 +64,7 @@ func SubscribeToEventOrFail(t *testing.T, connection *nats.Conn, eventType strin
 	}
 }
 
-func ValidateNatsSubjectOrFail(t *testing.T, subject string, notify ...chan bool) nats.MsgHandler {
+func ValidateNATSSubjectOrFail(t *testing.T, subject string, notify ...chan bool) nats.MsgHandler {
 	return func(msg *nats.Msg) {
 		for _, n := range notify {
 			n <- true

--- a/components/event-publisher-proxy/testing/nats.go
+++ b/components/event-publisher-proxy/testing/nats.go
@@ -34,13 +34,13 @@ var NATSServerModes = []struct {
 	},
 }
 
-func StartNATSServer(enableJetstream bool) *server.Server {
+func StartNATSServer(enableJetStream bool) *server.Server {
 	opts := test.DefaultTestOptions
 	opts.Port = server.RANDOM_PORT
-	opts.JetStream = enableJetstream
+	opts.JetStream = enableJetStream
 
 	log, _ := logger.New("json", "info")
-	if enableJetstream {
+	if enableJetStream {
 		log.WithContext().Info("Starting test NATS Server in Jetstream mode")
 	} else {
 		log.WithContext().Info("Starting test NATS Server in default mode")

--- a/components/event-publisher-proxy/testing/nats.go
+++ b/components/event-publisher-proxy/testing/nats.go
@@ -75,10 +75,10 @@ func ValidateNATSSubjectOrFail(t *testing.T, subject string, notify ...chan bool
 	}
 }
 
-// ValidateNatsMessageDataOrFail returns a function which can be used to validate a nats.Msg.
+// ValidateNATSMessageDataOrFail returns a function which can be used to validate a nats.Msg.
 // It reads the data from nats.Msg and unmarshalls it as a CloudEvent.
 // The data section of the CloudEvent is then checked against the value provided in data.
-func ValidateNatsMessageDataOrFail(t *testing.T, data string, notify ...chan bool) nats.MsgHandler {
+func ValidateNATSMessageDataOrFail(t *testing.T, data string, notify ...chan bool) nats.MsgHandler {
 	return func(msg *nats.Msg) {
 		for _, n := range notify {
 			n <- true

--- a/components/event-publisher-proxy/testing/nats.go
+++ b/components/event-publisher-proxy/testing/nats.go
@@ -41,7 +41,7 @@ func StartNATSServer(enableJetStream bool) *server.Server {
 
 	log, _ := logger.New("json", "info")
 	if enableJetStream {
-		log.WithContext().Info("Starting test NATS Server in Jetstream mode")
+		log.WithContext().Info("Starting test NATS Server in JetStream mode")
 	} else {
 		log.WithContext().Info("Starting test NATS Server in default mode")
 	}

--- a/components/event-publisher-proxy/testing/nats.go
+++ b/components/event-publisher-proxy/testing/nats.go
@@ -34,7 +34,7 @@ var NATSServerModes = []struct {
 	},
 }
 
-func StartNatsServer(enableJetstream bool) *server.Server {
+func StartNATSServer(enableJetstream bool) *server.Server {
 	opts := test.DefaultTestOptions
 	opts.Port = server.RANDOM_PORT
 	opts.JetStream = enableJetstream

--- a/components/event-publisher-proxy/testing/nats.go
+++ b/components/event-publisher-proxy/testing/nats.go
@@ -20,7 +20,7 @@ const (
 	StreamName = "kyma"
 )
 
-var NatsServerModes = []struct {
+var NATSServerModes = []struct {
 	Name             string
 	JetstreamEnabled bool
 }{

--- a/components/event-publisher-proxy/testing/nats.go
+++ b/components/event-publisher-proxy/testing/nats.go
@@ -48,7 +48,7 @@ func StartNATSServer(enableJetstream bool) *server.Server {
 	return test.RunServer(&opts)
 }
 
-func ConnectToNatsServer(url string) (*nats.Conn, error) {
+func ConnectToNATSServer(url string) (*nats.Conn, error) {
 	return pkgnats.Connect(url,
 		pkgnats.WithRetryOnFailedConnect(true),
 		pkgnats.WithMaxReconnects(3),

--- a/components/event-publisher-proxy/testing/nats.go
+++ b/components/event-publisher-proxy/testing/nats.go
@@ -22,15 +22,15 @@ const (
 
 var NATSServerModes = []struct {
 	Name             string
-	JetstreamEnabled bool
+	JetStreamEnabled bool
 }{
 	{
 		Name:             "jetstream disabled",
-		JetstreamEnabled: false,
+		JetStreamEnabled: false,
 	},
 	{
 		Name:             "jetstream enabled",
-		JetstreamEnabled: true,
+		JetStreamEnabled: true,
 	},
 }
 

--- a/resources/eventing/values.yaml
+++ b/resources/eventing/values.yaml
@@ -9,7 +9,7 @@ global:
       pullPolicy: "IfNotPresent"
     publisher_proxy:
       name: event-publisher-proxy
-      version: PR-15454
+      version: PR-15500
     nats:
       name: nats
       version: 2.8.4-alpine


### PR DESCRIPTION
"tiny" PR that only changes spelling for more consistency:
Beb -> BEB
Nats -> NATS
Jetstream -> JetStream

No functional changes.