### PR TITLE
Delete Consumer for every Unsubscription

### DIFF
--- a/components/eventing-controller/api/v1alpha1/subscription_types.go
+++ b/components/eventing-controller/api/v1alpha1/subscription_types.go
@@ -249,6 +249,15 @@ func (s Subscription) MarshalJSON() ([]byte, error) {
 	return json.Marshal(a)
 }
 
+// GetMaxInFlightMessages tries to convert the string-type maxInFlight to the integer.
+func (s *Subscription) GetMaxInFlightMessages(defaults *env.DefaultSubscriptionConfig) int {
+	// TODO: move this to validation webhook
+	if s.Spec.Config.MaxInFlightMessages == 0 {
+		return defaults.MaxInFlightMessages
+	}
+	return s.Spec.Config.MaxInFlightMessages
+}
+
 // +kubebuilder:object:root=true
 
 // SubscriptionList contains a list of Subscription.

--- a/components/eventing-controller/pkg/backend/nats/jetstream/jetstream_integration_test.go
+++ b/components/eventing-controller/pkg/backend/nats/jetstream/jetstream_integration_test.go
@@ -1318,7 +1318,7 @@ func TestJetStream_NATSSubscriptionCount(t *testing.T) {
 			require.Equal(t, err != nil, tc.wantErr)
 
 			if tc.wantErr {
-				// the createConsumer function won't create a new Subscription,
+				// the syncConsumersAndSubscriptions function won't create a new Subscription,
 				// because the subscription was manually deleted from the js.subscriptions map
 				// hence the consumer will be shown in the NATS Backend as still bound
 				err = jsBackend.SyncSubscription(sub)

--- a/components/eventing-controller/pkg/backend/nats/jetstream/jetstream_util.go
+++ b/components/eventing-controller/pkg/backend/nats/jetstream/jetstream_util.go
@@ -55,3 +55,17 @@ func toJetStreamConsumerDeliverPolicyOptOrDefault(deliverPolicy string) nats.Sub
 	}
 	return nats.DeliverNew()
 }
+
+func toJetStreamConsumerDeliverPolicy(deliverPolicy string) nats.DeliverPolicy {
+	switch deliverPolicy {
+	case ConsumerDeliverPolicyAll:
+		return nats.DeliverAllPolicy
+	case ConsumerDeliverPolicyLast:
+		return nats.DeliverLastPolicy
+	case ConsumerDeliverPolicyLastPerSubject:
+		return nats.DeliverLastPerSubjectPolicy
+	case ConsumerDeliverPolicyNew:
+		return nats.DeliverNewPolicy
+	}
+	return nats.DeliverNewPolicy
+}

--- a/components/eventing-controller/pkg/backend/utils/utils.go
+++ b/components/eventing-controller/pkg/backend/utils/utils.go
@@ -26,6 +26,13 @@ import (
 	"github.com/kyma-project/kyma/components/eventing-controller/pkg/ems/api/events/types"
 )
 
+const (
+	ConsumerDeliverPolicyAll            = "all"
+	ConsumerDeliverPolicyLast           = "last"
+	ConsumerDeliverPolicyLastPerSubject = "last_per_subject"
+	ConsumerDeliverPolicyNew            = "new"
+)
+
 type EventTypeInfo struct {
 	OriginalType  string
 	CleanType     string

--- a/resources/eventing/values.yaml
+++ b/resources/eventing/values.yaml
@@ -5,7 +5,7 @@ global:
   images:
     eventing_controller:
       name: eventing-controller
-      version: PR-15975
+      version: PR-16013
       pullPolicy: "IfNotPresent"
     publisher_proxy:
       name: event-publisher-proxy


### PR DESCRIPTION
**Description**
Create and delete durable NATS JetStream consumers to prevent dangling consumers

**Related issue(s)**
[#15978](https://github.com/kyma-project/kyma/issues/15978)