### PR TITLE
bump nats server

### DIFF
--- a/resources/eventing/values.yaml
+++ b/resources/eventing/values.yaml
@@ -12,7 +12,7 @@ global:
       version: PR-15713
     nats:
       name: nats
-      version: 2.9.2-alpine3.16
+      version: 2.9.3-alpine3.16
       directory: external
     nats_config_reloader:
       name: natsio/nats-server-config-reloader

--- a/resources/eventing/values.yaml
+++ b/resources/eventing/values.yaml
@@ -12,7 +12,7 @@ global:
       version: PR-15713
     nats:
       name: nats
-      version: 2.9.0-alpine3.16
+      version: 2.9.2-alpine3.16
       directory: external
     nats_config_reloader:
       name: natsio/nats-server-config-reloader


### PR DESCRIPTION
bump the nats server image to `2.9.3-alpine3.16`

look [here](https://github.com/nats-io/nats-server/releases/tag/v2.9.3) for release notes

look [here](https://hub.docker.com/layers/library/nats/2.9.3-alpine3.16/images/sha256-bf9cae35d4496a6557faaaa46222bc55961ffdea0f6d833968a7fe798581a289?context=explore) for image details