### PR TITLE
Restructure test files controllers/backend/backend and errors

### DIFF
--- a/components/eventing-controller/controllers/backend/reconciler_internal_unit_test.go
+++ b/components/eventing-controller/controllers/backend/reconciler_internal_unit_test.go
@@ -1,3 +1,4 @@
+//todo unit
 package backend
 
 import (
@@ -9,10 +10,9 @@ import (
 	"time"
 
 	"github.com/go-logr/zapr"
-	"github.com/stretchr/testify/assert"
-
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	"github.com/stretchr/testify/assert"
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -29,7 +29,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 
 	kymalogger "github.com/kyma-project/kyma/common/logging/logger"
-
 	eventingv1alpha1 "github.com/kyma-project/kyma/components/eventing-controller/api/v1alpha1"
 	"github.com/kyma-project/kyma/components/eventing-controller/logger"
 	"github.com/kyma-project/kyma/components/eventing-controller/pkg/deployment"
@@ -91,7 +90,7 @@ func TestGetSecretForPublisher(t *testing.T) {
 		expectedError  error
 	}{
 		{
-			name: "with valid message and namespace data", // nolint:gofmt
+			name:          "with valid message and namespace data", // nolint:gofmt
 			messagingData: []byte("[{		\"broker\": {			\"type\": \"sapmgw\"		},		\"oa2\": {			\"clientid\": \"clientid\",			\"clientsecret\": \"clientsecret\",			\"granttype\": \"client_credentials\",			\"tokenendpoint\": \"https://token\"		},		\"protocol\": [\"amqp10ws\"],		\"uri\": \"wss://amqp\"	}, {		\"broker\": {			\"type\": \"sapmgw\"		},		\"oa2\": {			\"clientid\": \"clientid\",			\"clientsecret\": \"clientsecret\",			\"granttype\": \"client_credentials\",			\"tokenendpoint\": \"https://token\"		},		\"protocol\": [\"amqp10ws\"],		\"uri\": \"wss://amqp\"	},	{		\"broker\": {			\"type\": \"saprestmgw\"		},		\"oa2\": {			\"clientid\": \"rest-clientid\",			\"clientsecret\": \"rest-client-secret\",			\"granttype\": \"client_credentials\",			\"tokenendpoint\": \"https://rest-token\"		},		\"protocol\": [\"httprest\"],		\"uri\": \"https://rest-messaging\"	}]"),
 			namespaceData: []byte("valid/namespace"),
 			expectedSecret: corev1.Secret{
@@ -118,7 +117,7 @@ func TestGetSecretForPublisher(t *testing.T) {
 			expectedError: errors.New("message is missing from BEB secret"),
 		},
 		{
-			name: "with empty namespace data", // nolint:gofmt
+			name:          "with empty namespace data", // nolint:gofmt
 			messagingData: []byte("[{		\"broker\": {			\"type\": \"sapmgw\"		},		\"oa2\": {			\"clientid\": \"clientid\",			\"clientsecret\": \"clientsecret\",			\"granttype\": \"client_credentials\",			\"tokenendpoint\": \"https://token\"		},		\"protocol\": [\"amqp10ws\"],		\"uri\": \"wss://amqp\"	}, {		\"broker\": {			\"type\": \"sapmgw\"		},		\"oa2\": {			\"clientid\": \"clientid\",			\"clientsecret\": \"clientsecret\",			\"granttype\": \"client_credentials\",			\"tokenendpoint\": \"https://token\"		},		\"protocol\": [\"amqp10ws\"],		\"uri\": \"wss://amqp\"	},	{		\"broker\": {			\"type\": \"saprestmgw\"		},		\"oa2\": {			\"clientid\": \"rest-clientid\",			\"clientsecret\": \"rest-client-secret\",			\"granttype\": \"client_credentials\",			\"tokenendpoint\": \"https://rest-token\"		},		\"protocol\": [\"httprest\"],		\"uri\": \"https://rest-messaging\"	}]"),
 			expectedError: errors.New("namespace is missing from BEB secret"),
 		},

--- a/components/eventing-controller/controllers/backend/reconciler_internal_unit_test.go
+++ b/components/eventing-controller/controllers/backend/reconciler_internal_unit_test.go
@@ -1,4 +1,4 @@
-//todo unit
+// todo unit
 package backend
 
 import (

--- a/components/eventing-controller/controllers/errors/skip_unit_test.go
+++ b/components/eventing-controller/controllers/errors/skip_unit_test.go
@@ -1,23 +1,25 @@
-package errors
+package errors_test
 
 import (
 	"errors"
 	"fmt"
 	"testing"
+
+	ctrlserrors "github.com/kyma-project/kyma/components/eventing-controller/controllers/errors"
 )
 
 func Test_NewSkippable(t *testing.T) {
 	testCases := []struct {
 		error error
 	}{
-		{error: NewSkippable(nil)},
-		{error: NewSkippable(NewSkippable(nil))},
-		{error: NewSkippable(fmt.Errorf("some error"))},
-		{error: NewSkippable(NewSkippable(fmt.Errorf("some error")))},
+		{error: ctrlserrors.NewSkippable(nil)},
+		{error: ctrlserrors.NewSkippable(ctrlserrors.NewSkippable(nil))},
+		{error: ctrlserrors.NewSkippable(fmt.Errorf("some error"))},
+		{error: ctrlserrors.NewSkippable(ctrlserrors.NewSkippable(fmt.Errorf("some error")))},
 	}
 
 	for _, tc := range testCases {
-		skippableErr := NewSkippable(tc.error)
+		skippableErr := ctrlserrors.NewSkippable(tc.error)
 		if skippableErr == nil {
 			t.Errorf("test NewSkippable retuned nil error")
 			continue
@@ -41,7 +43,7 @@ func Test_IsSkippable(t *testing.T) {
 		},
 		{
 			name:          "skippable error, should be skipped",
-			givenError:    NewSkippable(fmt.Errorf("some errore")),
+			givenError:    ctrlserrors.NewSkippable(fmt.Errorf("some errore")),
 			wantSkippable: true,
 		},
 		{
@@ -51,14 +53,14 @@ func Test_IsSkippable(t *testing.T) {
 		},
 		{
 			name:          "not-skippable error which wraps a skippable error, should not be skipped",
-			givenError:    fmt.Errorf("some error %w", NewSkippable(fmt.Errorf("some error"))),
+			givenError:    fmt.Errorf("some error %w", ctrlserrors.NewSkippable(fmt.Errorf("some error"))),
 			wantSkippable: false,
 		},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			if gotSkippable := IsSkippable(tc.givenError); tc.wantSkippable != gotSkippable {
+			if gotSkippable := ctrlserrors.IsSkippable(tc.givenError); tc.wantSkippable != gotSkippable {
 				t.Errorf("test skippable failed, want: %v but got: %v", tc.wantSkippable, gotSkippable)
 			}
 		})

--- a/components/eventing-controller/controllers/errors/skip_unit_test.go
+++ b/components/eventing-controller/controllers/errors/skip_unit_test.go
@@ -1,3 +1,4 @@
+// todo unit
 package errors_test
 
 import (

--- a/resources/eventing/values.yaml
+++ b/resources/eventing/values.yaml
@@ -5,7 +5,7 @@ global:
   images:
     eventing_controller:
       name: eventing-controller
-      version: PR-15482
+      version: PR-15502
       pullPolicy: "IfNotPresent"
     publisher_proxy:
       name: event-publisher-proxy


### PR DESCRIPTION
This pr restructures the tests in `controllers/backend` and `controllers/errors` of the `eventing-controller`
- The files of the tests are renamed as `unit`/`integration` respectively
- The tests have been move into extra modules by adding the `_test` prefix to the module name

This is a preparation for separating the tests into `unit` and `integration` tests via build tags.