### PR TITLE
Fix request body parsers in nodejs runtimes

### DIFF
--- a/components/function-runtimes/nodejs14/kubeless/kubeless_rt/kubeless.js
+++ b/components/function-runtimes/nodejs14/kubeless/kubeless_rt/kubeless.js
@@ -33,13 +33,11 @@ if (process.env["KYMA_INTERNAL_LOGGER_ENABLED"]) {
     app.use(morgan("combined"));
 }
 
-const bodParserOptions = {
-    type: req => !req.is('multipart/*'),
-    limit: `${bodySizeLimit}mb`,
-};
-app.use(bodyParser.raw(bodParserOptions));
-app.use(bodyParser.json({limit: `${bodySizeLimit}mb`}));
-app.use(bodyParser.urlencoded({limit: `${bodySizeLimit}mb`, extended: true}));
+app.use(bodyParser.json({ type: ['application/json', 'application/cloudevents+json'], limit: `${bodySizeLimit}mb`, strict: false  }))
+app.use(bodyParser.text({ type: ['text/*'], limit: `${bodySizeLimit}mb`  }))
+app.use(bodyParser.urlencoded({ limit: `${bodySizeLimit}mb`, extended: true }));
+app.use(bodyParser.raw({limit: `${bodySizeLimit}mb`}))
+
 
 const modName = process.env.MOD_NAME;
 const funcHandler = process.env.FUNC_HANDLER;

