### PR TITLE
Align status codes for errors in Application Gateway

### DIFF
--- a/components/central-application-gateway/cmd/applicationgateway/applicationproxy.go
+++ b/components/central-application-gateway/cmd/applicationgateway/applicationproxy.go
@@ -79,21 +79,21 @@ func main() {
 		Addr:         ":" + strconv.Itoa(options.externalAPIPort),
 		Handler:      externalHandler,
 		ReadTimeout:  time.Duration(options.requestTimeout) * time.Second,
-		WriteTimeout: time.Duration(options.requestTimeout) * time.Second,
+		WriteTimeout: time.Duration(options.requestTimeout+1) * time.Second,
 	}
 
 	internalSrv := &http.Server{
 		Addr:         ":" + strconv.Itoa(options.proxyPort),
 		Handler:      internalHandler,
 		ReadTimeout:  time.Duration(options.requestTimeout) * time.Second,
-		WriteTimeout: time.Duration(options.requestTimeout) * time.Second,
+		WriteTimeout: time.Duration(options.requestTimeout+1) * time.Second,
 	}
 
 	internalSrvCompass := &http.Server{
 		Addr:         ":" + strconv.Itoa(options.proxyPortCompass),
 		Handler:      internalHandlerForCompass,
 		ReadTimeout:  time.Duration(options.requestTimeout) * time.Second,
-		WriteTimeout: time.Duration(options.requestTimeout) * time.Second,
+		WriteTimeout: time.Duration(options.requestTimeout+1) * time.Second,
 	}
 
 	var g run.Group

--- a/components/central-application-gateway/cmd/applicationgateway/applicationproxy.go
+++ b/components/central-application-gateway/cmd/applicationgateway/applicationproxy.go
@@ -79,21 +79,19 @@ func main() {
 		Addr:         ":" + strconv.Itoa(options.externalAPIPort),
 		Handler:      externalHandler,
 		ReadTimeout:  time.Duration(options.requestTimeout) * time.Second,
-		WriteTimeout: time.Duration(options.requestTimeout+15) * time.Second,
+		WriteTimeout: time.Duration(options.requestTimeout) * time.Second,
 	}
 
 	internalSrv := &http.Server{
-		Addr:         ":" + strconv.Itoa(options.proxyPort),
-		Handler:      internalHandler,
-		ReadTimeout:  time.Duration(options.requestTimeout) * time.Second,
-		WriteTimeout: time.Duration(options.requestTimeout+15) * time.Second,
+		Addr:        ":" + strconv.Itoa(options.proxyPort),
+		Handler:     internalHandler,
+		ReadTimeout: time.Duration(options.requestTimeout) * time.Second,
 	}
 
 	internalSrvCompass := &http.Server{
-		Addr:         ":" + strconv.Itoa(options.proxyPortCompass),
-		Handler:      internalHandlerForCompass,
-		ReadTimeout:  time.Duration(options.requestTimeout) * time.Second,
-		WriteTimeout: time.Duration(options.requestTimeout+15) * time.Second,
+		Addr:        ":" + strconv.Itoa(options.proxyPortCompass),
+		Handler:     internalHandlerForCompass,
+		ReadTimeout: time.Duration(options.requestTimeout) * time.Second,
 	}
 
 	var g run.Group

--- a/components/central-application-gateway/cmd/applicationgateway/applicationproxy.go
+++ b/components/central-application-gateway/cmd/applicationgateway/applicationproxy.go
@@ -79,21 +79,21 @@ func main() {
 		Addr:         ":" + strconv.Itoa(options.externalAPIPort),
 		Handler:      externalHandler,
 		ReadTimeout:  time.Duration(options.requestTimeout) * time.Second,
-		WriteTimeout: time.Duration(options.requestTimeout+1) * time.Second,
+		WriteTimeout: time.Duration(options.requestTimeout+15) * time.Second,
 	}
 
 	internalSrv := &http.Server{
 		Addr:         ":" + strconv.Itoa(options.proxyPort),
 		Handler:      internalHandler,
 		ReadTimeout:  time.Duration(options.requestTimeout) * time.Second,
-		WriteTimeout: time.Duration(options.requestTimeout+1) * time.Second,
+		WriteTimeout: time.Duration(options.requestTimeout+15) * time.Second,
 	}
 
 	internalSrvCompass := &http.Server{
 		Addr:         ":" + strconv.Itoa(options.proxyPortCompass),
 		Handler:      internalHandlerForCompass,
 		ReadTimeout:  time.Duration(options.requestTimeout) * time.Second,
-		WriteTimeout: time.Duration(options.requestTimeout+1) * time.Second,
+		WriteTimeout: time.Duration(options.requestTimeout+15) * time.Second,
 	}
 
 	var g run.Group

