### PR TITLE
Include striped down otel collector image in telemetry operator

### DIFF
--- a/components/telemetry-operator/Makefile
+++ b/components/telemetry-operator/Makefile
@@ -76,7 +76,7 @@ test-local: manifests-local generate-local fmt-local vet-local envtest
 build: generate fmt vet ## Build manager binary.
 	go build -o bin/manager main.go
 
-lint-manifests:
+lint-manifests: controller-gen-local
 	./hack/lint-manifests.sh $(PROJECT_DIR) $(CONTROLLER_GEN)
 
 lint: lint-manifests

--- a/components/telemetry-operator/controller/tracepipeline/resources.go
+++ b/components/telemetry-operator/controller/tracepipeline/resources.go
@@ -145,9 +145,9 @@ func makeDeployment(config Config, configHash string) *appsv1.Deployment {
 				Spec: corev1.PodSpec{
 					Containers: []corev1.Container{
 						{
-							Name:    config.ResourceName,
-							Image:   config.CollectorImage,
-							Command: []string{"/otelcol-contrib", "--config=/conf/" + configMapKey},
+							Name:  config.ResourceName,
+							Image: config.CollectorImage,
+							Args:  []string{"--config=/conf/" + configMapKey},
 							EnvFrom: []corev1.EnvFromSource{
 								{
 									SecretRef: &corev1.SecretEnvSource{

--- a/components/telemetry-operator/main.go
+++ b/components/telemetry-operator/main.go
@@ -90,7 +90,7 @@ var (
 	maxLogPipelines            int
 )
 
-const otelImage = "eu.gcr.io/kyma-project/tpi/otel-collector:v20221125-767b8d0f"
+const otelImage = "eu.gcr.io/kyma-project/tpi/otel-collector:v20221125-9bbc6dff"
 
 //nolint:gochecknoinits
 func init() {

--- a/components/telemetry-operator/main.go
+++ b/components/telemetry-operator/main.go
@@ -90,6 +90,8 @@ var (
 	maxLogPipelines            int
 )
 
+const otelImage = "eu.gcr.io/kyma-project/tpi/otel-collector:v20221125-767b8d0f"
+
 //nolint:gochecknoinits
 func init() {
 	utilruntime.Must(clientgoscheme.AddToScheme(scheme))
@@ -140,7 +142,7 @@ func main() {
 
 	flag.BoolVar(&createServiceMonitor, "create-service-monitor", true, "Create Prometheus ServiceMonitor for opentelemetry-collector")
 	flag.StringVar(&traceCollectorDeploymentName, "trace-collector-deployment-name", "telemetry-trace-collector", "Deployment name for tracing OpenTelemetry Collector")
-	flag.StringVar(&traceCollectorImage, "trace-collector-image", "otel/opentelemetry-collector-contrib:0.60.0", "Image for tracing OpenTelemetry Collector")
+	flag.StringVar(&traceCollectorImage, "trace-collector-image", otelImage, "Image for tracing OpenTelemetry Collector")
 
 	flag.StringVar(&fluentBitConfigMap, "fluent-bit-cm-name", "telemetry-fluent-bit", "ConfigMap name of Fluent Bit")
 	flag.StringVar(&fluentBitSectionsConfigMap, "fluent-bit-sections-cm-name", "telemetry-fluent-bit-sections", "ConfigMap name of Fluent Bit Sections to be written by Fluent Bit controller")

--- a/resources/telemetry/charts/operator/templates/deployment.yaml
+++ b/resources/telemetry/charts/operator/templates/deployment.yaml
@@ -65,6 +65,9 @@ spec:
 {{- end }}
 {{- if not .Values.controllers.tracing.enabled }}
             - --enable-tracing=false
+{{- else }}
+            - --enable-tracing=true
+            - --trace-collector-image={{ include "imageurl" (dict "reg" .Values.global.containerRegistry "img" .Values.global.images.telemetry_otel_collector) }}
 {{- end }}
           name: manager
           ports:

--- a/resources/telemetry/values.yaml
+++ b/resources/telemetry/values.yaml
@@ -7,7 +7,7 @@ global:
       version: "v20221020-e314a071"
     telemetry_operator:
       name: "telemetry-operator"
-      version: "PR-16121"
+      version: "PR-16184"
     telemetry_webhook_cert_init:
       name: "webhook-cert-init"
       version: "v20221122-200937b4"

--- a/resources/telemetry/values.yaml
+++ b/resources/telemetry/values.yaml
@@ -11,6 +11,10 @@ global:
     telemetry_webhook_cert_init:
       name: "webhook-cert-init"
       version: "v20221122-200937b4"
+    telemetry_otel_collector:
+      name: "otel-collector"
+      version: "v20221125-767b8d0f"
+      directory: "tpi"
     fluent_bit:
       name: "fluent-bit"
       version: "1.9.9-cf0a130c"

--- a/resources/telemetry/values.yaml
+++ b/resources/telemetry/values.yaml
@@ -13,7 +13,7 @@ global:
       version: "v20221122-200937b4"
     telemetry_otel_collector:
       name: "otel-collector"
-      version: "v20221125-767b8d0f"
+      version: "v20221125-9bbc6dff"
       directory: "tpi"
     fluent_bit:
       name: "fluent-bit"


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- Use args instead of command to leverage entrypoint in otel image
- Make otel image configurable
- Add striped down otel image

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
https://github.com/kyma-project/kyma/issues/15830
