### PR TITLE
Remove Helm templating for telemetry busola extensions

### DIFF
--- a/resources/telemetry/charts/operator/templates/logparser_busola_extension_cm.yaml
+++ b/resources/telemetry/charts/operator/templates/logparser_busola_extension_cm.yaml
@@ -1,4 +1,3 @@
-{{ if .Values.dashboardExtension.enabled }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -64,4 +63,3 @@ data:
         "metadata.creationTimestamp": "Created at"
       }
     }
-{{ end }}

--- a/resources/telemetry/charts/operator/templates/logpipeline_busola_extension_cm.yaml
+++ b/resources/telemetry/charts/operator/templates/logpipeline_busola_extension_cm.yaml
@@ -1,4 +1,3 @@
-{{ if .Values.dashboardExtension.enabled }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -521,4 +520,3 @@ data:
         "metadata.creationTimestamp": "Created at"
       }
     }
-{{ end }}

--- a/resources/telemetry/charts/operator/values.yaml
+++ b/resources/telemetry/charts/operator/values.yaml
@@ -129,6 +129,3 @@ nodeSelector: {}
 tolerations: []
 
 affinity: {}
-
-dashboardExtension:
-  enabled: true


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Make dashboard extensions in the telemetry chart a plain Kubernetes manifest to allow importing it into the Busola image.

Changes proposed in this pull request:

- Remove Helm templating for telemetry busola extensions

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
See also https://github.com/kyma-project/kyma-dashboard/pull/24