### PR TITLE
Disable PSP and configure securityContext properly for observability pods

### DIFF
--- a/resources/kiali/templates/deployment.yaml
+++ b/resources/kiali/templates/deployment.yaml
@@ -57,6 +57,10 @@ spec:
       hostAliases:
       {{- toYaml .Values.deployment.host_aliases | nindent 6 }}
       {{- end }}
+      securityContext:
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
       containers:
       - image: {{ include "imageurl" (dict "reg" .Values.global.containerRegistry "img" .Values.global.images.kiali) }}
         imagePullPolicy: {{ .Values.deployment.image_pull_policy | default "Always" }}
@@ -69,7 +73,9 @@ spec:
           allowPrivilegeEscalation: false
           privileged: false
           readOnlyRootFilesystem: true
-          runAsNonRoot: true
+          capabilities:
+            drop:
+              - ALL
         ports:
         - name: api-port
           containerPort: {{ .Values.server.port | default 20001 }}

--- a/resources/kiali/templates/kyma-additions/auth-proxy-deployment.yaml
+++ b/resources/kiali/templates/kyma-additions/auth-proxy-deployment.yaml
@@ -32,6 +32,10 @@ spec:
       {{- if or .Values.authProxy.priorityClassName .Values.global.highPriorityClassName }}
       priorityClassName: {{ coalesce .Values.authProxy.priorityClassName .Values.global.highPriorityClassName }}
       {{- end }}
+      {{- if .Values.authProxy.securityContext }}
+      securityContext:
+{{ toYaml .Values.authProxy.securityContext | nindent 8 }}
+      {{- end }}
       containers:
       - image: {{ include "imageurl" (dict "reg" .Values.global.containerRegistry "img" .Values.global.images.oauth2_proxy) }}
         imagePullPolicy: {{ .Values.authProxy.image.pullPolicy }}
@@ -66,9 +70,9 @@ spec:
           httpGet:
             path: /ping
             port: http
-        {{- if .Values.authProxy.securityContext }}
+        {{- if .Values.authProxy.containerSecurityContext }}
         securityContext:
-{{ toYaml .Values.authProxy.securityContext | nindent 10 }}
+{{ toYaml .Values.authProxy.containerSecurityContext | nindent 10 }}
         {{- end }}
         resources:
 {{ toYaml .Values.authProxy.resources | indent 10 }}

--- a/resources/kiali/values.yaml
+++ b/resources/kiali/values.yaml
@@ -48,9 +48,19 @@ authProxy:
   env: {}
   nodeSelector: {}
   securityContext:
+    runAsUser: 1000
+    runAsGroup: 1000
+    fsGroup: 1000
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault
+  containerSecurityContext:
     allowPrivilegeEscalation: false
     privileged: false
-    runAsNonRoot: true
+    readOnlyRootFilesystem: true
+    capabilities:
+      drop:
+        - ALL
   image:
     pullPolicy: IfNotPresent
   priorityClassName: "kyma-system-priority"
@@ -136,6 +146,13 @@ deployment:
       cpu: 100m
       memory: 140Mi
   secret_name: "kiali"
+  security_context:
+    allowPrivilegeEscalation: false
+    privileged: false
+    readOnlyRootFilesystem: true
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault
   service_annotations: {}
   service_type: ""
   tolerations: []

--- a/resources/logging/charts/loki/templates/statefulset.yaml
+++ b/resources/logging/charts/loki/templates/statefulset.yaml
@@ -95,7 +95,10 @@ spec:
         {{- if .Values.chunkCleaner.enabled }}
         - name: chunk-cleaner
           image: {{ include "imageurl" (dict "reg" .Values.global.containerRegistry "img" .Values.global.images.alpine) }}
-          resources: {{- toYaml .Values.chunkCleaner.resources | nindent 12 }}
+          resources:
+            {{- toYaml .Values.chunkCleaner.resources | nindent 12 }}
+          securityContext:
+            {{- toYaml .Values.chunkCleaner.securityContext | nindent 12 }}
           command:
             - /bin/sh
             - -c

--- a/resources/logging/charts/loki/values.yaml
+++ b/resources/logging/charts/loki/values.yaml
@@ -161,7 +161,7 @@ podManagementPolicy: OrderedReady
 
 rbac:
   create: true
-  pspEnabled: true
+  pspEnabled: false
 
 readinessProbe:
   httpGet:
@@ -184,11 +184,16 @@ podSecurityContext:
   runAsGroup: 10001
   runAsNonRoot: true
   runAsUser: 10001
