### PR TITLE
Add missing CRD_NAME env for api-gateway cert webhook

### DIFF
--- a/resources/api-gateway/templates/webhook-certificates.yaml
+++ b/resources/api-gateway/templates/webhook-certificates.yaml
@@ -21,22 +21,24 @@ spec:
           type: RuntimeDefault
       restartPolicy: Never
       containers:
-      - name: init-certificates
-        image: "{{ include "imageurl" (dict "reg" .Values.global.containerRegistry "img" .Values.global.images.api_gateway_webhook_certificates) }}"
-        imagePullPolicy: IfNotPresent
-        env:
-        - name: SERVICE_NAME
-          value: {{ include "api-gateway.fullname" . }}-webhook-service
-        - name: SECRET_NAMESPACE
-          value: {{ .Release.Namespace }}
-        - name: SECRET_NAME
-          value: {{ include "api-gateway.fullname" . }}-webhook-server-cert
-        securityContext:
-          allowPrivilegeEscalation: false
-          readOnlyRootFilesystem: true
-          capabilities:
-            drop:
-              - ALL
+        - name: init-certificates
+          image: "{{ include "imageurl" (dict "reg" .Values.global.containerRegistry "img" .Values.global.images.api_gateway_webhook_certificates) }}"
+          imagePullPolicy: IfNotPresent
+          env:
+            - name: CRD_NAME
+              value: {{ .Values.webhook.crdName }}
+            - name: SERVICE_NAME
+              value: {{ include "api-gateway.fullname" . }}-webhook-service
+            - name: SECRET_NAMESPACE
+              value: {{ .Release.Namespace }}
+            - name: SECRET_NAME
+              value: {{ include "api-gateway.fullname" . }}-webhook-server-cert
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop:
+                - ALL
       serviceAccountName: {{ include "api-gateway.name" . }}-certificates-account
 ---
 apiVersion: batch/v1
@@ -59,14 +61,16 @@ spec:
         spec:
           restartPolicy: Never
           containers:
-          - name: init-certificates
-            image: "{{ include "imageurl" (dict "reg" .Values.global.containerRegistry "img" .Values.global.images.api_gateway_webhook_certificates) }}"
-            imagePullPolicy: IfNotPresent
-            env:
-            - name: SERVICE_NAME
-              value: {{ include "api-gateway.fullname" . }}-webhook-service
-            - name: SECRET_NAMESPACE
-              value: {{ .Release.Namespace }}
-            - name: SECRET_NAME
-              value: {{ include "api-gateway.fullname" . }}-webhook-server-cert
+            - name: init-certificates
+              image: "{{ include "imageurl" (dict "reg" .Values.global.containerRegistry "img" .Values.global.images.api_gateway_webhook_certificates) }}"
+              imagePullPolicy: IfNotPresent
+              env:
+                - name: CRD_NAME
+                  value: {{ .Values.webhook.crdName }}
+                - name: SERVICE_NAME
+                  value: {{ include "api-gateway.fullname" . }}-webhook-service
+                - name: SECRET_NAMESPACE
+                  value: {{ .Release.Namespace }}
+                - name: SECRET_NAME
+                  value: {{ include "api-gateway.fullname" . }}-webhook-server-cert
           serviceAccountName: {{ include "api-gateway.name" . }}-certificates-account

--- a/resources/api-gateway/values.yaml
+++ b/resources/api-gateway/values.yaml
@@ -100,6 +100,9 @@ tests:
     runAsNonRoot: true
     runAsGroup: 65534
 
+webhook:
+  crdName: "apirules.gateway.kyma-project.io"
+
 global:
   domainName: kyma.example.com
   containerRegistry:
@@ -107,7 +110,7 @@ global:
   images:
     api_gateway_controller:
       name: "api-gateway-controller"
-      version: "1.1.0"
+      version: "PR-99"
     api_gateway_webhook_certificates:
       name: "api-gateway-webhook-certificates"
-      version: "1.1.0"
+      version: "PR-99"

--- a/resources/api-gateway/values.yaml
+++ b/resources/api-gateway/values.yaml
@@ -110,7 +110,7 @@ global:
   images:
     api_gateway_controller:
       name: "api-gateway-controller"
-      version: "PR-99"
+      version: "1.1.0"
     api_gateway_webhook_certificates:
       name: "api-gateway-webhook-certificates"
-      version: "PR-99"
+      version: "1.1.0"


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- Add CRD_NAME env to the api-gateway cert webhook so that a newer version of api-gateway relying on this configuration will not fail. The CRD_NAME env is required because of https://github.com/kyma-project/api-gateway/pull/55.

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
