### PR TITLE
Use the configured NATS URL as the destination service value for the Eventing publisher proxy custom metrics

### DIFF
--- a/components/event-publisher-proxy/pkg/env/nats_config.go
+++ b/components/event-publisher-proxy/pkg/env/nats_config.go
@@ -13,7 +13,7 @@ const JetStreamSubjectPrefix = "kyma"
 // NATSConfig represents the environment config for the Event Publisher to NATS.
 type NATSConfig struct {
 	Port                 int           `envconfig:"INGRESS_PORT" default:"8080"`
-	URL                  string        `envconfig:"NATS_URL" default:"nats.nats.svc.cluster.local"`
+	URL                  string        `envconfig:"NATS_URL" required:"true"`
 	RetryOnFailedConnect bool          `envconfig:"RETRY_ON_FAILED_CONNECT" default:"true"`
 	MaxReconnects        int           `envconfig:"MAX_RECONNECTS" default:"-1"` // Negative means keep try reconnecting.
 	ReconnectWait        time.Duration `envconfig:"RECONNECT_WAIT" default:"5s"`

--- a/components/event-publisher-proxy/pkg/sender/jetstream.go
+++ b/components/event-publisher-proxy/pkg/sender/jetstream.go
@@ -48,7 +48,7 @@ func NewJetStreamMessageSender(ctx context.Context, connection *nats.Conn, envCf
 
 // URL returns the URL of the Sender's connection.
 func (s *JetStreamMessageSender) URL() string {
-	return s.connection.ConnectedUrl()
+	return s.envCfg.URL
 }
 
 // ConnectionStatus returns nats.Status for the NATS connection used by the JetStreamMessageSender.

--- a/components/eventing-controller/pkg/deployment/publisher_deployment.go
+++ b/components/eventing-controller/pkg/deployment/publisher_deployment.go
@@ -45,8 +45,6 @@ const (
 
 	configMapName               = "eventing"
 	configMapKeyEventTypePrefix = "eventTypePrefix"
-
-	natsURL = "eventing-nats.kyma-system.svc.cluster.local"
 )
 
 var (

--- a/components/eventing-controller/pkg/deployment/publisher_deployment.go
+++ b/components/eventing-controller/pkg/deployment/publisher_deployment.go
@@ -325,7 +325,7 @@ func getNATSEnvVars(natsConfig env.NatsConfig, publisherConfig env.PublisherConf
 	return []v1.EnvVar{
 		{Name: "BACKEND", Value: "nats"},
 		{Name: "PORT", Value: strconv.Itoa(int(publisherPortNum))},
-		{Name: "NATS_URL", Value: natsURL},
+		{Name: "NATS_URL", Value: natsConfig.URL},
 		{Name: "REQUEST_TIMEOUT", Value: publisherConfig.RequestTimeout},
 		{Name: "LEGACY_NAMESPACE", Value: "kyma"},
 		{

--- a/components/eventing-controller/pkg/deployment/publisher_deployment_integration_test.go
+++ b/components/eventing-controller/pkg/deployment/publisher_deployment_integration_test.go
@@ -13,6 +13,10 @@ import (
 	"github.com/kyma-project/kyma/components/eventing-controller/pkg/env"
 )
 
+const (
+	natsURL = "eventing-nats.kyma-system.svc.cluster.local"
+)
+
 func TestNewDeployment(t *testing.T) {
 	publisherConfig := env.PublisherConfig{
 		RequestsCPU:     "32m",
@@ -51,6 +55,7 @@ func TestNewDeployment(t *testing.T) {
 			case "NATS":
 				natsConfig = env.NatsConfig{
 					JSStreamName: "kyma",
+					URL:          natsURL,
 				}
 				deployment = NewNATSPublisherDeployment(natsConfig, publisherConfig)
 			case "BEB":

--- a/components/eventing-controller/pkg/env/nats_config.go
+++ b/components/eventing-controller/pkg/env/nats_config.go
@@ -11,7 +11,7 @@ const JetStreamSubjectPrefix = "kyma"
 // NatsConfig represents the environment config for the Eventing Controller with Nats.
 type NatsConfig struct {
 	// Following details are for eventing-controller to communicate to Nats
-	URL           string `envconfig:"NATS_URL" default:"nats.nats.svc.cluster.local"`
+	URL           string `envconfig:"NATS_URL" required:"true"`
 	MaxReconnects int
 	ReconnectWait time.Duration
 

--- a/components/eventing-controller/pkg/env/nats_config_test.go
+++ b/components/eventing-controller/pkg/env/nats_config_test.go
@@ -26,6 +26,7 @@ func TestGetNatsConfig(t *testing.T) {
 		{name: "Required values only gives valid config",
 			args: args{
 				envs: map[string]string{
+					"NATS_URL":          "natsurl",
 					"EVENT_TYPE_PREFIX": "etp",
 					"JS_STREAM_NAME":    "jsn",
 				},
@@ -33,7 +34,7 @@ func TestGetNatsConfig(t *testing.T) {
 				reconnectWait: 1 * time.Second,
 			},
 			want: NatsConfig{
-				URL:                     "nats.nats.svc.cluster.local",
+				URL:                     "natsurl",
 				MaxReconnects:           1,
 				ReconnectWait:           1 * time.Second,
 				EventTypePrefix:         "etp",

--- a/resources/eventing/values.yaml
+++ b/resources/eventing/values.yaml
@@ -5,11 +5,11 @@ global:
   images:
     eventing_controller:
       name: eventing-controller
-      version: PR-15838
+      version: PR-15608
       pullPolicy: "IfNotPresent"
     publisher_proxy:
       name: event-publisher-proxy
-      version: PR-15734
+      version: PR-15608
     nats:
       name: nats
       version: 2.9.3-alpine3.16


### PR DESCRIPTION
**Description**

Use the configured NATS URL as the destination service value for the Eventing publisher proxy custom metrics.

**Related issue(s)**

- https://github.com/kyma-project/kyma/issues/15472.
