### PR TITLE
Fix flaky reconciler test

### DIFF
--- a/components/eventing-controller/controllers/subscriptionv2/eventmesh/reconciler_integration_test.go
+++ b/components/eventing-controller/controllers/subscriptionv2/eventmesh/reconciler_integration_test.go
@@ -1512,7 +1512,7 @@ var _ = BeforeSuite(func(done Done) {
 	useExistingCluster := useExistingCluster
 	testEnv = &envtest.Environment{
 		CRDDirectoryPaths: []string{
-			filepath.Join("../../../", "config", "crd", "bases"),
+			filepath.Join("../../../", "config", "crd", "bases", "eventing.kyma-project.io_eventingbackends.yaml"),
 			filepath.Join("../../../", "config", "crd", "basesv1alpha2"),
 			filepath.Join("../../../", "config", "crd", "external"),
 		},


### PR DESCRIPTION
**Description**

this PR adds crd path fix, which should exclude its flakiness. To resolve the flakiness of the job completely, we also need this [PR](https://github.com/kyma-project/test-infra/pull/6336).

Changes proposed in this pull request:

- fix the crd path

here are the [runs for the job](https://status.build.kyma-project.io/?job=k15r_test_of_prowjob_pull-eventing-controller-unit-test). We have 13/15 green runs, whereas the only error happened due to an old problem, which should be resolved with deprecating the v1alpha1 and implementing this [PoC](https://github.com/kyma-project/kyma/issues/15925).