+  seccompProfile:
+    type: RuntimeDefault
 
 securityContext:
   allowPrivilegeEscalation: false
   privileged: false
   readOnlyRootFilesystem: true
+  capabilities:
+    drop:
+      - ALL
 
 service:
   type: ClusterIP
@@ -298,6 +303,13 @@ chunkCleaner:
     requests:
       cpu: 10m
       memory: 10Mi
+  securityContext:
+    allowPrivilegeEscalation: false
+    privileged: false
+    readOnlyRootFilesystem: true
+    capabilities:
+      drop:
+        - ALL
     
 grafana:
   datasource:

--- a/resources/monitoring/charts/grafana/templates/kyma-additions/auth-proxy-deployment.yaml
+++ b/resources/monitoring/charts/grafana/templates/kyma-additions/auth-proxy-deployment.yaml
@@ -37,6 +37,10 @@ spec:
       {{- if or .Values.priorityClassName .Values.global.priorityClassName }}
       priorityClassName: {{ coalesce .Values.priorityClassName .Values.global.priorityClassName }}
       {{- end }}
+      {{- if .Values.kyma.authProxy.securityContext }}
+      securityContext:
+{{ toYaml .Values.kyma.authProxy.securityContext | nindent 8 }}
+      {{- end }}
       containers:
       - image: "{{ include "imageurl" (dict "reg" .Values.global.containerRegistry "img" .Values.global.images.oauth2_proxy) }}"
         imagePullPolicy: {{ .Values.kyma.authProxy.image.pullPolicy }}
@@ -71,9 +75,9 @@ spec:
           httpGet:
             path: /ping
             port: http
-        {{- if .Values.kyma.authProxy.securityContext }}
+        {{- if .Values.kyma.authProxy.containerSecurityContext }}
         securityContext:
-{{ toYaml .Values.kyma.authProxy.securityContext | nindent 10 }}
+{{ toYaml .Values.kyma.authProxy.containerSecurityContext | nindent 10 }}
         {{- end }}
         resources:
 {{ toYaml .Values.kyma.authProxy.resources | indent 10 }}

--- a/resources/monitoring/charts/grafana/values.yaml
+++ b/resources/monitoring/charts/grafana/values.yaml
@@ -315,7 +315,7 @@ initChownData:
   ## If false, data ownership will not be reset at startup
   ## This allows the prometheus-server to be run with an arbitrary user
   ##
-  enabled: true
+  enabled: false
 
   ## initChownData container image
   ##

--- a/resources/monitoring/charts/grafana/values.yaml
+++ b/resources/monitoring/charts/grafana/values.yaml
@@ -95,10 +95,17 @@ podSecurityContext:
   runAsUser: 472
   runAsGroup: 472
   fsGroup: 472
+  runAsNonRoot: true
+  seccompProfile:
+    type: RuntimeDefault
 
 containerSecurityContext:
   allowPrivilegeEscalation: false
   privileged: false
+  readOnlyRootFilesystem: true
+  capabilities:
+    drop:
+      - ALL
 extraConfigmapMounts:
   []
   # - name: certs-configmap
@@ -130,6 +137,7 @@ downloadDashboards:
   securityContext:
     allowPrivilegeEscalation: false
     privileged: false
+    readOnlyRootFilesystem: true
 
 ## Pod Annotations
 # podAnnotations: {}
@@ -637,6 +645,10 @@ sidecar:
   securityContext:
     allowPrivilegeEscalation: false
     privileged: false
+    readOnlyRootFilesystem: true
+    capabilities:
+      drop:
+        - ALL
   # skipTlsVerify Set to true to skip tls verification for kube api calls
   # skipTlsVerify: true
   enableUniqueFilenames: false
@@ -798,9 +810,19 @@ kyma:
     env: {}
     nodeSelector: {}
     securityContext:
+      runAsUser: 1000
+      runAsGroup: 1000
+      fsGroup: 1000
+      runAsNonRoot: true
+      seccompProfile:
+        type: RuntimeDefault
+    containerSecurityContext:
       allowPrivilegeEscalation: false
       privileged: false
-      runAsNonRoot: true
+      readOnlyRootFilesystem: true
+      capabilities:
+        drop:
+          - ALL
     port: 3000
     image:
       pullPolicy: IfNotPresent

--- a/resources/monitoring/charts/kube-state-metrics/values.yaml
+++ b/resources/monitoring/charts/kube-state-metrics/values.yaml
@@ -91,7 +91,7 @@ prometheus:
 ## Ref: https://kubernetes.io/docs/concepts/policy/pod-security-policy/
 ##
 podSecurityPolicy:
