### PR TITLE
Improve telemetry-operator health checks

### DIFF
--- a/components/telemetry-operator/main.go
+++ b/components/telemetry-operator/main.go
@@ -19,11 +19,12 @@ package main
 import (
 	"errors"
 	"flag"
-	"github.com/kyma-project/kyma/components/telemetry-operator/internal/kubernetes"
-	"k8s.io/apimachinery/pkg/api/resource"
 	"os"
 	"strings"
 	"time"
+
+	"github.com/kyma-project/kyma/components/telemetry-operator/internal/kubernetes"
+	"k8s.io/apimachinery/pkg/api/resource"
 
 	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -51,7 +52,6 @@ import (
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	ctrl "sigs.k8s.io/controller-runtime"
-	"sigs.k8s.io/controller-runtime/pkg/healthz"
 	k8sWebhook "sigs.k8s.io/controller-runtime/pkg/webhook"
 	//+kubebuilder:scaffold:imports
 )
@@ -236,11 +236,11 @@ func main() {
 
 	//+kubebuilder:scaffold:builder
 
-	if err := mgr.AddHealthzCheck("healthz", healthz.Ping); err != nil {
+	if err := mgr.AddHealthzCheck("healthz", mgr.GetWebhookServer().StartedChecker()); err != nil {
 		setupLog.Error(err, "Failed to set up health check")
 		os.Exit(1)
 	}
-	if err := mgr.AddReadyzCheck("readyz", healthz.Ping); err != nil {
+	if err := mgr.AddReadyzCheck("readyz", mgr.GetWebhookServer().StartedChecker()); err != nil {
 		setupLog.Error(err, "Failed to set up ready check")
 		os.Exit(1)
 	}

--- a/resources/telemetry/charts/operator/templates/deployment.yaml
+++ b/resources/telemetry/charts/operator/templates/deployment.yaml
@@ -83,6 +83,13 @@ spec:
           ports:
           - containerPort: 9443
             protocol: TCP
+            name: webook
+          - containerPort: 8081
+            protocol: TCP
+            name: health
+          - containerPort: 8080
+            protocol: TCP
+            name: metrics
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
           image: "{{ include "imageurl" (dict "reg" .Values.global.containerRegistry "img" .Values.global.images.telemetry_operator) }}"

--- a/resources/telemetry/values.yaml
+++ b/resources/telemetry/values.yaml
@@ -7,7 +7,7 @@ global:
       version: "v20221020-e314a071"
     telemetry_operator:
       name: "telemetry-operator"
-      version: "PR-16283"
+      version: "PR-16297"
     telemetry_webhook_cert_init:
       name: "webhook-cert-init"
       version: "v20221122-200937b4"

--- a/tests/fast-integration/telemetry-test/suite.js
+++ b/tests/fast-integration/telemetry-test/suite.js
@@ -68,7 +68,7 @@ describe('Telemetry Operator', function() {
   });
 
   it('Should be ready', async function() {
-    const res = await k8sCoreV1Api.listNamespacedPod(
+    const podRes = await k8sCoreV1Api.listNamespacedPod(
         'kyma-system',
         'true',
         undefined,
@@ -76,8 +76,21 @@ describe('Telemetry Operator', function() {
         undefined,
         'control-plane=telemetry-operator',
     );
-    const podList = res.body.items;
+    const podList = podRes.body.items;
     assert.equal(podList.length, 1);
+
+    const epRes = await k8sCoreV1Api.listNamespacedEndpoints(
+        'kyma-system',
+        'true',
+        undefined,
+        undefined,
+        undefined,
+        'control-plane=telemetry-operator',
+    );
+    const epList = epRes.body.items;
+    assert.equal(epList.length, 2);
+    assert.isNotEmpty(epList[0].subsets);
+    assert.isNotEmpty(epList[0].subsets[0].addresses);
   });
 
   context('Configurable Logging', function() {


### PR DESCRIPTION
This PR reflects the webhook server status on the telemetry-operator's health checks by using the webhook server's StartedChecker. The check is successful if the webhook server has been started and accepts incoming connections.

Furthermore, missing ports are added to the operator deployment.

<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- Use webhook server's StartedChecker for health probe
- Add missing ports to telemetry-operator deployment

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
#16244 