### PR TITLE
Image update for compass runtime agent graphQL fix cherrypick 2.9

### DIFF
--- a/resources/compass-runtime-agent/values.yaml
+++ b/resources/compass-runtime-agent/values.yaml
@@ -5,7 +5,7 @@ global:
   images:
     compass_runtime_agent:
       name: "compass-runtime-agent"
-      version: "v20221110-3e3269e4"
+      version: "v20221123-9e5d5b2f"
   istio:
     gateway:
       name: kyma-gateway


### PR DESCRIPTION
From version: "v20221110-3e3269e4" to version: "v20221123-9e5d5b2f" created after https://github.com/kyma-project/kyma/pull/16164 in image [repository](https://console.cloud.google.com/gcr/images/kyma-project/EU/compass-runtime-agent)