### PR TITLE
Remove migration guide 2.8-2.9

### DIFF
--- a/docs/migration-guide-2.8-2.9.md
+++ b/docs/migration-guide-2.8-2.9.md
@@ -1,5 +1,0 @@
----
-title: Migration Guide 2.8-2.9
----
-
-Due to the [deprecation of PodSecurityPolicy (PSP)](https://kubernetes.io/blog/2021/04/06/podsecuritypolicy-deprecation-past-present-and-future/) with Kubernetes 1.21 and the plan of its removal in the 1.25 release, we removed the usage of PSPs for many of our Kyma resources. To delete leftover PSP resources, when you upgrade from Kyma 2.8 to 2.9, either run the script [2.8-2.9-cleanup-psp.sh](./assets/2.8-2.9-cleanup-psp.sh) or run the commands from the script manually.


### PR DESCRIPTION
**Changes proposed in this pull request:**

- remove the 2.8-2.9 migration guides

**Related issue(s):**
- #16148 
