### PR TITLE
Distribute NATS Pods on Multiple Zones

### DIFF
--- a/resources/eventing/charts/nats/values.yaml
+++ b/resources/eventing/charts/nats/values.yaml
@@ -223,9 +223,14 @@ affinity:
           labelSelector:
             matchLabels:
               nats_cluster: eventing-nats
+          topologyKey: topology.kubernetes.io/zone
+        weight: 70
+      - podAffinityTerm:
+          labelSelector:
+            matchLabels:
+              nats_cluster: eventing-nats
           topologyKey: kubernetes.io/hostname
-        weight: 100
-
+        weight: 35
 # Annotations to add to the NATS pods
 # ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/
 podAnnotations: {


### PR DESCRIPTION


**Description**
Distribute NATS Pods on multiple zones with anti-affinity. With this HA of NATS JetStream is enabled.

**Related issue(s)**
#15085 
