### PR TITLE
Enfore trace collector restart if configuration changes

### DIFF
--- a/components/telemetry-operator/controller/tracepipeline/config_hash.go
+++ b/components/telemetry-operator/controller/tracepipeline/config_hash.go
@@ -1,0 +1,37 @@
+package tracepipeline
+
+import (
+	"crypto/sha256"
+	"fmt"
+	"hash"
+)
+
+type ConfigHash struct {
+	hash hash.Hash
+}
+
+func NewConfigHash() *ConfigHash {
+	return &ConfigHash{
+		hash: sha256.New(),
+	}
+}
+
+func (c *ConfigHash) AddStringMap(m map[string]string) *ConfigHash {
+	for k, v := range m {
+		c.hash.Write([]byte(k))
+		c.hash.Write([]byte(v))
+	}
+	return c
+}
+
+func (c *ConfigHash) AddByteMap(m map[string][]byte) *ConfigHash {
+	for k, v := range m {
+		c.hash.Write([]byte(k))
+		c.hash.Write(v)
+	}
+	return c
+}
+
+func (c *ConfigHash) Build() string {
+	return fmt.Sprintf("%x", c.hash.Sum(nil))
+}

--- a/components/telemetry-operator/controller/tracepipeline/config_hash.go
+++ b/components/telemetry-operator/controller/tracepipeline/config_hash.go
@@ -4,32 +4,42 @@ import (
 	"crypto/sha256"
 	"fmt"
 	"hash"
+
+	corev1 "k8s.io/api/core/v1"
 )
 
 type ConfigHash struct {
 	hash hash.Hash
 }
 
