### PR TITLE
Remove internal names from CRD description fields

### DIFF
--- a/components/telemetry-operator/apis/telemetry/v1alpha1/logparser_types.go
+++ b/components/telemetry-operator/apis/telemetry/v1alpha1/logparser_types.go
@@ -20,12 +20,12 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-// LogParserSpec defines the desired state of LogParser
+// Defines the desired state of LogParser.
 type LogParserSpec struct {
 	// INSERT ADDITIONAL SPEC FIELDS - desired state of cluster
 	// Important: Run "make" to regenerate code after modifying this file
 
-	// Parser allows defining user defined parsers to be applied to the logs
+	// Configures a user defined log parser to be applied to the logs
 	Parser string `json:"parser,omitempty"`
 }
 
@@ -35,7 +35,7 @@ type LogParserSpec struct {
 //+kubebuilder:printcolumn:name="Status",type=string,JSONPath=`.status.conditions[-1].type`
 //+kubebuilder:printcolumn:name="Age",type=date,JSONPath=`.metadata.creationTimestamp`
 
-// LogParser is the Schema for the logparsers API
+// LogParser is the Schema for the logparsers API.
 type LogParser struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
@@ -46,7 +46,7 @@ type LogParser struct {
 
 //+kubebuilder:object:root=true
 
-// LogParserList contains a list of LogParser
+// LogParserList contains a list of LogParser.
 type LogParserList struct {
 	metav1.TypeMeta `json:",inline"`
 	metav1.ListMeta `json:"metadata,omitempty"`
@@ -68,7 +68,7 @@ type LogParserCondition struct {
 	Type               LogParserConditionType `json:"type,omitempty"`
 }
 
-// LogParserStatus defines the observed state of LogParser
+// Shows the observed state of the LogParser.
 type LogParserStatus struct {
 	Conditions []LogParserCondition `json:"conditions,omitempty"`
 }

--- a/components/telemetry-operator/apis/telemetry/v1alpha1/logparser_types.go
+++ b/components/telemetry-operator/apis/telemetry/v1alpha1/logparser_types.go
@@ -20,12 +20,12 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-// Defines the desired state of LogParser.
+// LogParserSpec defines the desired state of LogParser.
 type LogParserSpec struct {
 	// INSERT ADDITIONAL SPEC FIELDS - desired state of cluster
 	// Important: Run "make" to regenerate code after modifying this file
 
-	// Configures a user defined log parser to be applied to the logs
+	// Configures a user defined Fluent Bit parser to be applied to the logs.
 	Parser string `json:"parser,omitempty"`
 }
 
@@ -39,8 +39,9 @@ type LogParserSpec struct {
 type LogParser struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
-
-	Spec   LogParserSpec   `json:"spec,omitempty"`
+	// Defines the desired state of LogParser.
+	Spec LogParserSpec `json:"spec,omitempty"`
+	// Shows the observed state of the LogParser.
 	Status LogParserStatus `json:"status,omitempty"`
 }
 
@@ -68,7 +69,7 @@ type LogParserCondition struct {
 	Type               LogParserConditionType `json:"type,omitempty"`
 }
 
-// Shows the observed state of the LogParser.
+// LogParserStatus shows the observed state of the LogParser.
 type LogParserStatus struct {
 	Conditions []LogParserCondition `json:"conditions,omitempty"`
 }

--- a/components/telemetry-operator/apis/telemetry/v1alpha1/logpipeline_types.go
+++ b/components/telemetry-operator/apis/telemetry/v1alpha1/logpipeline_types.go
@@ -72,7 +72,7 @@ type Filter struct {
 	Custom string `json:"custom,omitempty"`
 }
 
-// Configures an output to the Kyma-internal Loki instance. Note: This output is considered legacy and is only provided for backwards compatibility with the in-cluster Loki instance. It might not be compatible with latest Loki versions. For integration with a Loki-based system, use the `custom` output with name `loki` instead..
+// Configures an output to the Kyma-internal Loki instance. Note: This output is considered legacy and is only provided for backwards compatibility with the in-cluster Loki instance. It might not be compatible with latest Loki versions. For integration with a Loki-based system, use the `custom` output with name `loki` instead.
 type LokiOutput struct {
 	URL        ValueType         `json:"url,omitempty"`
 	Labels     map[string]string `json:"labels,omitempty"`
@@ -111,11 +111,9 @@ type TLSConfig struct {
 // Output describes a Fluent Bit output configuration section.
 type Output struct {
 	// Custom output definition in the Fluent Bit syntax. Note: If you use a `custom` output, you put the LogPipeline in unsupported mode.
-	Custom string `json:"custom,omitempty"`
-	// Defines an HTTP based output.
-	HTTP *HTTPOutput `json:"http,omitempty"`
-	// Defines a grafana-loki based output.
-	Loki *LokiOutput `json:"grafana-loki,omitempty"`
+	Custom string      `json:"custom,omitempty"`
+	HTTP   *HTTPOutput `json:"http,omitempty"`
+	Loki   *LokiOutput `json:"grafana-loki,omitempty"`
 }
 
 func (o *Output) IsCustomDefined() bool {

--- a/components/telemetry-operator/apis/telemetry/v1alpha1/logpipeline_types.go
+++ b/components/telemetry-operator/apis/telemetry/v1alpha1/logpipeline_types.go
@@ -20,7 +20,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-// LogPipelineSpec defines the desired state of LogPipeline
+// Defines the desired state of LogPipeline
 type LogPipelineSpec struct {
 	// INSERT ADDITIONAL SPEC FIELDS - desired state of cluster
 	// Important: Run "make" to regenerate code after modifying this file
@@ -32,77 +32,90 @@ type LogPipelineSpec struct {
 	Variables []VariableRef `json:"variables,omitempty"`
 }
 
-// Input describes a log input for a LogPipeline
+// Describes a log input for a LogPipeline.
 type Input struct {
-	// Application configures in more detail from which containers application logs are enabled as input
+	// Configures in more detail from which containers application logs are enabled as input.
 	Application ApplicationInput `json:"application,omitempty"`
 }
 
-// ApplicationInput is the default type of Input that handles application logs from runtime containers. It configures in more detail from which containers logs are selected as input
+// Specifies the default type of Input that handles application logs from runtime containers. It configures in more detail from which containers logs are selected as input.
 type ApplicationInput struct {
 	Namespaces InputNamespaces `json:"namespaces,omitempty"`
 	Containers InputContainers `json:"containers,omitempty"`
-	// KeepAnnotations indicates whether to keep all Kubernetes annotations. The default is false.
+	// Defines whether to keep all Kubernetes annotations. The default is false.
 	KeepAnnotations bool `json:"keepAnnotations,omitempty"`
-	// DropLabels indicates whether to drop all Kubernetes labels. The default is false.
+	// Defines whether to drop all Kubernetes labels. The default is false.
 	DropLabels bool `json:"dropLabels,omitempty"`
 }
 
-// InputNamespaces describes whether application logs from specific Namespaces are selected. The options are mutually exclusive. System Namespaces are excluded by default from the collection
+// Describes whether application logs from specific Namespaces are selected. The options are mutually exclusive. System Namespaces are excluded by default from the collection.
 type InputNamespaces struct {
-	// Include describes to include only the container logs of the specified Namespace names
+	// Include only the container logs of the specified Namespace names.
 	Include []string `json:"include,omitempty"`
-	// Exclude describes to exclude only the container logs of the specified Namespace names
+	// Exclude the container logs of the specified Namespace names.
 	Exclude []string `json:"exclude,omitempty"`
-	// System describes to include the container logs of the system Namespaces like kube-system, istio-system, and kyma-system
+	// Describes to include the container logs of the system Namespaces like kube-system, istio-system, and kyma-system.
 	System bool `json:"system,omitempty"`
 }
 
-// InputContainers describes whether application logs from specific containers are selected. The options are mutually exclusive.
+// Describes whether application logs from specific containers are selected. The options are mutually exclusive.
 type InputContainers struct {
-	// Include describes to include only the container logs with the specified container names
+	// Specifies to include only the container logs with the specified container names.
 	Include []string `json:"include,omitempty"`
-	// Exclude describes to exclude only the container logs with the specified container names
+	// Specifies to exclude only the container logs with the specified container names.
 	Exclude []string `json:"exclude,omitempty"`
 }
 
-// Filter describes a filtering option on the logs of the pipeline
+// Describes a filtering option on the logs of the pipeline.
 type Filter struct {
-	// Custom filter definition in the Fluent Bit syntax. Note: If you use a `custom` filter, you put the LogPipeline in unsupported mode
+	// Custom filter definition in the Fluent Bit syntax. Note: If you use a `custom` filter, you put the LogPipeline in unsupported mode.
 	Custom string `json:"custom,omitempty"`
 }
 
-// LokiOutput configures an output to the Kyma-internal Loki instance. Note: This output is considered legacy and is only provided for backwards compatibility with the in-cluster Loki instance. It might not be compatible with latest Loki versions. For integration with a Loki-based system, use the `custom` output with name `loki` instead.
+// Configures an output to the Kyma-internal Loki instance. Note: This output is considered legacy and is only provided for backwards compatibility with the in-cluster Loki instance. It might not be compatible with latest Loki versions. For integration with a Loki-based system, use the `custom` output with name `loki` instead..
 type LokiOutput struct {
 	URL        ValueType         `json:"url,omitempty"`
 	Labels     map[string]string `json:"labels,omitempty"`
 	RemoveKeys []string          `json:"removeKeys,omitempty"`
 }
 
-// HttpOutput configures an HTTP-based output compatible with the Fluent Bit HTTP output plugin
+// Configures an HTTP-based output compatible with the Fluent Bit HTTP output plugin.
 type HTTPOutput struct {
-	Host      ValueType `json:"host,omitempty"`
-	User      ValueType `json:"user,omitempty"`
-	Password  ValueType `json:"password,omitempty"`
-	URI       string    `json:"uri,omitempty"`
-	Port      string    `json:"port,omitempty"`
-	Compress  string    `json:"compress,omitempty"`
-	Format    string    `json:"format,omitempty"`
+	// Defines the host of the HTTP receiver.
+	Host ValueType `json:"host,omitempty"`
+	// Defines the basic auth user.
+	User ValueType `json:"user,omitempty"`
+	// Defines the basic auth password.
+	Password ValueType `json:"password,omitempty"`
+	// Defines the URI of the HTTP receiver. Default is "/".
+	URI string `json:"uri,omitempty"`
+	// Defines the port of the HTTP receiver. Default is 443.
+	Port string `json:"port,omitempty"`
+	// Defines the compression algorithm to use.
+	Compress string `json:"compress,omitempty"`
+	// Defines the log encoding to be used. Default is json.
+	Format string `json:"format,omitempty"`
+	// Defines TLS settings for the HTTP connection.
 	TLSConfig TLSConfig `json:"tls,omitempty"`
-	Dedot     bool      `json:"dedot,omitempty"`
+	// Enables de-dotting of Kubernetes labels and annotations for compatibility with ElasticSearch based backends. Dots (.) will be replaced by underscores (_).
+	Dedot bool `json:"dedot,omitempty"`
 }
 
 type TLSConfig struct {
-	Disabled                  bool `json:"disabled,omitempty"`
+	// Disable TLS.
+	Disabled bool `json:"disabled,omitempty"`
+	// Disable TLS certificate validation.
 	SkipCertificateValidation bool `json:"skipCertificateValidation,omitempty"`
 }
 
-// Output describes a Fluent Bit output configuration section
+// Output describes a Fluent Bit output configuration section.
 type Output struct {
-	// Custom output definition in the Fluent Bit syntax. Note: If you use a `custom` output, you put the LogPipeline in unsupported mode
-	Custom string      `json:"custom,omitempty"`
-	HTTP   *HTTPOutput `json:"http,omitempty"`
-	Loki   *LokiOutput `json:"grafana-loki,omitempty"`
+	// Custom output definition in the Fluent Bit syntax. Note: If you use a `custom` output, you put the LogPipeline in unsupported mode.
+	Custom string `json:"custom,omitempty"`
+	// Defines an HTTP based output.
+	HTTP *HTTPOutput `json:"http,omitempty"`
+	// Defines a grafana-loki based output.
+	Loki *LokiOutput `json:"grafana-loki,omitempty"`
 }
 
 func (o *Output) IsCustomDefined() bool {
@@ -172,7 +185,7 @@ type LogPipelineCondition struct {
 	Type               LogPipelineConditionType `json:"type,omitempty"`
 }
 
-// LogPipelineStatus defines the observed state of LogPipeline
+// Shows the observed state of the LogPipeline
 type LogPipelineStatus struct {
 	Conditions      []LogPipelineCondition `json:"conditions,omitempty"`
 	UnsupportedMode bool                   `json:"unsupportedMode,omitempty"`

--- a/components/telemetry-operator/apis/telemetry/v1alpha1/logpipeline_types.go
+++ b/components/telemetry-operator/apis/telemetry/v1alpha1/logpipeline_types.go
@@ -20,27 +20,31 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-// Defines the desired state of LogPipeline
+// LogPipelineSpec defines the desired state of LogPipeline
 type LogPipelineSpec struct {
 	// INSERT ADDITIONAL SPEC FIELDS - desired state of cluster
 	// Important: Run "make" to regenerate code after modifying this file
 
-	Input     Input         `json:"input,omitempty"`
-	Filters   []Filter      `json:"filters,omitempty"`
+	// Describes a log input for a LogPipeline.
+	Input   Input    `json:"input,omitempty"`
+	Filters []Filter `json:"filters,omitempty"`
+	// Describes a Fluent Bit output configuration section.
 	Output    Output        `json:"output,omitempty"`
 	Files     []FileMount   `json:"files,omitempty"`
 	Variables []VariableRef `json:"variables,omitempty"`
 }
 
-// Describes a log input for a LogPipeline.
+// Input describes a log input for a LogPipeline.
 type Input struct {
 	// Configures in more detail from which containers application logs are enabled as input.
 	Application ApplicationInput `json:"application,omitempty"`
 }
 
-// Specifies the default type of Input that handles application logs from runtime containers. It configures in more detail from which containers logs are selected as input.
+// ApplicationInput specifies the default type of Input that handles application logs from runtime containers. It configures in more detail from which containers logs are selected as input.
 type ApplicationInput struct {
+	// Describes whether application logs from specific Namespaces are selected. The options are mutually exclusive. System Namespaces are excluded by default from the collection.
 	Namespaces InputNamespaces `json:"namespaces,omitempty"`
+	// Describes whether application logs from specific containers are selected. The options are mutually exclusive.
 	Containers InputContainers `json:"containers,omitempty"`
 	// Defines whether to keep all Kubernetes annotations. The default is false.
 	KeepAnnotations bool `json:"keepAnnotations,omitempty"`
@@ -48,7 +52,7 @@ type ApplicationInput struct {
 	DropLabels bool `json:"dropLabels,omitempty"`
 }
 
-// Describes whether application logs from specific Namespaces are selected. The options are mutually exclusive. System Namespaces are excluded by default from the collection.
+// InputNamespaces describes whether application logs from specific Namespaces are selected. The options are mutually exclusive. System Namespaces are excluded by default from the collection.
 type InputNamespaces struct {
 	// Include only the container logs of the specified Namespace names.
 	Include []string `json:"include,omitempty"`
@@ -58,7 +62,7 @@ type InputNamespaces struct {
 	System bool `json:"system,omitempty"`
 }
 
-// Describes whether application logs from specific containers are selected. The options are mutually exclusive.
+// InputContainers describes whether application logs from specific containers are selected. The options are mutually exclusive.
 type InputContainers struct {
 	// Specifies to include only the container logs with the specified container names.
 	Include []string `json:"include,omitempty"`
@@ -72,14 +76,14 @@ type Filter struct {
 	Custom string `json:"custom,omitempty"`
 }
 
-// Configures an output to the Kyma-internal Loki instance. Note: This output is considered legacy and is only provided for backwards compatibility with the in-cluster Loki instance. It might not be compatible with latest Loki versions. For integration with a Loki-based system, use the `custom` output with name `loki` instead.
+// LokiOutput configures an output to the Kyma-internal Loki instance.
 type LokiOutput struct {
 	URL        ValueType         `json:"url,omitempty"`
 	Labels     map[string]string `json:"labels,omitempty"`
 	RemoveKeys []string          `json:"removeKeys,omitempty"`
 }
 
-// Configures an HTTP-based output compatible with the Fluent Bit HTTP output plugin.
+// HTTPOutput configures an HTTP-based output compatible with the Fluent Bit HTTP output plugin.
 type HTTPOutput struct {
 	// Defines the host of the HTTP receiver.
 	Host ValueType `json:"host,omitempty"`
@@ -110,10 +114,12 @@ type TLSConfig struct {
 
 // Output describes a Fluent Bit output configuration section.
 type Output struct {
-	// Custom output definition in the Fluent Bit syntax. Note: If you use a `custom` output, you put the LogPipeline in unsupported mode.
-	Custom string      `json:"custom,omitempty"`
-	HTTP   *HTTPOutput `json:"http,omitempty"`
-	Loki   *LokiOutput `json:"grafana-loki,omitempty"`
+	// Defines a custom output in the Fluent Bit syntax. Note: If you use a `custom` output, you put the LogPipeline in unsupported mode.
+	Custom string `json:"custom,omitempty"`
+	// Configures an HTTP-based output compatible with the Fluent Bit HTTP output plugin.
+	HTTP *HTTPOutput `json:"http,omitempty"`
+	// Configures an output to the Kyma-internal Loki instance. Note: This output is considered legacy and is only provided for backwards compatibility with the in-cluster Loki instance. It might not be compatible with latest Loki versions. For integration with a Loki-based system, use the `custom` output with name `loki` instead.
+	Loki *LokiOutput `json:"grafana-loki,omitempty"`
 }
 
 func (o *Output) IsCustomDefined() bool {
@@ -150,13 +156,13 @@ func (o *Output) pluginCount() int {
 	return plugins
 }
 
-// FileMount provides file content to be consumed by a LogPipeline configuration
+// Provides file content to be consumed by a LogPipeline configuration
 type FileMount struct {
 	Name    string `json:"name,omitempty"`
 	Content string `json:"content,omitempty"`
 }
 
-// VariableRef references a Kubernetes secret that should be provided as environment variable to Fluent Bit
+// References a Kubernetes secret that should be provided as environment variable to Fluent Bit
 type VariableRef struct {
 	Name      string          `json:"name,omitempty"`
 	ValueFrom ValueFromSource `json:"valueFrom,omitempty"`
@@ -183,7 +189,7 @@ type LogPipelineCondition struct {
 	Type               LogPipelineConditionType `json:"type,omitempty"`
 }
 
-// Shows the observed state of the LogPipeline
+// LogPipelineStatus shows the observed state of the LogPipeline
 type LogPipelineStatus struct {
 	Conditions      []LogPipelineCondition `json:"conditions,omitempty"`
 	UnsupportedMode bool                   `json:"unsupportedMode,omitempty"`
@@ -240,7 +246,9 @@ type LogPipeline struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 
-	Spec   LogPipelineSpec   `json:"spec,omitempty"`
+	// Defines the desired state of LogPipeline
+	Spec LogPipelineSpec `json:"spec,omitempty"`
+	// Shows the observed state of the LogPipeline
 	Status LogPipelineStatus `json:"status,omitempty"`
 }
 

--- a/components/telemetry-operator/apis/telemetry/v1alpha1/tracepipeline_types.go
+++ b/components/telemetry-operator/apis/telemetry/v1alpha1/tracepipeline_types.go
@@ -22,33 +22,33 @@ import (
 
 // TracePipelineSpec defines the desired state of TracePipeline
 type TracePipelineSpec struct {
-	// Output configures the trace receiver of a TracePipeline.
+	// Configures the trace receiver of a TracePipeline.
 	Output TracePipelineOutput `json:"output,omitempty"`
 }
 
 type TracePipelineOutput struct {
-	// Otlp defines an output using the OpenTelmetry protocol.
+	// Defines an output using the OpenTelmetry protocol.
 	Otlp *OtlpOutput `json:"otlp,omitempty"`
 }
 
 type OtlpOutput struct {
-	// Protocol defines the OTLP protocol (http or grpc).
+	// Defines the OTLP protocol (http or grpc).
 	Protocol string `json:"protocol,omitempty"`
-	// Endpoint defines the host and port (<host>:<port>) of an OTLP endpoint.
+	// Defines the host and port (<host>:<port>) of an OTLP endpoint.
 	Endpoint ValueType `json:"endpoint,omitempty"`
-	// Authentication defines authentication options for the OTLP output
+	// Defines authentication options for the OTLP output
 	Authentication *AuthenticationOptions `json:"authentication,omitempty"`
 }
 
 type AuthenticationOptions struct {
-	// Basic contains credentials for HTTP basic auth
+	// Contains credentials for HTTP basic auth
 	Basic *BasicAuthOptions `json:"basic,omitempty"`
 }
 
 type BasicAuthOptions struct {
-	// User contains the basic auth username or a secret reference
+	// Contains the basic auth username or a secret reference
 	User ValueType `json:"user,omitempty"`
-	// Password contains the basic auth password or a secret reference
+	// Contains the basic auth password or a secret reference
 	Password ValueType `json:"password,omitempty"`
 }
 

--- a/components/telemetry-operator/config/crd/bases/telemetry.kyma-project.io_logparsers.yaml
+++ b/components/telemetry-operator/config/crd/bases/telemetry.kyma-project.io_logparsers.yaml
@@ -25,7 +25,7 @@ spec:
     name: v1alpha1
     schema:
       openAPIV3Schema:
-        description: LogParser is the Schema for the logparsers API
+        description: LogParser is the Schema for the logparsers API.
         properties:
           apiVersion:
             description: 'APIVersion defines the versioned schema of this representation
@@ -40,15 +40,15 @@ spec:
           metadata:
             type: object
           spec:
-            description: LogParserSpec defines the desired state of LogParser
+            description: Defines the desired state of LogParser.
             properties:
               parser:
-                description: Parser allows defining user defined parsers to be applied
-                  to the logs
+                description: Configures a user defined log parser to be applied to
+                  the logs
                 type: string
             type: object
           status:
-            description: LogParserStatus defines the observed state of LogParser
+            description: Shows the observed state of the LogParser.
             properties:
               conditions:
                 items:

--- a/components/telemetry-operator/config/crd/bases/telemetry.kyma-project.io_logparsers.yaml
+++ b/components/telemetry-operator/config/crd/bases/telemetry.kyma-project.io_logparsers.yaml
@@ -43,8 +43,8 @@ spec:
             description: Defines the desired state of LogParser.
             properties:
               parser:
-                description: Configures a user defined log parser to be applied to
-                  the logs
+                description: Configures a user defined Fluent Bit parser to be applied
+                  to the logs.
                 type: string
             type: object
           status:

--- a/components/telemetry-operator/config/crd/bases/telemetry.kyma-project.io_logpipelines.yaml
+++ b/components/telemetry-operator/config/crd/bases/telemetry.kyma-project.io_logpipelines.yaml
@@ -47,8 +47,8 @@ spec:
             properties:
               files:
                 items:
-                  description: FileMount provides file content to be consumed by a
-                    LogPipeline configuration
+                  description: Provides file content to be consumed by a LogPipeline
+                    configuration
                   properties:
                     content:
                       type: string
@@ -125,10 +125,10 @@ spec:
                     type: object
                 type: object
               output:
-                description: Output describes a Fluent Bit output configuration section.
+                description: Describes a Fluent Bit output configuration section.
                 properties:
                   custom:
-                    description: 'Custom output definition in the Fluent Bit syntax.
+                    description: 'Defines a custom output in the Fluent Bit syntax.
                       Note: If you use a `custom` output, you put the LogPipeline
                       in unsupported mode.'
                     type: string
@@ -258,8 +258,8 @@ spec:
                 type: object
               variables:
                 items:
-                  description: VariableRef references a Kubernetes secret that should
-                    be provided as environment variable to Fluent Bit
+                  description: References a Kubernetes secret that should be provided
+                    as environment variable to Fluent Bit
                   properties:
                     name:
                       type: string

--- a/components/telemetry-operator/config/crd/bases/telemetry.kyma-project.io_logpipelines.yaml
+++ b/components/telemetry-operator/config/crd/bases/telemetry.kyma-project.io_logpipelines.yaml
@@ -133,7 +133,12 @@ spec:
                       in unsupported mode.'
                     type: string
                   grafana-loki:
-                    description: Defines a grafana-loki based output.
+                    description: 'Configures an output to the Kyma-internal Loki instance.
+                      Note: This output is considered legacy and is only provided
+                      for backwards compatibility with the in-cluster Loki instance.
+                      It might not be compatible with latest Loki versions. For integration
+                      with a Loki-based system, use the `custom` output with name
+                      `loki` instead.'
                     properties:
                       labels:
                         additionalProperties:
@@ -162,7 +167,8 @@ spec:
                         type: object
                     type: object
                   http:
-                    description: Defines an HTTP based output.
+                    description: Configures an HTTP-based output compatible with the
+                      Fluent Bit HTTP output plugin.
                     properties:
                       compress:
                         description: Defines the compression algorithm to use.

--- a/components/telemetry-operator/config/crd/bases/telemetry.kyma-project.io_logpipelines.yaml
+++ b/components/telemetry-operator/config/crd/bases/telemetry.kyma-project.io_logpipelines.yaml
@@ -43,7 +43,7 @@ spec:
           metadata:
             type: object
           spec:
-            description: LogPipelineSpec defines the desired state of LogPipeline
+            description: Defines the desired state of LogPipeline
             properties:
               files:
                 items:
@@ -58,90 +58,82 @@ spec:
                 type: array
               filters:
                 items:
-                  description: Filter describes a filtering option on the logs of
-                    the pipeline
+                  description: Describes a filtering option on the logs of the pipeline.
                   properties:
                     custom:
                       description: 'Custom filter definition in the Fluent Bit syntax.
                         Note: If you use a `custom` filter, you put the LogPipeline
-                        in unsupported mode'
+                        in unsupported mode.'
                       type: string
                   type: object
                 type: array
               input:
-                description: Input describes a log input for a LogPipeline
+                description: Describes a log input for a LogPipeline.
                 properties:
                   application:
-                    description: Application configures in more detail from which
-                      containers application logs are enabled as input
+                    description: Configures in more detail from which containers application
+                      logs are enabled as input.
                     properties:
                       containers:
-                        description: InputContainers describes whether application
-                          logs from specific containers are selected. The options
-                          are mutually exclusive.
+                        description: Describes whether application logs from specific
+                          containers are selected. The options are mutually exclusive.
                         properties:
                           exclude:
-                            description: Exclude describes to exclude only the container
-                              logs with the specified container names
+                            description: Specifies to exclude only the container logs
+                              with the specified container names.
                             items:
                               type: string
                             type: array
                           include:
-                            description: Include describes to include only the container
-                              logs with the specified container names
+                            description: Specifies to include only the container logs
+                              with the specified container names.
                             items:
                               type: string
                             type: array
                         type: object
                       dropLabels:
-                        description: DropLabels indicates whether to drop all Kubernetes
-                          labels. The default is false.
+                        description: Defines whether to drop all Kubernetes labels.
+                          The default is false.
                         type: boolean
                       keepAnnotations:
-                        description: KeepAnnotations indicates whether to keep all
-                          Kubernetes annotations. The default is false.
+                        description: Defines whether to keep all Kubernetes annotations.
+                          The default is false.
                         type: boolean
                       namespaces:
-                        description: InputNamespaces describes whether application
-                          logs from specific Namespaces are selected. The options
-                          are mutually exclusive. System Namespaces are excluded by
-                          default from the collection
+                        description: Describes whether application logs from specific
+                          Namespaces are selected. The options are mutually exclusive.
+                          System Namespaces are excluded by default from the collection.
                         properties:
                           exclude:
-                            description: Exclude describes to exclude only the container
-                              logs of the specified Namespace names
+                            description: Exclude the container logs of the specified
+                              Namespace names.
                             items:
                               type: string
                             type: array
                           include:
-                            description: Include describes to include only the container
-                              logs of the specified Namespace names
+                            description: Include only the container logs of the specified
+                              Namespace names.
                             items:
                               type: string
                             type: array
                           system:
-                            description: System describes to include the container
-                              logs of the system Namespaces like kube-system, istio-system,
-                              and kyma-system
+                            description: Describes to include the container logs of
+                              the system Namespaces like kube-system, istio-system,
+                              and kyma-system.
                             type: boolean
                         type: object
                     type: object
                 type: object
               output:
-                description: Output describes a Fluent Bit output configuration section
+                description: Output describes a Fluent Bit output configuration section.
                 properties:
                   custom:
                     description: 'Custom output definition in the Fluent Bit syntax.
                       Note: If you use a `custom` output, you put the LogPipeline
-                      in unsupported mode'
+                      in unsupported mode.'
                     type: string
                   grafana-loki:
-                    description: 'LokiOutput configures an output to the Kyma-internal
-                      Loki instance. Note: This output is considered legacy and is
-                      only provided for backwards compatibility with the in-cluster
-                      Loki instance. It might not be compatible with latest Loki versions.
-                      For integration with a Loki-based system, use the `custom` output
-                      with name `loki` instead.'
+                    description: Defines a grafana-loki based output.
                     properties:
                       labels:
                         additionalProperties:
@@ -170,16 +162,22 @@ spec:
                         type: object
                     type: object
                   http:
-                    description: HttpOutput configures an HTTP-based output compatible
-                      with the Fluent Bit HTTP output plugin
+                    description: Defines an HTTP based output.
                     properties:
                       compress:
+                        description: Defines the compression algorithm to use.
                         type: string
                       dedot:
+                        description: Enables de-dotting of Kubernetes labels and annotations
+                          for compatibility with ElasticSearch based backends. Dots
+                          (.) will be replaced by underscores (_).
                         type: boolean
                       format:
+                        description: Defines the log encoding to be used. Default
+                          is json.
                         type: string
                       host:
+                        description: Defines the host of the HTTP receiver.
                         properties:
                           value:
                             type: string
@@ -197,6 +195,7 @@ spec:
                             type: object
                         type: object
                       password:
+                        description: Defines the basic auth password.
                         properties:
                           value:
                             type: string
@@ -214,17 +213,25 @@ spec:
                             type: object
                         type: object
                       port:
+                        description: Defines the port of the HTTP receiver. Default
+                          is 443.
                         type: string
                       tls:
+                        description: Defines TLS settings for the HTTP connection.
                         properties:
                           disabled:
+                            description: Disable TLS.
                             type: boolean
                           skipCertificateValidation:
+                            description: Disable TLS certificate validation.
                             type: boolean
                         type: object
                       uri:
+                        description: Defines the URI of the HTTP receiver. Default
+                          is "/".
                         type: string
                       user:
+                        description: Defines the basic auth user.
                         properties:
                           value:
                             type: string
@@ -266,7 +273,7 @@ spec:
                 type: array
             type: object
           status:
-            description: LogPipelineStatus defines the observed state of LogPipeline
+            description: Shows the observed state of the LogPipeline
             properties:
               conditions:
                 items:

--- a/components/telemetry-operator/config/crd/bases/telemetry.kyma-project.io_tracepipelines.yaml
+++ b/components/telemetry-operator/config/crd/bases/telemetry.kyma-project.io_tracepipelines.yaml
@@ -36,22 +36,20 @@ spec:
             description: TracePipelineSpec defines the desired state of TracePipeline
             properties:
               output:
-                description: Output configures the trace receiver of a TracePipeline.
+                description: Configures the trace receiver of a TracePipeline.
                 properties:
                   otlp:
-                    description: Otlp defines an output using the OpenTelmetry protocol.
+                    description: Defines an output using the OpenTelmetry protocol.
                     properties:
                       authentication:
-                        description: Authentication defines authentication options
-                          for the OTLP output
+                        description: Defines authentication options for the OTLP output
                         properties:
                           basic:
-                            description: Basic contains credentials for HTTP basic
-                              auth
+                            description: Contains credentials for HTTP basic auth
                             properties:
                               password:
-                                description: Password contains the basic auth password
-                                  or a secret reference
+                                description: Contains the basic auth password or a
+                                  secret reference
                                 properties:
                                   value:
                                     type: string
@@ -69,8 +67,8 @@ spec:
                                     type: object
                                 type: object
                               user:
-                                description: User contains the basic auth username
-                                  or a secret reference
+                                description: Contains the basic auth username or a
+                                  secret reference
                                 properties:
                                   value:
                                     type: string
@@ -90,8 +88,8 @@ spec:
                             type: object
                         type: object
                       endpoint:
-                        description: Endpoint defines the host and port (<host>:<port>)
-                          of an OTLP endpoint.
+                        description: Defines the host and port (<host>:<port>) of
+                          an OTLP endpoint.
                         properties:
                           value:
                             type: string
@@ -109,7 +107,7 @@ spec:
                             type: object
                         type: object
                       protocol:
-                        description: Protocol defines the OTLP protocol (http or grpc).
+                        description: Defines the OTLP protocol (http or grpc).
                         type: string
                     type: object
                 type: object

--- a/installation/resources/crds/telemetry/logparsers.crd.yaml
+++ b/installation/resources/crds/telemetry/logparsers.crd.yaml
@@ -25,7 +25,7 @@ spec:
     name: v1alpha1
     schema:
       openAPIV3Schema:
-        description: LogParser is the Schema for the logparsers API
+        description: LogParser is the Schema for the logparsers API.
         properties:
           apiVersion:
             description: 'APIVersion defines the versioned schema of this representation
@@ -40,15 +40,15 @@ spec:
           metadata:
             type: object
           spec:
-            description: LogParserSpec defines the desired state of LogParser
+            description: Defines the desired state of LogParser.
             properties:
               parser:
-                description: Parser allows defining user defined parsers to be applied
-                  to the logs
+                description: Configures a user defined log parser to be applied to
+                  the logs
                 type: string
             type: object
           status:
-            description: LogParserStatus defines the observed state of LogParser
+            description: Shows the observed state of the LogParser.
             properties:
               conditions:
                 items:

--- a/installation/resources/crds/telemetry/logparsers.crd.yaml
+++ b/installation/resources/crds/telemetry/logparsers.crd.yaml
@@ -43,8 +43,8 @@ spec:
             description: Defines the desired state of LogParser.
             properties:
               parser:
-                description: Configures a user defined log parser to be applied to
-                  the logs
+                description: Configures a user defined Fluent Bit parser to be applied
+                  to the logs.
                 type: string
             type: object
           status:

--- a/installation/resources/crds/telemetry/logpipelines.crd.yaml
+++ b/installation/resources/crds/telemetry/logpipelines.crd.yaml
@@ -47,8 +47,8 @@ spec:
             properties:
               files:
                 items:
-                  description: FileMount provides file content to be consumed by a
-                    LogPipeline configuration
+                  description: Provides file content to be consumed by a LogPipeline
+                    configuration
                   properties:
                     content:
                       type: string
@@ -125,10 +125,10 @@ spec:
                     type: object
                 type: object
               output:
-                description: Output describes a Fluent Bit output configuration section.
+                description: Describes a Fluent Bit output configuration section.
                 properties:
                   custom:
-                    description: 'Custom output definition in the Fluent Bit syntax.
+                    description: 'Defines a custom output in the Fluent Bit syntax.
                       Note: If you use a `custom` output, you put the LogPipeline
                       in unsupported mode.'
                     type: string
@@ -258,8 +258,8 @@ spec:
                 type: object
               variables:
                 items:
-                  description: VariableRef references a Kubernetes secret that should
-                    be provided as environment variable to Fluent Bit
+                  description: References a Kubernetes secret that should be provided
+                    as environment variable to Fluent Bit
                   properties:
                     name:
                       type: string

--- a/installation/resources/crds/telemetry/logpipelines.crd.yaml
+++ b/installation/resources/crds/telemetry/logpipelines.crd.yaml
@@ -133,7 +133,12 @@ spec:
                       in unsupported mode.'
                     type: string
                   grafana-loki:
-                    description: Defines a grafana-loki based output.
+                    description: 'Configures an output to the Kyma-internal Loki instance.
+                      Note: This output is considered legacy and is only provided
+                      for backwards compatibility with the in-cluster Loki instance.
+                      It might not be compatible with latest Loki versions. For integration
+                      with a Loki-based system, use the `custom` output with name
+                      `loki` instead.'
                     properties:
                       labels:
                         additionalProperties:
@@ -162,7 +167,8 @@ spec:
                         type: object
                     type: object
                   http:
-                    description: Defines an HTTP based output.
+                    description: Configures an HTTP-based output compatible with the
+                      Fluent Bit HTTP output plugin.
                     properties:
                       compress:
                         description: Defines the compression algorithm to use.

--- a/installation/resources/crds/telemetry/logpipelines.crd.yaml
+++ b/installation/resources/crds/telemetry/logpipelines.crd.yaml
@@ -43,7 +43,7 @@ spec:
           metadata:
             type: object
           spec:
-            description: LogPipelineSpec defines the desired state of LogPipeline
+            description: Defines the desired state of LogPipeline
             properties:
               files:
                 items:
@@ -58,90 +58,82 @@ spec:
                 type: array
               filters:
                 items:
-                  description: Filter describes a filtering option on the logs of
-                    the pipeline
+                  description: Describes a filtering option on the logs of the pipeline.
                   properties:
                     custom:
                       description: 'Custom filter definition in the Fluent Bit syntax.
                         Note: If you use a `custom` filter, you put the LogPipeline
-                        in unsupported mode'
+                        in unsupported mode.'
                       type: string
                   type: object
                 type: array
               input:
-                description: Input describes a log input for a LogPipeline
+                description: Describes a log input for a LogPipeline.
                 properties:
                   application:
-                    description: Application configures in more detail from which
-                      containers application logs are enabled as input
+                    description: Configures in more detail from which containers application
+                      logs are enabled as input.
                     properties:
                       containers:
-                        description: InputContainers describes whether application
-                          logs from specific containers are selected. The options
-                          are mutually exclusive.
+                        description: Describes whether application logs from specific
+                          containers are selected. The options are mutually exclusive.
                         properties:
                           exclude:
-                            description: Exclude describes to exclude only the container
-                              logs with the specified container names
+                            description: Specifies to exclude only the container logs
+                              with the specified container names.
                             items:
                               type: string
                             type: array
                           include:
-                            description: Include describes to include only the container
-                              logs with the specified container names
+                            description: Specifies to include only the container logs
+                              with the specified container names.
                             items:
                               type: string
                             type: array
                         type: object
                       dropLabels:
-                        description: DropLabels indicates whether to drop all Kubernetes
-                          labels. The default is false.
+                        description: Defines whether to drop all Kubernetes labels.
+                          The default is false.
                         type: boolean
                       keepAnnotations:
-                        description: KeepAnnotations indicates whether to keep all
-                          Kubernetes annotations. The default is false.
+                        description: Defines whether to keep all Kubernetes annotations.
+                          The default is false.
                         type: boolean
                       namespaces:
-                        description: InputNamespaces describes whether application
-                          logs from specific Namespaces are selected. The options
-                          are mutually exclusive. System Namespaces are excluded by
-                          default from the collection
+                        description: Describes whether application logs from specific
+                          Namespaces are selected. The options are mutually exclusive.
+                          System Namespaces are excluded by default from the collection.
                         properties:
                           exclude:
-                            description: Exclude describes to exclude only the container
-                              logs of the specified Namespace names
+                            description: Exclude the container logs of the specified
+                              Namespace names.
                             items:
                               type: string
                             type: array
                           include:
-                            description: Include describes to include only the container
-                              logs of the specified Namespace names
+                            description: Include only the container logs of the specified
+                              Namespace names.
                             items:
                               type: string
                             type: array
                           system:
-                            description: System describes to include the container
-                              logs of the system Namespaces like kube-system, istio-system,
-                              and kyma-system
+                            description: Describes to include the container logs of
+                              the system Namespaces like kube-system, istio-system,
+                              and kyma-system.
                             type: boolean
                         type: object
                     type: object
                 type: object
               output:
-                description: Output describes a Fluent Bit output configuration section
+                description: Output describes a Fluent Bit output configuration section.
                 properties:
                   custom:
                     description: 'Custom output definition in the Fluent Bit syntax.
                       Note: If you use a `custom` output, you put the LogPipeline
-                      in unsupported mode'
+                      in unsupported mode.'
                     type: string
                   grafana-loki:
-                    description: 'LokiOutput configures an output to the Kyma-internal
-                      Loki instance. Note: This output is considered legacy and is
-                      only provided for backwards compatibility with the in-cluster
-                      Loki instance. It might not be compatible with latest Loki versions.
-                      For integration with a Loki-based system, use the `custom` output
-                      with name `loki` instead.'
+                    description: Defines a grafana-loki based output.
                     properties:
                       labels:
                         additionalProperties:
@@ -170,16 +162,22 @@ spec:
                         type: object
                     type: object
                   http:
-                    description: HttpOutput configures an HTTP-based output compatible
-                      with the Fluent Bit HTTP output plugin
+                    description: Defines an HTTP based output.
                     properties:
                       compress:
+                        description: Defines the compression algorithm to use.
                         type: string
                       dedot:
+                        description: Enables de-dotting of Kubernetes labels and annotations
+                          for compatibility with ElasticSearch based backends. Dots
+                          (.) will be replaced by underscores (_).
                         type: boolean
                       format:
+                        description: Defines the log encoding to be used. Default
+                          is json.
                         type: string
                       host:
+                        description: Defines the host of the HTTP receiver.
                         properties:
                           value:
                             type: string
@@ -197,6 +195,7 @@ spec:
                             type: object
                         type: object
                       password:
+                        description: Defines the basic auth password.
                         properties:
                           value:
                             type: string
@@ -214,17 +213,25 @@ spec:
                             type: object
                         type: object
                       port:
+                        description: Defines the port of the HTTP receiver. Default
+                          is 443.
                         type: string
                       tls:
+                        description: Defines TLS settings for the HTTP connection.
                         properties:
                           disabled:
+                            description: Disable TLS.
                             type: boolean
                           skipCertificateValidation:
+                            description: Disable TLS certificate validation.
                             type: boolean
                         type: object
                       uri:
+                        description: Defines the URI of the HTTP receiver. Default
+                          is "/".
                         type: string
                       user:
+                        description: Defines the basic auth user.
                         properties:
                           value:
                             type: string
@@ -266,7 +273,7 @@ spec:
                 type: array
             type: object
           status:
-            description: LogPipelineStatus defines the observed state of LogPipeline
+            description: Shows the observed state of the LogPipeline
             properties:
               conditions:
                 items:

--- a/resources/telemetry/charts/operator/values.yaml
+++ b/resources/telemetry/charts/operator/values.yaml
@@ -121,4 +121,4 @@ tolerations: []
 affinity: {}
 
 dashboardExtension:
-  enabled: false
+  enabled: true


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

The controller-gen generates CRD description fields out of source level comments on the related Go structs. These comments followed the godoc conventions and started with the field name. This exposed the internal Go field names to the CRD descriptions. This PR changes the comments to follow the examples given in the [Kubebuilder book](https://book.kubebuilder.io/cronjob-tutorial/api-design.html).

Changes proposed in this pull request:

- Remove internal names from CRD description fields

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
#15894 