### PR TITLE
Allow adding custom service accounts to Jaeger authorizationPolicy

### DIFF
--- a/resources/tracing/templates/kyma-additions/authorization-policy.yaml
+++ b/resources/tracing/templates/kyma-additions/authorization-policy.yaml
@@ -19,11 +19,17 @@ spec:
           - cluster.local/ns/{{ .Release.Namespace }}/sa/{{ include "jaeger-operator.fullname" . }}-auth-proxy
           - cluster.local/ns/{{ .Release.Namespace }}/sa/kiali
           - cluster.local/ns/{{ .Release.Namespace }}/sa/monitoring-grafana
+{{- with .Values.authorizationPolicy.query.extraPrincipals }}
+  {{- toYaml . | nindent 10 }}
+{{- end }}
 {{ end }}
   - from:
     - source:
         principals:
         - cluster.local/ns/{{ .Release.Namespace }}/sa/monitoring-prometheus
+{{- with .Values.authorizationPolicy.monitoring.extraPrincipals }}
+  {{- toYaml . | nindent 8 }}
+{{- end }}
     to:
       - operation:
           ports: # Jaeger metrics, limit to Prometheus. Istio does not detect this to be an HTTP connection due to the port name. No further restriction of method and path possible.

--- a/resources/tracing/values.yaml
+++ b/resources/tracing/values.yaml
@@ -202,3 +202,12 @@ authProxy:
     requests:
       cpu: 20m
       memory: 15Mi
+
+# Additional service accounts to grant Jaeger access via Istio Authorization Policy
+authorizationPolicy:
+  query:
+    extraPrincipals:
+#      - cluster.local/ns/kiali/sa/kiali-server-service-account
+  monitoring:
+     extraPrincipals:
+#      - cluster.local/ns/kiali/sa/kiali-server-service-account


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

After adding an example to deploy a custom Kiali instance in PR https://github.com/kyma-project/examples/pull/207, this PR allows to add additional service accounts to the Jaeger authorizationPolicy via overrides to integrate Kiali.

Changes proposed in this pull request:

- Allow adding custom service accounts to Jaeger authorizationPolicy

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
https://github.com/kyma-project/kyma/issues/15410