--- a/components/central-application-gateway/internal/metadata/applications/repository.go
+++ b/components/central-application-gateway/internal/metadata/applications/repository.go
@@ -130,7 +130,7 @@ func (r *repository) getApplication(appName string) (*v1alpha1.Application, appe
 		if k8serrors.IsNotFound(err) {
 			message := fmt.Sprintf("Application: %s not found.", appName)
 			log.Warn(message)
-			return nil, apperrors.Internal(message)
+			return nil, apperrors.NotFound(message)
 		}
 
 		message := fmt.Sprintf("failed to get Application '%s' : %s", appName, err.Error())

--- a/components/central-application-gateway/internal/proxy/factory_test.go
+++ b/components/central-application-gateway/internal/proxy/factory_test.go
@@ -203,7 +203,7 @@ func TestPathExtractionErrors(t *testing.T) {
 			handler.ServeHTTP(rr, req)
 
 			// then
-			assert.Equal(t, http.StatusInternalServerError, rr.Code)
+			assert.Equal(t, http.StatusBadRequest, rr.Code)
 		})
 	}
 }

--- a/components/central-application-gateway/internal/proxy/proxy.go
+++ b/components/central-application-gateway/internal/proxy/proxy.go
@@ -80,7 +80,7 @@ func (p *proxy) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 func (p *proxy) extractPath(u *url.URL) (model.APIIdentifier, string, *url.URL, apperrors.AppError) {
 	apiIdentifier, path, gwURL, err := p.extractPathFunc(u)
 	if err != nil {
-		return model.APIIdentifier{}, "", nil, apperrors.Internal("failed to extract API Identifier from path")
+		return model.APIIdentifier{}, "", nil, apperrors.WrongInput("failed to extract API Identifier from path")
 	}
 
 	return apiIdentifier, path, gwURL, nil

--- a/components/central-application-gateway/internal/proxy/reverseproxy.go
+++ b/components/central-application-gateway/internal/proxy/reverseproxy.go
@@ -1,6 +1,8 @@
 package proxy
 
 import (
+	"context"
+	"errors"
 	"net/http"
 	"net/http/httputil"
 	"net/url"
@@ -147,7 +149,7 @@ func urlRewriter(gatewayURL, target, loc *url.URL) *url.URL {
 
 func codeRewriter(rw http.ResponseWriter, err error) {
 
-	if strings.Contains("context deadline exceeded", err.Error()) {
+	if errors.Is(err, context.DeadlineExceeded) {
 		rw.WriteHeader(http.StatusGatewayTimeout)
 		return
 	}

--- a/components/central-application-gateway/internal/proxy/reverseproxy.go
+++ b/components/central-application-gateway/internal/proxy/reverseproxy.go
@@ -150,6 +150,7 @@ func urlRewriter(gatewayURL, target, loc *url.URL) *url.URL {
 func codeRewriter(rw http.ResponseWriter, err error) {
 
 	if errors.Is(err, context.DeadlineExceeded) {
+		log.Infof("%s: HTTP status code was rewritten to 504", err)
 		rw.WriteHeader(http.StatusGatewayTimeout)
 		return
 	}

--- a/components/central-application-gateway/internal/proxy/reverseproxy.go
+++ b/components/central-application-gateway/internal/proxy/reverseproxy.go
@@ -54,7 +54,7 @@ func newProxy(targetURL string, requestParameters *authorization.RequestParamete
 		log.Infof("Modified request url : '%s', schema : '%s', path : '%s'", req.URL.String(), req.URL.Scheme, req.URL.Path)
 	}
 	errorHandler := func(rw http.ResponseWriter, req *http.Request, err error) {
-		codeRewriter(err, rw)
+		codeRewriter(rw, err)
 	}
 	return &httputil.ReverseProxy{Director: director, Transport: transport, ErrorHandler: errorHandler}, nil
 }
@@ -145,7 +145,7 @@ func urlRewriter(gatewayURL, target, loc *url.URL) *url.URL {
 	return gatewayURL
 }
 
-func codeRewriter(err error, rw http.ResponseWriter) {
+func codeRewriter(rw http.ResponseWriter, err error) {
 
 	if strings.Contains("context deadline exceeded", err.Error()) {
 		rw.WriteHeader(http.StatusGatewayTimeout)

--- a/resources/application-connector/values.yaml
+++ b/resources/application-connector/values.yaml
@@ -35,7 +35,7 @@ global:
       version: "7f767208"
     central_application_gateway:
       name: "central-application-gateway"
-      version: "ab54b86e"
+      version: "PR-15717"
     busybox:
       name: "busybox"
       version: "1.34.1"

--- a/tests/components/application-connector/resources/charts/gateway-test/charts/test/templates/applications/missing-resources-error-handling.yml
+++ b/tests/components/application-connector/resources/charts/gateway-test/charts/test/templates/applications/missing-resources-error-handling.yml
@@ -12,7 +12,7 @@ spec:
     - displayName: application-doesnt-exist
       name: application-doesnt-exist
       providerDisplayName: Kyma
-      description: Should return 500 when application doesn't exist
+      description: Should return 404 when application doesn't exist
       id: "{{ uuidv4 }}"
       entries:
         - type: API

--- a/tests/components/application-connector/resources/charts/gateway-test/charts/test/templates/applications/path-related-error-handling.yml
+++ b/tests/components/application-connector/resources/charts/gateway-test/charts/test/templates/applications/path-related-error-handling.yml
@@ -12,7 +12,7 @@ spec:
     - displayName: missing-srv-app
       name: missing-srv-app
       providerDisplayName: Kyma
-      description: Should return 500 when service and application are missing in the path
+      description: Should return 400 when service and application are missing in the path
       id: "{{ uuidv4 }}"
       entries:
         - type: API
@@ -21,7 +21,7 @@ spec:
     - displayName: missing-srv
       name: missing-srv
       providerDisplayName: Kyma
-      description: Should return 500 when service is missing in the path
+      description: Should return 400 when service is missing in the path
       id: "{{ uuidv4 }}"
       entries:
         - type: API

--- a/tests/components/application-connector/resources/charts/gateway-test/charts/test/templates/applications/proxy-errors.yml
+++ b/tests/components/application-connector/resources/charts/gateway-test/charts/test/templates/applications/proxy-errors.yml
@@ -22,7 +22,7 @@ spec:
     - displayName: timeout
       name: timeout
       providerDisplayName: timeout
-      description: Should return 503 when target times out
+      description: Should return 504 when target times out
       id: "{{ uuidv4 }}"
       entries:
         - type: API

--- a/tests/components/application-connector/resources/charts/gateway-test/charts/test/templates/applications/proxy-errors.yml
+++ b/tests/components/application-connector/resources/charts/gateway-test/charts/test/templates/applications/proxy-errors.yml
@@ -22,8 +22,7 @@ spec:
     - displayName: timeout
       name: timeout
       providerDisplayName: timeout
-      description: Should return 503 when target times out
-      #In future error should return 504, above is temporary
+      description: Should return 504 when target times out
       id: "{{ uuidv4 }}"
       entries:
         - type: API

--- a/tests/components/application-connector/resources/charts/gateway-test/charts/test/templates/applications/proxy-errors.yml
+++ b/tests/components/application-connector/resources/charts/gateway-test/charts/test/templates/applications/proxy-errors.yml
@@ -22,7 +22,8 @@ spec:
     - displayName: timeout
       name: timeout
       providerDisplayName: timeout
-      description: Should return 504 when target times out
+      description: Should return 503 when target times out
+      #In future error should return 504, above is temporary
       id: "{{ uuidv4 }}"
       entries:
         - type: API

--- a/tests/components/application-connector/resources/charts/gateway-test/values.yaml
+++ b/tests/components/application-connector/resources/charts/gateway-test/values.yaml
@@ -5,11 +5,11 @@ global:
   images:
     gatewayTest:
       name: "gateway-test"
-      version: "v20221005-19bb01b8"
+      version: "PR-15717"
 
     mockApplication:
       name: "mock-app"
-      version: "v20221005-19bb01b8"
+      version: "PR-15717"
 
   serviceAccountName: "test-account"
   namespace: "test"

--- a/tests/components/application-connector/resources/charts/gateway-test/values.yaml
+++ b/tests/components/application-connector/resources/charts/gateway-test/values.yaml
@@ -5,11 +5,11 @@ global:
   images:
     gatewayTest:
       name: "gateway-test"
-      version: "PR-15717"
+      version: "v20221005-19bb01b8"
 
     mockApplication:
       name: "mock-app"
-      version: "PR-15717"
+      version: "v20221005-19bb01b8"
 
   serviceAccountName: "test-account"
   namespace: "test"

--- a/tests/components/application-connector/resources/installation-config/mini-kyma-os.yaml
+++ b/tests/components/application-connector/resources/installation-config/mini-kyma-os.yaml
@@ -8,5 +8,6 @@ prerequisites:
     namespace: "istio-system"
 components:
   - name: "istio-resources"
+  - name: "cluster-users"
   - name: "application-connector"
     namespace: "kyma-integration"


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**
REST service should return 5xx for errors that occurred on the server side and 4xx for errors on the client side. Error code should be as informative as possible. 

Changes proposed in this pull request:

- `404 Not Found` status code when the application specified in the path doesn't exist
- `400 Bad Request` status code when application, service or entry for the Compass use case is not specified in the path
- `504 Gateway Timeout` when call to target API timeouts Application Gateway
- deletion of the `WriteTimeout` from the Internal Server and Internal Compass Server due to inconsistencies in timeouts. It was done to handle correctly timeout code rewriting.

**Related issue(s)**
#14842 