### PR TITLE
replace `"io/ioutil"` with `"io"` in `event-publisher-proxy`

### DIFF
--- a/resources/eventing/values.yaml
+++ b/resources/eventing/values.yaml
@@ -9,7 +9,7 @@ global:
       pullPolicy: "IfNotPresent"
     publisher_proxy:
       name: event-publisher-proxy
-      version: PR-15609
+      version: PR-15533
     nats:
       name: nats
       version: 2.9.0-alpine3.16


### PR DESCRIPTION
`"io/ioutil"` was deprecated and thus was replaced with `"io"` in this PR.

[More details](https://pkg.go.dev/io/ioutil)