### PR TITLE
Add a section on Response rewriting to Application Gateway details

### DIFF
--- a/components/central-application-gateway/README.md
+++ b/components/central-application-gateway/README.md
@@ -54,6 +54,8 @@ Central Application Gateway exposes:
 - an external API implementing a health endpoint for liveness and readiness probes
 - 2 internal APIs implementing a proxy handler accessible via a service of type `ClusterIP`
 
+Application Gateway also supports redirects for the request flows in which the URL host remains unchanged. For more details, see [Response rewriting](../../docs/05-technical-reference/ac-01-application-gateway-details.md#response-rewriting).
+
 ### Standalone mode
 
 The proxy API exposes the following endpoint:

--- a/docs/01-overview/main-areas/application-connectivity/ac-02-application-gateway.md
+++ b/docs/01-overview/main-areas/application-connectivity/ac-02-application-gateway.md
@@ -2,8 +2,10 @@
 title: Application Gateway
 ---
 
-Application Gateway is an intermediary component between a Function or a service and an external API. 
-It [proxies the requests](../../../05-technical-reference/00-architecture/ac-03-application-gateway.md) from Functions and services in Kyma to external APIs based on the configuration stored in Secrets.
+Application Gateway is an intermediary component between a Function or a microservice and an external API. 
+It [proxies the requests](../../../05-technical-reference/00-architecture/ac-03-application-gateway.md) from Functions and microservices in Kyma to external APIs based on the configuration stored in Secrets.
+
+Application Gateway also supports redirects for the request flows in which the URL host remains unchanged. For more details, see [Response rewriting](../../../05-technical-reference/ac-01-application-gateway-details.md#response-rewriting).
 
 ## Supported API authentication for Application CR
 

--- a/docs/05-technical-reference/ac-01-application-gateway-details.md
+++ b/docs/05-technical-reference/ac-01-application-gateway-details.md
@@ -44,3 +44,11 @@ Application Gateway proxies the following headers while making calls to the regi
 - `X-Forwarded-Client-Cert`
 
 In addition, the `User-Agent` header is set to an empty value not specified in the call, which prevents setting the default value.
+
+## Response rewriting
+
+If during a call from an external system to the target path (`TARGET_PATH`), the target responds with `Created` (`201`) or with a redirect (`3xx`) within the same Application CR (`APP_NAME`) and service (`SERVICE_NAME`), the `Location` header is modified so that the original target path is replaced with the Application Gateway URL and port, with the sub-path pointing to the called service attached at the end, in this format: `{APP_GATEWAY_URL}:{APP_GATEWAY_PORT}/{APP_NAME}/{SERVICE_NAME}/{SUB-PATH}`.
+
+For example, if an external system calls `https://httpbin.org`, and it's redirected to `https://httpbin.org/basic-auth/user/passwd`, Application Gateway changes the URL to `http://central-application-gateway.kyma-system:8080/httpbin/httpbin/basic-auth/user/passwd`.
+
+This allows the redirects to go through Application Gateway, and thus, it allows for passing authorization, custom headers, URL parameters, and the body without an issue.

--- a/docs/05-technical-reference/ac-01-application-gateway-details.md
+++ b/docs/05-technical-reference/ac-01-application-gateway-details.md
@@ -47,8 +47,6 @@ In addition, the `User-Agent` header is set to an empty value not specified in t
 
 ## Response rewriting
 
-If during a call from an external system to the target path (`TARGET_PATH`), the target responds with `Created` (`201`) or with a redirect (`3xx`) within the same Application CR (`APP_NAME`) and service (`SERVICE_NAME`), the `Location` header is modified so that the original target path is replaced with the Application Gateway URL and port, with the sub-path pointing to the called service attached at the end, in this format: `{APP_GATEWAY_URL}:{APP_GATEWAY_PORT}/{APP_NAME}/{SERVICE_NAME}/{SUB-PATH}`.
+If during a call to the external system, the target responds with a redirect (`3xx` status code) that points to the URL with the same host and different path, the `Location` header is modified so that the original target path is replaced with the Application Gateway URL and port, with the sub-path pointing to the called service attached at the end, in this format: `{APP_GATEWAY_URL}:{APP_GATEWAY_PORT}/{APP_NAME}/{SERVICE_NAME}/{SUB-PATH}`.
 
-For example, if an external system calls `https://httpbin.org`, and it's redirected to `https://httpbin.org/basic-auth/user/passwd`, Application Gateway changes the URL to `http://central-application-gateway.kyma-system:8080/httpbin/httpbin/basic-auth/user/passwd`.
-
-This allows the redirects to go through Application Gateway, and thus, it allows for passing authorization, custom headers, URL parameters, and the body without an issue.
+This addition makes the HTTP clients (the ones that called the Application Gateway before) follow redirects through the Application Gateway, and not to the service directly. This allows the redirects to go through Application Gateway, and thus, it allows for passing authorization, custom headers, URL parameters, and the body without an issue.

--- a/docs/05-technical-reference/ac-01-application-gateway-details.md
+++ b/docs/05-technical-reference/ac-01-application-gateway-details.md
@@ -47,6 +47,9 @@ In addition, the `User-Agent` header is set to an empty value not specified in t
 
 ## Response rewriting
 
-If during a call to the external system, the target responds with a redirect (`3xx` status code) that points to the URL with the same host and a different path, the `Location` header is modified so that the original target path is replaced with the Application Gateway URL and port, with the sub-path pointing to the called service attached at the end, in this format: `{APP_GATEWAY_URL}:{APP_GATEWAY_PORT}/{APP_NAME}/{SERVICE_NAME}/{SUB-PATH}`.
+Application Gateway performs response rewriting in situations when during a call to the external system, the target responds with a redirect (`3xx` status code) that points to the URL with the same host and a different path.
+In such a case, the `Location` header is modified so that the original target path is replaced with the Application Gateway URL and port. The sub-path pointing to the called service remains attached at the end. 
+The modified `Location` header has the following format: `{APP_GATEWAY_URL}:{APP_GATEWAY_PORT}/{APP_NAME}/{SERVICE_NAME}/{SUB-PATH}`.
 
-This functionality makes the HTTP clients that originally called Application Gateway follow redirects through the Gateway, and not to the service directly. This allows for passing authorization, custom headers, URL parameters, and the body without an issue.
+This functionality makes the HTTP clients that originally called Application Gateway follow redirects through the Gateway, and not to the service directly. 
+This allows for passing authorization, custom headers, URL parameters, and the body without an issue.

--- a/docs/05-technical-reference/ac-01-application-gateway-details.md
+++ b/docs/05-technical-reference/ac-01-application-gateway-details.md
@@ -2,7 +2,7 @@
 title: Application Gateway details
 ---
 
-Application Gateway is an intermediary component between a Function or a service and an external API.
+Application Gateway is an intermediary component between a Function or a microservice and an external API.
 
 ## Application Gateway URL
 
@@ -47,6 +47,6 @@ In addition, the `User-Agent` header is set to an empty value not specified in t
 
 ## Response rewriting
 
-If during a call to the external system, the target responds with a redirect (`3xx` status code) that points to the URL with the same host and different path, the `Location` header is modified so that the original target path is replaced with the Application Gateway URL and port, with the sub-path pointing to the called service attached at the end, in this format: `{APP_GATEWAY_URL}:{APP_GATEWAY_PORT}/{APP_NAME}/{SERVICE_NAME}/{SUB-PATH}`.
+If during a call to the external system, the target responds with a redirect (`3xx` status code) that points to the URL with the same host and a different path, the `Location` header is modified so that the original target path is replaced with the Application Gateway URL and port, with the sub-path pointing to the called service attached at the end, in this format: `{APP_GATEWAY_URL}:{APP_GATEWAY_PORT}/{APP_NAME}/{SERVICE_NAME}/{SUB-PATH}`.
 
-This addition makes the HTTP clients (the ones that called the Application Gateway before) follow redirects through the Application Gateway, and not to the service directly. This allows the redirects to go through Application Gateway, and thus, it allows for passing authorization, custom headers, URL parameters, and the body without an issue.
+This functionality makes the HTTP clients that originally called Application Gateway follow redirects through the Gateway, and not to the service directly. This allows for passing authorization, custom headers, URL parameters, and the body without an issue.


### PR DESCRIPTION
**Description**

Add a section on Response rewriting to [Application Gateway details](https://kyma-project.io/docs/kyma/latest/05-technical-reference/ac-01-application-gateway-details).

Changes proposed in this pull request:

- Describe how Application Gateway handles redirects within the same App CR and service

**Related issue(s)**
#14717