--- a/components/function-runtimes/nodejs14/kubeless/kubeless_rt/kubeless.js
+++ b/components/function-runtimes/nodejs14/kubeless/kubeless_rt/kubeless.js
@@ -36,7 +36,7 @@ if (process.env["KYMA_INTERNAL_LOGGER_ENABLED"]) {
 app.use(bodyParser.json({ type: ['application/json', 'application/cloudevents+json'], limit: `${bodySizeLimit}mb`, strict: false  }))
 app.use(bodyParser.text({ type: ['text/*'], limit: `${bodySizeLimit}mb`  }))
 app.use(bodyParser.urlencoded({ limit: `${bodySizeLimit}mb`, extended: true }));
-app.use(bodyParser.raw({limit: `${bodySizeLimit}mb`}))
+app.use(bodyParser.raw({limit: `${bodySizeLimit}mb`, type: () => true}))
 
 
 const modName = process.env.MOD_NAME;

--- a/components/function-runtimes/nodejs14/kubeless/kubeless_rt/lib/ce.js
+++ b/components/function-runtimes/nodejs14/kubeless/kubeless_rt/lib/ce.js
@@ -24,15 +24,12 @@ function buildEvent(req, res, tracer) {
         emitCloudEvent: (type, source, data, optionalCloudEventAttributes) => emitCloudEvent(type, source, data, optionalCloudEventAttributes),
     };
 
-    if (req.body){
-        let stringifiedReqestBody = req.body.toString(charset);
-        if (!req.is('multipart/*') && req.body.length > 0) {
+    if(req.body){
+        if (!req.is('multipart/*')) {
             if(isCloudEvent(req)) {
-                event = Object.assign(event,buildCloudEventAttributes(req, JSON.parse(stringifiedReqestBody)));    
-            } else if (isOfJsonContentType(req)) {
-                event = Object.assign(event,{'data':JSON.parse(stringifiedReqestBody)});
+                event = Object.assign(event,buildCloudEventAttributes(req));    
             } else {
-                event = Object.assign(event,{'data':stringifiedReqestBody});
+                event = Object.assign(event,{'data':req.body});
             }
         }
     }
@@ -89,16 +86,13 @@ function isCloudEvent(req) {
     return req.is('application/cloudevents+json') || hasCeHeaders(req);
 }
 
-function isOfJsonContentType(req) {
-    return req.is('application/json');
-}
 
 function hasCeHeaders(req) {
     return req.get('ce-type') && req.get('ce-source');
 }
 
-function buildCloudEventAttributes(req, data) {
-    const receivedEvent = HTTP.toEvent({ headers: req.headers, body: data });  
+function buildCloudEventAttributes(req) {
+    const receivedEvent = HTTP.toEvent({ headers: req.headers, body: req.body });  
     return {
         'ce-type': receivedEvent.type,
         'ce-source': receivedEvent.source,

--- a/components/function-runtimes/nodejs16/lib/ce.js
+++ b/components/function-runtimes/nodejs16/lib/ce.js
@@ -25,14 +25,13 @@ function buildEvent(req, res, tracer) {
         emitCloudEvent: (type, source, data, optionalCloudEventAttributes) => emitCloudEvent(type, source, data, optionalCloudEventAttributes),
     };
 
-    let stringifiedReqestBody = req.body.toString(charset);
-    if (!req.is('multipart/*') && req.body.length > 0) {
-        if(isCloudEvent(req)) {
-            event = Object.assign(event,buildCloudEventAttributes(req, JSON.parse(stringifiedReqestBody)));    
-        } else if (isOfJsonContentType(req)) {
-            event = Object.assign(event,{'data':JSON.parse(stringifiedReqestBody)});
-        } else {
-            event = Object.assign(event,{'data':stringifiedReqestBody});
+    if(req.body){
+        if (!req.is('multipart/*')) {
+            if(isCloudEvent(req)) {
+                event = Object.assign(event,buildCloudEventAttributes(req));    
+            } else {
+                event = Object.assign(event,{'data':req.body});
+            }
         }
     }
     return event;
@@ -88,16 +87,13 @@ function isCloudEvent(req) {
     return req.is('application/cloudevents+json') || hasCeHeaders(req);
 }
 
-function isOfJsonContentType(req) {
-    return req.is('application/json');
-}
 
 function hasCeHeaders(req) {
     return req.get('ce-type') && req.get('ce-source');
 }
 
-function buildCloudEventAttributes(req, data) {
-    const receivedEvent = HTTP.toEvent({ headers: req.headers, body: data });  
+function buildCloudEventAttributes(req) {
+    const receivedEvent = HTTP.toEvent({ headers: req.headers, body: req.body });  
     return {
         'ce-type': receivedEvent.type,
         'ce-source': receivedEvent.source,

--- a/components/function-runtimes/nodejs16/server.js
+++ b/components/function-runtimes/nodejs16/server.js
@@ -26,6 +26,7 @@ const tracer = setupTracer([serviceName, serviceNamespace].join('.'));
 
 //require express must be called AFTER tracer was setup!!!!!!
 const express = require("express");
+const { type } = require('os');
 const app = express();
 
 
@@ -60,7 +61,7 @@ if (process.env["KYMA_INTERNAL_LOGGER_ENABLED"]) {
 app.use(bodyParser.json({ type: ['application/json', 'application/cloudevents+json'], limit: `${bodySizeLimit}mb`, strict: false  }))
 app.use(bodyParser.text({ type: ['text/*'], limit: `${bodySizeLimit}mb`  }))
 app.use(bodyParser.urlencoded({ limit: `${bodySizeLimit}mb`, extended: true }));
-app.use(bodyParser.raw({limit: `${bodySizeLimit}mb`}))
+app.use(bodyParser.raw({limit: `${bodySizeLimit}mb`, type: () => true}))
 
 app.use(helper.handleTimeOut);
 

--- a/components/function-runtimes/nodejs16/server.js
+++ b/components/function-runtimes/nodejs16/server.js
@@ -57,14 +57,10 @@ if (process.env["KYMA_INTERNAL_LOGGER_ENABLED"]) {
 }
 
 
-const bodParserOptions = {
-    type: req => !req.is('multipart/*'),
-    limit: `${bodySizeLimit}mb`,
-};
-app.use(bodyParser.raw(bodParserOptions));
-app.use(bodyParser.json({ limit: `${bodySizeLimit}mb` }));
+app.use(bodyParser.json({ type: ['application/json', 'application/cloudevents+json'], limit: `${bodySizeLimit}mb`, strict: false  }))
+app.use(bodyParser.text({ type: ['text/*'], limit: `${bodySizeLimit}mb`  }))
 app.use(bodyParser.urlencoded({ limit: `${bodySizeLimit}mb`, extended: true }));
-
+app.use(bodyParser.raw({limit: `${bodySizeLimit}mb`}))
 
 app.use(helper.handleTimeOut);
 

--- a/resources/serverless/values.yaml
+++ b/resources/serverless/values.yaml
@@ -89,10 +89,10 @@ global:
       version: "PR-16183"
     function_runtime_nodejs14:
       name: "function-runtime-nodejs14"
-      version: "PR-16116"
+      version: "PR-16259"
     function_runtime_nodejs16:
       name: "function-runtime-nodejs16"
-      version: "PR-16116"
+      version: "PR-16259"
     function_runtime_python39:
       name: "function-runtime-python39"
       version: "PR-16240"


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- configure `type` option for body parsers so that a proper one is used based on content-type header
- do not artificially stringify/parse request body while building payload for function handler - let body parsers do it

**Related issue(s)**
https://github.com/kyma-project/kyma/issues/15768