### PR TITLE
Clean consumers for nats restart

### DIFF
--- a/components/eventing-controller/pkg/backend/jetstreamv2/jetstream.go
+++ b/components/eventing-controller/pkg/backend/jetstreamv2/jetstream.go
@@ -295,7 +295,6 @@ func (js *JetStream) cleanupUnnecessaryJetStreamSubscribers(
 	subscription *eventingv1alpha2.Subscription,
 	log *zap.SugaredLogger,
 	key SubscriptionSubjectIdentifier) error {
-
 	consumer, err := js.jsCtx.ConsumerInfo(js.Config.JSStreamName, key.ConsumerName())
 	if err != nil {
 		if errors.Is(err, nats.ErrConsumerNotFound) {

--- a/components/eventing-controller/pkg/backend/jetstreamv2/jetstream_integration_test.go
+++ b/components/eventing-controller/pkg/backend/jetstreamv2/jetstream_integration_test.go
@@ -910,6 +910,142 @@ func TestJSSubscriptionUsingCESDK(t *testing.T) {
 	require.NoError(t, jsBackend.DeleteSubscription(sub))
 }
 
+// TestJetStreamSubAfterSync_DeleteOldFilterConsumerForFilterChangeWhileNatsDown tests the SyncSubscription method
+// when subscription CR filters change while NATS JetStream is down.
+func TestJetStreamSubAfterSync_DeleteOldFilterConsumerForFilterChangeWhileNatsDown(t *testing.T) {
+	// given
+	testEnvironment := setupTestEnvironment(t)
+	jsBackend := testEnvironment.jsBackend
+	defer testEnvironment.natsServer.Shutdown()
+	defer testEnvironment.jsClient.natsConn.Close()
+	defer func() { _ = testEnvironment.jsClient.DeleteStream(testEnvironment.natsConfig.JSStreamName) }()
+
+	testEnvironment.jsBackend.Config.JSStreamStorageType = StorageTypeFile
+	testEnvironment.jsBackend.Config.MaxReconnects = 0
+	initErr := jsBackend.Initialize(nil)
+	require.NoError(t, initErr)
+
+	subscriber := evtesting.NewSubscriber()
+	defer subscriber.Shutdown()
+	require.True(t, subscriber.IsRunning())
+
+	// Now, add a new filter to subscription
+	sub := evtestingv2.NewSubscription("sub", "foo",
+		evtestingv2.WithCleanEventSourceAndType(),
+		evtestingv2.WithNotCleanEventSourceAndType(),
+		evtestingv2.WithSinkURL(subscriber.SinkURL),
+		evtestingv2.WithTypeMatchingStandard(),
+		evtestingv2.WithMaxInFlight(DefaultMaxInFlights),
+	)
+	AddJSCleanEventTypesToStatus(sub, testEnvironment.cleaner)
+
+	// when
+	err := jsBackend.SyncSubscription(sub)
+
+	// then
+	require.NoError(t, err)
+
+	// get cleaned subject
+	subject, err := testEnvironment.cleaner.CleanEventType(sub.Spec.Types[1])
+	require.NoError(t, err)
+	require.NotEmpty(t, subject)
+
+	require.Len(t, jsBackend.subscriptions, 2)
+	secondJsSubject := jsBackend.getJetStreamSubject(sub.Spec.Source, subject, sub.Spec.TypeMatching)
+	secondJsSubKey := NewSubscriptionSubjectIdentifier(sub, secondJsSubject)
+	secondJsSub := jsBackend.subscriptions[secondJsSubKey]
+	require.NotNil(t, secondJsSub)
+	require.True(t, secondJsSub.IsValid())
+
+	// test if subscription is working properly by sending an event
+	// and checking if it is received by the subscriber
+	data := fmt.Sprintf("data-%s", time.Now().Format(time.RFC850))
+	expectedDataInStore := fmt.Sprintf("\"%s\"", data)
+	require.NoError(t, SendEventToJetStream(jsBackend, data))
+	require.NoError(t, subscriber.CheckEvent(expectedDataInStore))
+
+	// set metadata on NATS subscriptions
+	// so that we can later verify if the nats subscriptions are the same (not re-created by Sync)
+	msgLimit, bytesLimit := 2048, 2048
+	for _, jsSub := range jsBackend.subscriptions {
+		require.True(t, jsSub.IsValid())
+		require.NoError(t, jsSub.SetPendingLimits(msgLimit, bytesLimit))
+	}
+
+	// test if subscription is working properly by sending an event
+	// and checking if it is received by the subscriber
+	data = fmt.Sprintf("data-%s", time.Now().Format(time.RFC850))
+	expectedDataInStore = fmt.Sprintf("\"%s\"", data)
+	require.NoError(t, SendEventToJetStream(jsBackend, data))
+	require.NoError(t, subscriber.CheckEvent(expectedDataInStore))
+
+	// set metadata on NATS subscriptions
+	// so that we can later verify if the nats subscriptions are the same (not re-created by Sync)
+	msgLimit, bytesLimit = 2048, 2048
+	require.Len(t, jsBackend.subscriptions, 2)
+	for _, jsSub := range jsBackend.subscriptions {
+		require.True(t, jsSub.IsValid())
+		require.NoError(t, jsSub.SetPendingLimits(msgLimit, bytesLimit))
+	}
+
+	// shutdown the JetStream and start so that existing subscription gets invalid.
+	// shutdown the JetStream and start so that existing subscription gets invalid.
+	testEnvironment.natsServer.Shutdown()
+	require.Eventually(t, func() bool {
+		return !testEnvironment.jsBackend.Conn.IsConnected()
+	}, 30*time.Second, 2*time.Second)
+
+	// given
+	// Now, remove the second filter from subscription while NATS JetStream is down
+	sub.Spec.Types = sub.Spec.Types[:1]
+	AddJSCleanEventTypesToStatus(sub, testEnvironment.cleaner)
+
+	// SyncSubscription binds the existing subscription to JetStream created one
+	err = jsBackend.SyncSubscription(sub)
+	require.Error(t, err)
+
+	// when
+	// restart the NATS server
+	_ = evtesting.RunNatsServerOnPort(
+		evtesting.WithPort(testEnvironment.natsPort),
+		evtesting.WithJetStreamEnabled())
+	// the unacknowledged message must still be present in the stream
+
+	require.Eventually(t, func() bool {
+		info, streamErr := testEnvironment.jsClient.StreamInfo(testEnvironment.natsConfig.JSStreamName)
+		require.NoError(t, streamErr)
+		return info != nil && streamErr == nil
+	}, 60*time.Second, 5*time.Second)
+
+	// when
+	err = jsBackend.SyncSubscription(sub)
+
+	// then
+	require.NoError(t, err)
+
+	// get new cleaned subject
+	firstSubject, err := testEnvironment.cleaner.CleanEventType(sub.Spec.Types[0])
+	require.NoError(t, err)
+	require.NotEmpty(t, firstSubject)
+
+	// check if the NATS subscription are NOT the same after sync
+	// because the subscriptions should have being re-created for new subject
+	require.Len(t, jsBackend.subscriptions, 1)
+	firstJsSubject := jsBackend.getJetStreamSubject(sub.Spec.Source, firstSubject, sub.Spec.TypeMatching)
+	firstJsSubKey := NewSubscriptionSubjectIdentifier(sub, firstJsSubject)
+	firstJsSub := jsBackend.subscriptions[firstJsSubKey]
+	require.NotNil(t, firstJsSub)
+	require.True(t, firstJsSub.IsValid())
+	// make sure new filter does have JetStream consumer
+	firstCon, err := jsBackend.jsCtx.ConsumerInfo(jsBackend.Config.JSStreamName, firstJsSubKey.consumerName)
+	require.NotNil(t, firstCon)
+	require.NoError(t, err)
+	// make sure old filter doesn't have any JetStream consumer
+	secondCon, err := jsBackend.jsCtx.ConsumerInfo(jsBackend.Config.JSStreamName, secondJsSubKey.consumerName)
+	require.Nil(t, secondCon)
+	require.ErrorIs(t, err, nats.ErrConsumerNotFound)
+}
+
 // TestJetStream_NoNATSSubscription tests if the error is being triggered
 // when expected entries in js.subscriptions map are missing.
 func TestJetStream_NATSSubscriptionCount(t *testing.T) {

--- a/components/eventing-controller/pkg/backend/nats/jetstream/jetstream.go
+++ b/components/eventing-controller/pkg/backend/nats/jetstream/jetstream.go
@@ -12,9 +12,9 @@ import (
 	"sync"
 	"time"
 
+	backendutils "github.com/kyma-project/kyma/components/eventing-controller/pkg/backend/utils"
 	"k8s.io/apimachinery/pkg/api/resource"
 
-	backendutils "github.com/kyma-project/kyma/components/eventing-controller/pkg/backend/utils"
 
 	cev2 "github.com/cloudevents/sdk-go/v2"
 	cev2protocol "github.com/cloudevents/sdk-go/v2/protocol"
@@ -451,8 +451,9 @@ func (js *JetStream) syncSubscriptionFilter(key SubscriptionSubjectIdentifier, s
 	return nil
 }
 
-// true if cached JetStream consumer filter subject exists in subscription CR
-func (js *JetStream) existsCachedSubscriptionFilter(cachedSubscriptionKey SubscriptionSubjectIdentifier, subscription *eventingv1alpha1.Subscription) bool {
+// true if cached JetStream consumer filter subject exists in subscription CR.
+func (js *JetStream) existsCachedSubscriptionFilter(cachedSubscriptionKey SubscriptionSubjectIdentifier,
+	subscription *eventingv1alpha1.Subscription) bool {
 	for _, subject := range subscription.Status.CleanEventTypes {
 		jsSubject := js.GetJetStreamSubject(subject)
 		jsSubKey := NewSubscriptionSubjectIdentifier(subscription, jsSubject)

--- a/components/eventing-controller/pkg/backend/nats/jetstream/jetstream.go
+++ b/components/eventing-controller/pkg/backend/nats/jetstream/jetstream.go
@@ -409,7 +409,8 @@ func getStreamConfig(natsConfig env.NatsConfig) (*nats.StreamConfig, error) {
 }
 
 // syncSubscriptionEventFilters syncs the Kyma subscription filters with NATS subscriptions.
-func (js *JetStream) syncSubscriptionEventFilters(subscription *eventingv1alpha1.Subscription, log *zap.SugaredLogger) error {
+func (js *JetStream) syncSubscriptionEventFilters(subscription *eventingv1alpha1.Subscription,
+	log *zap.SugaredLogger) error {
 	for key, jsSub := range js.subscriptions {
 		if js.isJsSubAssociatedWithKymaSub(key, subscription) {
 			err := js.syncSubscriptionEventFilter(key, subscription, jsSub, log)
@@ -423,7 +424,8 @@ func (js *JetStream) syncSubscriptionEventFilters(subscription *eventingv1alpha1
 
 // syncSubscriptionEventFilter syncs controller runtime subscriptions to subscription CR event filters and to JetStream
 // subscriptions/consumers.
-func (js *JetStream) syncSubscriptionEventFilter(key SubscriptionSubjectIdentifier, subscription *eventingv1alpha1.Subscription, subscriber backendnats.Subscriber, log *zap.SugaredLogger) error {
+func (js *JetStream) syncSubscriptionEventFilter(key SubscriptionSubjectIdentifier,
+	subscription *eventingv1alpha1.Subscription, subscriber backendnats.Subscriber, log *zap.SugaredLogger) error {
 	// don't try to delete invalid subscriber and its consumer if subscriber has type in subscription CR it belongs to.
 	// This means that it will be bound to the existing JetStream consumer in later steps.
 	if !subscriber.IsValid() && js.runtimeSubscriptionExistsInKymaSub(key, subscription) {
@@ -451,7 +453,6 @@ func (js *JetStream) cleanupUnnecessaryJetStreamSubscribers(
 	subscription *eventingv1alpha1.Subscription,
 	log *zap.SugaredLogger,
 	key SubscriptionSubjectIdentifier) error {
-
 	consumer, err := js.jsCtx.ConsumerInfo(js.Config.JSStreamName, key.ConsumerName())
 	if err != nil {
 		if errors.Is(err, nats.ErrConsumerNotFound) {

--- a/components/eventing-controller/pkg/backend/nats/jetstream/jetstream.go
+++ b/components/eventing-controller/pkg/backend/nats/jetstream/jetstream.go
@@ -5,16 +5,16 @@ import (
 	"crypto/md5" // #nosec
 	"encoding/hex"
 	"fmt"
-	"github.com/kyma-project/kyma/components/eventing-controller/utils"
 	"net/http"
 	"reflect"
 	"strings"
 	"sync"
 	"time"
 
+	"github.com/kyma-project/kyma/components/eventing-controller/utils"
+
 	backendutils "github.com/kyma-project/kyma/components/eventing-controller/pkg/backend/utils"
 	"k8s.io/apimachinery/pkg/api/resource"
-
 
 	cev2 "github.com/cloudevents/sdk-go/v2"
 	cev2protocol "github.com/cloudevents/sdk-go/v2/protocol"

--- a/components/eventing-controller/pkg/backend/nats/jetstream/jetstream.go
+++ b/components/eventing-controller/pkg/backend/nats/jetstream/jetstream.go
@@ -5,6 +5,7 @@ import (
 	"crypto/md5" // #nosec
 	"encoding/hex"
 	"fmt"
+	"github.com/kyma-project/kyma/components/eventing-controller/utils"
 	"net/http"
 	"reflect"
 	"strings"
@@ -28,7 +29,6 @@ import (
 	backendnats "github.com/kyma-project/kyma/components/eventing-controller/pkg/backend/nats"
 	"github.com/kyma-project/kyma/components/eventing-controller/pkg/env"
 	"github.com/kyma-project/kyma/components/eventing-controller/pkg/tracing"
-	"github.com/kyma-project/kyma/components/eventing-controller/utils"
 )
 
 var _ Backend = &JetStream{}
@@ -420,13 +420,18 @@ func (js *JetStream) syncSubscriptionFilters(subscription *eventingv1alpha1.Subs
 }
 
 func (js *JetStream) syncSubscriptionFilter(key SubscriptionSubjectIdentifier, subscription *eventingv1alpha1.Subscription, subscriber backendnats.Subscriber, log *zap.SugaredLogger) error {
-	if !js.isJsSubAssociatedWithKymaSub(key, subscription) || !subscriber.IsValid() {
+	if !js.isJsSubAssociatedWithKymaSub(key, subscription) {
+		return nil
+	}
+
+	// cached subscription is invalid and its subject exists in subscription CR filters
+	if !subscriber.IsValid() && js.existsCachedSubscriptionFilter(key, subscription) {
 		return nil
 	}
 
 	// TODO: optimize this call of ConsumerInfo
 	// as jsSub.ConsumerInfo() will send an REST call to nats-server for each subject
-	info, err := subscriber.ConsumerInfo()
+	info, err := js.jsCtx.ConsumerInfo(js.Config.JSStreamName, key.ConsumerName())
 	if err != nil {
 		if errors.Is(err, nats.ErrConsumerNotFound) {
 			log.Infow("Deleting invalid Consumer!")
@@ -446,7 +451,20 @@ func (js *JetStream) syncSubscriptionFilter(key SubscriptionSubjectIdentifier, s
 	return nil
 }
 
+// true if cached JetStream consumer filter subject exists in subscription CR
+func (js *JetStream) existsCachedSubscriptionFilter(cachedSubscriptionKey SubscriptionSubjectIdentifier, subscription *eventingv1alpha1.Subscription) bool {
+	for _, subject := range subscription.Status.CleanEventTypes {
+		jsSubject := js.GetJetStreamSubject(subject)
+		jsSubKey := NewSubscriptionSubjectIdentifier(subscription, jsSubject)
+		if cachedSubscriptionKey.consumerName == jsSubKey.consumerName {
+			return true
+		}
+	}
+	return false
+}
+
 func (js *JetStream) cleanupUnnecessaryJetStreamSubscribers(jsSub backendnats.Subscriber, subscription *eventingv1alpha1.Subscription, log *zap.SugaredLogger, info *nats.ConsumerInfo, key SubscriptionSubjectIdentifier) error {
+	// check whether JetStream consumer filter subject exists in subscription CR
 	if utils.ContainsString(js.GetJetStreamSubjects(subscription.Status.CleanEventTypes), info.Config.FilterSubject) {
 		return nil
 	}

--- a/components/eventing-controller/pkg/backend/nats/jetstream/jetstream_integration_test.go
+++ b/components/eventing-controller/pkg/backend/nats/jetstream/jetstream_integration_test.go
@@ -1634,11 +1634,6 @@ func TestJetStreamSubAfterSync_DeleteOldFilterConsumerForFilterChangeWhileNatsDo
 		return info != nil && streamErr == nil
 	}, 60*time.Second, 5*time.Second)
 
-	// SyncSubscription binds the existing subscription to JetStream created one
-	err = jsBackend.SyncSubscription(sub)
-	// then
-	require.NoError(t, err)
-
 	// when
 	err = jsBackend.SyncSubscription(sub)
 

--- a/components/eventing-controller/pkg/backend/nats/jetstream/jetstream_integration_test.go
+++ b/components/eventing-controller/pkg/backend/nats/jetstream/jetstream_integration_test.go
@@ -1541,4 +1541,8 @@ func TestJetStreamSubAfterSync_ForExplicitlyBoundSubscriptionDeletion(t *testing
 	oldCon, err := jsBackend.jsCtx.ConsumerInfo(jsBackend.Config.JSStreamName, oldJsSubKey.consumerName)
 	require.Nil(t, oldCon)
 	require.ErrorIs(t, err, nats.ErrConsumerNotFound)
+<<<<<<< HEAD
 }
+=======
+}
+>>>>>>> 025d91723 (Add Int Test for NATS Created Consumer Deletion)

--- a/components/eventing-controller/pkg/backend/nats/jetstream/jetstream_integration_test.go
+++ b/components/eventing-controller/pkg/backend/nats/jetstream/jetstream_integration_test.go
@@ -1541,8 +1541,128 @@ func TestJetStreamSubAfterSync_ForExplicitlyBoundSubscriptionDeletion(t *testing
 	oldCon, err := jsBackend.jsCtx.ConsumerInfo(jsBackend.Config.JSStreamName, oldJsSubKey.consumerName)
 	require.Nil(t, oldCon)
 	require.ErrorIs(t, err, nats.ErrConsumerNotFound)
-<<<<<<< HEAD
 }
-=======
+
+// TestJetStreamSubAfterSync_DeleteOldFilterConsumerForFilterChangeWhileNatsDown tests the SyncSubscription method
+// when subscription CR filters change while NATS JetStream is down.
+func TestJetStreamSubAfterSync_DeleteOldFilterConsumerForFilterChangeWhileNatsDown(t *testing.T) {
+	// given
+	testEnvironment := setupTestEnvironment(t, false)
+	jsBackend := testEnvironment.jsBackend
+	defer testEnvironment.natsServer.Shutdown()
+	defer testEnvironment.jsClient.natsConn.Close()
+
+	testEnvironment.jsBackend.Config.JSStreamStorageType = StorageTypeFile
+	testEnvironment.jsBackend.Config.MaxReconnects = 0
+	initErr := jsBackend.Initialize(nil)
+	require.NoError(t, initErr)
+
+	subscriber := evtesting.NewSubscriber()
+	defer subscriber.Shutdown()
+	require.True(t, subscriber.IsRunning())
+
+	defaultMaxInflight := 9
+	defaultSubsConfig := env.DefaultSubscriptionConfig{MaxInFlightMessages: defaultMaxInflight}
+	sub := evtesting.NewSubscription("sub", "foo",
+		evtesting.WithNotCleanFilter(),
+		evtesting.WithSinkURL(subscriber.SinkURL),
+		evtesting.WithStatusConfig(defaultSubsConfig),
+	)
+	require.NoError(t, addJSCleanEventTypesToStatus(sub, testEnvironment.cleaner))
+
+	// when
+	err := jsBackend.SyncSubscription(sub)
+
+	// then
+	require.NoError(t, err)
+
+	// get cleaned subject
+	subject, err := backendnats.GetCleanSubject(sub.Spec.Filter.Filters[0], testEnvironment.cleaner)
+	require.NoError(t, err)
+	require.NotEmpty(t, subject)
+
+	require.Len(t, jsBackend.subscriptions, 1)
+	oldJsSubject := jsBackend.GetJetStreamSubject(subject)
+	oldJsSubKey := NewSubscriptionSubjectIdentifier(sub, oldJsSubject)
+	oldJsSub := jsBackend.subscriptions[oldJsSubKey]
+	require.NotNil(t, oldJsSub)
+	require.True(t, oldJsSub.IsValid())
+
+	// test if subscription is working properly by sending an event
+	// and checking if it is received by the subscriber
+	data := fmt.Sprintf("data-%s", time.Now().Format(time.RFC850))
+	expectedDataInStore := fmt.Sprintf("\"%s\"", data)
+	require.NoError(t, SendEventToJetStream(jsBackend, data))
+	require.NoError(t, subscriber.CheckEvent(expectedDataInStore))
+
+	// set metadata on NATS subscriptions
+	// so that we can later verify if the nats subscriptions are the same (not re-created by Sync)
+	msgLimit, bytesLimit := 2048, 2048
+	require.Len(t, jsBackend.subscriptions, 1)
+	for _, jsSub := range jsBackend.subscriptions {
+		require.True(t, jsSub.IsValid())
+		require.NoError(t, jsSub.SetPendingLimits(msgLimit, bytesLimit))
+	}
+
+	//shutdown the JetStream and start so that existing subscription gets invalid.
+	testEnvironment.natsServer.Shutdown()
+	require.Eventually(t, func() bool {
+		return !testEnvironment.jsBackend.conn.IsConnected()
+	}, 30*time.Second, 2*time.Second)
+
+	// TODO: change subscription CR filters while NATS JetStream is down
+	// given
+	// Now, change the filter in subscription
+	sub.Spec.Filter.Filters[0].EventType.Value = fmt.Sprintf("%schanged", evtesting.OrderCreatedEventTypeNotClean)
+	// Sync the subscription status
+	require.NoError(t, addJSCleanEventTypesToStatus(sub, testEnvironment.cleaner))
+	// SyncSubscription binds the existing subscription to JetStream created one
+	err = jsBackend.SyncSubscription(sub)
+	require.Error(t, err)
+
+	// when
+	// restart the NATS server
+	_ = evtesting.RunNatsServerOnPort(
+		evtesting.WithPort(testEnvironment.natsPort),
+		evtesting.WithJetStreamEnabled())
+	// the unacknowledged message must still be present in the stream
+
+	require.Eventually(t, func() bool {
+		info, err := testEnvironment.jsClient.StreamInfo(defaultStreamName)
+		require.NoError(t, err)
+		return info != nil && err == nil
+	}, 60*time.Second, 5*time.Second)
+
+	// SyncSubscription binds the existing subscription to JetStream created one
+	err = jsBackend.SyncSubscription(sub)
+	// then
+	require.NoError(t, err)
+
+	// when
+	err = jsBackend.SyncSubscription(sub)
+
+	// then
+	require.NoError(t, err)
+
+	// get new cleaned subject
+	newSubject, err := backendnats.GetCleanSubject(sub.Spec.Filter.Filters[0], testEnvironment.cleaner)
+	require.NoError(t, err)
+	require.NotEmpty(t, newSubject)
+
+	// check if the NATS subscription are NOT the same after sync
+	// because the subscriptions should have being re-created for new subject
+	require.Len(t, jsBackend.subscriptions, 1)
+	newJsSubject := jsBackend.GetJetStreamSubject(newSubject)
+	newJsSubKey := NewSubscriptionSubjectIdentifier(sub, newJsSubject)
+	newJsSub := jsBackend.subscriptions[newJsSubKey]
+	require.NotNil(t, newJsSub)
+	require.True(t, newJsSub.IsValid())
+	// make sure new filter does have JetStream consumer
+	newCon, err := jsBackend.jsCtx.ConsumerInfo(jsBackend.Config.JSStreamName, newJsSubKey.consumerName)
+	require.NotNil(t, newCon)
+	require.NoError(t, err)
+	// make sure old filter doesn't have any JetStream consumer
+	oldCon, err := jsBackend.jsCtx.ConsumerInfo(jsBackend.Config.JSStreamName, oldJsSubKey.consumerName)
+	require.Nil(t, oldCon)
+	require.ErrorIs(t, err, nats.ErrConsumerNotFound)
 }
->>>>>>> 025d91723 (Add Int Test for NATS Created Consumer Deletion)

--- a/components/eventing-controller/pkg/backend/nats/jetstream/jetstream_integration_test.go
+++ b/components/eventing-controller/pkg/backend/nats/jetstream/jetstream_integration_test.go
@@ -1551,6 +1551,7 @@ func TestJetStreamSubAfterSync_DeleteOldFilterConsumerForFilterChangeWhileNatsDo
 	jsBackend := testEnvironment.jsBackend
 	defer testEnvironment.natsServer.Shutdown()
 	defer testEnvironment.jsClient.natsConn.Close()
+	defer func() { _ = testEnvironment.jsClient.DeleteStream(defaultStreamName) }()
 
 	testEnvironment.jsBackend.Config.JSStreamStorageType = StorageTypeFile
 	testEnvironment.jsBackend.Config.MaxReconnects = 0
@@ -1604,13 +1605,13 @@ func TestJetStreamSubAfterSync_DeleteOldFilterConsumerForFilterChangeWhileNatsDo
 		require.NoError(t, jsSub.SetPendingLimits(msgLimit, bytesLimit))
 	}
 
-	//shutdown the JetStream and start so that existing subscription gets invalid.
+	// shutdown the JetStream and start so that existing subscription gets invalid.
 	testEnvironment.natsServer.Shutdown()
 	require.Eventually(t, func() bool {
 		return !testEnvironment.jsBackend.conn.IsConnected()
 	}, 30*time.Second, 2*time.Second)
 
-	// TODO: change subscription CR filters while NATS JetStream is down
+	// change subscription CR filters while NATS JetStream is down
 	// given
 	// Now, change the filter in subscription
 	sub.Spec.Filter.Filters[0].EventType.Value = fmt.Sprintf("%schanged", evtesting.OrderCreatedEventTypeNotClean)
@@ -1628,9 +1629,9 @@ func TestJetStreamSubAfterSync_DeleteOldFilterConsumerForFilterChangeWhileNatsDo
 	// the unacknowledged message must still be present in the stream
 
 	require.Eventually(t, func() bool {
-		info, err := testEnvironment.jsClient.StreamInfo(defaultStreamName)
-		require.NoError(t, err)
-		return info != nil && err == nil
+		info, streamErr := testEnvironment.jsClient.StreamInfo(defaultStreamName)
+		require.NoError(t, streamErr)
+		return info != nil && streamErr == nil
 	}, 60*time.Second, 5*time.Second)
 
 	// SyncSubscription binds the existing subscription to JetStream created one

--- a/components/eventing-controller/testing/v2/test_helpers.go
+++ b/components/eventing-controller/testing/v2/test_helpers.go
@@ -692,6 +692,12 @@ func WithCleanEventTypeOld() SubscriptionOpt {
 	return WithSourceAndType(EventSourceClean, OrderCreatedEventType)
 }
 
+// WithCleanEventSourceAndType is a SubscriptionOpt that initializes subscription with a not clean event source and
+// type.
+func WithCleanEventSourceAndType() SubscriptionOpt {
+	return WithSourceAndType(EventSourceClean, OrderCreatedV1Event)
+}
+
 // WithNotCleanEventSourceAndType is a SubscriptionOpt that initializes subscription with a not clean event source and type
 func WithNotCleanEventSourceAndType() SubscriptionOpt {
 	return WithSourceAndType(EventSourceUnclean, OrderCreatedUncleanEvent)

--- a/resources/eventing/values.yaml
+++ b/resources/eventing/values.yaml
@@ -5,7 +5,7 @@ global:
   images:
     eventing_controller:
       name: eventing-controller
-      version: PR-16213
+      version: PR-16038
       pullPolicy: "IfNotPresent"
     publisher_proxy:
       name: event-publisher-proxy

--- a/resources/eventing/values.yaml
+++ b/resources/eventing/values.yaml
@@ -5,7 +5,7 @@ global:
   images:
     eventing_controller:
       name: eventing-controller
-      version: PR-16038
+      version: PR-16069
       pullPolicy: "IfNotPresent"
     publisher_proxy:
       name: event-publisher-proxy


### PR DESCRIPTION
**Description**

Clean up the dangling NATS JetStream consumers left while NATS is down but subscription CR filters are changed/deleted. In these cases old filter subscription was not deleted when NATS starts again.

Changes proposed in this pull request:

- Fix the issue
- Create integration test case for this

**Related issue(s)**
[#15978](https://github.com/kyma-project/kyma/issues/15978)