-func NewConfigHash() *ConfigHash {
-	return &ConfigHash{
+func NewConfigHash(configMaps []corev1.ConfigMap, secrets []corev1.Secret) *ConfigHash {
+	configHash := ConfigHash{
 		hash: sha256.New(),
 	}
+
+	for _, cm := range configMaps {
+		configHash.addStringMap(cm.Data)
+	}
+
+	for _, secret := range secrets {
+		configHash.addByteMap(secret.Data)
+	}
+
+	return &configHash
 }
 
-func (c *ConfigHash) AddStringMap(m map[string]string) *ConfigHash {
+func (c *ConfigHash) addStringMap(m map[string]string) {
 	for k, v := range m {
 		c.hash.Write([]byte(k))
 		c.hash.Write([]byte(v))
 	}
-	return c
 }
 
-func (c *ConfigHash) AddByteMap(m map[string][]byte) *ConfigHash {
+func (c *ConfigHash) addByteMap(m map[string][]byte) {
 	for k, v := range m {
 		c.hash.Write([]byte(k))
 		c.hash.Write(v)
 	}
-	return c
 }
 
 func (c *ConfigHash) Build() string {

--- a/components/telemetry-operator/controller/tracepipeline/config_hash.go
+++ b/components/telemetry-operator/controller/tracepipeline/config_hash.go
@@ -8,40 +8,30 @@ import (
 	corev1 "k8s.io/api/core/v1"
 )
 
-type ConfigHash struct {
-	hash hash.Hash
-}
-
-func NewConfigHash(configMaps []corev1.ConfigMap, secrets []corev1.Secret) *ConfigHash {
-	configHash := ConfigHash{
-		hash: sha256.New(),
-	}
+func CreateConfigHash(configMaps []corev1.ConfigMap, secrets []corev1.Secret) string {
+	h := sha256.New()
 
 	for _, cm := range configMaps {
-		configHash.addStringMap(cm.Data)
+		addStringMap(h, cm.Data)
 	}
 
 	for _, secret := range secrets {
-		configHash.addByteMap(secret.Data)
+		addByteMap(h, secret.Data)
 	}
 
-	return &configHash
+	return fmt.Sprintf("%x", h.Sum(nil))
 }
 
-func (c *ConfigHash) addStringMap(m map[string]string) {
+func addStringMap(h hash.Hash, m map[string]string) {
 	for k, v := range m {
-		c.hash.Write([]byte(k))
-		c.hash.Write([]byte(v))
+		h.Write([]byte(k))
+		h.Write([]byte(v))
 	}
 }
 
-func (c *ConfigHash) addByteMap(m map[string][]byte) {
+func addByteMap(h hash.Hash, m map[string][]byte) {
 	for k, v := range m {
-		c.hash.Write([]byte(k))
-		c.hash.Write(v)
+		h.Write([]byte(k))
+		h.Write(v)
 	}
-}
-
-func (c *ConfigHash) Build() string {
-	return fmt.Sprintf("%x", c.hash.Sum(nil))
 }

--- a/components/telemetry-operator/controller/tracepipeline/config_hash_test.go
+++ b/components/telemetry-operator/controller/tracepipeline/config_hash_test.go
@@ -41,18 +41,18 @@ var (
 )
 
 func TestEqualConfig(t *testing.T) {
-	hash1 := NewConfigHash([]corev1.ConfigMap{configMap1}, []corev1.Secret{secret1}).Build()
-	hash2 := NewConfigHash([]corev1.ConfigMap{configMap1}, []corev1.Secret{secret1}).Build()
+	hash1 := CreateConfigHash([]corev1.ConfigMap{configMap1}, []corev1.Secret{secret1})
+	hash2 := CreateConfigHash([]corev1.ConfigMap{configMap1}, []corev1.Secret{secret1})
 	require.Equal(t, hash1, hash2)
 }
 
 func TestUnequalConfig(t *testing.T) {
-	hash1 := NewConfigHash([]corev1.ConfigMap{configMap1}, []corev1.Secret{secret1}).Build()
-	hash2 := NewConfigHash([]corev1.ConfigMap{configMap2}, []corev1.Secret{secret2}).Build()
+	hash1 := CreateConfigHash([]corev1.ConfigMap{configMap1}, []corev1.Secret{secret1})
+	hash2 := CreateConfigHash([]corev1.ConfigMap{configMap2}, []corev1.Secret{secret2})
 	require.NotEqual(t, hash1, hash2)
 }
 
 func TestEmptyConfig(t *testing.T) {
-	hash := NewConfigHash([]corev1.ConfigMap{emptyConfigMap}, []corev1.Secret{emptySecret}).Build()
+	hash := CreateConfigHash([]corev1.ConfigMap{emptyConfigMap}, []corev1.Secret{emptySecret})
 	require.NotEmpty(t, hash)
 }

--- a/components/telemetry-operator/controller/tracepipeline/config_hash_test.go
+++ b/components/telemetry-operator/controller/tracepipeline/config_hash_test.go
@@ -1,0 +1,37 @@
+package tracepipeline
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+var (
+	empty1  = map[string]string{}
+	empty2  = map[string][]byte{}
+	config1 = map[string]string{
+		"a": "b",
+		"c": "d",
+	}
+	config2 = map[string][]byte{
+		"1": []byte("2"),
+		"3": []byte("4"),
+	}
+)
+
+func TestEqualConfig(t *testing.T) {
+	hash1 := NewConfigHash().AddStringMap(config1).AddByteMap(config2).Build()
+	hash2 := NewConfigHash().AddStringMap(config1).AddByteMap(config2).Build()
+	require.Equal(t, hash1, hash2)
+}
+
+func TestUnequalConfig(t *testing.T) {
+	hash1 := NewConfigHash().AddStringMap(config1).AddByteMap(config2).Build()
+	hash2 := NewConfigHash().AddByteMap(config2).AddByteMap(config2).Build()
+	require.NotEqual(t, hash1, hash2)
+}
+
+func TestEmptyConfig(t *testing.T) {
+	hash := NewConfigHash().AddStringMap(empty1).AddByteMap(empty2).Build()
+	require.NotEmpty(t, hash)
+}

--- a/components/telemetry-operator/controller/tracepipeline/config_hash_test.go
+++ b/components/telemetry-operator/controller/tracepipeline/config_hash_test.go
@@ -4,34 +4,55 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
 )
 
 var (
-	empty1  = map[string]string{}
-	empty2  = map[string][]byte{}
-	config1 = map[string]string{
-		"a": "b",
-		"c": "d",
+	secret1 = corev1.Secret{
+		Data: map[string][]byte{
+			"1": []byte("2"),
+			"3": []byte("4"),
+		},
 	}
-	config2 = map[string][]byte{
-		"1": []byte("2"),
-		"3": []byte("4"),
+	secret2 = corev1.Secret{
+		Data: map[string][]byte{
+			"2": []byte("1"),
+			"4": []byte("3"),
+		},
+	}
+	configMap1 = corev1.ConfigMap{
+		Data: map[string]string{
+			"a": "b",
+			"c": "d",
+		},
+	}
+	configMap2 = corev1.ConfigMap{
+		Data: map[string]string{
+			"b": "a",
+			"d": "c",
+		},
+	}
+	emptySecret = corev1.Secret{
+		Data: map[string][]byte{},
+	}
+	emptyConfigMap = corev1.ConfigMap{
+		Data: map[string]string{},
 	}
 )
 
 func TestEqualConfig(t *testing.T) {
-	hash1 := NewConfigHash().AddStringMap(config1).AddByteMap(config2).Build()
-	hash2 := NewConfigHash().AddStringMap(config1).AddByteMap(config2).Build()
+	hash1 := NewConfigHash([]corev1.ConfigMap{configMap1}, []corev1.Secret{secret1}).Build()
+	hash2 := NewConfigHash([]corev1.ConfigMap{configMap1}, []corev1.Secret{secret1}).Build()
 	require.Equal(t, hash1, hash2)
 }
 
 func TestUnequalConfig(t *testing.T) {
-	hash1 := NewConfigHash().AddStringMap(config1).AddByteMap(config2).Build()
-	hash2 := NewConfigHash().AddByteMap(config2).AddByteMap(config2).Build()
+	hash1 := NewConfigHash([]corev1.ConfigMap{configMap1}, []corev1.Secret{secret1}).Build()
+	hash2 := NewConfigHash([]corev1.ConfigMap{configMap2}, []corev1.Secret{secret2}).Build()
 	require.NotEqual(t, hash1, hash2)
 }
 
 func TestEmptyConfig(t *testing.T) {
-	hash := NewConfigHash().AddStringMap(empty1).AddByteMap(empty2).Build()
+	hash := NewConfigHash([]corev1.ConfigMap{emptyConfigMap}, []corev1.Secret{emptySecret}).Build()
 	require.NotEmpty(t, hash)
 }

--- a/components/telemetry-operator/controller/tracepipeline/controller.go
+++ b/components/telemetry-operator/controller/tracepipeline/controller.go
@@ -117,7 +117,7 @@ func (r *Reconciler) installOrUpgradeOtelCollector(ctx context.Context, tracing 
 		return fmt.Errorf("failed to create otel collector configmap: %w", err)
 	}
 
-	configHash := NewConfigHash([]corev1.ConfigMap{*configMap}, []corev1.Secret{*secret}).Build()
+	configHash := CreateConfigHash([]corev1.ConfigMap{*configMap}, []corev1.Secret{*secret})
 	deployment := makeDeployment(r.config, configHash)
 	if err = controllerutil.SetControllerReference(tracing, deployment, r.Scheme); err != nil {
 		return err

--- a/components/telemetry-operator/controller/tracepipeline/controller.go
+++ b/components/telemetry-operator/controller/tracepipeline/controller.go
@@ -117,7 +117,8 @@ func (r *Reconciler) installOrUpgradeOtelCollector(ctx context.Context, tracing 
 		return fmt.Errorf("failed to create otel collector configmap: %w", err)
 	}
 
-	deployment := makeDeployment(r.config)
+	configHash := NewConfigHash().AddByteMap(secretData).AddStringMap(configMap.Data).Build()
+	deployment := makeDeployment(r.config, configHash)
 	if err = controllerutil.SetControllerReference(tracing, deployment, r.Scheme); err != nil {
 		return err
 	}

--- a/components/telemetry-operator/controller/tracepipeline/controller.go
+++ b/components/telemetry-operator/controller/tracepipeline/controller.go
@@ -117,7 +117,7 @@ func (r *Reconciler) installOrUpgradeOtelCollector(ctx context.Context, tracing 
 		return fmt.Errorf("failed to create otel collector configmap: %w", err)
 	}
 
-	configHash := NewConfigHash().AddByteMap(secretData).AddStringMap(configMap.Data).Build()
+	configHash := NewConfigHash([]corev1.ConfigMap{*configMap}, []corev1.Secret{*secret}).Build()
 	deployment := makeDeployment(r.config, configHash)
 	if err = controllerutil.SetControllerReference(tracing, deployment, r.Scheme); err != nil {
 		return err

--- a/components/telemetry-operator/controller/tracepipeline/resources_test.go
+++ b/components/telemetry-operator/controller/tracepipeline/resources_test.go
@@ -83,7 +83,7 @@ func TestMakeSecret(t *testing.T) {
 }
 
 func TestMakeDeployment(t *testing.T) {
-	deployment := makeDeployment(config)
+	deployment := makeDeployment(config, "123")
 	labels := getLabels(config)
 
 	require.NotNil(t, deployment)
@@ -92,7 +92,10 @@ func TestMakeDeployment(t *testing.T) {
 	require.Equal(t, *deployment.Spec.Replicas, int32(1))
 	require.Equal(t, deployment.Spec.Selector.MatchLabels, labels)
 	require.Equal(t, deployment.Spec.Template.ObjectMeta.Labels, labels)
-	require.Equal(t, deployment.Spec.Template.ObjectMeta.Annotations, podAnnotations)
+	for k, v := range defaultPodAnnotations {
+		require.Equal(t, deployment.Spec.Template.ObjectMeta.Annotations[k], v)
+	}
+	require.Equal(t, deployment.Spec.Template.ObjectMeta.Annotations[configHashAnnotationKey], "123")
 	require.NotEmpty(t, deployment.Spec.Template.Spec.Containers[0].EnvFrom)
 }
 

--- a/resources/telemetry/values.yaml
+++ b/resources/telemetry/values.yaml
@@ -7,7 +7,7 @@ global:
       version: "PR-15860"
     telemetry_operator:
       name: "telemetry-operator"
-      version: "PR-15873"
+      version: "PR-15941"
     fluent_bit:
       name: "fluent-bit"
       version: "1.9.9-cf0a130c"


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

The OpenTelemetry Collector does not automatically load changed configurations and requires a restart after a config change. This PR adds a hash of the relevant ConfigMap and Secret to the collector Pod template to enforce a restart when a new config is applied.

Changes proposed in this pull request:

- Enfore trace collector restart if configuration changes

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
#15831