-  enabled: true
+  enabled: false
   annotations: {}
     ## Specify pod annotations
     ## Ref: https://kubernetes.io/docs/concepts/policy/pod-security-policy/#apparmor
@@ -109,6 +109,9 @@ securityContext:
   runAsGroup: 65534
   runAsUser: 65534
   fsGroup: 65534
+  runAsNonRoot: true
+  seccompProfile:
+    type: RuntimeDefault
 
 ## Specify security settings for a Container
 ## Allows overrides and additional options compared to (Pod) securityContext
@@ -116,6 +119,10 @@ securityContext:
 containerSecurityContext:
   allowPrivilegeEscalation: false
   privileged: false
+  readOnlyRootFilesystem: true
+  capabilities:
+    drop:
+      - ALL
 
 ## Node labels for pod assignment
 ## Ref: https://kubernetes.io/docs/user-guide/node-selection/

--- a/resources/monitoring/charts/prometheus-istio/values.yaml
+++ b/resources/monitoring/charts/prometheus-istio/values.yaml
@@ -424,6 +424,10 @@ configmapReload:
     containerSecurityContext:
       allowPrivilegeEscalation: false
       privileged: false
+      readOnlyRootFilesystem: true
+      capabilities:
+        drop:
+          - ALL
 
     ## configmap-reload resource requests and limits
     ## Ref: http://kubernetes.io/docs/user-guide/compute-resources/
@@ -1110,11 +1114,17 @@ server:
     runAsNonRoot: true
     runAsGroup: 65534
     fsGroup: 65534
+    seccompProfile:
+      type: RuntimeDefault
 
   ## Security context to be added to server container
   containerSecurityContext:
     allowPrivilegeEscalation: false
     privileged: false
+    readOnlyRootFilesystem: true
+    capabilities:
+      drop:
+        - ALL
 
   service:
     ## If false, no Service will be created for the Prometheus server

--- a/resources/monitoring/charts/prometheus-node-exporter/values.yaml
+++ b/resources/monitoring/charts/prometheus-node-exporter/values.yaml
@@ -84,10 +84,16 @@ securityContext:
   runAsGroup: 65534
   runAsNonRoot: true
   runAsUser: 65534
+  seccompProfile:
+    type: RuntimeDefault
 
 containerSecurityContext:
   allowPrivilegeEscalation: false
   privileged: false
+  readOnlyRootFilesystem: true
+  capabilities:
+    drop:
+      - ALL
 
 rbac:
   ## If true, create & use RBAC resources
@@ -95,7 +101,7 @@ rbac:
   create: true
   ## If true, create & use Pod Security Policy resources
   ## https://kubernetes.io/docs/concepts/policy/pod-security-policy/
-  pspEnabled: true
+  pspEnabled: false
   pspAnnotations: {}
 
 # for deployments that have node_exporter deployed outside of the cluster, list

--- a/resources/monitoring/charts/prometheus-pushgateway/values.yaml
+++ b/resources/monitoring/charts/prometheus-pushgateway/values.yaml
@@ -123,9 +123,15 @@ podSecurityContext:
   fsGroup: 65534
   runAsUser: 65534
   runAsNonRoot: true
+  seccompProfile:
+    type: RuntimeDefault
 containerSecurityContext:
   allowPrivilegeEscalation: false
   privileged: false
+  readOnlyRootFilesystem: true
+  capabilities:
+    drop:
+      - ALL
 
 ## Affinity for pod assignment
 ## Ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity

--- a/resources/monitoring/values.yaml
+++ b/resources/monitoring/values.yaml
@@ -181,7 +181,7 @@ global:
     ## Create ClusterRoles that extend the existing view, edit and admin ClusterRoles to interact with prometheus-operator CRDs
     ## Ref: https://kubernetes.io/docs/reference/access-authn-authz/rbac/#aggregated-clusterroles
     createAggregateClusterRoles: false
-    pspEnabled: true
+    pspEnabled: false
     pspAnnotations: {}
       ## Specify pod annotations
       ## Ref: https://kubernetes.io/docs/concepts/policy/pod-security-policy/#apparmor
@@ -749,6 +749,8 @@ alertmanager:
       runAsNonRoot: true
       runAsUser: 1000
       fsGroup: 2000
+      seccompProfile:
+        type: RuntimeDefault
 
     ## ListenLocal makes the Alertmanager server listen on loopback, so that it does not bind against the Pod IP.
     ## Note this is only for the Alertmanager UI, not the gossip communication.
@@ -848,7 +850,7 @@ grafana:
   rbac:
     ## If true, Grafana PSPs will be created
     ##
-    pspEnabled: true
+    pspEnabled: false
 
   ingress:
     ## If true, Grafana Ingress will be created
