### PR TITLE
bump nats-prometheus-exporter to v0.10.1

### DIFF
--- a/resources/eventing/values.yaml
+++ b/resources/eventing/values.yaml
@@ -20,7 +20,7 @@ global:
       directory: external
     prometheus_nats_exporter:
       name: natsio/prometheus-nats-exporter
-      version: 0.10.0
+      version: 0.10.1
       directory: external
 
   jetstream:


### PR DESCRIPTION
Title says it all.

docker repo: https://hub.docker.com/layers/natsio/prometheus-nats-exporter/0.10.1/images/sha256-37a39c6aa042b203af7e55c5cf7db3858f93f3236b8ad4b66d93769652fdcdc0?context=explore

release notes: https://github.com/nats-io/prometheus-nats-exporter/releases/tag/v0.10.1