### PR TITLE
Fix retry on conflict in Serverless integration tests

### DIFF
--- a/resources/serverless/values.yaml
+++ b/resources/serverless/values.yaml
@@ -111,7 +111,7 @@ global:
   testImages:
     function_controller_test:
       name: "function-controller-test"
-      version: "v20221102-bcd2a2b1"
+      version: "PR-16172"
     git_server:
       name: "gitserver"
       version: "708f6a87"

--- a/tests/function-controller/pkg/function/function.go
+++ b/tests/function-controller/pkg/function/function.go
@@ -97,14 +97,18 @@ func (f *Function) Update(spec serverlessv1alpha2.FunctionSpec) error {
 		// correct update must first perform get
 		fn, err := f.Get()
 		if err != nil {
-			return err // RetryOnConflict doesn't work with wrapped errors
+			// RetryOnConflict doesn't work with wrapped errors
+			// https://github.com/kubernetes/client-go/blob/9927afa2880713c4332723b7f0865adee5e63a7b/util/retry/util.go#L89-L93
+			return err
 		}
 
 		fnCopy := fn.DeepCopy()
 		fnCopy.Spec = spec
 
 		_, err = f.resCli.Update(fnCopy)
-		return err // RetryOnConflict doesn't work with wrapped errors
+		// RetryOnConflict doesn't work with wrapped errors
+		// https://github.com/kubernetes/client-go/blob/9927afa2880713c4332723b7f0865adee5e63a7b/util/retry/util.go#L89-L93
+		return err
 	}, f.log)
 	return errors.Wrapf(err, "while updating Function %s in namespace %s", f.name, f.namespace)
 

--- a/tests/function-controller/pkg/function/v1alpha1/function.go
+++ b/tests/function-controller/pkg/function/v1alpha1/function.go
@@ -92,14 +92,18 @@ func (f *Function) Update(spec serverlessv1alpha1.FunctionSpec) error {
 		// correct update must first perform get
 		fn, err := f.Get()
 		if err != nil {
-			return err // RetryOnConflict doesn't work with wrapped errors
+			// RetryOnConflict doesn't work with wrapped errors
+			// https://github.com/kubernetes/client-go/blob/9927afa2880713c4332723b7f0865adee5e63a7b/util/retry/util.go#L89-L93
+			return err
 		}
 
 		fnCopy := fn.DeepCopy()
 		fnCopy.Spec = spec
 
 		_, err = f.resCli.Update(fnCopy)
-		return err // RetryOnConflict doesn't work with wrapped errors
+		// RetryOnConflict doesn't work with wrapped errors
+		// https://github.com/kubernetes/client-go/blob/9927afa2880713c4332723b7f0865adee5e63a7b/util/retry/util.go#L89-L93
+		return err
 	}, f.log)
 
 	return errors.Wrapf(err, "while updating Function %s in namespace %s", f.name, f.namespace)

--- a/tests/function-controller/pkg/resource/resource.go
+++ b/tests/function-controller/pkg/resource/resource.go
@@ -171,13 +171,10 @@ func (r *Resource) Update(res interface{}) (*unstructured.Unstructured, error) {
 	}
 
 	var result *unstructured.Unstructured
-	err = retry.RetryOnConflict(retry.DefaultBackoff, func() error {
-		var errUpdate error
-		result, errUpdate = r.ResCli.Update(context.Background(), unstructuredObj, metav1.UpdateOptions{})
-		return errUpdate
-	}, r.log)
+
+	result, err = r.ResCli.Update(context.Background(), unstructuredObj, metav1.UpdateOptions{})
 	if err != nil {
-		return nil, errors.Wrapf(err, "while updating resource %s '%s'", r.kind, unstructuredObj.GetName())
+		return nil, err // upstream caller RetryOnConflict doesn't work with wrapped errors
 	}
 
 	namespace := "-"

--- a/tests/function-controller/pkg/resource/resource.go
+++ b/tests/function-controller/pkg/resource/resource.go
@@ -174,7 +174,9 @@ func (r *Resource) Update(res interface{}) (*unstructured.Unstructured, error) {
 
 	result, err = r.ResCli.Update(context.Background(), unstructuredObj, metav1.UpdateOptions{})
 	if err != nil {
-		return nil, err // upstream caller RetryOnConflict doesn't work with wrapped errors
+		// upstream caller RetryOnConflict doesn't work with wrapped errors
+		// https://github.com/kubernetes/client-go/blob/9927afa2880713c4332723b7f0865adee5e63a7b/util/retry/util.go#L89-L93
+		return nil, err
 	}
 
 	namespace := "-"

--- a/tests/function-controller/pkg/retry/retry.go
+++ b/tests/function-controller/pkg/retry/retry.go
@@ -11,6 +11,7 @@ import (
 
 var (
 	DefaultBackoff = retry.DefaultBackoff
+	DefaultRetry   = retry.DefaultRetry
 	ErrInvalidFunc = goerrors.New("invalid function")
 )
 


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**
Fixes a bug in conflict handling during function updates. This should make the test less flaky.

Changes proposed in this pull request:

- Fix retry on conflict in Serverless integration tests
- ...
- ...

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
