### PR TITLE
add wait for jaeger pods in FIT

### DIFF
--- a/tests/fast-integration/eventing-test/common/common.js
+++ b/tests/fast-integration/eventing-test/common/common.js
@@ -3,6 +3,15 @@ const eventMeshSecretFilePath = process.env.EVENTMESH_SECRET_FILE || '';
 const natsBackend = 'nats';
 const bebBackend = 'beb';
 const kymaSystem = 'kyma-system';
+const jaegerEndpoint = 'tracing-jaeger-collector';
+const conditionReady = {
+  condition: 'Ready',
+  status: 'True',
+};
+const telemetryOperatorLabel = {
+  key: 'control-plane',
+  value: 'telemetry-operator',
+};
 const jaegerLabel = {
   key: 'app',
   value: 'jaeger',
@@ -34,4 +43,7 @@ module.exports = {
   kymaSystem,
   jaegerLabel,
   jaegerOperatorLabel,
+  jaegerEndpoint,
+  conditionReady,
+  telemetryOperatorLabel,
 };

--- a/tests/fast-integration/eventing-test/common/common.js
+++ b/tests/fast-integration/eventing-test/common/common.js
@@ -2,6 +2,15 @@ const fs = require('fs');
 const eventMeshSecretFilePath = process.env.EVENTMESH_SECRET_FILE || '';
 const natsBackend = 'nats';
 const bebBackend = 'beb';
+const kymaSystem = 'kyma-system';
+const jaegerLabel = {
+  key: 'app',
+  value: 'jaeger',
+};
+const jaegerOperatorLabel = {
+  key: 'app.kubernetes.io/name',
+  value: 'tracing-jaeger-operator',
+};
 
 // returns the EventMesh namespace from the secret.
 function getEventMeshNamespace() {
@@ -22,4 +31,7 @@ module.exports = {
   getEventMeshNamespace,
   natsBackend,
   bebBackend,
+  kymaSystem,
+  jaegerLabel,
+  jaegerOperatorLabel,
 };

--- a/tests/fast-integration/eventing-test/eventing-test.js
+++ b/tests/fast-integration/eventing-test/eventing-test.js
@@ -83,7 +83,8 @@ describe('Eventing tests', function() {
     debug('🐈‍');
     await sleep(20_000);
     debug('🐕');
-    await waitForPodWithLabelAndCondition('control-plane', 'telemetry-operator', kymaNs, 'Ready', 'True', 60_000);
+    await waitForPodWithLabelAndCondition('control-plane', 'telemetry-operator', 'kyma-system',
+        'Ready', 'True', 60_000);
   });
 
   before('Get stream config for JetStream', async function() {

--- a/tests/fast-integration/eventing-test/eventing-test.js
+++ b/tests/fast-integration/eventing-test/eventing-test.js
@@ -32,7 +32,7 @@ const {
   k8sApply,
   deleteK8sPod,
   eventingSubscription,
-  waitForPodStatusWithLabel,
+  waitForPodStatusWithLabel, waitForDeployment,
 } = require('../utils');
 const {
   eventingMonitoringTest,
@@ -54,6 +54,8 @@ const {
 const {
   bebBackend,
   natsBackend, getEventMeshNamespace,
+  kymaSystem,
+  jaegerLabel, jaegerOperatorLabel,
 } = require('./common/common');
 const {
   assert,
@@ -70,6 +72,11 @@ describe('Eventing tests', function() {
   before('Ensure the test and mock namespaces exist', async function() {
     await waitForNamespace(testNamespace);
     await waitForNamespace(mockNamespace);
+  });
+
+  before('Ensure tracing is ready', async function() {
+    await waitForPodStatusWithLabel(jaegerLabel.key, jaegerLabel.value, kymaSystem);
+    await waitForPodStatusWithLabel(jaegerOperatorLabel.key, jaegerOperatorLabel.value, kymaSystem);
   });
 
   before('Expose Grafana', async function() {

--- a/tests/fast-integration/eventing-test/eventing-test.js
+++ b/tests/fast-integration/eventing-test/eventing-test.js
@@ -53,7 +53,7 @@ const {
 const {
   bebBackend,
   natsBackend, getEventMeshNamespace,
-  kymaSystem,
+  kymaSystem, telemetryOperatorLabel, readyCondition, conditionReady, jaegerLabel, jaegerEndpoint,
   // jaegerLabel, jaegerOperatorLabel,
 } = require('./common/common');
 const {
@@ -74,17 +74,15 @@ describe('Eventing tests', function() {
   });
 
   before('Ensure tracing is ready', async function() {
-    await waitForPodWithLabelAndCondition('app', 'jaeger', kymaSystem, 'Ready', 'True');
-    await waitForEndpoint('tracing-jaeger-collector', kymaSystem);
+    await waitForPodWithLabelAndCondition(jaegerLabel.key, jaegerLabel.value, kymaSystem, conditionReady.condition,
+        conditionReady.status);
+    await waitForEndpoint(jaegerEndpoint, kymaSystem);
   });
 
   before('Expose Grafana', async function() {
     await exposeGrafana();
-    debug('🐈‍');
-    await sleep(20_000);
-    debug('🐕');
-    await waitForPodWithLabelAndCondition('control-plane', 'telemetry-operator', 'kyma-system',
-        'Ready', 'True', 60_000);
+    await waitForPodWithLabelAndCondition( telemetryOperatorLabel.key, telemetryOperatorLabel.value, kymaSystem,
+        conditionReady.condition, conditionReady.status, 60_000);
   });
 
   before('Get stream config for JetStream', async function() {

--- a/tests/fast-integration/eventing-test/eventing-test.js
+++ b/tests/fast-integration/eventing-test/eventing-test.js
@@ -80,9 +80,9 @@ describe('Eventing tests', function() {
 
   before('Expose Grafana', async function() {
     await exposeGrafana();
-    debug('wait?');
+    debug('🐈‍⬛');
     await sleep(20_000);
-    debug('wait!');
+    debug('🐕');
   });
 
   before('Get stream config for JetStream', async function() {

--- a/tests/fast-integration/eventing-test/eventing-test.js
+++ b/tests/fast-integration/eventing-test/eventing-test.js
@@ -31,7 +31,7 @@ const {
   isDebugEnabled,
   k8sApply,
   deleteK8sPod,
-  eventingSubscription, waitForEndpoint, waitForPodStatusWithLabel, waitForPodWithLabelAndCondition, sleep,
+  eventingSubscription, waitForEndpoint, waitForPodStatusWithLabel, waitForPodWithLabelAndCondition,
 } = require('../utils');
 const {
   eventingMonitoringTest,
@@ -53,8 +53,7 @@ const {
 const {
   bebBackend,
   natsBackend, getEventMeshNamespace,
-  kymaSystem, telemetryOperatorLabel, readyCondition, conditionReady, jaegerLabel, jaegerEndpoint,
-  // jaegerLabel, jaegerOperatorLabel,
+  kymaSystem, telemetryOperatorLabel, conditionReady, jaegerLabel, jaegerEndpoint,
 } = require('./common/common');
 const {
   assert,

--- a/tests/fast-integration/eventing-test/eventing-test.js
+++ b/tests/fast-integration/eventing-test/eventing-test.js
@@ -32,7 +32,6 @@ const {
   k8sApply,
   deleteK8sPod,
   eventingSubscription,
-  waitForPodStatusWithLabel, waitForDeployment,
 } = require('../utils');
 const {
   eventingMonitoringTest,

--- a/tests/fast-integration/eventing-test/eventing-test.js
+++ b/tests/fast-integration/eventing-test/eventing-test.js
@@ -76,11 +76,13 @@ describe('Eventing tests', function() {
   before('Ensure tracing is ready', async function() {
     await waitForPodWithLabelAndCondition('app', 'jaeger', kymaSystem, 'Ready', 'True');
     await waitForEndpoint('tracing-jaeger-collector', kymaSystem);
-    sleep(60_000);
   });
 
   before('Expose Grafana', async function() {
     await exposeGrafana();
+    debug('wait?');
+    await sleep(20_000);
+    debug('wait!');
   });
 
   before('Get stream config for JetStream', async function() {

--- a/tests/fast-integration/eventing-test/eventing-test.js
+++ b/tests/fast-integration/eventing-test/eventing-test.js
@@ -31,7 +31,7 @@ const {
   isDebugEnabled,
   k8sApply,
   deleteK8sPod,
-  eventingSubscription,
+  eventingSubscription, waitForEndpoint, waitForPodStatusWithLabel, waitForPodWithLabelAndCondition,
 } = require('../utils');
 const {
   eventingMonitoringTest,
@@ -54,7 +54,7 @@ const {
   bebBackend,
   natsBackend, getEventMeshNamespace,
   kymaSystem,
-  jaegerLabel, jaegerOperatorLabel,
+  // jaegerLabel, jaegerOperatorLabel,
 } = require('./common/common');
 const {
   assert,
@@ -74,8 +74,10 @@ describe('Eventing tests', function() {
   });
 
   before('Ensure tracing is ready', async function() {
-    await waitForPodStatusWithLabel(jaegerLabel.key, jaegerLabel.value, kymaSystem);
-    await waitForPodStatusWithLabel(jaegerOperatorLabel.key, jaegerOperatorLabel.value, kymaSystem);
+    // await waitForPodStatusWithLabel(jaegerLabel.key, jaegerLabel.value, kymaSystem);
+    // await waitForPodStatusWithLabel(jaegerOperatorLabel.key, jaegerOperatorLabel.value, kymaSystem);
+    await waitForPodWithLabelAndCondition('app', 'jaeger', kymaSystem, 'Ready', 'True');
+    await waitForEndpoint('tracing-jaeger-collector', kymaSystem);
   });
 
   before('Expose Grafana', async function() {

--- a/tests/fast-integration/eventing-test/eventing-test.js
+++ b/tests/fast-integration/eventing-test/eventing-test.js
@@ -80,9 +80,10 @@ describe('Eventing tests', function() {
 
   before('Expose Grafana', async function() {
     await exposeGrafana();
-    debug('🐈‍⬛');
+    debug('🐈‍');
     await sleep(20_000);
     debug('🐕');
+    await waitForPodWithLabelAndCondition('control-plane', 'telemetry-operator', kymaNs, 'Ready', 'True', 60_000);
   });
 
   before('Get stream config for JetStream', async function() {

--- a/tests/fast-integration/eventing-test/eventing-test.js
+++ b/tests/fast-integration/eventing-test/eventing-test.js
@@ -31,7 +31,7 @@ const {
   isDebugEnabled,
   k8sApply,
   deleteK8sPod,
-  eventingSubscription, waitForEndpoint, waitForPodStatusWithLabel, waitForPodWithLabelAndCondition,
+  eventingSubscription, waitForEndpoint, waitForPodStatusWithLabel, waitForPodWithLabelAndCondition, sleep,
 } = require('../utils');
 const {
   eventingMonitoringTest,
@@ -74,10 +74,9 @@ describe('Eventing tests', function() {
   });
 
   before('Ensure tracing is ready', async function() {
-    // await waitForPodStatusWithLabel(jaegerLabel.key, jaegerLabel.value, kymaSystem);
-    // await waitForPodStatusWithLabel(jaegerOperatorLabel.key, jaegerOperatorLabel.value, kymaSystem);
     await waitForPodWithLabelAndCondition('app', 'jaeger', kymaSystem, 'Ready', 'True');
     await waitForEndpoint('tracing-jaeger-collector', kymaSystem);
+    sleep(10_000);
   });
 
   before('Expose Grafana', async function() {

--- a/tests/fast-integration/eventing-test/eventing-test.js
+++ b/tests/fast-integration/eventing-test/eventing-test.js
@@ -76,7 +76,7 @@ describe('Eventing tests', function() {
   before('Ensure tracing is ready', async function() {
     await waitForPodWithLabelAndCondition('app', 'jaeger', kymaSystem, 'Ready', 'True');
     await waitForEndpoint('tracing-jaeger-collector', kymaSystem);
-    sleep(10_000);
+    sleep(60_000);
   });
 
   before('Expose Grafana', async function() {

--- a/tests/fast-integration/monitoring/grafana.js
+++ b/tests/fast-integration/monitoring/grafana.js
@@ -29,6 +29,14 @@ const {
 
 const kymaNs = 'kyma-system';
 const kymaProxyDeployment = 'monitoring-auth-proxy-grafana';
+const grafanaLabel = {
+  key: 'app',
+  value: 'grafana',
+};
+const conditionReady = {
+  condition: 'Ready',
+  status: 'True',
+};
 const proxySecret = {
   apiVersion: 'v1',
   kind: 'Secret',
@@ -167,9 +175,10 @@ async function restartProxyPod() {
   expect(patchedDeploymentRep1.body.spec.replicas).to.be.equal(1);
 
   // We have to wait for the deployment to redeploy the actual pod.
-  await sleep(1000);
+  await sleep(1_000);
   await waitForDeployment(kymaProxyDeployment, kymaNs);
-  await waitForPodWithLabelAndCondition('app', 'grafana', kymaNs, 'Ready', 'True', 60_000);
+  await waitForPodWithLabelAndCondition(grafanaLabel.key, grafanaLabel.value, kymaNs, conditionReady.condition,
+      conditionReady.status, 60_000);
 }
 
 async function checkGrafanaRedirect(redirectURL, httpStatus) {

--- a/tests/fast-integration/monitoring/grafana.js
+++ b/tests/fast-integration/monitoring/grafana.js
@@ -20,7 +20,7 @@ const {
   sleep,
   waitForDeployment,
   waitForPodWithLabel,
-  error,
+  error, waitForPodWithLabelAndCondition,
 } = require('../utils');
 
 const {
@@ -169,6 +169,7 @@ async function restartProxyPod() {
   // We have to wait for the deployment to redeploy the actual pod.
   await sleep(1000);
   await waitForDeployment(kymaProxyDeployment, kymaNs);
+  await waitForPodWithLabelAndCondition('app', 'grafana', kymaNs, 'Ready', 'True', 60_000);
 }
 
 async function checkGrafanaRedirect(redirectURL, httpStatus) {

--- a/tests/fast-integration/test/fixtures/commerce-mock/index.js
+++ b/tests/fast-integration/test/fixtures/commerce-mock/index.js
@@ -315,7 +315,7 @@ async function checkInClusterEventTracing(targetNamespace) {
   ];
 
   // wait sometime for jaeger to complete tracing data
-  await sleep(60_000);
+  await sleep(10_000);
   await checkTrace(traceId, correctTraceProcessSequence);
 }
 

--- a/tests/fast-integration/test/fixtures/commerce-mock/index.js
+++ b/tests/fast-integration/test/fixtures/commerce-mock/index.js
@@ -315,7 +315,7 @@ async function checkInClusterEventTracing(targetNamespace) {
   ];
 
   // wait sometime for jaeger to complete tracing data
-  await sleep(10 * 1000);
+  await sleep(60_000);
   await checkTrace(traceId, correctTraceProcessSequence);
 }
 

--- a/tests/fast-integration/utils/index.js
+++ b/tests/fast-integration/utils/index.js
@@ -724,7 +724,8 @@ function waitForPodWithLabelAndCondition(
       `/api/v1/namespaces/${namespace}/pods`,
       query,
       (_type, _apiObj, watchObj) => {
-        debug(`Waiting for pod "${namespace}/${watchObj.object.metadata.name}" lol`);
+        debug(`Waiting for pod "${namespace}/${watchObj.object.metadata.name}" 
+          to have condition "${condition}: ${conditionStatus}" for ${timeout/1000} seconds`);
         return (
           watchObj.object.status.conditions &&
             watchObj.object.status.conditions.some(
@@ -733,8 +734,7 @@ function waitForPodWithLabelAndCondition(
         );
       },
       timeout,
-      `Waiting for pod condition ${condition}:${conditionStatus} and label ${labelKey}=${labelValue} 
-      timeout (${timeout} ms)`,
+      `not found.`,
   );
 }
 function waitForPodStatusWithLabel(

--- a/tests/fast-integration/utils/index.js
+++ b/tests/fast-integration/utils/index.js
@@ -345,7 +345,7 @@ function waitForK8sObject(path, query, checkFn, timeout, timeoutMsg) {
   });
 }
 
-function waitForNamespace(name, timeout = 30000) {
+function waitForNamespace(name, timeout = 30_000) {
   return waitForK8sObject(
       `/api/v1/namespaces/${name}`,
       {},
@@ -360,7 +360,7 @@ function waitForNamespace(name, timeout = 30000) {
   );
 }
 
-function waitForClusterAddonsConfiguration(name, timeout = 90000) {
+function waitForClusterAddonsConfiguration(name, timeout = 90_000) {
   return waitForK8sObject(
       '/apis/addons.kyma-project.io/v1alpha1/clusteraddonsconfigurations',
       {},
@@ -372,7 +372,7 @@ function waitForClusterAddonsConfiguration(name, timeout = 90000) {
   );
 }
 
-function waitForApplicationCr(appName, timeout = 300000) {
+function waitForApplicationCr(appName, timeout = 300_000) {
   return waitForK8sObject(
       '/apis/applicationconnector.kyma-project.io/v1alpha1/applications',
       {},
@@ -386,7 +386,7 @@ function waitForApplicationCr(appName, timeout = 300000) {
   );
 }
 
-function waitForEndpoint(name, namespace = 'default', timeout = 300000) {
+function waitForEndpoint(name, namespace = 'default', timeout = 300_000) {
   return waitForK8sObject(
       `/api/v1/namespaces/${namespace}/endpoints`,
       {},
@@ -401,7 +401,7 @@ function waitForEndpoint(name, namespace = 'default', timeout = 300000) {
   );
 }
 
-function waitForFunction(name, namespace = 'default', timeout = 90000) {
+function waitForFunction(name, namespace = 'default', timeout = 90_000) {
   return waitForK8sObject(
       `/apis/serverless.kyma-project.io/v1alpha1/namespaces/${namespace}/functions`,
       {},
@@ -466,7 +466,7 @@ async function getEventingBackend(namespace = 'kyma-system') {
   return '';
 }
 
-function waitForSubscription(name, namespace = 'default', timeout = 180000) {
+function waitForSubscription(name, namespace = 'default', timeout = 180_000) {
   return waitForK8sObject(
       `/apis/eventing.kyma-project.io/v1alpha1/namespaces/${namespace}/subscriptions`,
       {},
@@ -484,7 +484,7 @@ function waitForSubscription(name, namespace = 'default', timeout = 180000) {
   );
 }
 
-function waitForReplicaSet(name, namespace = 'default', timeout = 90000) {
+function waitForReplicaSet(name, namespace = 'default', timeout = 90_000) {
   return waitForK8sObject(
       `/apis/apps/v1/namespaces/${namespace}/replicasets`,
       {},
@@ -501,7 +501,7 @@ function waitForReplicaSet(name, namespace = 'default', timeout = 90000) {
   );
 }
 
-function waitForDaemonSet(name, namespace = 'default', timeout = 90000) {
+function waitForDaemonSet(name, namespace = 'default', timeout = 90_000) {
   return waitForK8sObject(
       `/apis/apps/v1/watch/namespaces/${namespace}/daemonsets/${name}`,
       {},
@@ -515,7 +515,7 @@ function waitForDaemonSet(name, namespace = 'default', timeout = 90000) {
   );
 }
 
-function waitForDeployment(name, namespace = 'default', timeout = 90000) {
+function waitForDeployment(name, namespace = 'default', timeout = 90_000) {
   return waitForK8sObject(
       `/apis/apps/v1/namespaces/${namespace}/deployments`,
       {},
@@ -533,7 +533,7 @@ function waitForDeployment(name, namespace = 'default', timeout = 90000) {
   );
 }
 
-function waitForStatefulSet(name, namespace = 'default', timeout = 90000) {
+function waitForStatefulSet(name, namespace = 'default', timeout = 90_000) {
   return waitForK8sObject(
       `/apis/apps/v1/namespaces/${namespace}/statefulsets`,
       {},
@@ -548,7 +548,7 @@ function waitForStatefulSet(name, namespace = 'default', timeout = 90000) {
   );
 }
 
-function waitForJob(name, namespace = 'default', timeout = 900000, success = 1) {
+function waitForJob(name, namespace = 'default', timeout = 900_000, success = 1) {
   return waitForK8sObject(
       `/apis/batch/v1/namespaces/${namespace}/jobs`,
       {},
@@ -611,7 +611,7 @@ async function printContainerLogs(selector, container, namespace = 'default', ti
   process.stdout.write('Done getting logs\n');
 }
 
-function waitForVirtualService(namespace, apiRuleName, timeout = 30000) {
+function waitForVirtualService(namespace, apiRuleName, timeout = 30_000) {
   const path = `/apis/networking.istio.io/v1beta1/namespaces/${namespace}/virtualservices`;
   const query = {
     labelSelector: `apirule.gateway.kyma-project.io/v1alpha1=${apiRuleName}.${namespace}`,
@@ -738,6 +738,7 @@ function waitForPodWithLabelAndCondition(
       and condition ${condition}=${conditionStatus} timeout (${timeout} ms)`,
   );
 }
+
 function waitForPodStatusWithLabel(
     labelKey,
     labelValue,
@@ -763,7 +764,7 @@ function waitForPodStatusWithLabel(
 function waitForConfigMap(
     cmName,
     namespace = 'default',
-    timeout = 90000,
+    timeout = 90_000,
 ) {
   return waitForK8sObject(
       `/api/v1/namespaces/${namespace}/configmaps`,

--- a/tests/fast-integration/utils/index.js
+++ b/tests/fast-integration/utils/index.js
@@ -715,7 +715,7 @@ function waitForPodWithLabelAndCondition(
     namespace = 'default',
     condition = 'Ready',
     conditionStatus = 'True',
-    timeout = 90000,
+    timeout = 90_000,
 ) {
   const query = {
     labelSelector: `${labelKey}=${labelValue}`,
@@ -725,7 +725,7 @@ function waitForPodWithLabelAndCondition(
       query,
       (_type, _apiObj, watchObj) => {
         debug(`Waiting for pod "${namespace}/${watchObj.object.metadata.name}" 
-          to have condition "${condition}: ${conditionStatus}" for ${timeout/1000} seconds`);
+          to have condition "${condition}: ${conditionStatus}" for ${timeout} ms`);
         return (
           watchObj.object.status.conditions &&
             watchObj.object.status.conditions.some(
@@ -734,7 +734,8 @@ function waitForPodWithLabelAndCondition(
         );
       },
       timeout,
-      `not found.`,
+      `Waiting for pod with label ${labelKey}=${labelValue} 
+      and condition ${condition}=${conditionStatus} timeout (${timeout} ms)`,
   );
 }
 function waitForPodStatusWithLabel(
@@ -742,7 +743,7 @@ function waitForPodStatusWithLabel(
     labelValue,
     namespace = 'default',
     status = 'Running',
-    timeout = 90000,
+    timeout = 90_000,
 ) {
   const query = {
     labelSelector: `${labelKey}=${labelValue}`,


### PR DESCRIPTION
To improve reliability of fast-integration test, this PR adds a coupled of functions to wait for the readiness of crucial k8s resources.