### PR TITLE
bump nats server image to v2.9.7

### DIFF
--- a/resources/eventing/values.yaml
+++ b/resources/eventing/values.yaml
@@ -12,7 +12,7 @@ global:
       version: PR-16115
     nats:
       name: nats
-      version: 2.9.6-alpine3.16
+      version: 2.9.7-alpine3.16
       directory: external
     nats_config_reloader:
       name: natsio/nats-server-config-reloader


### PR DESCRIPTION
IMPORTANT: please leave this on hold until we ran loadtestes

bump nats-server image to 2.9.7-alpine3.16
[repo](https://hub.docker.com/layers/library/nats/2.9.7-alpine3.16/images/sha256-d4698031a0afeb1ed37b240a9632b22a2d0fcea5fd48af3c8b28e1eba3348033?context=explore)
[release notes](https://github.com/nats-io/nats-server/releases/tag/v2.9.7)
