### PR TITLE
Duplicate definition of GF_PATHS_PROVISIONING env variable in grafana

### DIFF
--- a/resources/monitoring/charts/grafana/values.yaml
+++ b/resources/monitoring/charts/grafana/values.yaml
@@ -363,8 +363,6 @@ admin:
 
 ## Extra environment variables that will be pass onto deployment pods
 env:
-  # https://grafana.com/docs/grafana/latest/installation/configuration/#paths
-  GF_PATHS_PROVISIONING: /etc/grafana/provisioning
   # https://grafana.com/docs/grafana/latest/installation/configuration/#users
   GF_USERS_AUTO_ASSIGN_ORG: "true"
   GF_USERS_AUTO_ASSIGN_ORG_ROLE: Editor


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**
Env variable already hardcoded in the templating: https://github.com/kyma-project/kyma/blob/main/resources/monitoring/charts/grafana/templates/_pod.tpl#L375 so it is duplicated in the values.yaml env section causing this warning

`Warning:  spec.template.spec.containers[2].env[7].name: duplicate name "GF_PATHS_PROVISIONING"`


Changes proposed in this pull request:

- removed redundant env variable
- ...
- ...

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
