### PR TITLE
Disable TLS when non https endpoint used

### DIFF
--- a/components/telemetry-operator/controller/tracepipeline/resources.go
+++ b/components/telemetry-operator/controller/tracepipeline/resources.go
@@ -109,7 +109,7 @@ func getOutputType(output v1alpha1.TracePipelineOutput) string {
 
 func makeExporterConfig(output v1alpha1.TracePipelineOutput) map[string]any {
 	outputType := getOutputType(output)
-	isInsecure := len(strings.TrimSpace(output.Otlp.Endpoint.Value)) > 0 && !strings.HasPrefix(output.Otlp.Endpoint.Value, "https://")
+	isInsecure := len(strings.TrimSpace(output.Otlp.Endpoint.Value)) > 0 && strings.HasPrefix(output.Otlp.Endpoint.Value, "http://")
 	var headers map[string]any
 	if output.Otlp.Authentication != nil && output.Otlp.Authentication.Basic.IsDefined() {
 		headers = map[string]any{

--- a/components/telemetry-operator/controller/tracepipeline/resources.go
+++ b/components/telemetry-operator/controller/tracepipeline/resources.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/utils/pointer"
+	"strings"
 
 	"github.com/kyma-project/kyma/components/telemetry-operator/apis/telemetry/v1alpha1"
 	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
@@ -108,6 +109,7 @@ func getOutputType(output v1alpha1.TracePipelineOutput) string {
 
 func makeExporterConfig(output v1alpha1.TracePipelineOutput) map[string]any {
 	outputType := getOutputType(output)
+	isInsecure := len(strings.TrimSpace(output.Otlp.Endpoint.Value)) > 0 && !strings.HasPrefix(output.Otlp.Endpoint.Value, "https://")
 	var headers map[string]any
 	if output.Otlp.Authentication != nil && output.Otlp.Authentication.Basic.IsDefined() {
 		headers = map[string]any{
@@ -118,6 +120,9 @@ func makeExporterConfig(output v1alpha1.TracePipelineOutput) map[string]any {
 		outputType: map[string]any{
 			"endpoint": fmt.Sprintf("${%s}", otlpEndpointVariable),
 			"headers":  headers,
+			"tls": map[string]any{
+				"insecure": isInsecure,
+			},
 			"sending_queue": map[string]any{
 				"enabled":    true,
 				"queue_size": 512,

--- a/components/telemetry-operator/controller/tracepipeline/resources_test.go
+++ b/components/telemetry-operator/controller/tracepipeline/resources_test.go
@@ -27,6 +27,22 @@ var (
 		},
 	}
 
+	tracePipelineHttp = v1alpha1.TracePipelineOutput{
+		Otlp: &v1alpha1.OtlpOutput{
+			Endpoint: v1alpha1.ValueType{
+				Value: "http://localhost",
+			},
+		},
+	}
+
+	tracePipelineHttps = v1alpha1.TracePipelineOutput{
+		Otlp: &v1alpha1.OtlpOutput{
+			Endpoint: v1alpha1.ValueType{
+				Value: "https://localhost",
+			},
+		},
+	}
+
 	tracePipelineWithBasicAuth = v1alpha1.TracePipelineOutput{
 		Otlp: &v1alpha1.OtlpOutput{
 			Endpoint: v1alpha1.ValueType{
@@ -58,6 +74,39 @@ func TestMakeConfigMap(t *testing.T) {
 	var collectorConfigYaml interface{}
 	require.NoError(t, yaml.Unmarshal([]byte(collectorConfig), &collectorConfigYaml), "Otel Collector config must be valid yaml")
 	require.True(t, strings.Contains(collectorConfig, expectedEndpoint), "Otel Collector config must contain OTLP endpoint")
+}
+
+func TestMakeConfigMapTLSInsecureNoScheme(t *testing.T) {
+	cm := makeConfigMap(config, tracePipeline)
+
+	require.NotNil(t, cm)
+	collectorConfig := cm.Data[configMapKey]
+	require.NotEmpty(t, collectorConfig)
+
+	expectedTLSConfig := "insecure: true"
+	require.True(t, strings.Contains(collectorConfig, expectedTLSConfig), "Otel Collector config must contain TLS insecure true")
+}
+
+func TestMakeConfigMapTLSInsecureHttp(t *testing.T) {
+	cm := makeConfigMap(config, tracePipelineHttp)
+
+	require.NotNil(t, cm)
+	collectorConfig := cm.Data[configMapKey]
+	require.NotEmpty(t, collectorConfig)
+
+	expectedTLSConfig := "insecure: true"
+	require.True(t, strings.Contains(collectorConfig, expectedTLSConfig), "Otel Collector config must contain TLS insecure true")
+}
+
+func TestMakeConfigMapTLSInsecureHttps(t *testing.T) {
+	cm := makeConfigMap(config, tracePipelineHttps)
+
+	require.NotNil(t, cm)
+	collectorConfig := cm.Data[configMapKey]
+	require.NotEmpty(t, collectorConfig)
+
+	expectedTLSConfig := "insecure: false"
+	require.True(t, strings.Contains(collectorConfig, expectedTLSConfig), "Otel Collector config must contain TLS insecure false")
 }
 
 func TestMakeConfigMapWithBasicAuth(t *testing.T) {

--- a/components/telemetry-operator/controller/tracepipeline/resources_test.go
+++ b/components/telemetry-operator/controller/tracepipeline/resources_test.go
@@ -83,7 +83,7 @@ func TestMakeConfigMapTLSInsecureNoScheme(t *testing.T) {
 	collectorConfig := cm.Data[configMapKey]
 	require.NotEmpty(t, collectorConfig)
 
-	expectedTLSConfig := "insecure: true"
+	expectedTLSConfig := "insecure: false"
 	require.True(t, strings.Contains(collectorConfig, expectedTLSConfig), "Otel Collector config must contain TLS insecure true")
 }
 

--- a/resources/telemetry/values.yaml
+++ b/resources/telemetry/values.yaml
@@ -7,7 +7,7 @@ global:
       version: "v20221020-e314a071"
     telemetry_operator:
       name: "telemetry-operator"
-      version: "PR-16304"
+      version: "PR-16357"
     telemetry_webhook_cert_init:
       name: "webhook-cert-init"
       version: "v20221122-200937b4"


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- OTLP gRPC exporter use by default TLS enabled and required cert file, this cause TLS hand shake error with Kyma Jaeger collector. TLS will be disabled when used endpoint is not a https endpoint

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
