### PR TITLE
Delete Consumer with Unsubscription

### DIFF
--- a/components/eventing-controller/pkg/backend/nats/jetstream/jetstream.go
+++ b/components/eventing-controller/pkg/backend/nats/jetstream/jetstream.go
@@ -599,7 +599,6 @@ func (js *JetStream) deleteSubscriptionFromJetStream(jsSub backendnats.Subscribe
 		}
 	}
 
-	// if JS sub is not valid, then we need to delete the consumer on JetStream
 	if err := js.deleteConsumerFromJetStream(jsSubKey.ConsumerName()); err != nil &&
 		!errors.Is(err, nats.ErrConsumerNotFound) {
 		return fmt.Errorf("failed to delete consumer %s from JetStream: %w", jsSubKey.ConsumerName(), err)

--- a/components/eventing-controller/pkg/backend/nats/jetstream/jetstream.go
+++ b/components/eventing-controller/pkg/backend/nats/jetstream/jetstream.go
@@ -597,11 +597,12 @@ func (js *JetStream) deleteSubscriptionFromJetStream(jsSub backendnats.Subscribe
 		if err := jsSub.Unsubscribe(); err != nil {
 			return xerrors.Errorf("failed to unsubscribe subscription %v from JetStream: %v", jsSub, err)
 		}
-	} else {
-		// if JS sub is not valid, then we need to delete the consumer on JetStream
-		if err := js.deleteConsumerFromJetStream(jsSubKey.ConsumerName()); err != nil {
-			return err
-		}
+	}
+
+	// if JS sub is not valid, then we need to delete the consumer on JetStream
+	if err := js.deleteConsumerFromJetStream(jsSubKey.ConsumerName()); err != nil &&
+		!errors.Is(err, nats.ErrConsumerNotFound) {
+		return fmt.Errorf("failed to delete consumer %s from JetStream: %w", jsSubKey.ConsumerName(), err)
 	}
 
 	delete(js.subscriptions, jsSubKey)

--- a/components/eventing-controller/pkg/backend/nats/jetstream/jetstream_integration_test.go
+++ b/components/eventing-controller/pkg/backend/nats/jetstream/jetstream_integration_test.go
@@ -1428,6 +1428,7 @@ func TestJetStreamSubAfterSync_ForExplicitlyBoundSubscriptionDeletion(t *testing
 	jsBackend := testEnvironment.jsBackend
 	defer testEnvironment.natsServer.Shutdown()
 	defer testEnvironment.jsClient.natsConn.Close()
+	defer func() { _ = testEnvironment.jsClient.DeleteStream(defaultStreamName) }()
 
 	testEnvironment.jsBackend.Config.JSStreamStorageType = StorageTypeFile
 	testEnvironment.jsBackend.Config.MaxReconnects = 0

--- a/resources/eventing/values.yaml
+++ b/resources/eventing/values.yaml
@@ -5,7 +5,7 @@ global:
   images:
     eventing_controller:
       name: eventing-controller
-      version: PR-16018
+      version: PR-16038
       pullPolicy: "IfNotPresent"
     publisher_proxy:
       name: event-publisher-proxy


### PR DESCRIPTION
**Description**

Delete the NAT JetStream consumer always after unsubscription explicitly

Changes proposed in this pull request:

- Delete consumer always after unsubscribing
- Adapt filter change/delete integration tests

**Related issue(s)**
[#15978](https://github.com/kyma-project/kyma/issues/15978)
