### PR TITLE
Restore jetstreamEnabled flag for 2.8.x releases to prevent eventing issues

### DIFF
--- a/resources/eventing/values.yaml
+++ b/resources/eventing/values.yaml
@@ -24,6 +24,7 @@ global:
       directory: external
 
   jetstream:
+    enabled: true
     # Storage type of the stream, memory or file.
     storage: file
 


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- Restored the global.jetstream.enabled flag in 'resources/eventing/values.yaml'. (It was removed in [PR](https://github.com/kyma-project/kyma/pull/15560))

- Tested the upgrade from 2.8.0 to PR-15885, and the PVCs were not deleted:
![image](https://user-images.githubusercontent.com/9897945/197541119-c06a2e39-cdf5-4bdd-bbcc-9a4f65e7dfb8.png)


**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
- https://github.com/kyma-project/kyma/issues/15883
