### PR TITLE
Set response content-type in Python runtime

### DIFF
--- a/components/function-runtimes/python39/kubeless/kubeless.py
+++ b/components/function-runtimes/python39/kubeless/kubeless.py
@@ -91,6 +91,10 @@ def exception_handler():
 @app.route('/<:re:.*>', method=['GET', 'POST', 'PATCH', 'DELETE'])
 def handler():
     req = bottle.request
+    req_content_type = req.content_type
+    if req_content_type:
+        bottle.response.content_type = req_content_type
+
     tracer = tracer_provider.get_tracer(req)
     event = Event(req, tracer)
 


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Read the request content-type and use it in the response

**Related issue(s)**
https://github.com/kyma-project/kyma/issues/15758