### PR TITLE
[Telemetry Operator] Harden otel-collector deployment

### DIFF
--- a/components/telemetry-operator/controller/tracepipeline/controller.go
+++ b/components/telemetry-operator/controller/tracepipeline/controller.go
@@ -55,7 +55,7 @@ func NewReconciler(client client.Client, config Config, scheme *runtime.Scheme) 
 func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	logger := logf.FromContext(ctx)
 
-	logger.Info("Reconciliation triggered")
+	logger.V(1).Info("Reconciliation triggered")
 
 	var tracePipeline telemetryv1alpha1.TracePipeline
 	if err := r.Get(ctx, req.NamespacedName, &tracePipeline); err != nil {

--- a/components/telemetry-operator/controller/tracepipeline/controller.go
+++ b/components/telemetry-operator/controller/tracepipeline/controller.go
@@ -32,19 +32,24 @@ import (
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 )
 
+type Config struct {
+	CreateServiceMonitor bool
+	BaseName             string
+	Namespace            string
+
+	Deployment DeploymentConfig
+	Service    ServiceConfig
+}
+
 type DeploymentConfig struct {
-	Name              string
 	Image             string
 	PriorityClassName string
 	CPULimit          resource.Quantity
 	MemoryLimit       resource.Quantity
 }
 
-type Config struct {
-	CreateServiceMonitor bool
-	Namespace            string
-
-	Deployment DeploymentConfig
+type ServiceConfig struct {
+	OTLPServiceName string
 }
 
 type Reconciler struct {
@@ -107,7 +112,7 @@ func (r *Reconciler) installOrUpgradeOtelCollector(ctx context.Context, tracing 
 		return fmt.Errorf("failed to create otel collector deployment: %w", err)
 	}
 
-	service := makeCollectorService(r.config)
+	service := makeOTLPService(r.config)
 	if err = controllerutil.SetControllerReference(tracing, service, r.Scheme); err != nil {
 		return err
 	}

--- a/components/telemetry-operator/controller/tracepipeline/controller.go
+++ b/components/telemetry-operator/controller/tracepipeline/controller.go
@@ -46,6 +46,8 @@ type DeploymentConfig struct {
 	PriorityClassName string
 	CPULimit          resource.Quantity
 	MemoryLimit       resource.Quantity
+	CPURequest        resource.Quantity
+	MemoryRequest     resource.Quantity
 }
 
 type ServiceConfig struct {

--- a/components/telemetry-operator/controller/tracepipeline/controller.go
+++ b/components/telemetry-operator/controller/tracepipeline/controller.go
@@ -19,6 +19,7 @@ package tracepipeline
 import (
 	"context"
 	"fmt"
+	"k8s.io/apimachinery/pkg/api/resource"
 
 	telemetryv1alpha1 "github.com/kyma-project/kyma/components/telemetry-operator/apis/telemetry/v1alpha1"
 	"github.com/kyma-project/kyma/components/telemetry-operator/controller"
@@ -35,6 +36,8 @@ type DeploymentConfig struct {
 	Name              string
 	Image             string
 	PriorityClassName string
+	CPULimit          resource.Quantity
+	MemoryLimit       resource.Quantity
 }
 
 type Config struct {

--- a/components/telemetry-operator/controller/tracepipeline/controller.go
+++ b/components/telemetry-operator/controller/tracepipeline/controller.go
@@ -31,11 +31,17 @@ import (
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 )
 
+type DeploymentConfig struct {
+	Name              string
+	Image             string
+	PriorityClassName string
+}
+
 type Config struct {
 	CreateServiceMonitor bool
-	CollectorNamespace   string
-	ResourceName         string
-	CollectorImage       string
+	Namespace            string
+
+	Deployment DeploymentConfig
 }
 
 type Reconciler struct {

--- a/components/telemetry-operator/controller/tracepipeline/controller_test.go
+++ b/components/telemetry-operator/controller/tracepipeline/controller_test.go
@@ -44,7 +44,7 @@ var _ = Describe("Deploying a TracePipeline", func() {
 		}
 		tracePipeline := &telemetryv1alpha1.TracePipeline{
 			ObjectMeta: metav1.ObjectMeta{
-				Name: "test-tracepipeline",
+				Name: "dummy",
 			},
 			Spec: telemetryv1alpha1.TracePipelineSpec{
 				Output: telemetryv1alpha1.TracePipelineOutput{
@@ -175,7 +175,7 @@ func validateOwnerReferences(ownerRefernces []metav1.OwnerReference) error {
 		return fmt.Errorf("unexpected owner reference type: %s", ownerReference.Kind)
 	}
 
-	if ownerReference.Name != "test-tracepipeline" {
+	if ownerReference.Name != "dummy" {
 		return fmt.Errorf("unexpected owner reference name: %s", ownerReference.Kind)
 	}
 

--- a/components/telemetry-operator/controller/tracepipeline/controller_test.go
+++ b/components/telemetry-operator/controller/tracepipeline/controller_test.go
@@ -3,6 +3,7 @@ package tracepipeline
 import (
 	"context"
 	"fmt"
+	"k8s.io/apimachinery/pkg/types"
 	"time"
 
 	telemetryv1alpha1 "github.com/kyma-project/kyma/components/telemetry-operator/apis/telemetry/v1alpha1"
@@ -11,7 +12,6 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/types"
 )
 
 var _ = Describe("Deploying a TracePipeline", func() {
@@ -26,10 +26,6 @@ var _ = Describe("Deploying a TracePipeline", func() {
 			ObjectMeta: metav1.ObjectMeta{
 				Name: "kyma-system",
 			},
-		}
-		otelCollectorResourceLookupKey := types.NamespacedName{
-			Name:      "telemetry-trace-collector",
-			Namespace: "kyma-system",
 		}
 		data := map[string][]byte{
 			"user":     []byte("secret-username"),
@@ -84,7 +80,10 @@ var _ = Describe("Deploying a TracePipeline", func() {
 
 			Eventually(func() error {
 				var otelCollectorDeployment appsv1.Deployment
-				if err := k8sClient.Get(ctx, otelCollectorResourceLookupKey, &otelCollectorDeployment); err != nil {
+				if err := k8sClient.Get(ctx, types.NamespacedName{
+					Name:      "telemetry-trace-collector",
+					Namespace: "kyma-system",
+				}, &otelCollectorDeployment); err != nil {
 					return err
 				}
 				if err := validateOwnerReferences(otelCollectorDeployment.OwnerReferences); err != nil {
@@ -101,7 +100,10 @@ var _ = Describe("Deploying a TracePipeline", func() {
 
 			Eventually(func() error {
 				var otelCollectorService v1.Service
-				if err := k8sClient.Get(ctx, otelCollectorResourceLookupKey, &otelCollectorService); err != nil {
+				if err := k8sClient.Get(ctx, types.NamespacedName{
+					Name:      "telemetry-otlp-traces",
+					Namespace: "kyma-system",
+				}, &otelCollectorService); err != nil {
 					return err
 				}
 				if err := validateOwnerReferences(otelCollectorService.OwnerReferences); err != nil {
@@ -112,7 +114,10 @@ var _ = Describe("Deploying a TracePipeline", func() {
 
 			Eventually(func() error {
 				var otelCollectorConfigMap v1.ConfigMap
-				if err := k8sClient.Get(ctx, otelCollectorResourceLookupKey, &otelCollectorConfigMap); err != nil {
+				if err := k8sClient.Get(ctx, types.NamespacedName{
+					Name:      "telemetry-trace-collector",
+					Namespace: "kyma-system",
+				}, &otelCollectorConfigMap); err != nil {
 					return err
 				}
 				if err := validateOwnerReferences(otelCollectorConfigMap.OwnerReferences); err != nil {
@@ -123,7 +128,10 @@ var _ = Describe("Deploying a TracePipeline", func() {
 
 			Eventually(func() error {
 				var otelCollectorSecret v1.Secret
-				if err := k8sClient.Get(ctx, otelCollectorResourceLookupKey, &otelCollectorSecret); err != nil {
+				if err := k8sClient.Get(ctx, types.NamespacedName{
+					Name:      "telemetry-trace-collector",
+					Namespace: "kyma-system",
+				}, &otelCollectorSecret); err != nil {
 					return err
 				}
 				if err := validateOwnerReferences(otelCollectorSecret.OwnerReferences); err != nil {

--- a/components/telemetry-operator/controller/tracepipeline/resources.go
+++ b/components/telemetry-operator/controller/tracepipeline/resources.go
@@ -251,8 +251,8 @@ func makePodAnnotations(configHash string) map[string]string {
 func makeResourceRequirements(config Config) corev1.ResourceRequirements {
 	return corev1.ResourceRequirements{
 		Requests: map[corev1.ResourceName]resource.Quantity{
-			corev1.ResourceCPU:    resource.MustParse("150m"),
-			corev1.ResourceMemory: resource.MustParse("256Mi"),
+			corev1.ResourceCPU:    config.Deployment.CPURequest,
+			corev1.ResourceMemory: config.Deployment.MemoryRequest,
 		},
 		Limits: map[corev1.ResourceName]resource.Quantity{
 			corev1.ResourceCPU:    config.Deployment.CPULimit,

--- a/components/telemetry-operator/controller/tracepipeline/resources.go
+++ b/components/telemetry-operator/controller/tracepipeline/resources.go
@@ -30,7 +30,7 @@ var (
 	replicas = int32(1)
 )
 
-func getLabels(config Config) map[string]string {
+func makeDefaultLabels(config Config) map[string]string {
 	return map[string]string{
 		"app.kubernetes.io/name": config.Deployment.Name,
 	}
@@ -79,7 +79,7 @@ func makeConfigMap(config Config, output v1alpha1.TracePipelineOutput) *corev1.C
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      config.Deployment.Name,
 			Namespace: config.Namespace,
-			Labels:    getLabels(config),
+			Labels:    makeDefaultLabels(config),
 		},
 		Data: map[string]string{
 			configMapKey: confYAML,
@@ -92,7 +92,7 @@ func makeSecret(config Config, secretData map[string][]byte) *corev1.Secret {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      config.Deployment.Name,
 			Namespace: config.Namespace,
-			Labels:    getLabels(config),
+			Labels:    makeDefaultLabels(config),
 		},
 		Data: secretData,
 	}
@@ -147,7 +147,7 @@ func makeProcessorsConfig() map[string]any {
 }
 
 func makeDeployment(config Config, configHash string) *appsv1.Deployment {
-	labels := getLabels(config)
+	labels := makeDefaultLabels(config)
 	optional := true
 	annotations := makePodAnnotations(configHash)
 	resources := makeResourceRequirements(config)
@@ -261,7 +261,7 @@ func makeResourceRequirements(config Config) corev1.ResourceRequirements {
 }
 
 func makeCollectorService(config Config) *corev1.Service {
-	labels := getLabels(config)
+	labels := makeDefaultLabels(config)
 	return &corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      config.Deployment.Name,
@@ -296,7 +296,7 @@ func makeCollectorService(config Config) *corev1.Service {
 }
 
 func makeMetricsService(config Config) *corev1.Service {
-	labels := getLabels(config)
+	labels := makeDefaultLabels(config)
 	return &corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      config.Deployment.Name + "-metrics",
@@ -319,7 +319,7 @@ func makeMetricsService(config Config) *corev1.Service {
 }
 
 func makeServiceMonitor(config Config) *monitoringv1.ServiceMonitor {
-	labels := getLabels(config)
+	labels := makeDefaultLabels(config)
 	return &monitoringv1.ServiceMonitor{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      config.Deployment.Name,

--- a/components/telemetry-operator/controller/tracepipeline/resources.go
+++ b/components/telemetry-operator/controller/tracepipeline/resources.go
@@ -188,6 +188,16 @@ func makeDeployment(config Config, configHash string) *appsv1.Deployment {
 							},
 							Resources:    collectorResources,
 							VolumeMounts: []corev1.VolumeMount{{Name: "config", MountPath: "/conf"}},
+							LivenessProbe: &corev1.Probe{
+								ProbeHandler: corev1.ProbeHandler{
+									HTTPGet: &corev1.HTTPGetAction{Path: "/", Port: intstr.IntOrString{IntVal: 13133}},
+								},
+							},
+							ReadinessProbe: &corev1.Probe{
+								ProbeHandler: corev1.ProbeHandler{
+									HTTPGet: &corev1.HTTPGetAction{Path: "/", Port: intstr.IntOrString{IntVal: 13133}},
+								},
+							},
 						},
 					},
 					Volumes: []corev1.Volume{

--- a/components/telemetry-operator/controller/tracepipeline/resources.go
+++ b/components/telemetry-operator/controller/tracepipeline/resources.go
@@ -21,7 +21,6 @@ const (
 	configHashAnnotationKey = "checksum/config"
 	collectorUser           = 10001
 	collectorContainerName  = "collector"
-	collectorProbePort      = 13133
 )
 
 var (
@@ -202,12 +201,12 @@ func makeDeployment(config Config, configHash string) *appsv1.Deployment {
 							VolumeMounts: []corev1.VolumeMount{{Name: "config", MountPath: "/conf"}},
 							LivenessProbe: &corev1.Probe{
 								ProbeHandler: corev1.ProbeHandler{
-									HTTPGet: &corev1.HTTPGetAction{Path: "/", Port: intstr.IntOrString{IntVal: collectorProbePort}},
+									HTTPGet: &corev1.HTTPGetAction{Path: "/", Port: intstr.IntOrString{IntVal: 13133}},
 								},
 							},
 							ReadinessProbe: &corev1.Probe{
 								ProbeHandler: corev1.ProbeHandler{
-									HTTPGet: &corev1.HTTPGetAction{Path: "/", Port: intstr.IntOrString{IntVal: collectorProbePort}},
+									HTTPGet: &corev1.HTTPGetAction{Path: "/", Port: intstr.IntOrString{IntVal: 13133}},
 								},
 							},
 						},

--- a/components/telemetry-operator/controller/tracepipeline/resources.go
+++ b/components/telemetry-operator/controller/tracepipeline/resources.go
@@ -60,6 +60,9 @@ func makeConfigMap(config Config, output v1alpha1.TracePipelineOutput) *corev1.C
 		},
 		"exporters":  exporterConfig,
 		"processors": processorsConfig,
+		"extensions": map[string]any{
+			"health_check": map[string]any{},
+		},
 		"service": map[string]any{
 			"pipelines": map[string]any{
 				"traces": map[string]any{
@@ -73,6 +76,7 @@ func makeConfigMap(config Config, output v1alpha1.TracePipelineOutput) *corev1.C
 					"address": "0.0.0.0:8888",
 				},
 			},
+			"extensions": []string{"health_check"},
 		},
 	})
 

--- a/components/telemetry-operator/controller/tracepipeline/resources_test.go
+++ b/components/telemetry-operator/controller/tracepipeline/resources_test.go
@@ -12,8 +12,10 @@ import (
 
 var (
 	config = Config{
-		ResourceName:       "collector",
-		CollectorNamespace: "kyma-system",
+		Deployment: DeploymentConfig{
+			Name: "collector",
+		},
+		Namespace: "kyma-system",
 	}
 	tracePipeline = v1alpha1.TracePipelineOutput{
 		Otlp: &v1alpha1.OtlpOutput{
@@ -46,8 +48,8 @@ func TestMakeConfigMap(t *testing.T) {
 	cm := makeConfigMap(config, tracePipeline)
 
 	require.NotNil(t, cm)
-	require.Equal(t, cm.Name, config.ResourceName)
-	require.Equal(t, cm.Namespace, config.CollectorNamespace)
+	require.Equal(t, cm.Name, config.Deployment.Name)
+	require.Equal(t, cm.Namespace, config.Namespace)
 	expectedEndpoint := fmt.Sprintf("endpoint: ${%s}", otlpEndpointVariable)
 	collectorConfig := cm.Data[configMapKey]
 
@@ -75,8 +77,8 @@ func TestMakeSecret(t *testing.T) {
 	secret := makeSecret(config, secretData)
 
 	require.NotNil(t, secret)
-	require.Equal(t, secret.Name, config.ResourceName)
-	require.Equal(t, secret.Namespace, config.CollectorNamespace)
+	require.Equal(t, secret.Name, config.Deployment.Name)
+	require.Equal(t, secret.Namespace, config.Namespace)
 
 	require.Equal(t, "otlpEndpoint", string(secret.Data[otlpEndpointVariable]), "Secret must contain OTLP endpoint")
 	require.Equal(t, "basicAuthHeader", string(secret.Data[basicAuthHeaderVariable]), "Secret must contain basic auth header")
@@ -87,8 +89,8 @@ func TestMakeDeployment(t *testing.T) {
 	labels := getLabels(config)
 
 	require.NotNil(t, deployment)
-	require.Equal(t, deployment.Name, config.ResourceName)
-	require.Equal(t, deployment.Namespace, config.CollectorNamespace)
+	require.Equal(t, deployment.Name, config.Deployment.Name)
+	require.Equal(t, deployment.Namespace, config.Namespace)
 	require.Equal(t, *deployment.Spec.Replicas, int32(1))
 	require.Equal(t, deployment.Spec.Selector.MatchLabels, labels)
 	require.Equal(t, deployment.Spec.Template.ObjectMeta.Labels, labels)
@@ -120,8 +122,8 @@ func TestMakeCollectorService(t *testing.T) {
 	labels := getLabels(config)
 
 	require.NotNil(t, service)
-	require.Equal(t, service.Name, config.ResourceName)
-	require.Equal(t, service.Namespace, config.CollectorNamespace)
+	require.Equal(t, service.Name, config.Deployment.Name)
+	require.Equal(t, service.Namespace, config.Namespace)
 	require.Equal(t, service.Spec.Selector, labels)
 	require.NotEmpty(t, service.Spec.Ports)
 }
@@ -131,9 +133,9 @@ func TestMakeServiceMonitor(t *testing.T) {
 	labels := getLabels(config)
 
 	require.NotNil(t, serviceMonitor)
-	require.Equal(t, serviceMonitor.Name, config.ResourceName)
-	require.Equal(t, serviceMonitor.Namespace, config.CollectorNamespace)
-	require.Contains(t, serviceMonitor.Spec.NamespaceSelector.MatchNames, config.CollectorNamespace)
+	require.Equal(t, serviceMonitor.Name, config.Deployment.Name)
+	require.Equal(t, serviceMonitor.Namespace, config.Namespace)
+	require.Contains(t, serviceMonitor.Spec.NamespaceSelector.MatchNames, config.Namespace)
 	require.Equal(t, serviceMonitor.Spec.Selector.MatchLabels, labels)
 }
 
@@ -142,8 +144,8 @@ func TestMakeMetricsService(t *testing.T) {
 	labels := getLabels(config)
 
 	require.NotNil(t, service)
-	require.Equal(t, service.Name, config.ResourceName+"-metrics")
-	require.Equal(t, service.Namespace, config.CollectorNamespace)
+	require.Equal(t, service.Name, config.Deployment.Name+"-metrics")
+	require.Equal(t, service.Namespace, config.Namespace)
 	require.Equal(t, service.Spec.Selector, labels)
 	require.NotEmpty(t, service.Spec.Ports)
 }

--- a/components/telemetry-operator/controller/tracepipeline/resources_test.go
+++ b/components/telemetry-operator/controller/tracepipeline/resources_test.go
@@ -86,7 +86,7 @@ func TestMakeSecret(t *testing.T) {
 
 func TestMakeDeployment(t *testing.T) {
 	deployment := makeDeployment(config, "123")
-	labels := getLabels(config)
+	labels := makeDefaultLabels(config)
 
 	require.NotNil(t, deployment)
 	require.Equal(t, deployment.Name, config.Deployment.Name)
@@ -119,7 +119,7 @@ func TestMakeDeployment(t *testing.T) {
 
 func TestMakeCollectorService(t *testing.T) {
 	service := makeCollectorService(config)
-	labels := getLabels(config)
+	labels := makeDefaultLabels(config)
 
 	require.NotNil(t, service)
 	require.Equal(t, service.Name, config.Deployment.Name)
@@ -130,7 +130,7 @@ func TestMakeCollectorService(t *testing.T) {
 
 func TestMakeServiceMonitor(t *testing.T) {
 	serviceMonitor := makeServiceMonitor(config)
-	labels := getLabels(config)
+	labels := makeDefaultLabels(config)
 
 	require.NotNil(t, serviceMonitor)
 	require.Equal(t, serviceMonitor.Name, config.Deployment.Name)
@@ -141,7 +141,7 @@ func TestMakeServiceMonitor(t *testing.T) {
 
 func TestMakeMetricsService(t *testing.T) {
 	service := makeMetricsService(config)
-	labels := getLabels(config)
+	labels := makeDefaultLabels(config)
 
 	require.NotNil(t, service)
 	require.Equal(t, service.Name, config.Deployment.Name+"-metrics")

--- a/components/telemetry-operator/controller/tracepipeline/resources_test.go
+++ b/components/telemetry-operator/controller/tracepipeline/resources_test.go
@@ -97,8 +97,22 @@ func TestMakeDeployment(t *testing.T) {
 	}
 	require.Equal(t, deployment.Spec.Template.ObjectMeta.Annotations[configHashAnnotationKey], "123")
 	require.NotEmpty(t, deployment.Spec.Template.Spec.Containers[0].EnvFrom)
-	require.NotNil(t, deployment.Spec.Template.Spec.Containers[0].LivenessProbe)
-	require.NotNil(t, deployment.Spec.Template.Spec.Containers[0].ReadinessProbe)
+
+	require.NotNil(t, deployment.Spec.Template.Spec.Containers[0].LivenessProbe, "liveness probe must be defined")
+	require.NotNil(t, deployment.Spec.Template.Spec.Containers[0].ReadinessProbe, "readiness probe must be defined")
+
+	podSecurityContext := deployment.Spec.Template.Spec.SecurityContext
+	require.NotNil(t, podSecurityContext, "pod security context must be defined")
+	require.NotZero(t, podSecurityContext.RunAsUser, "must run as non-root")
+	require.True(t, *podSecurityContext.RunAsNonRoot, "must run as non-root")
+
+	containerSecurityContext := deployment.Spec.Template.Spec.Containers[0].SecurityContext
+	require.NotNil(t, containerSecurityContext, "container security context must be defined")
+	require.NotZero(t, containerSecurityContext.RunAsUser, "must run as non-root")
+	require.True(t, *containerSecurityContext.RunAsNonRoot, "must run as non-root")
+	require.False(t, *containerSecurityContext.Privileged, "must not be privileged")
+	require.False(t, *containerSecurityContext.AllowPrivilegeEscalation, "must not escalate to privileged")
+	require.True(t, *containerSecurityContext.ReadOnlyRootFilesystem, "must use readonly fs")
 }
 
 func TestMakeCollectorService(t *testing.T) {

--- a/components/telemetry-operator/controller/tracepipeline/resources_test.go
+++ b/components/telemetry-operator/controller/tracepipeline/resources_test.go
@@ -97,6 +97,8 @@ func TestMakeDeployment(t *testing.T) {
 	}
 	require.Equal(t, deployment.Spec.Template.ObjectMeta.Annotations[configHashAnnotationKey], "123")
 	require.NotEmpty(t, deployment.Spec.Template.Spec.Containers[0].EnvFrom)
+	require.NotNil(t, deployment.Spec.Template.Spec.Containers[0].LivenessProbe)
+	require.NotNil(t, deployment.Spec.Template.Spec.Containers[0].ReadinessProbe)
 }
 
 func TestMakeCollectorService(t *testing.T) {

--- a/components/telemetry-operator/controller/tracepipeline/suite_test.go
+++ b/components/telemetry-operator/controller/tracepipeline/suite_test.go
@@ -47,9 +47,11 @@ var cancel context.CancelFunc
 
 var testConfig = Config{
 	CreateServiceMonitor: false,
-	CollectorNamespace:   "kyma-system",
-	ResourceName:         "telemetry-trace-collector",
-	CollectorImage:       "otel/opentelemetry-collector-contrib:0.60.0",
+	Namespace:            "kyma-system",
+	Deployment: DeploymentConfig{
+		Name:  "telemetry-trace-collector",
+		Image: "otel/opentelemetry-collector-contrib:0.60.0",
+	},
 }
 
 func TestAPIs(t *testing.T) {

--- a/components/telemetry-operator/controller/tracepipeline/suite_test.go
+++ b/components/telemetry-operator/controller/tracepipeline/suite_test.go
@@ -47,9 +47,9 @@ var cancel context.CancelFunc
 
 var testConfig = Config{
 	CreateServiceMonitor: false,
+	BaseName:             "telemetry-trace-collector",
 	Namespace:            "kyma-system",
 	Deployment: DeploymentConfig{
-		Name:  "telemetry-trace-collector",
 		Image: "otel/opentelemetry-collector-contrib:0.60.0",
 	},
 }

--- a/components/telemetry-operator/controller/tracepipeline/suite_test.go
+++ b/components/telemetry-operator/controller/tracepipeline/suite_test.go
@@ -51,9 +51,11 @@ var testConfig = Config{
 	BaseName:             "telemetry-trace-collector",
 	Namespace:            "kyma-system",
 	Deployment: DeploymentConfig{
-		Image:       "otel/opentelemetry-collector-contrib:0.60.0",
-		CPULimit:    resource.MustParse("1"),
-		MemoryLimit: resource.MustParse("1Gi"),
+		Image:         "otel/opentelemetry-collector-contrib:0.60.0",
+		CPULimit:      resource.MustParse("1"),
+		MemoryLimit:   resource.MustParse("1Gi"),
+		CPURequest:    resource.MustParse("150m"),
+		MemoryRequest: resource.MustParse("256Mi"),
 	},
 	Service: ServiceConfig{
 		OTLPServiceName: "telemetry-otlp-traces",

--- a/components/telemetry-operator/controller/tracepipeline/suite_test.go
+++ b/components/telemetry-operator/controller/tracepipeline/suite_test.go
@@ -18,6 +18,7 @@ package tracepipeline
 
 import (
 	"context"
+	"k8s.io/apimachinery/pkg/api/resource"
 	"path/filepath"
 	"testing"
 
@@ -50,7 +51,9 @@ var testConfig = Config{
 	BaseName:             "telemetry-trace-collector",
 	Namespace:            "kyma-system",
 	Deployment: DeploymentConfig{
-		Image: "otel/opentelemetry-collector-contrib:0.60.0",
+		Image:       "otel/opentelemetry-collector-contrib:0.60.0",
+		CPULimit:    resource.MustParse("1"),
+		MemoryLimit: resource.MustParse("1Gi"),
 	},
 }
 

--- a/components/telemetry-operator/controller/tracepipeline/suite_test.go
+++ b/components/telemetry-operator/controller/tracepipeline/suite_test.go
@@ -55,6 +55,9 @@ var testConfig = Config{
 		CPULimit:    resource.MustParse("1"),
 		MemoryLimit: resource.MustParse("1Gi"),
 	},
+	Service: ServiceConfig{
+		OTLPServiceName: "telemetry-otlp-traces",
+	},
 }
 
 func TestAPIs(t *testing.T) {

--- a/components/telemetry-operator/main.go
+++ b/components/telemetry-operator/main.go
@@ -80,6 +80,8 @@ var (
 	traceCollectorPriorityClass        string
 	traceCollectorCPULimit             string
 	traceCollectorMemoryLimit          string
+	traceCollectorCPURequest           string
+	traceCollectorMemoryRequest        string
 
 	fluentBitEnvSecret         string
 	fluentBitFilesConfigMap    string
@@ -153,6 +155,8 @@ func main() {
 	flag.StringVar(&traceCollectorPriorityClass, "trace-collector-priority-class", "", "Priority class name for tracing OpenTelemetry Collector")
 	flag.StringVar(&traceCollectorCPULimit, "trace-collector-cpu-limit", "1", "CPU limit for tracing OpenTelemetry Collector")
 	flag.StringVar(&traceCollectorMemoryLimit, "trace-collector-memory-limit", "1Gi", "Memory limit for tracing OpenTelemetry Collector")
+	flag.StringVar(&traceCollectorCPURequest, "trace-collector-cpu-request", "150m", "CPU request for tracing OpenTelemetry Collector")
+	flag.StringVar(&traceCollectorMemoryRequest, "trace-collector-memory-request", "256Mi", "Memory request for tracing OpenTelemetry Collector")
 
 	flag.StringVar(&fluentBitConfigMap, "fluent-bit-cm-name", "telemetry-fluent-bit", "ConfigMap name of Fluent Bit")
 	flag.StringVar(&fluentBitSectionsConfigMap, "fluent-bit-sections-cm-name", "telemetry-fluent-bit-sections", "ConfigMap name of Fluent Bit Sections to be written by Fluent Bit controller")
@@ -285,6 +289,12 @@ func validateFlags() error {
 	if _, err := resource.ParseQuantity(traceCollectorMemoryLimit); err != nil {
 		return fmt.Errorf("--trace-collector-memory-limit has to be a valid quantity: %v", err)
 	}
+	if _, err := resource.ParseQuantity(traceCollectorCPURequest); err != nil {
+		return fmt.Errorf("--trace-collector-cpu-request has to be a valid quantity: %v", err)
+	}
+	if _, err := resource.ParseQuantity(traceCollectorMemoryRequest); err != nil {
+		return fmt.Errorf("--trace-collector-memory-request has to be a valid quantity: %v", err)
+	}
 
 	return nil
 }
@@ -337,6 +347,8 @@ func createTracePipelineReconciler(client client.Client) *tracepipelinereconcile
 			PriorityClassName: traceCollectorPriorityClass,
 			CPULimit:          resource.MustParse(traceCollectorCPULimit),
 			MemoryLimit:       resource.MustParse(traceCollectorMemoryLimit),
+			CPURequest:        resource.MustParse(traceCollectorCPURequest),
+			MemoryRequest:     resource.MustParse(traceCollectorMemoryRequest),
 		},
 		Service: tracepipelinereconciler.ServiceConfig{
 			OTLPServiceName: traceCollectorOTLPServiceName,

--- a/components/telemetry-operator/main.go
+++ b/components/telemetry-operator/main.go
@@ -73,12 +73,13 @@ var (
 	syncPeriod           time.Duration
 	telemetryNamespace   string
 
-	createServiceMonitor         bool
-	traceCollectorDeploymentName string
-	traceCollectorImage          string
-	traceCollectorPriorityClass  string
-	traceCollectorCPULimit       string
-	traceCollectorMemoryLimit    string
+	createServiceMonitor          bool
+	traceCollectorBaseName        string
+	traceCollectorOTLPServiceName string
+	traceCollectorImage           string
+	traceCollectorPriorityClass   string
+	traceCollectorCPULimit        string
+	traceCollectorMemoryLimit     string
 
 	fluentBitEnvSecret         string
 	fluentBitFilesConfigMap    string
@@ -146,7 +147,8 @@ func main() {
 	flag.StringVar(&telemetryNamespace, "telemetry-namespace", "kyma-system", "Telemetry namespace")
 
 	flag.BoolVar(&createServiceMonitor, "create-service-monitor", true, "Create Prometheus ServiceMonitor for opentelemetry-collector")
-	flag.StringVar(&traceCollectorDeploymentName, "trace-collector-deployment-name", "telemetry-trace-collector", "Deployment name for tracing OpenTelemetry Collector")
+	flag.StringVar(&traceCollectorBaseName, "trace-collector-base-name", "telemetry-trace-collector", "Default name for tracing OpenTelemetry Collector Kubernetes resources")
+	flag.StringVar(&traceCollectorOTLPServiceName, "trace-collector-otlp-service-name", "telemetry-otlp-traces", "Default name for tracing OpenTelemetry Collector Kubernetes resources")
 	flag.StringVar(&traceCollectorImage, "trace-collector-image", otelImage, "Image for tracing OpenTelemetry Collector")
 	flag.StringVar(&traceCollectorPriorityClass, "trace-collector-priority-class", "", "Priority class name for tracing OpenTelemetry Collector")
 	flag.StringVar(&traceCollectorCPULimit, "trace-collector-cpu-limit", "1", "CPU limit for tracing OpenTelemetry Collector")
@@ -329,7 +331,7 @@ func createTracePipelineReconciler(client client.Client) *tracepipelinereconcile
 	config := tracepipelinereconciler.Config{
 		CreateServiceMonitor: createServiceMonitor,
 		Namespace:            telemetryNamespace,
-		BaseName:             traceCollectorDeploymentName,
+		BaseName:             traceCollectorBaseName,
 		Deployment: tracepipelinereconciler.DeploymentConfig{
 			Image:             traceCollectorImage,
 			PriorityClassName: traceCollectorPriorityClass,
@@ -337,7 +339,7 @@ func createTracePipelineReconciler(client client.Client) *tracepipelinereconcile
 			MemoryLimit:       resource.MustParse(traceCollectorMemoryLimit),
 		},
 		Service: tracepipelinereconciler.ServiceConfig{
-			OTLPServiceName: "telemetry-otlp-traces",
+			OTLPServiceName: traceCollectorOTLPServiceName,
 		},
 	}
 	return tracepipelinereconciler.NewReconciler(client, config, scheme)

--- a/components/telemetry-operator/main.go
+++ b/components/telemetry-operator/main.go
@@ -73,13 +73,13 @@ var (
 	syncPeriod           time.Duration
 	telemetryNamespace   string
 
-	createServiceMonitor          bool
-	traceCollectorBaseName        string
-	traceCollectorOTLPServiceName string
-	traceCollectorImage           string
-	traceCollectorPriorityClass   string
-	traceCollectorCPULimit        string
-	traceCollectorMemoryLimit     string
+	traceCollectorCreateServiceMonitor bool
+	traceCollectorBaseName             string
+	traceCollectorOTLPServiceName      string
+	traceCollectorImage                string
+	traceCollectorPriorityClass        string
+	traceCollectorCPULimit             string
+	traceCollectorMemoryLimit          string
 
 	fluentBitEnvSecret         string
 	fluentBitFilesConfigMap    string
@@ -146,7 +146,7 @@ func main() {
 	flag.StringVar(&certDir, "cert-dir", ".", "Webhook TLS certificate directory")
 	flag.StringVar(&telemetryNamespace, "telemetry-namespace", "kyma-system", "Telemetry namespace")
 
-	flag.BoolVar(&createServiceMonitor, "create-service-monitor", true, "Create Prometheus ServiceMonitor for opentelemetry-collector")
+	flag.BoolVar(&traceCollectorCreateServiceMonitor, "trace-collector-create-service-monitor", true, "Create Prometheus ServiceMonitor for opentelemetry-collector")
 	flag.StringVar(&traceCollectorBaseName, "trace-collector-base-name", "telemetry-trace-collector", "Default name for tracing OpenTelemetry Collector Kubernetes resources")
 	flag.StringVar(&traceCollectorOTLPServiceName, "trace-collector-otlp-service-name", "telemetry-otlp-traces", "Default name for tracing OpenTelemetry Collector Kubernetes resources")
 	flag.StringVar(&traceCollectorImage, "trace-collector-image", otelImage, "Image for tracing OpenTelemetry Collector")
@@ -329,7 +329,7 @@ func createLogParserValidator(client client.Client) *logparserwebhook.Validating
 
 func createTracePipelineReconciler(client client.Client) *tracepipelinereconciler.Reconciler {
 	config := tracepipelinereconciler.Config{
-		CreateServiceMonitor: createServiceMonitor,
+		CreateServiceMonitor: traceCollectorCreateServiceMonitor,
 		Namespace:            telemetryNamespace,
 		BaseName:             traceCollectorBaseName,
 		Deployment: tracepipelinereconciler.DeploymentConfig{

--- a/components/telemetry-operator/main.go
+++ b/components/telemetry-operator/main.go
@@ -74,6 +74,7 @@ var (
 	createServiceMonitor         bool
 	traceCollectorDeploymentName string
 	traceCollectorImage          string
+	traceCollectorPriorityClass  string
 
 	fluentBitEnvSecret         string
 	fluentBitFilesConfigMap    string
@@ -143,6 +144,7 @@ func main() {
 	flag.BoolVar(&createServiceMonitor, "create-service-monitor", true, "Create Prometheus ServiceMonitor for opentelemetry-collector")
 	flag.StringVar(&traceCollectorDeploymentName, "trace-collector-deployment-name", "telemetry-trace-collector", "Deployment name for tracing OpenTelemetry Collector")
 	flag.StringVar(&traceCollectorImage, "trace-collector-image", otelImage, "Image for tracing OpenTelemetry Collector")
+	flag.StringVar(&traceCollectorPriorityClass, "trace-collector-priority-class", otelImage, "Priority class name for tracing OpenTelemetry Collector")
 
 	flag.StringVar(&fluentBitConfigMap, "fluent-bit-cm-name", "telemetry-fluent-bit", "ConfigMap name of Fluent Bit")
 	flag.StringVar(&fluentBitSectionsConfigMap, "fluent-bit-sections-cm-name", "telemetry-fluent-bit-sections", "ConfigMap name of Fluent Bit Sections to be written by Fluent Bit controller")
@@ -313,9 +315,12 @@ func createLogParserValidator(client client.Client) *logparserwebhook.Validating
 func createTracePipelineReconciler(client client.Client) *tracepipelinereconciler.Reconciler {
 	config := tracepipelinereconciler.Config{
 		CreateServiceMonitor: createServiceMonitor,
-		CollectorNamespace:   telemetryNamespace,
-		ResourceName:         traceCollectorDeploymentName,
-		CollectorImage:       traceCollectorImage,
+		Namespace:            telemetryNamespace,
+		Deployment: tracepipelinereconciler.DeploymentConfig{
+			Name:              traceCollectorDeploymentName,
+			Image:             traceCollectorImage,
+			PriorityClassName: traceCollectorPriorityClass,
+		},
 	}
 	return tracepipelinereconciler.NewReconciler(client, config, scheme)
 }

--- a/components/telemetry-operator/main.go
+++ b/components/telemetry-operator/main.go
@@ -329,12 +329,15 @@ func createTracePipelineReconciler(client client.Client) *tracepipelinereconcile
 	config := tracepipelinereconciler.Config{
 		CreateServiceMonitor: createServiceMonitor,
 		Namespace:            telemetryNamespace,
+		BaseName:             traceCollectorDeploymentName,
 		Deployment: tracepipelinereconciler.DeploymentConfig{
-			Name:              traceCollectorDeploymentName,
 			Image:             traceCollectorImage,
 			PriorityClassName: traceCollectorPriorityClass,
 			CPULimit:          resource.MustParse(traceCollectorCPULimit),
 			MemoryLimit:       resource.MustParse(traceCollectorMemoryLimit),
+		},
+		Service: tracepipelinereconciler.ServiceConfig{
+			OTLPServiceName: "telemetry-otlp-traces",
 		},
 	}
 	return tracepipelinereconciler.NewReconciler(client, config, scheme)

--- a/resources/telemetry/charts/operator/templates/deployment.yaml
+++ b/resources/telemetry/charts/operator/templates/deployment.yaml
@@ -74,6 +74,10 @@ spec:
 {{- if or .Values.priorityClassName .Values.global.priorityClassName }}
             - --trace-collector-priority-class={{ coalesce .Values.priorityClassName .Values.global.priorityClassName }}
 {{- end }}
+            - --traceCollectorCPULimit={{ .Values.traceCollector.resources.limits.cpu }}
+            - --traceCollectorMemoryLimit={{ .Values.traceCollector.resources.limits.memory }}
+            - --traceCollectorCPURequest={{ .Values.traceCollector.resources.requests.cpu }}
+            - --traceCollectorMemoryRequest={{ .Values.traceCollector.resources.requests.memory }}
 {{- end }}
           name: manager
           ports:

--- a/resources/telemetry/charts/operator/templates/deployment.yaml
+++ b/resources/telemetry/charts/operator/templates/deployment.yaml
@@ -74,10 +74,10 @@ spec:
 {{- if or .Values.priorityClassName .Values.global.priorityClassName }}
             - --trace-collector-priority-class={{ coalesce .Values.priorityClassName .Values.global.priorityClassName }}
 {{- end }}
-            - --traceCollectorCPULimit={{ .Values.traceCollector.resources.limits.cpu }}
-            - --traceCollectorMemoryLimit={{ .Values.traceCollector.resources.limits.memory }}
-            - --traceCollectorCPURequest={{ .Values.traceCollector.resources.requests.cpu }}
-            - --traceCollectorMemoryRequest={{ .Values.traceCollector.resources.requests.memory }}
+            - --trace-collector-cpu-limit={{ .Values.traceCollector.resources.limits.cpu }}
+            - --trace-collector-memory-limit={{ .Values.traceCollector.resources.limits.memory }}
+            - --trace-collector-cpu-request={{ .Values.traceCollector.resources.requests.cpu }}
+            - --trace-collector-memory-request={{ .Values.traceCollector.resources.requests.memory }}
 {{- end }}
           name: manager
           ports:

--- a/resources/telemetry/charts/operator/templates/deployment.yaml
+++ b/resources/telemetry/charts/operator/templates/deployment.yaml
@@ -71,6 +71,9 @@ spec:
 {{- else }}
             - --enable-tracing=true
             - --trace-collector-image={{ include "imageurl" (dict "reg" .Values.global.containerRegistry "img" .Values.global.images.telemetry_otel_collector) }}
+{{- if or .Values.priorityClassName .Values.global.priorityClassName }}
+            - --trace-collector-priority-class={{ coalesce .Values.priorityClassName .Values.global.priorityClassName }}
+{{- end }}
 {{- end }}
           name: manager
           ports:

--- a/resources/telemetry/charts/operator/values.yaml
+++ b/resources/telemetry/charts/operator/values.yaml
@@ -129,3 +129,12 @@ nodeSelector: {}
 tolerations: []
 
 affinity: {}
+
+traceCollector:
+  resources:
+    limits:
+      cpu: 1
+      memory: 1Gi
+    requests:
+      cpu: 150m
+      memory: 256Mi

--- a/resources/telemetry/values.yaml
+++ b/resources/telemetry/values.yaml
@@ -7,7 +7,7 @@ global:
       version: "v20221020-e314a071"
     telemetry_operator:
       name: "telemetry-operator"
-      version: "PR-16211"
+      version: "PR-16226"
     telemetry_webhook_cert_init:
       name: "webhook-cert-init"
       version: "v20221122-200937b4"

--- a/resources/telemetry/values.yaml
+++ b/resources/telemetry/values.yaml
@@ -13,7 +13,7 @@ global:
       version: "v20221122-200937b4"
     telemetry_otel_collector:
       name: "otel-collector"
-      version: "0.66.0-9bbc6dff"
+      version: "0.66.0-61707459"
       directory: "tpi"
     fluent_bit:
       name: "fluent-bit"


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- Add collector liveness/readiness probes
- Set collector liveness/readiness probes according to https://github.com/open-telemetry/opentelemetry-operator/issues/1264
- Split collector service into an OTLP and an OpenCensus service
- Make CPU/memory limits configurable

**Related issue(s)**
https://github.com/kyma-project/kyma/issues/16198
