### PR TITLE
Skip OTLP collector endpoint availability check in functions

### DIFF
--- a/components/function-runtimes/nodejs14/kubeless/kubeless_rt/lib/tracer.js
+++ b/components/function-runtimes/nodejs14/kubeless/kubeless_rt/lib/tracer.js
@@ -56,21 +56,13 @@ function getTracer(serviceName) {
   const traceCollectorEndpoint = process.env.TRACE_COLLECTOR_ENDPOINT;
 
   if(traceCollectorEndpoint){
-    axios(traceCollectorEndpoint).catch((err) => {
-      if (err.response && err.response.status === 405) {
-        // TODO: resolve dependencies via serverless operator
-        // 405 is the right status code for the GET method if jaeger service exists
-        // because the only allowed method is POST and usage of other methods are not allowe
-        // https://github.com/jaegertracing/jaeger/blob/7872d1b07439c3f2d316065b1fd53e885b26a66f/cmd/collector/app/handler/http_handler.go#L60
-        const exporter = new OTLPTraceExporter({
-          url: traceCollectorEndpoint
-        });
-    
-        provider.addSpanProcessor(new SimpleSpanProcessor(exporter));
-      }
+      const exporter = new OTLPTraceExporter({
+      url: traceCollectorEndpoint
     });
-  }
 
+    provider.addSpanProcessor(new SimpleSpanProcessor(exporter));
+  }
+  
   // Initialize the OpenTelemetry APIs to use the NodeTracerProvider bindings
   provider.register({
     propagator: new B3Propagator({injectEncoding: B3InjectEncoding.MULTI_HEADER}),

--- a/components/function-runtimes/nodejs16/lib/tracer.js
+++ b/components/function-runtimes/nodejs16/lib/tracer.js
@@ -52,19 +52,11 @@ function setupTracer(serviceName){
   const traceCollectorEndpoint = process.env.TRACE_COLLECTOR_ENDPOINT;
 
   if(traceCollectorEndpoint){
-    axios(traceCollectorEndpoint).catch((err) => {
-      if (err.response && err.response.status === 405) {
-        // TODO: resolve dependencies via serverless operator
-        // 405 is the right status code for the GET method if jaeger service exists
-        // because the only allowed method is POST and usage of other methods are not allowe
-        // https://github.com/jaegertracing/jaeger/blob/7872d1b07439c3f2d316065b1fd53e885b26a66f/cmd/collector/app/handler/http_handler.go#L60
-        const exporter = new OTLPTraceExporter({
-          url: traceCollectorEndpoint
-        });
-    
-        provider.addSpanProcessor(new SimpleSpanProcessor(exporter));
-      }
+    const exporter = new OTLPTraceExporter({
+      url: traceCollectorEndpoint
     });
+
+    provider.addSpanProcessor(new SimpleSpanProcessor(exporter));
   }
 
   // Initialize the OpenTelemetry APIs to use the NodeTracerProvider bindings

--- a/resources/serverless/values.yaml
+++ b/resources/serverless/values.yaml
@@ -87,18 +87,15 @@ global:
     function_build_init:
       name: "function-build-init"
       version: "PR-15990"
-    function_runtime_nodejs12:
-      name: "function-runtime-nodejs12"
-      version: "v20221011-831da39d"
     function_runtime_nodejs14:
       name: "function-runtime-nodejs14"
-      version: "v20221011-831da39d"
+      version: "PR-16052"
     function_runtime_nodejs16:
       name: "function-runtime-nodejs16"
-      version: "v20221011-831da39d"
+      version: "PR-16052"
     function_runtime_python39:
       name: "function-runtime-python39"
-      version: "PR-16061"
+      version: "PR-16052"
     kaniko_executor:
       name: "kaniko-executor"
       version: "1.9.0-4ced14d5"


### PR DESCRIPTION
**Description**

This PR removes the availability check of the OTLP endpoint in serverless functions.
Sometimes it happens (i.e whenever kyma upgrades include new istio versions ) that functions and jaeger gets restarted simultaneously.
At the function start time jaeger ( or its side-car ) might be still warming up. In such case the function not being able to reach it at start time would be configured to not send traces (until it is restarted again at the time when jaeger is available).

**Related issue(s)**
https://github.com/kyma-project/kyma/issues/15994