### PR TITLE
fast-integration: use dummy credentials for BTP operator in SKR tests

### DIFF
--- a/tests/fast-integration/skr-test/provision/provision-skr.js
+++ b/tests/fast-integration/skr-test/provision/provision-skr.js
@@ -47,7 +47,7 @@ async function getOrProvisionSKR(options, skipProvisioning, provisioningTimeout)
 
 async function provisionSKRInstance(options, timeout) {
   try {
-    const btpOperatorCreds = BTPOperatorCreds.fromEnv();
+    const btpOperatorCreds = BTPOperatorCreds.dummy();
 
     console.log(`\nInstanceID ${options.instanceID}`,
         `Runtime ${options.runtimeName}`, `Application ${options.appName}`, `Suffix ${options.suffix}`);

--- a/tests/fast-integration/smctl/helpers.js
+++ b/tests/fast-integration/smctl/helpers.js
@@ -198,6 +198,15 @@ class BTPOperatorCreds {
     );
   }
 
+  static dummy() {
+    return new BTPOperatorCreds(
+        'dummy_client_id',
+        'dummy_client_secret',
+        'dummy_url',
+        'dummy_token_url',
+    );
+  }
+
   constructor(clientid, clientsecret, smURL, url) {
     this.clientid = clientid;
     this.clientsecret = clientsecret;


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Whenever the skr test fails, it checks reconciler status. Reconciler stores sensitive data in plaintext and returns them in full to the caller and these get printed to stdout.
https://storage.googleapis.com/kyma-prow-logs/logs/skr-aws-integration-dev/1586886956606820352/build-log.txt

Because SKR tests don't create any services or bindings, we can safely remediate by rotating creds and using dummy values in tests.

[pjtested](https://status.build.kyma-project.io/log?container=test&id=1587774067765678080&job=wozniakjan_test_of_prowjob_skr-aws-integration-dev)