### PR TITLE
refactor of constructing build job

### DIFF
--- a/components/function-controller/internal/controllers/serverless/utils.go
+++ b/components/function-controller/internal/controllers/serverless/utils.go
@@ -6,7 +6,6 @@ import (
 	"path"
 	"strings"
 
-	"github.com/kyma-project/kyma/components/function-controller/internal/controllers/serverless/runtime"
 	serverlessv1alpha2 "github.com/kyma-project/kyma/components/function-controller/pkg/apis/serverless/v1alpha2"
 	appsv1 "k8s.io/api/apps/v1"
 	batchv1 "k8s.io/api/batch/v1"
@@ -115,20 +114,6 @@ func getArg(args []string, arg string) string {
 		}
 	}
 	return ""
-}
-
-func getBuildJobVolumeMounts(rtmConfig runtime.Config) []corev1.VolumeMount {
-	volumeMounts := []corev1.VolumeMount{
-		// Must be mounted with SubPath otherwise files are symlinks and it is not possible to use COPY in Dockerfile
-		// If COPY is not used, then the cache will not work
-		{Name: "sources", ReadOnly: true, MountPath: path.Join(baseDir, rtmConfig.DependencyFile), SubPath: FunctionDepsKey},
-		{Name: "sources", ReadOnly: true, MountPath: path.Join(baseDir, rtmConfig.FunctionFile), SubPath: FunctionSourceKey},
-		{Name: "runtime", ReadOnly: true, MountPath: path.Join(workspaceMountPath, "Dockerfile"), SubPath: "Dockerfile"},
-		{Name: "credentials", ReadOnly: true, MountPath: "/docker"},
-	}
-	// add package registry config volume mount depending on the used runtime
-	volumeMounts = append(volumeMounts, getPackageConfigVolumeMountsForRuntime(rtmConfig.Runtime)...)
-	return volumeMounts
 }
 
 func getPackageConfigVolumeMountsForRuntime(rtm serverlessv1alpha2.Runtime) []corev1.VolumeMount {

--- a/resources/serverless/values.yaml
+++ b/resources/serverless/values.yaml
@@ -80,13 +80,13 @@ global:
       directory: "tpi"
     function_controller:
       name: "function-controller"
-      version: "v20221114-432a0472"
+      version: "PR-16091"
     function_webhook:
       name: "function-webhook"
-      version: "v20221114-432a0472"
+      version: "PR-16091"
     function_build_init:
       name: "function-build-init"
-      version: "v20221114-432a0472"
+      version: "PR-16091"
     function_runtime_nodejs14:
       name: "function-runtime-nodejs14"
       version: "v20221110-f5cb45c7"


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- code refactor of constructing build jobs

**Related issue(s)**
See also #15923 (these refactor is near previous touched code)

**Hint for reviewer**
It's only proposal. Before, there was long and very similar methods `buildJob()` and `buildGitJob()`. Now, we have few extracted small methods which produces parts of pod's configuration.
I assumed that tests check whether my changes not introduce regression and I don't did manual tests. Is it good assumption?