### PR TITLE
Fix a broken link to the Grafana documentation on gauge

### DIFF
--- a/docs/03-tutorials/00-observability/obsv-02-create-and-configure-grafana-dashboard.md
+++ b/docs/03-tutorials/00-observability/obsv-02-create-and-configure-grafana-dashboard.md
@@ -4,7 +4,7 @@ title: Create a Grafana dashboard
 
 Kyma comes with a set of dashboards for monitoring Kubernetes clusters. These dashboards display metrics that the Prometheus server collects.
 
-You can create and configure a basic Grafana dashboard of a [Gauge](https://grafana.com/docs/grafana/next/visualizations/gauge-panel/#gauge) type. On the dashboard, you see how the values of the `cpu_temperature_celsius` metric change in time, representing the current processor temperature ranging from 60 to 90 degrees Celsius. The dashboard shows explicitly when the CPU temperature exceeds the pre-defined threshold of 75 degrees Celsius.
+You can create and configure a basic Grafana dashboard of a [Gauge](https://grafana.com/docs/grafana/next/panels-visualizations/visualizations/gauge/) type. On the dashboard, you see how the values of the `cpu_temperature_celsius` metric change in time, representing the current processor temperature ranging from 60 to 90 degrees Celsius. The dashboard shows explicitly when the CPU temperature exceeds the pre-defined threshold of 75 degrees Celsius.
 
 In addition to creating a dashboard during runtime, you can also add it to the Kubernetes resources in your repository. This way, the dashboard configuration is portable and you can deploy it together with the application in any new cluster.
 


### PR DESCRIPTION
**Description**

As Grafana changed a little the structure of their documentation (or its URLs, to be precise), the link to Grafana documentation on gauge in Kyma's Observability documentation stopped working. This PR fixes that.

Changes proposed in this pull request:

- Fix a broken link  to the Grafana documentation on gauge in [`obsv-02-create-and-configure-grafana-dashboard.md`](https://github.com/kyma-project/kyma/blob/main/docs/03-tutorials/00-observability/obsv-02-create-and-configure-grafana-dashboard.md)

**Related issue(s)**
https://status.build.kyma-project.io/view/gs/kyma-prow-logs/logs/kyma-governance-nightly/1580045837361221632
