### PR TITLE
Copy .npmrc into nodejs16 runtime

### DIFF
--- a/resources/serverless/templates/runtimes.yaml
+++ b/resources/serverless/templates/runtimes.yaml
@@ -40,6 +40,7 @@ data:
     RUN mkdir -p /usr/src/app/function
     WORKDIR /usr/src/app/function
 
+    COPY /registry-config/* /usr/src/app/function/
     COPY $SRC_DIR/package.json /usr/src/app/function/package.json
 
     RUN npm install --production


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- copy mounted `.npmrc` config into nodejs16 runtime 

**Related issue(s)**
Fixes https://github.com/kyma-project/kyma/issues/16175