### PR TITLE
Fix showing multi-line string LogParser configurations in Busola

### DIFF
--- a/resources/telemetry/charts/operator/templates/logparser_busola_extension_cm.yaml
+++ b/resources/telemetry/charts/operator/templates/logparser_busola_extension_cm.yaml
@@ -21,7 +21,8 @@ data:
       "body": [
         {
           "source": "spec.parser",
-          "widget": "CodeViewer"
+          "widget": "CodeViewer",
+          "language": "'plaintext'"
         }
       ]
     }
@@ -30,7 +31,8 @@ data:
       {
         "widget": "CodeEditor",
         "path": "spec.parser",
-        "simple": true
+        "simple": true,
+        "language": "'plaintext'"
       }
     ]
   general: |-


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Fix showing multi-line string LogParser configurations in Busola

Changes proposed in this pull request:

- Set correct CodeEditor and Codeviewer "language" for LogParser Busola extension to present multi-line strings correctly

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
#15894