### PR TITLE
Fix the command to add the workloads to Service Mesh

### DIFF
--- a/docs/03-tutorials/00-application-connectivity/ac-03-register-manage-services.md
+++ b/docs/03-tutorials/00-application-connectivity/ac-03-register-manage-services.md
@@ -34,7 +34,7 @@ This guide shows you how to register a service of your external solution in Kyma
 
 2. Enable [Istio sidecar injection](../../01-overview/main-areas/service-mesh/smsh-03-istio-sidecars-in-kyma.md) in the Namespace:
    ```bash
-   kubectl label $NAMESPACE default istio-injection=enabled
+   kubectl label namespace $NAMESPACE istio-injection=enabled
    ```
 
 ## Register a service


### PR DESCRIPTION
**Description**

There was an error in the command to enable automatic Istio sidecar injection in the [Register a service tutorial](https://kyma-project.io/docs/kyma/2.7/03-tutorials/00-application-connectivity/ac-03-register-manage-services/). Instead of replacing the Namespace name with a variable, the command option was replaced, and there was a variable + the hardcoded Namespace name left. 
This PR fixes that. 

Changes proposed in this pull request:

- Fix the typo in the command to enable automatic Istio sidecar injection in a given Namespace
