### PR TITLE
Add stream re-creation check in eventing FI tests

### DIFF
--- a/tests/fast-integration/eventing-test/eventing-test-prep.js
+++ b/tests/fast-integration/eventing-test/eventing-test-prep.js
@@ -41,7 +41,7 @@ const {
   debug,
   createEventingBackendK8sSecret,
   createK8sConfigMap,
-  createAPIRuleForService,
+  createApiRuleForService,
   deleteApiRule,
 } = require('../utils');
 const {
@@ -107,7 +107,7 @@ describe('Eventing tests preparation', function() {
     // Create a configmap that contains stream data for jetstream so that during the test,
     // we can verify that the stream was not affected/recreated
     debug('expose the eventing-nats service with an apirule');
-    const vs = await createAPIRuleForService(eventingNatsApiRuleAName,
+    const vs = await createApiRuleForService(eventingNatsApiRuleAName,
         kymaSystem,
         eventingNatsSvcName,
         8222);

--- a/tests/fast-integration/eventing-test/eventing-test.js
+++ b/tests/fast-integration/eventing-test/eventing-test.js
@@ -32,6 +32,7 @@ const {
   k8sApply,
   deleteK8sPod,
   eventingSubscription, waitForEndpoint, waitForPodStatusWithLabel, waitForPodWithLabelAndCondition,
+  createAPIRuleForService, getConfigMap, deleteApiRule,
 } = require('../utils');
 const {
   eventingMonitoringTest,
@@ -48,6 +49,11 @@ const {
   getNatsPods,
   getStreamConfigForJetStream,
   skipAtLeastOnceDeliveryTest,
+  skipStreamReCreationTest,
+  getJetStreamStreamData,
+  streamDataConfigMapName,
+  eventingNatsSvcName,
+  eventingNatsApiRuleAName,
   subscriptionNames,
 } = require('./utils');
 const {
@@ -104,6 +110,7 @@ describe('Eventing tests', function() {
     }
 
     if (backend === natsBackend) {
+      testStreamNotReCreated();
       testJetStreamAtLeastOnceDelivery();
     }
   }
@@ -120,6 +127,45 @@ describe('Eventing tests', function() {
 
     it('order.created.v1 binary cloud event from CommerceMock should trigger the lastorder function', async function() {
       await sendCloudEventBinaryModeAndCheckResponse(backend, mockNamespace);
+    });
+  }
+
+  function testStreamNotReCreated() {
+    context('stream check with JetStream backend', function() {
+      let wantStreamData = null;
+      let gotStreamData = null;
+      before('check if stream creation timestamp is available', async function() {
+        try {
+          const cm = await getConfigMap(streamDataConfigMapName);
+          wantStreamData = cm.data;
+        } catch (err) {
+          console.log('Skipping the stream recreation check due to missing configmap!');
+          this.skip();
+        }
+        if (skipStreamReCreationTest(wantStreamData)) {
+          console.log('Skipping the stream recreation check due to missing info!');
+          this.skip();
+        }
+      });
+
+      it('Get the current stream creation timestamp', async function() {
+        const vs = await createAPIRuleForService(eventingNatsApiRuleAName,
+            kymaSystem,
+            eventingNatsSvcName,
+            8222);
+        const vsHost = vs.spec.hosts[0];
+        gotStreamData = await getJetStreamStreamData(vsHost);
+      });
+
+      it('Compare the stream creation timestamp', async function() {
+        assert.equal(gotStreamData.streamName, wantStreamData.streamName);
+        assert.equal(gotStreamData.streamCreationTime, wantStreamData.streamCreationTime);
+      });
+
+
+      it('Delete the APIRule created', async function() {
+        await deleteApiRule(eventingNatsApiRuleAName, kymaSystem);
+      });
     });
   }
 

--- a/tests/fast-integration/eventing-test/eventing-test.js
+++ b/tests/fast-integration/eventing-test/eventing-test.js
@@ -32,7 +32,7 @@ const {
   k8sApply,
   deleteK8sPod,
   eventingSubscription, waitForEndpoint, waitForPodStatusWithLabel, waitForPodWithLabelAndCondition,
-  createAPIRuleForService, getConfigMap, deleteApiRule,
+  createApiRuleForService, getConfigMap, deleteApiRule,
 } = require('../utils');
 const {
   eventingMonitoringTest,
@@ -49,7 +49,7 @@ const {
   getNatsPods,
   getStreamConfigForJetStream,
   skipAtLeastOnceDeliveryTest,
-  skipStreamReCreationTest,
+  isStreamCreationTimeMissing,
   getJetStreamStreamData,
   streamDataConfigMapName,
   eventingNatsSvcName,
@@ -130,6 +130,8 @@ describe('Eventing tests', function() {
     });
   }
 
+  // testStreamNotReCreated - compares the stream creation timestamp before and after upgrade
+  // and if the timestamp is the same, we conclude that the stream is not re created.
   function testStreamNotReCreated() {
     context('stream check with JetStream backend', function() {
       let wantStreamData = null;
@@ -142,14 +144,14 @@ describe('Eventing tests', function() {
           console.log('Skipping the stream recreation check due to missing configmap!');
           this.skip();
         }
-        if (skipStreamReCreationTest(wantStreamData)) {
-          console.log('Skipping the stream recreation check due to missing info!');
+        if (isStreamCreationTimeMissing(wantStreamData)) {
+          console.log('Skipping the stream recreation check as the stream creation timestamp is missing!');
           this.skip();
         }
       });
 
       it('Get the current stream creation timestamp', async function() {
-        const vs = await createAPIRuleForService(eventingNatsApiRuleAName,
+        const vs = await createApiRuleForService(eventingNatsApiRuleAName,
             kymaSystem,
             eventingNatsSvcName,
             8222);
@@ -163,7 +165,7 @@ describe('Eventing tests', function() {
       });
 
 
-      it('Delete the APIRule created', async function() {
+      it('Delete the created APIRule', async function() {
         await deleteApiRule(eventingNatsApiRuleAName, kymaSystem);
       });
     });

--- a/tests/fast-integration/eventing-test/utils.js
+++ b/tests/fast-integration/eventing-test/utils.js
@@ -146,7 +146,7 @@ function skipAtLeastOnceDeliveryTest() {
       streamConfig['consumer_deliver_policy'] === 'all');
 }
 
-function skipStreamReCreationTest(streamData) {
+function isStreamCreationTimeMissing(streamData) {
   return streamData.streamCreationTime === undefined;
 }
 
@@ -176,6 +176,6 @@ module.exports = {
   getStreamConfigForJetStream,
   skipAtLeastOnceDeliveryTest,
   getJetStreamStreamData,
-  skipStreamReCreationTest,
+  isStreamCreationTimeMissing,
   subscriptionNames,
 };

--- a/tests/fast-integration/utils/index.js
+++ b/tests/fast-integration/utils/index.js
@@ -1458,7 +1458,7 @@ function deleteEventingBackendK8sSecret(name, namespace='default') {
  * @param {string} svcName - service to expose as apirule
  * @param {int} port - port of the service to expose as apirule
  */
-async function createAPIRuleForService(name, namespace='default', svcName, port) {
+async function createApiRuleForService(name, namespace='default', svcName, port) {
   const apiRuleJson = {
     apiVersion: 'gateway.kyma-project.io/v1beta1',
     kind: 'APIRule',
@@ -1832,7 +1832,7 @@ module.exports = {
   deleteEventingBackendK8sSecret,
   createK8sConfigMap,
   deleteK8sConfigMap,
-  createAPIRuleForService,
+  createApiRuleForService,
   deleteApiRule,
   getTraceDAG,
   printStatusOfInClusterEventingInfrastructure,


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- Get the stream creation timestamp during the preparation phase, and store the value in a configmap
- The value is obtained by exposing the `eventing-nats` svc on port `8222` via an APIRule.
- During the eventing  upgrade test, we check if these values match
- We skip this test if either the creation timestamp is not exposed by the service (before NATS 2.9.7) or if the configmap is not found (the prep stage is run from the FI test of the previous release and hence the cm is not created).

Note: This test will only be effective (not skipped) after kyma 2.10 release.

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
