### PR TITLE
Trace logging in upgrade tests

### DIFF
--- a/tests/fast-integration/test/fixtures/commerce-mock/index.js
+++ b/tests/fast-integration/test/fixtures/commerce-mock/index.js
@@ -334,7 +334,7 @@ async function checkTrace(traceId, expectedTraceProcessSequence) {
   expect(traceDAG).to.have.length(1);
 
   debug('ACTUAL SPANS:')
-  logsSpansGraph(0, traceDAG[0], traceData)
+  logSpansGraph(0, traceDAG[0], traceData)
   debug('EXPECTED SPANS:')
   for (let i = 0; i < expectedTraceProcessSequence.lenth; i++) {
     debug(`${buildLevel(i)} ${expectedTraceProcessSequence[i]}`)

--- a/tests/fast-integration/test/fixtures/commerce-mock/index.js
+++ b/tests/fast-integration/test/fixtures/commerce-mock/index.js
@@ -322,6 +322,12 @@ async function checkInClusterEventTracing(targetNamespace) {
 async function checkTrace(traceId, expectedTraceProcessSequence) {
   const traceRes = await getJaegerTrace(traceId);
 
+  // log the expected trace
+  debug('expected spans:');
+  for (i = 0; i < expectedTraceProcessSequence.length; i++) {
+    debug(`${buildLevel(i)} ${expectedTraceProcessSequence[i]}`);
+  }
+
   // the trace response should have data for single trace
   expect(traceRes.data).to.have.length(1);
 
@@ -333,12 +339,9 @@ async function checkTrace(traceId, expectedTraceProcessSequence) {
   const traceDAG = await getTraceDAG(traceData);
   expect(traceDAG).to.have.length(1);
 
-  debug('ACTUAL SPANS:');
+  // log the actual trace
+  debug('actual spans:');
   logSpansGraph(0, traceDAG[0], traceData);
-  debug('EXPECTED SPANS:');
-  for (let i = 0; i < expectedTraceProcessSequence.lenth; i++) {
-    debug(`${buildLevel(i)} ${expectedTraceProcessSequence[i]}`);
-  }
 
   // searching through the trace-graph for the expected span sequence staring at the root element
   const wasFound = findSpanSequence(expectedTraceProcessSequence, 0, traceDAG[0], traceData);
@@ -353,8 +356,9 @@ async function checkTrace(traceId, expectedTraceProcessSequence) {
 
 function logSpansGraph(position, currentSpan, traceData) {
   const actualSpan = traceData.processes[currentSpan.processID].serviceName;
-  let newPosition = position +1;
+  debug(`${buildLevel(position)} ${actualSpan}`);
 
+  const newPosition = position +1;
   for (let i = 0; i < currentSpan.childSpans.length; i++) {
     logSpansGraph(newPosition, currentSpan.childSpans[i], traceData);
   }

--- a/tests/fast-integration/test/fixtures/commerce-mock/index.js
+++ b/tests/fast-integration/test/fixtures/commerce-mock/index.js
@@ -353,7 +353,7 @@ async function checkTrace(traceId, expectedTraceProcessSequence) {
 
 
 function logSpansGraph(position, currentSpan, traceData) {
-    const span = traceData.processes[curentSpan.process.ID].serviceName;
+    const span = traceData.processes[currentSpan.process.ID].serviceName;
     debug(`${buildLevel(position)} ${span}`)
     
     for (let i = 0; i < currentSpan.childSpans.length; i++) {

--- a/tests/fast-integration/test/fixtures/commerce-mock/index.js
+++ b/tests/fast-integration/test/fixtures/commerce-mock/index.js
@@ -333,6 +333,13 @@ async function checkTrace(traceId, expectedTraceProcessSequence) {
   const traceDAG = await getTraceDAG(traceData);
   expect(traceDAG).to.have.length(1);
 
+  debug('ACTUAL SPANS:')
+  logsSpansGraph(0, traceDAG[0], traceData)
+  debug('EXPECTED SPANS:')
+  for (let i = 0; i < expectedTraceProcessSequence.lenth; i++) {
+    debug(`${buildLevel(i)} ${expectedTraceProcessSequence[i]}`)
+  }
+
   // searching through the trace-graph for the expected span sequence staring at the root element
   const wasFound = findSpanSequence(expectedTraceProcessSequence, 0, traceDAG[0], traceData);
   if (!wasFound) {

--- a/tests/fast-integration/test/fixtures/commerce-mock/index.js
+++ b/tests/fast-integration/test/fixtures/commerce-mock/index.js
@@ -356,7 +356,7 @@ function logSpansGraph(position, currentSpan, traceData) {
   let newPosition = position +1;
 
   for (let i = 0; i < currentSpan.childSpans.length; i++) {
-    findSpanSequence(expectedSpans, newPosition, currentSpan.childSpans[i], traceData);
+    logSpansGraph(newPosition, currentSpan.childSpans[i], traceData);
   }
 }
 

--- a/tests/fast-integration/test/fixtures/commerce-mock/index.js
+++ b/tests/fast-integration/test/fixtures/commerce-mock/index.js
@@ -333,11 +333,11 @@ async function checkTrace(traceId, expectedTraceProcessSequence) {
   const traceDAG = await getTraceDAG(traceData);
   expect(traceDAG).to.have.length(1);
 
-  debug('ACTUAL SPANS:')
-  logSpansGraph(0, traceDAG[0], traceData)
-  debug('EXPECTED SPANS:')
+  debug('ACTUAL SPANS:');
+  logSpansGraph(0, traceDAG[0], traceData);
+  debug('EXPECTED SPANS:');
   for (let i = 0; i < expectedTraceProcessSequence.lenth; i++) {
-    debug(`${buildLevel(i)} ${expectedTraceProcessSequence[i]}`)
+    debug(`${buildLevel(i)} ${expectedTraceProcessSequence[i]}`);
   }
 
   // searching through the trace-graph for the expected span sequence staring at the root element
@@ -356,7 +356,7 @@ function logSpansGraph(position, currentSpan, traceData) {
   let newPosition = position +1;
 
   for (let i = 0; i < currentSpan.childSpans.length; i++) {
-    findSpanSequence(expectedSpans, newPosition, currentSpan.childSpans[i], traceData)
+    findSpanSequence(expectedSpans, newPosition, currentSpan.childSpans[i], traceData);
   }
 }
 

--- a/tests/fast-integration/test/fixtures/commerce-mock/index.js
+++ b/tests/fast-integration/test/fixtures/commerce-mock/index.js
@@ -344,6 +344,16 @@ async function checkTrace(traceId, expectedTraceProcessSequence) {
   expect(wasFound).to.be.true;
 }
 
+
+function logSpansGraph(position, currentSpan, traceData) {
+    const span = traceData.processes[curentSpan.process.ID].serviceName;
+    debug(`${buildLevel(position)} ${span}`)
+    
+    for (let i = 0; i < currentSpan.childSpans.length; i++) {
+        logSpansGraph(position + 1, currentSpan.childSPans[i], traceData)
+    }
+}
+
 // findSpanSequence recursively searches through the trace-graph to find all expected spans in the right, consecutive
 // order while ignoring the spans that are not expected.
 function findSpanSequence(expectedSpans, position, currentSpan, traceData) {

--- a/tests/fast-integration/test/fixtures/commerce-mock/index.js
+++ b/tests/fast-integration/test/fixtures/commerce-mock/index.js
@@ -344,7 +344,7 @@ async function checkTrace(traceId, expectedTraceProcessSequence) {
   logSpansGraph(0, traceDAG[0], traceData);
 
   // searching through the trace-graph for the expected span sequence staring at the root element
-  const wasFound = findSpanSequence(expectedTraceProcessSequence, 0, traceDAG[0], traceData);
+  const wasFound = findSpanSequence(expectedTraceProcessSequence, 0, traceDAG[0], traceData, 0);
   if (!wasFound) {
     debug(`Not all expected spans found in the expected order:`);
     for (let i = 0; i < expectedTraceProcessSequence.length; i++) {
@@ -366,28 +366,28 @@ function logSpansGraph(position, currentSpan, traceData) {
 
 // findSpanSequence recursively searches through the trace-graph to find all expected spans in the right, consecutive
 // order while ignoring the spans that are not expected.
-function findSpanSequence(expectedSpans, position, currentSpan, traceData) {
+function findSpanSequence(expectedSpans, position, currentSpan, traceData, numberFound) {
   // validate if the actual span is the expected span
   const actualSpan = traceData.processes[currentSpan.processID].serviceName;
-  const expectedSpan = expectedSpans[position];
-  let newPosition = position;
+  const expectedSpan = expectedSpans[numberFound];
   const debugMsg = `${buildLevel(position)} ${actualSpan}`;
+
   // if this span contains the currently expected span, the position will be increased
   if (actualSpan === expectedSpan) {
-    newPosition++;
+    numberFound++;
     debug(debugMsg);
   } else {
     debug(`${debugMsg} expected ${expectedSpan}`);
   }
 
   // check if all traces have been found yet
-  if (newPosition === expectedSpans.length) {
+  if (numberFound === expectedSpans.length) {
     return true;
   }
 
   // recursive search through all the child spans
   for (let i = 0; i < currentSpan.childSpans.length; i++) {
-    if (findSpanSequence(expectedSpans, newPosition, currentSpan.childSpans[i], traceData)) {
+    if (findSpanSequence(expectedSpans, position +1, currentSpan.childSpans[i], traceData, numberFound)) {
       return true;
     }
   }

--- a/tests/fast-integration/test/fixtures/commerce-mock/index.js
+++ b/tests/fast-integration/test/fixtures/commerce-mock/index.js
@@ -344,14 +344,7 @@ async function checkTrace(traceId, expectedTraceProcessSequence) {
   logSpansGraph(0, traceDAG[0], traceData);
 
   // searching through the trace-graph for the expected span sequence staring at the root element
-  const wasFound = findSpanSequence(expectedTraceProcessSequence, 0, traceDAG[0], traceData, 0);
-  if (!wasFound) {
-    debug(`Not all expected spans found in the expected order:`);
-    for (let i = 0; i < expectedTraceProcessSequence.length; i++) {
-      debug(`${expectedTraceProcessSequence[i]}`);
-    }
-  }
-  expect(wasFound).to.be.true;
+  expect(findSpanSequence(expectedTraceProcessSequence, 0, traceDAG[0], traceData, 0)).to.be.true;
 }
 
 function logSpansGraph(position, currentSpan, traceData) {

--- a/tests/fast-integration/test/fixtures/commerce-mock/index.js
+++ b/tests/fast-integration/test/fixtures/commerce-mock/index.js
@@ -353,11 +353,11 @@ async function checkTrace(traceId, expectedTraceProcessSequence) {
 
 
 function logSpansGraph(position, currentSpan, traceData) {
-    const span = traceData.processes[currentSpan.process.ID].serviceName;
+    const span = traceData.processes[currentSpan.processID].serviceName;
     debug(`${buildLevel(position)} ${span}`)
-    
+
     for (let i = 0; i < currentSpan.childSpans.length; i++) {
-        logSpansGraph(position + 1, currentSpan.childSPans[i], traceData)
+        logSpansGraph(position + 1, currentSpan.childSpans[i], traceData)
     }
 }
 

--- a/tests/fast-integration/test/fixtures/commerce-mock/index.js
+++ b/tests/fast-integration/test/fixtures/commerce-mock/index.js
@@ -351,14 +351,13 @@ async function checkTrace(traceId, expectedTraceProcessSequence) {
   expect(wasFound).to.be.true;
 }
 
-
 function logSpansGraph(position, currentSpan, traceData) {
-    const span = traceData.processes[currentSpan.processID].serviceName;
-    debug(`${buildLevel(position)} ${span}`)
+  const actualSpan = traceData.processes[currentSpan.processID].serviceName;
+  let newPosition = position +1;
 
-    for (let i = 0; i < currentSpan.childSpans.length; i++) {
-        logSpansGraph(position + 1, currentSpan.childSpans[i], traceData)
-    }
+  for (let i = 0; i < currentSpan.childSpans.length; i++) {
+    findSpanSequence(expectedSpans, newPosition, currentSpan.childSpans[i], traceData)
+  }
 }
 
 // findSpanSequence recursively searches through the trace-graph to find all expected spans in the right, consecutive

--- a/tests/fast-integration/test/fixtures/commerce-mock/index.js
+++ b/tests/fast-integration/test/fixtures/commerce-mock/index.js
@@ -324,7 +324,7 @@ async function checkTrace(traceId, expectedTraceProcessSequence) {
 
   // log the expected trace
   debug('expected spans:');
-  for (i = 0; i < expectedTraceProcessSequence.length; i++) {
+  for (let i = 0; i < expectedTraceProcessSequence.length; i++) {
     debug(`${buildLevel(i)} ${expectedTraceProcessSequence[i]}`);
   }
 

--- a/tests/fast-integration/test/fixtures/commerce-mock/index.js
+++ b/tests/fast-integration/test/fixtures/commerce-mock/index.js
@@ -344,6 +344,7 @@ async function checkTrace(traceId, expectedTraceProcessSequence) {
   logSpansGraph(0, traceDAG[0], traceData);
 
   // searching through the trace-graph for the expected span sequence staring at the root element
+  debug('trying to match expected and actual');
   expect(findSpanSequence(expectedTraceProcessSequence, 0, traceDAG[0], traceData, 0)).to.be.true;
 }
 
@@ -370,7 +371,7 @@ function findSpanSequence(expectedSpans, position, currentSpan, traceData, numbe
     numberFound++;
     debug(debugMsg);
   } else {
-    debug(`${debugMsg} expected ${expectedSpan}`);
+    debug(`${debugMsg} [expected ${expectedSpan}, continue to search]`);
   }
 
   // check if all traces have been found yet


### PR DESCRIPTION
This adds some extra trace logging to the upgrade test, since this is one of the points that let's the job break frequently.

```
[DEBUG] fetching trace: bb4bade97471a9b8d68403d7d5748b04 from jaeger
[DEBUG] waiting for trace (id: bb4bade97471a9b8d68403d7d5748b04) from jaeger...
[DEBUG] expected spans:
[DEBUG]   -> istio-ingressgateway.istio-system
[DEBUG]    └> lastorder-qsj77.test-evnt
[DEBUG]     └> eventing-publisher-proxy.kyma-system
[DEBUG]      └> eventing-controller.kyma-system
[DEBUG]       └> lastorder-qsj77.test-evnt
[DEBUG] actual spans:
[DEBUG]   -> istio-ingressgateway.istio-system
[DEBUG]    └> lastorder-qsj77.test-evnt
[DEBUG]     └> lastorder-qsj77.test-evnt
[DEBUG]      └> lastorder-qsj77.test-evnt
[DEBUG]       └> eventing-publisher-proxy.kyma-system
[DEBUG]        └> eventing-controller.kyma-system
[DEBUG]         └> lastorder-qsj77.test-evnt
[DEBUG]          └> lastorder-qsj77.test-evnt
[DEBUG]     └> lastorder-qsj77.test-evnt
[DEBUG] trying to match expected and actual
[DEBUG]   -> istio-ingressgateway.istio-system
[DEBUG]    └> lastorder-qsj77.test-evnt
[DEBUG]     └> lastorder-qsj77.test-evnt [expected eventing-publisher-proxy.kyma-system, continue to search]
[DEBUG]      └> lastorder-qsj77.test-evnt [expected eventing-publisher-proxy.kyma-system, continue to search]
[DEBUG]       └> eventing-publisher-proxy.kyma-system
[DEBUG]        └> eventing-controller.kyma-system
[DEBUG]         └> lastorder-qsj77.test-evnt
      ✓ In-cluster event should have correct tracing spans (10672ms
```