@@ -1697,7 +1699,7 @@ prometheus-node-exporter:
   rbac:
     ## If true, create PSPs for node-exporter
     ##
-    pspEnabled: true
+    pspEnabled: false
 
 ## Manages Prometheus and Alertmanager components
 ##
@@ -1960,6 +1962,8 @@ prometheusOperator:
     runAsGroup: 65534
     runAsNonRoot: true
     runAsUser: 65534
+    seccompProfile:
+      type: RuntimeDefault
 
   ## Container-specific security context configuration
   ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
@@ -1968,6 +1972,9 @@ prometheusOperator:
     allowPrivilegeEscalation: false
     readOnlyRootFilesystem: true
     privileged: false
+    capabilities:
+      drop:
+        - ALL
 
   ## Prometheus-operator image
   ##
@@ -2904,6 +2911,8 @@ prometheus:
       runAsNonRoot: true
       runAsUser: 1000
       fsGroup: 2000
+      seccompProfile:
+        type: RuntimeDefault
 
     ## Priority class assigned to the Pods
     ##

--- a/resources/telemetry/charts/fluent-bit/values.yaml
+++ b/resources/telemetry/charts/fluent-bit/values.yaml
@@ -38,7 +38,10 @@ openShift:
     create: true
     annotations: {}
 
-podSecurityContext: {}
+podSecurityContext:
+  runAsNonRoot: false
+  seccompProfile:
+    type: RuntimeDefault
 #   fsGroup: 2000
 
 hostNetwork: false
@@ -61,13 +64,15 @@ hostAliases: []
 #     - "foo.local"
 #     - "bar.local"
 
-securityContext: {}
-#   capabilities:
-#     drop:
-#     - ALL
-#   readOnlyRootFilesystem: true
-#   runAsNonRoot: true
-#   runAsUser: 1000
+securityContext:
+  allowPrivilegeEscalation: false
+  privileged: false
+  capabilities:
+    drop:
+      - ALL
+    add:
+      - FOWNER
+  readOnlyRootFilesystem: true
 
 service:
   type: ClusterIP
@@ -262,6 +267,13 @@ extraContainers: |
       - name: http-metrics
         containerPort: 2021
         protocol: TCP
+    securityContext:
+      allowPrivilegeEscalation: false
+      privileged: false
+      readOnlyRootFilesystem: true
+      capabilities:
+        drop:
+          - ALL
     volumeMounts:
       - name: varfluentbit
         mountPath: /data
@@ -475,6 +487,13 @@ initContainers: |-
   - name: prep-fluent-bit-config
     image: "{{ include "imageurl" (dict "reg" $.Values.global.containerRegistry "img" $.Values.global.images.busybox) }}"
     command: ['sh', '-c', 'cp /main/* /fluent-bit/etc/ && mkdir -p /fluent-bit/etc/dynamic/ && cp /dynamic/* /fluent-bit/etc/dynamic && mkdir -p /fluent-bit/etc/dynamic-parsers/ && cp /dynamic-parsers/* /fluent-bit/etc/dynamic-parsers || touch /fluent-bit/etc/dynamic/empty.conf']
+    securityContext:
+      allowPrivilegeEscalation: false
+      privileged: false
+      readOnlyRootFilesystem: true
+      capabilities:
+        drop:
+          - ALL
     volumeMounts:
     - mountPath: /fluent-bit/etc/
       name: shared-fluent-bit-config

--- a/resources/telemetry/charts/operator/values.yaml
+++ b/resources/telemetry/charts/operator/values.yaml
@@ -22,9 +22,16 @@ podAnnotations: {}
 
 podSecurityContext:
   runAsNonRoot: true
+  seccompProfile:
+    type: RuntimeDefault
 
 securityContext:
   allowPrivilegeEscalation: false
+  privileged: false
+  readOnlyRootFilesystem: false
+  capabilities:
+    drop:
+      - ALL
 
 livenessProbe:
   httpGet:

--- a/resources/tracing/templates/deployment.yaml
+++ b/resources/tracing/templates/deployment.yaml
@@ -53,6 +53,10 @@ spec:
             name: cert
             readOnly: true
           args: ["start"]
+          {{- with .Values.containerSecurityContext }}
+          securityContext:
+{{ toYaml . | indent 12 }}
+          {{- end }}
           env:
             - name: WATCH_NAMESPACE
               {{- if .Values.rbac.clusterRole }}

