### PR TITLE
bump nats server image to v2.9.5-alpine3.16

### DIFF
--- a/resources/eventing/values.yaml
+++ b/resources/eventing/values.yaml
@@ -12,7 +12,7 @@ global:
       version: PR-15940
     nats:
       name: nats
-      version: 2.9.3-alpine3.16
+      version: 2.9.5-alpine3.16
       directory: external
     nats_config_reloader:
       name: natsio/nats-server-config-reloader


### PR DESCRIPTION
docker repo: https://hub.docker.com/_/nats/

release notes: https://github.com/nats-io/nats-server/releases/tag/v2.9.5