### PR TITLE
Fix EventMesh namespace in Exact type matching for Sub v1alpha2 CRD

### DIFF
--- a/components/eventing-controller/pkg/backend/utils/eventmesh_utils.go
+++ b/components/eventing-controller/pkg/backend/utils/eventmesh_utils.go
@@ -92,7 +92,7 @@ func getQos(qosStr string) (types.Qos, error) {
 func getEventMeshEvents(typeInfos []EventTypeInfo, typeMatching eventingv1alpha2.TypeMatching,
 	defaultNamespace, source string) types.Events {
 	eventMeshNamespace := defaultNamespace
-	if typeMatching == eventingv1alpha2.TypeMatchingExact {
+	if typeMatching == eventingv1alpha2.TypeMatchingExact && source != "" {
 		eventMeshNamespace = source
 	}
 

--- a/components/eventing-controller/pkg/backend/utils/eventmesh_utils_test.go
+++ b/components/eventing-controller/pkg/backend/utils/eventmesh_utils_test.go
@@ -535,7 +535,36 @@ func Test_getEventMeshEvents(t *testing.T) {
 		g.Expect(gotBEBEvents).To(Equal(expectedEventMeshEvents))
 	})
 
-	t.Run("with exact type matching", func(t *testing.T) {
+	t.Run("with exact type matching with empty source", func(t *testing.T) {
+		// given
+		eventTypeInfos := getTypeInfos([]string{
+			eventingtestingv2.OrderCreatedV1Event,
+			eventingtestingv2.OrderCreatedV2Event,
+		})
+
+		defaultNamespace := eventingtestingv2.EventMeshNamespace
+		typeMatching := eventingv1alpha2.TypeMatchingExact
+		source := ""
+
+		expectedEventMeshEvents := types.Events{
+			types.Event{
+				Source: defaultNamespace,
+				Type:   eventingtestingv2.OrderCreatedV1Event,
+			},
+			types.Event{
+				Source: defaultNamespace,
+				Type:   eventingtestingv2.OrderCreatedV2Event,
+			},
+		}
+
+		// when
+		gotBEBEvents := getEventMeshEvents(eventTypeInfos, typeMatching, defaultNamespace, source)
+
+		// then
+		g.Expect(gotBEBEvents).To(Equal(expectedEventMeshEvents))
+	})
+
+	t.Run("with exact type matching with non-empty source", func(t *testing.T) {
 		// given
 		eventTypeInfos := getTypeInfos([]string{
 			eventingtestingv2.OrderCreatedV1Event,

--- a/resources/eventing/values.yaml
+++ b/resources/eventing/values.yaml
@@ -5,7 +5,7 @@ global:
   images:
     eventing_controller:
       name: eventing-controller
-      version: PR-16158
+      version: PR-16213
       pullPolicy: "IfNotPresent"
     publisher_proxy:
       name: event-publisher-proxy


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- We decided in "[Summary of all publish-subscribe cases with the new CRD version](https://github.com/kyma-project/kyma/issues/15618#issuecomment-1310364282)" that `source` for the CE header will be picked up from the secret in the case of EM v1alpha2 (standard and exact). This PR changes which eventMesh namespace will be used in case of Exact Type Marching.
- If the source is not provided [case: EventMesh + Exact TypeMatching], then the EventMesh namespace will be used from the secret. If provided, it will be used as EventMesh namespace.

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
