### PR TITLE
Fix a broken link to documentation on Kubernetes operators

### DIFF
--- a/components/README.md
+++ b/components/README.md
@@ -13,16 +13,16 @@ Every Kyma component resides in a dedicated folder which contains its sources an
 The component's name consists of a term describing the component, followed by the **component type**. The first part of the name may differ depending on the component's purpose.
 This table lists the available types:
 
-| Type | Description | Example|
+| Type | Description | Example |
 |---|---|---|
-| **controller** | A [Kubernetes Controller](https://kubernetes.io/docs/concepts/workloads/controllers/) which reacts to a standard Kubernetes resource or manages [CustomResourceDefinition](https://kubernetes.io/docs/tasks/access-kubernetes-api/custom-resources/custom-resource-definitions/) resources. The component's name reflects the name of the primary resource it controls.| Function-controller |
-| **controller-manager** |A daemon that embeds all [Kubernetes Controllers](https://kubernetes.io/docs/concepts/workloads/controllers/) of a domain. Such an approach brings operational benefits in comparison to shipping all controllers separately. A `controller-manager` takes the name of the domain it belongs to. | - |
-| **operator** |is a [Kubernetes Operator](https://coreos.com/operators/) which covers the application-specific logic behind the operation of the application, such as steps to upscale a stateful application. It reacts on changes made to custom resources derived from a given [CustomResourceDefinition](https://kubernetes.io/docs/tasks/access-kubernetes-api/custom-resources/custom-resource-definitions/). It uses the name of the application it operates. | telemetry-operator |
+| **controller** | A [Kubernetes Controller](https://kubernetes.io/docs/concepts/workloads/controllers/) which reacts to a standard Kubernetes resource or manages [CustomResourceDefinition](https://kubernetes.io/docs/tasks/access-kubernetes-api/custom-resources/custom-resource-definitions/) resources. The component's name reflects the name of the primary resource it controls. | Function-controller |
+| **controller-manager** | A daemon that embeds all [Kubernetes Controllers](https://kubernetes.io/docs/concepts/workloads/controllers/) of a domain. Such an approach brings operational benefits in comparison to shipping all controllers separately. A `controller-manager` takes the name of the domain it belongs to. | - |
+| **operator** | A [Kubernetes Operator](https://kubernetes.io/docs/concepts/extend-kubernetes/operator/) which covers the application-specific logic behind the operation of the application, such as steps to upscale a stateful application. It reacts on changes made to custom resources derived from a given [CustomResourceDefinition](https://kubernetes.io/docs/tasks/access-kubernetes-api/custom-resources/custom-resource-definitions/). It uses the name of the application it operates. | telemetry-operator |
 | **job** | A [Kubernetes Job](https://kubernetes.io/docs/tasks/job/) which performs a task once or periodically. It uses the name of the task it performs. |istio-patch-job (not renamed yet)|
 | **proxy** | Acts as a proxy for an existing component, usually introducing a security model for this component. It uses the component's name. | - |
-| **service** | Serves an HTTP/S-based API, usually securely exposed to the public. It uses the domain name and the API it serves.| - |
-| **broker** | Implements the [Open Service Broker](https://www.openservicebrokerapi.org/) specification to enrich the Kyma Service Catalog with the services of a provider. It uses the name of the provider it integrates with.| azure-broker |
-| **configurer** | A one-time task which usually runs as an [Init Container](https://kubernetes.io/docs/concepts/workloads/pods/init-containers/) in order to configure the application.| - |
+| **service** | Serves an HTTP/S-based API, usually securely exposed to the public. It uses the domain name and the API it serves. | - |
+| **broker** | Implements the [Open Service Broker](https://www.openservicebrokerapi.org/) specification to enrich the Kyma Service Catalog with the services of a provider. It uses the name of the provider it integrates with. | azure-broker |
+| **configurer** | A one-time task which usually runs as an [Init Container](https://kubernetes.io/docs/concepts/workloads/pods/init-containers/) in order to configure the application. | - |
 
 ## Development
 


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Fix a broken link in [Kyma components' REAMDE](https://github.com/kyma-project/kyma/tree/main/components) to documentation on Kubernetes operators

**Related issue(s)**
https://status.build.kyma-project.io/view/gs/kyma-prow-logs/logs/kyma-governance-nightly/1579683240921272320
