### PR TITLE
Register template for keda-v0.0.1-alpha

### DIFF
--- a/modules/alpha/kustomization.yaml
+++ b/modules/alpha/kustomization.yaml
@@ -1,3 +1,5 @@
 apiVersion: kustomize.config.k8s.io/v1alpha1
 kind: Component
 
+resources:
+- moduletemplate-keda.yaml

--- a/modules/alpha/moduletemplate-keda.yaml
+++ b/modules/alpha/moduletemplate-keda.yaml
@@ -1,0 +1,61 @@
+apiVersion: operator.kyma-project.io/v1alpha1
+kind: ModuleTemplate
+metadata:
+  name: moduletemplate-keda
+  namespace: kcp-system
+  labels:
+    "operator.kyma-project.io/managed-by": "lifecycle-manager"
+    "operator.kyma-project.io/controller-name": "manifest"
+    "operator.kyma-project.io/module-name": "keda"
+  annotations:
+    "operator.kyma-project.io/module-version": "0.0.1-d8a2c4c"
+    "operator.kyma-project.io/module-provider": "internal"
+    "operator.kyma-project.io/descriptor-schema-version": "v2"
+spec:
+  target: remote
+  channel: alpha
+  data:
+    apiVersion: operator.kyma-project.io/v1alpha1
+    kind: Keda
+    metadata:
+      name: keda-sample
+    spec:
+      logging:
+        operator:
+          level: "debug"
+  descriptor:
+    component:
+      componentReferences: []
+      name: kyma.project.io/module/keda
+      provider: internal
+      repositoryContexts:
+      - baseUrl: europe-docker.pkg.dev/kyma-project/prod/unsigned
+        componentNameMapping: urlPath
+        type: ociRegistry
+      resources:
+      - access:
+          digest: sha256:552bb3e3ff8da4a4934b053573cd7b34cceecf37b97640315c1dc5d6a844e79d
+          type: localOciBlob
+        name: keda
+        relation: local
+        type: helm-chart
+        version: 0.0.1-d8a2c4c
+      - access:
+          digest: sha256:f4a599c4310b0fe9133b67b72d9b15ee96b52a1872132528c83978239b5effef
+          type: localOciBlob
+        name: config
+        relation: local
+        type: yaml
+        version: 0.0.1-d8a2c4c
+      sources:
+      - access:
+          commit: d8a2c4c673c7d586e5ab01d7cada9a62bc088b4f
+          ref: refs/heads/main
+          repoUrl: github.com/kyma-project/keda-manager
+          type: github
+        name: keda-manager
+        type: git
+        version: 0.0.1-d8a2c4c
+      version: 0.0.1-d8a2c4c
+    meta:
+      schemaVersion: v2


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- add module template for keda module (v0.0.1-alpha)

How to use it:

[Get latest (unstable) binary for kyma cli](https://github.com/kyma-project/module-manager/issues/157)
```
kyma-unstable alpha deploy

kubectl apply -k modules/alpha                                                                     
moduletemplate.operator.kyma-project.io/moduletemplate-keda created
```

**Related issue(s)**
https://github.com/kyma-project/keda-manager/issues/58
https://github.com/kyma-project/module-manager/issues/157