--- a/resources/tracing/templates/kyma-additions/auth-proxy-deployment.yaml
+++ b/resources/tracing/templates/kyma-additions/auth-proxy-deployment.yaml
@@ -33,6 +33,10 @@ spec:
       {{- if .Values.global.priorityClassName }}
       priorityClassName: {{ .Values.global.priorityClassName }}
       {{- end }}
+      {{- if .Values.authProxy.securityContext }}
+      securityContext:
+{{ toYaml .Values.authProxy.securityContext | nindent 8 }}
+      {{- end }}
       containers:
       - image: "{{ include "imageurl" (dict "reg" .Values.global.containerRegistry "img" .Values.global.images.oauth2_proxy) }}"
         imagePullPolicy: {{ .Values.authProxy.image.pullPolicy }}
@@ -67,9 +71,9 @@ spec:
           httpGet:
             path: /ping
             port: http
-        {{- if .Values.authProxy.securityContext }}
+        {{- if .Values.authProxy.containerSecurityContext }}
         securityContext:
-{{ toYaml .Values.authProxy.securityContext | nindent 10 }}
+{{ toYaml .Values.authProxy.containerSecurityContext | nindent 10 }}
         {{- end }}
         resources:
 {{ toYaml .Values.authProxy.resources | indent 10 }}

--- a/resources/tracing/values.yaml
+++ b/resources/tracing/values.yaml
@@ -82,8 +82,16 @@ jaeger:
       runAsUser: 1000
       runAsGroup: 1000
       fsGroup: 1000
+      runAsNonRoot: true
+      seccompProfile:
+        type: RuntimeDefault
+    containerSecurityContext:
       allowPrivilegeEscalation: false
       privileged: false
+      readOnlyRootFilesystem: true
+      capabilities:
+        drop:
+          - ALL
 
 rbac:
   # Specifies whether RBAC resources should be created
@@ -132,8 +140,16 @@ tolerations: []
 affinity: {}
 
 securityContext:
+  runAsNonRoot: true
+  seccompProfile:
+    type: RuntimeDefault
+
+containerSecurityContext:
   allowPrivilegeEscalation: false
   privileged: false
+  capabilities:
+    drop:
+      - ALL
 
 priorityClassName:
 
@@ -188,11 +204,20 @@ authProxy:
     upstreamTimeout: 1m
   env: {}
   nodeSelector: {}
-  podSecurityContext: {}
   securityContext:
+    runAsUser: 1000
+    runAsGroup: 1000
+    fsGroup: 1000
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault
+  containerSecurityContext:
     allowPrivilegeEscalation: false
     privileged: false
-    runAsNonRoot: true
+    readOnlyRootFilesystem: true
+    capabilities:
+      drop:
+        - ALL
   image:
     pullPolicy: IfNotPresent
   resources:

--- a/resources/tracing/values.yaml
+++ b/resources/tracing/values.yaml
@@ -85,13 +85,13 @@ jaeger:
       runAsNonRoot: true
       seccompProfile:
         type: RuntimeDefault
-    containerSecurityContext:
-      allowPrivilegeEscalation: false
-      privileged: false
-      readOnlyRootFilesystem: true
-      capabilities:
-        drop:
-          - ALL
+    #containerSecurityContext: # available with jaeger-operator 1.38
+    #  allowPrivilegeEscalation: false
+    #  privileged: false
+    #  readOnlyRootFilesystem: true
+    #  capabilities:
+    #    drop:
+    #      - ALL
 
 rbac:
   # Specifies whether RBAC resources should be created


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- disabled all PSPs
- Configured securityContext were possible
- disabled garafanas initChownData initContainer as it is not required and needs special permissions

Left warnings for restricted security level are:
```
Warning: monitoring-prometheus-node-exporter-kj8bv: host namespaces, hostPort, restricted volume types
Warning: telemetry-fluent-bit-vbk9q: unrestricted capabilities, restricted volume types, runAsNonRoot != true
Warning: tracing-jaeger-7d6cdffb9b-9rfz5: allowPrivilegeEscalation != false, unrestricted capabilities
```

Left warnings for baseline security level are:
```
Warning: monitoring-prometheus-node-exporter-kj8bv: host namespaces, hostPath volumes, hostPort
```

The reasoning behind that is:
- fluent-bit must read from the host filesystem and requires capabilities for that and must run as root
- prometheus-node-exporter requires to access to the host as well
- with the jaeger-operator in current version a securityContext on container level cannot be set, we would need to update first

I applied these default settings:
```
podSecurityContext:
    runAsNonRoot: true
    seccompProfile:
      type: RuntimeDefault

containerSecurityContext:
  allowPrivilegeEscalation: false
  privileged: false
  readOnlyRootFilesystem: true
  capabilities:
    drop:
      - ALL
```

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
