### PR TITLE
Rename Serverless internal registry initContainer

### DIFF
--- a/resources/serverless/charts/docker-registry/templates/deployment.yaml
+++ b/resources/serverless/charts/docker-registry/templates/deployment.yaml
@@ -48,7 +48,7 @@ spec:
       hostPID: false # Optional. The default is false if the entry is not there.
       hostIPC: false # Optional. The default is false if the entry is not there.
       initContainers:
-        - name: init-registry-config
+        - name: generate-htpasswd
           image: "{{ include "imageurl" (dict "reg" .Values.global.containerRegistry "img" .Values.global.images.registry) }}"
 {{- if .Values.initContainers.securityContext }}
           securityContext:


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**
During the security-related changes  made to the Serverless chart,  extra functionality were added to the registry initContianer. So, it was renamed it to better reflect it's current function. 

Normally this should be fine. However, since the Reconciler uses PATCH() by default to update resources, in this case, it will add a new initContainer to the deployment, not replace it. The end result is a deployment with 2 initContainers, one of them has old permission configuration which causes it to break. 


To test this:
- Create a 2.9.1 kyma cluster on Gardener. K3d uses it's own local registry so this won't work
- Upgrade to current main
- describe the failing `serverless-docker-registry`  pod in `kyma-system` namespace.

Changes proposed in this pull request:

- Rename Serverless internal registry initContainer
- ...
- ...

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
https://github.com/kyma-project/kyma/issues/15245
https://github.com/kyma-project/kyma/issues/16195
https://github.com/kyma-project/kyma/issues/16205