### PR TITLE
remove v1 to v2 status conversion and pretty print cleaneventtypes

### DIFF
--- a/components/eventing-controller/api/v1alpha1/subscription_conversion_unit_test.go
+++ b/components/eventing-controller/api/v1alpha1/subscription_conversion_unit_test.go
@@ -23,6 +23,18 @@ func Test_Conversion(t *testing.T) {
 
 	testCases := []TestCase{
 		{
+			name: "Converting NATS Subscription with empty Status",
+			alpha1Sub: newDefaultSubscription(
+				testingv1.WithEmptyFilter(),
+				testingv1.WithEmptyConfig(),
+				testingv1.WithEmptyStatus(),
+			),
+			alpha2Sub: newV2DefaultSubscription(
+				testingv2.WithEmptyStatus(),
+				testingv2.WithEmptyConfig(),
+			),
+		},
+		{
 			name: "Converting NATS Subscription with empty Filters",
 			alpha1Sub: newDefaultSubscription(
 				testingv1.WithEmptyFilter(),
@@ -189,13 +201,6 @@ func v1ToV2Assertions(t *testing.T, wantSub, convertedSub *v1alpha2.Subscription
 	assert.Equal(t, wantSub.Spec.Source, convertedSub.Spec.Source)
 	assert.Equal(t, wantSub.Spec.Types, convertedSub.Spec.Types)
 	assert.Equal(t, wantSub.Spec.Config, convertedSub.Spec.Config)
-
-	// Status
-	assert.Equal(t, wantSub.Status.Ready, convertedSub.Status.Ready)
-	assert.Equal(t, wantSub.Status.Conditions, convertedSub.Status.Conditions)
-	assert.Equal(t, wantSub.Status.Types, convertedSub.Status.Types)
-
-	assert.Equal(t, wantSub.Status.Backend, convertedSub.Status.Backend)
 }
 
 func v2ToV1Assertions(t *testing.T, wantSub, convertedSub *v1alpha1.Subscription) {

--- a/components/eventing-controller/api/v1alpha2/subscription_types.go
+++ b/components/eventing-controller/api/v1alpha2/subscription_types.go
@@ -64,7 +64,6 @@ type SubscriptionStatus struct {
 //+kubebuilder:subresource:status
 //+kubebuilder:printcolumn:name="Ready",type="string",JSONPath=".status.ready"
 //+kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp"
-//+kubebuilder:printcolumn:name="Clean Event Types",type="string",JSONPath=".status.cleanEventTypes"
 
 // Subscription is the Schema for the subscriptions API.
 type Subscription struct {

--- a/components/eventing-controller/config/crd/basesv1alpha2/eventing.kyma-project.io_subscriptions.yaml
+++ b/components/eventing-controller/config/crd/basesv1alpha2/eventing.kyma-project.io_subscriptions.yaml
@@ -23,9 +23,6 @@ spec:
     - jsonPath: .metadata.creationTimestamp
       name: Age
       type: date
-    - jsonPath: .status.cleanEventTypes
-      name: Clean Event Types
-      type: string
     name: v1alpha2
     schema:
       openAPIV3Schema:

--- a/components/eventing-controller/config/samples/eventing_v1alpha2_subscription.yaml
+++ b/components/eventing-controller/config/samples/eventing_v1alpha2_subscription.yaml
@@ -6,9 +6,9 @@ metadata:
 spec:
   sink: http://test.tunas-testing.svc.cluster.local
   typeMatching: exact
-  source: ""
+  source: "kyma"
   types:
     - sap.kyma.custom.noapp.order.created.v1
     - sap.kyma.custom.noapp.order.created.v2
   config:
-    "maxInFlightMessages": "10"
+    "maxInFlightMessages": "6"

--- a/components/eventing-controller/controllers/subscriptionv2/jetstream/errors.go
+++ b/components/eventing-controller/controllers/subscriptionv2/jetstream/errors.go
@@ -8,4 +8,5 @@ var (
 	errFailedToRemoveFinalizer    = errors.New("failed to remove finalizer from subscription")
 	errFailedToAddFinalizer       = errors.New("failed to add finalizer to subscription")
 	errFailedToGetCleanEventTypes = errors.New("failed to get clean event types for subscription")
+	errEmptySourceValue           = errors.New("source value cannot be empty")
 )

--- a/components/eventing-controller/controllers/subscriptionv2/jetstream/reconciler.go
+++ b/components/eventing-controller/controllers/subscriptionv2/jetstream/reconciler.go
@@ -136,6 +136,14 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 		return ctrl.Result{}, nil
 	}
 
+	// TODO: move this to the validation webhook
+	if srcErr := validateSource(desiredSubscription); srcErr != nil {
+		if syncErr := r.syncSubscriptionStatus(ctx, desiredSubscription, false, srcErr); syncErr != nil {
+			return ctrl.Result{}, syncErr
+		}
+		return ctrl.Result{}, srcErr
+	}
+
 	// update the cleanEventTypes and config values in the subscription status, if changed
 	statusChanged, err := r.syncInitialStatus(desiredSubscription)
 	if err != nil {

--- a/components/eventing-controller/controllers/subscriptionv2/jetstream/reconciler_internal_unit_test.go
+++ b/components/eventing-controller/controllers/subscriptionv2/jetstream/reconciler_internal_unit_test.go
@@ -52,6 +52,10 @@ func Test_Reconcile(t *testing.T) {
 		controllertesting.WithSource(controllertesting.EventSourceClean),
 		controllertesting.WithEventType(controllertesting.OrderCreatedV1Event),
 	)
+	// A subscription with empty source.
+	testSubEmptySrc := controllertesting.NewSubscription("sub2", namespaceName,
+		controllertesting.WithFinalizers([]string{eventingv1alpha2.Finalizer}),
+	)
 
 	backendSyncErr := errors.New("backend sync error")
 	missingSubSyncErr := jetstreamv2.ErrMissingSubscription
@@ -102,6 +106,17 @@ func Test_Reconcile(t *testing.T) {
 			},
 			wantReconcileResult: ctrl.Result{},
 			wantReconcileError:  nil,
+		},
+		{
+			name:              "Return error and default Result{} when sub has invalid source",
+			givenSubscription: testSubEmptySrc,
+			givenReconcilerSetup: func() (*Reconciler, *mocks.Backend) {
+				te := setupTestEnvironment(t, testSubEmptySrc)
+				te.Backend.On("Initialize", mock.Anything).Return(nil)
+				return NewReconciler(ctx, te.Client, te.Backend, te.Logger, te.Recorder, te.Cleaner, happyValidator), te.Backend
+			},
+			wantReconcileResult: ctrl.Result{},
+			wantReconcileError:  errEmptySourceValue,
 		},
 		{
 			name:              "Return error and default Result{} when backend sync returns error",

--- a/components/eventing-controller/controllers/subscriptionv2/jetstream/utils.go
+++ b/components/eventing-controller/controllers/subscriptionv2/jetstream/utils.go
@@ -25,6 +25,13 @@ func setSubReadyStatus(desiredSubscriptionStatus *eventingv1alpha2.SubscriptionS
 	return false
 }
 
+func validateSource(sub *eventingv1alpha2.Subscription) error {
+	if sub.Spec.Source == "" && sub.Spec.TypeMatching != eventingv1alpha2.TypeMatchingExact {
+		return utils.MakeError(errEmptySourceValue, nil)
+	}
+	return nil
+}
+
 //----------------------------------------
 // Condition utils
 //----------------------------------------

--- a/components/eventing-controller/controllers/subscriptionv2/jetstream/utils_unit_test.go
+++ b/components/eventing-controller/controllers/subscriptionv2/jetstream/utils_unit_test.go
@@ -1,0 +1,239 @@
+package jetstream
+
+import (
+	"testing"
+
+	"github.com/kyma-project/kyma/components/eventing-controller/api/v1alpha2"
+	subtesting "github.com/kyma-project/kyma/components/eventing-controller/testing/v2"
+	"github.com/pkg/errors"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+)
+
+func Test_isInDeletion(t *testing.T) {
+	testCases := []struct {
+		name       string
+		givenSub   *v1alpha2.Subscription
+		wantResult bool
+	}{
+		{
+			name:       "subscription with no deletion timestamp",
+			givenSub:   subtesting.NewSubscription("test", "test"),
+			wantResult: false,
+		},
+		{
+			name: "subscription with deletion timestamp",
+			givenSub: subtesting.NewSubscription("test", "test",
+				subtesting.WithNonZeroDeletionTimestamp()),
+			wantResult: true,
+		},
+	}
+	for _, testCase := range testCases {
+		tc := testCase
+		t.Run(tc.name, func(t *testing.T) {
+			// when
+			result := isInDeletion(tc.givenSub)
+
+			// then
+			require.Equal(t, tc.wantResult, result)
+		})
+	}
+}
+
+func Test_containsFinalizer(t *testing.T) {
+	testCases := []struct {
+		name       string
+		givenSub   *v1alpha2.Subscription
+		wantResult bool
+	}{
+		{
+			name: "subscription containing finalizer",
+			givenSub: subtesting.NewSubscription("test", "test",
+				subtesting.WithFinalizers([]string{v1alpha2.Finalizer})),
+			wantResult: true,
+		},
+		{
+			name: "subscription containing finalizer",
+			givenSub: subtesting.NewSubscription("test", "test",
+				subtesting.WithFinalizers([]string{"invalid"})),
+			wantResult: false,
+		},
+		{
+			name:       "subscription not containing finalizer",
+			givenSub:   subtesting.NewSubscription("test", "test"),
+			wantResult: false,
+		},
+	}
+	for _, testCase := range testCases {
+		tc := testCase
+		t.Run(tc.name, func(t *testing.T) {
+			// when
+			result := containsFinalizer(tc.givenSub)
+
+			// then
+			require.Equal(t, tc.wantResult, result)
+		})
+	}
+}
+
+func Test_setSubReadyStatus(t *testing.T) {
+	testCases := []struct {
+		name         string
+		givenSub     *v1alpha2.Subscription
+		givenIsReady bool
+		wantResult   bool
+	}{
+		{
+			name: "subscription ready status not changed",
+			givenSub: subtesting.NewSubscription("test", "test",
+				subtesting.WithStatus(true)),
+			givenIsReady: true,
+			wantResult:   false,
+		},
+		{
+			name: "subscription ready status not changed",
+			givenSub: subtesting.NewSubscription("test", "test",
+				subtesting.WithStatus(false)),
+			givenIsReady: false,
+			wantResult:   false,
+		},
+		{
+			name: "subscription ready status changed",
+			givenSub: subtesting.NewSubscription("test", "test",
+				subtesting.WithStatus(true)),
+			givenIsReady: false,
+			wantResult:   true,
+		},
+		{
+			name: "subscription ready status changed",
+			givenSub: subtesting.NewSubscription("test", "test",
+				subtesting.WithStatus(false)),
+			givenIsReady: true,
+			wantResult:   true,
+		},
+	}
+	for _, testCase := range testCases {
+		tc := testCase
+		t.Run(tc.name, func(t *testing.T) {
+			// when
+			result := setSubReadyStatus(&tc.givenSub.Status, tc.givenIsReady)
+
+			// then
+			require.Equal(t, tc.wantResult, result)
+			require.Equal(t, tc.givenSub.Status.Ready, tc.givenIsReady)
+		})
+	}
+}
+
+// Test_SyncSubscription_ForSource tests the subscription with and without valid source.
+func Test_validateSource(t *testing.T) {
+	// given
+	testCases := []struct {
+		name      string
+		givenSub  *v1alpha2.Subscription
+		wantError error
+	}{
+		{
+			name: "empty source and TypeMatching Standard should return error",
+			givenSub: subtesting.NewSubscription("test", "test",
+				subtesting.WithTypeMatchingStandard()),
+			wantError: errEmptySourceValue,
+		},
+		{
+			name: "valid source and TypeMatching Standard should not return error",
+			givenSub: subtesting.NewSubscription("test", "test",
+				subtesting.WithSource("source"),
+				subtesting.WithTypeMatchingStandard()),
+			wantError: nil,
+		},
+		{
+			name: "empty source and TypeMatching Exact should not return error",
+			givenSub: subtesting.NewSubscription("test", "test",
+				subtesting.WithTypeMatchingExact()),
+			wantError: nil,
+		},
+	}
+
+	for _, testCase := range testCases {
+		tc := testCase
+		t.Run(tc.name, func(t *testing.T) {
+			// when
+			err := validateSource(tc.givenSub)
+
+			// then
+			assert.ErrorIs(t, err, tc.wantError)
+		})
+	}
+}
+
+func Test_initializeDesiredConditions(t *testing.T) {
+	// given
+	expectedConditions := []v1alpha2.Condition{v1alpha2.MakeCondition(
+		v1alpha2.ConditionSubscriptionActive,
+		v1alpha2.ConditionReasonNATSSubscriptionNotActive,
+		corev1.ConditionFalse, "")}
+
+	// when
+	conditions := initializeDesiredConditions()
+
+	// then
+	require.Equal(t, len(conditions), 1)
+	require.True(t, v1alpha2.ConditionsEquals(conditions, expectedConditions))
+}
+
+func Test_setConditionSubscriptionActive(t *testing.T) {
+	err := errors.New("some error")
+	condition1 := v1alpha2.MakeCondition(
+		v1alpha2.ConditionSubscriptionActive,
+		v1alpha2.ConditionReasonNATSSubscriptionNotActive,
+		corev1.ConditionFalse, "")
+	condition2 := v1alpha2.MakeCondition(
+		v1alpha2.ConditionSubscribed,
+		v1alpha2.ConditionReasonSubscriptionDeleted,
+		corev1.ConditionFalse, "")
+	conditionReady := v1alpha2.MakeCondition(
+		v1alpha2.ConditionSubscriptionActive,
+		v1alpha2.ConditionReasonNATSSubscriptionActive,
+		corev1.ConditionTrue, "")
+	conditionNotReady := v1alpha2.MakeCondition(
+		v1alpha2.ConditionSubscriptionActive,
+		v1alpha2.ConditionReasonNATSSubscriptionNotActive,
+		corev1.ConditionFalse, err.Error())
+
+	testCases := []struct {
+		name            string
+		givenConditions []v1alpha2.Condition
+		givenError      error
+		wantConditions  []v1alpha2.Condition
+	}{
+		{
+			name:            "no error should set the condition to ready",
+			givenConditions: []v1alpha2.Condition{condition1, condition2},
+			givenError:      nil,
+			wantConditions:  []v1alpha2.Condition{conditionReady, condition2},
+		},
+		{
+			name:            "error should set the condition to ready",
+			givenConditions: []v1alpha2.Condition{condition1, condition2},
+			givenError:      err,
+			wantConditions:  []v1alpha2.Condition{conditionNotReady, condition2},
+		},
+		{
+			name:            "if condition is not present, do nothing",
+			givenConditions: []v1alpha2.Condition{condition2},
+			givenError:      err,
+			wantConditions:  []v1alpha2.Condition{condition2},
+		},
+	}
+	for _, testCase := range testCases {
+		tc := testCase
+		t.Run(tc.name, func(t *testing.T) {
+			// when
+			setConditionSubscriptionActive(tc.givenConditions, tc.givenError)
+
+			// then
+			require.True(t, v1alpha2.ConditionsEquals(tc.givenConditions, tc.wantConditions))
+		})
+	}
+}

--- a/components/eventing-controller/pkg/backend/jetstreamv2/jetstream.go
+++ b/components/eventing-controller/pkg/backend/jetstreamv2/jetstream.go
@@ -67,11 +67,6 @@ func (js *JetStream) SyncSubscription(subscription *eventingv1alpha2.Subscriptio
 		return err
 	}
 
-	// TODO: move this to the validation webhook
-	if subscription.Spec.Source == "" {
-		return fmt.Errorf("%v", "source value cannot be empty")
-	}
-
 	if err := js.syncSubscriptionTypes(subscription); err != nil {
 		return err
 	}

--- a/components/eventing-controller/testing/test_helpers.go
+++ b/components/eventing-controller/testing/test_helpers.go
@@ -400,6 +400,20 @@ func WithEmptyFilter() SubscriptionOpt {
 	}
 }
 
+func WithEmptyStatus() SubscriptionOpt {
+	return func(subscription *eventingv1alpha1.Subscription) {
+		subscription.Status = eventingv1alpha1.SubscriptionStatus{
+			CleanEventTypes: []string{},
+		}
+	}
+}
+
+func WithEmptyConfig() SubscriptionOpt {
+	return func(subscription *eventingv1alpha1.Subscription) {
+		subscription.Spec.Config = nil
+	}
+}
+
 func WithOrderCreatedFilter() SubscriptionOpt {
 	return WithFilter(EventSource, OrderCreatedEventType)
 }

--- a/components/eventing-controller/testing/v2/test_helpers.go
+++ b/components/eventing-controller/testing/v2/test_helpers.go
@@ -416,6 +416,18 @@ func WithEmptyTypes() SubscriptionOpt {
 	}
 }
 
+func WithEmptyStatus() SubscriptionOpt {
+	return func(subscription *eventingv1alpha2.Subscription) {
+		subscription.Status = eventingv1alpha2.SubscriptionStatus{}
+	}
+}
+
+func WithEmptyConfig() SubscriptionOpt {
+	return func(subscription *eventingv1alpha2.Subscription) {
+		subscription.Spec.Config = map[string]string{}
+	}
+}
+
 func WithOrderCreatedFilter() SubscriptionOpt {
 	return WithEventType(OrderCreatedEventType)
 }

--- a/resources/eventing/values.yaml
+++ b/resources/eventing/values.yaml
@@ -5,7 +5,7 @@ global:
   images:
     eventing_controller:
       name: eventing-controller
-      version: PR-15895
+      version: PR-15906
       pullPolicy: "IfNotPresent"
     publisher_proxy:
       name: event-publisher-proxy


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- Removed v1alpha1 to v1alpha2 status conversion since the status for v1alpha2 will be set by the reconciler
- Removed cleanEventTypes pretty print since it is now an object and crd's only support simple jsonPaths
- Moved the source check from the backend to the reconciler
- Added unit tests for reconciler utils

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
#13797