### PR TITLE
Set permissive mTLS policy for publisher-proxy metrics port

### DIFF
--- a/resources/eventing/charts/publisher-proxy/templates/peerauthentication.yaml
+++ b/resources/eventing/charts/publisher-proxy/templates/peerauthentication.yaml
@@ -9,4 +9,4 @@ spec:
     matchLabels: {{- include "publisher-proxy.peerauth.selectorLabels" . | nindent 6 }}
   portLevelMtls:
     {{ .Values.metrics.config.port }}:
-      mode: STRICT
+      mode: PERMISSIVE

--- a/resources/eventing/charts/publisher-proxy/templates/servicemonitor.yaml
+++ b/resources/eventing/charts/publisher-proxy/templates/servicemonitor.yaml
@@ -15,9 +15,4 @@ spec:
   endpoints:
     - port: {{ .Values.global.ports.namePrefix }}{{ .Values.metrics.config.portName }}
       interval: {{ .Values.metrics.config.interval }}
-      scheme: https
-      tlsConfig: 
-        caFile: /etc/prometheus/secrets/istio.default/root-cert.pem
-        certFile: /etc/prometheus/secrets/istio.default/cert-chain.pem
-        keyFile: /etc/prometheus/secrets/istio.default/key.pem
-        insecureSkipVerify: true  # Prometheus does not support Istio security naming, thus skip verifying target pod ceritifcate
+      scheme: http


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- add flag to enable loosening of the mTLS mode for publisher proxy
- set the policy to `PERMISSIVE` for the publisher's metrics port
