### PR TITLE
Made JetStream tests use unique stream names

### DIFF
--- a/components/eventing-controller/controllers/subscription/jetstream/reconciler_internal_integration_test.go
+++ b/components/eventing-controller/controllers/subscription/jetstream/reconciler_internal_integration_test.go
@@ -11,7 +11,6 @@ import (
 	"github.com/kyma-project/kyma/components/eventing-controller/pkg/backend/jetstreamv2"
 
 	kymalogger "github.com/kyma-project/kyma/common/logging/logger"
-	natsserver "github.com/nats-io/nats-server/v2/server"
 	"github.com/onsi/gomega"
 	gomegatypes "github.com/onsi/gomega/types"
 	v1 "k8s.io/api/core/v1"
@@ -67,7 +66,7 @@ func TestUnavailableNATSServer(t *testing.T) {
 		reconcilertesting.HaveSubscriptionNotReady(),
 	)
 
-	ens.NatsServer = startJetStream(natsPort)
+	ens.NatsServer = reconcilertesting.StartDefaultJetStreamServer(natsPort)
 	utils.TestSubscriptionOnK8s(ens.TestEnsemble, sub, reconcilertesting.HaveSubscriptionReady())
 
 	t.Cleanup(ens.Cancel)
@@ -107,7 +106,8 @@ func TestCreateSubscription(t *testing.T) {
 					reconcilertesting.OrderCreatedEventType: {
 						natstesting.BeExistingSubscription(),
 						natstesting.BeValidSubscription(),
-						natstesting.BeJetStreamSubscriptionWithSubject(reconcilertesting.OrderCreatedEventType),
+						natstesting.BeJetStreamSubscriptionWithSubject(reconcilertesting.OrderCreatedEventType,
+							ens.JetStreamBackend.Config),
 					},
 				},
 			},
@@ -272,7 +272,8 @@ func TestCreateSubscription(t *testing.T) {
 					reconcilertesting.OrderCreatedEventType: {
 						natstesting.BeExistingSubscription(),
 						natstesting.BeValidSubscription(),
-						natstesting.BeJetStreamSubscriptionWithSubject(reconcilertesting.OrderCreatedEventType),
+						natstesting.BeJetStreamSubscriptionWithSubject(reconcilertesting.OrderCreatedEventType,
+							ens.JetStreamBackend.Config),
 					},
 				},
 			},
@@ -352,7 +353,8 @@ func TestChangeSubscription(t *testing.T) {
 					utils.NewCleanEventType("0"): {
 						natstesting.BeExistingSubscription(),
 						natstesting.BeValidSubscription(),
-						natstesting.BeJetStreamSubscriptionWithSubject(utils.NewCleanEventType("0")),
+						natstesting.BeJetStreamSubscriptionWithSubject(utils.NewCleanEventType("0"),
+							ens.JetStreamBackend.Config),
 					},
 				},
 			},
@@ -514,7 +516,8 @@ func TestChangeSubscription(t *testing.T) {
 					utils.NewCleanEventType(""): {
 						natstesting.BeExistingSubscription(),
 						natstesting.BeValidSubscription(),
-						natstesting.BeJetStreamSubscriptionWithSubject(utils.NewCleanEventType("")),
+						natstesting.BeJetStreamSubscriptionWithSubject(utils.NewCleanEventType(""),
+							ens.JetStreamBackend.Config),
 					},
 				},
 			},
@@ -663,7 +666,8 @@ func TestEmptyEventTypePrefix(t *testing.T) {
 	expectedNatsSubscription := []gomegatypes.GomegaMatcher{
 		natstesting.BeExistingSubscription(),
 		natstesting.BeValidSubscription(),
-		natstesting.BeJetStreamSubscriptionWithSubject(reconcilertesting.OrderCreatedEventTypePrefixEmpty),
+		natstesting.BeJetStreamSubscriptionWithSubject(reconcilertesting.OrderCreatedEventTypePrefixEmpty,
+			ens.JetStreamBackend.Config),
 	}
 
 	testSubscriptionOnNATS(ens, sub, reconcilertesting.OrderCreatedEventTypePrefixEmpty, expectedNatsSubscription...)
@@ -704,13 +708,16 @@ func ensureNATSSubscriptionIsDeleted(ens *utils.JetStreamTestEnsemble,
 func setupTestEnsemble(ctx context.Context, eventTypePrefix string,
 	g *gomega.GomegaWithT, natsPort int) *utils.JetStreamTestEnsemble {
 	useExistingCluster := useExistingCluster
+	natsServer := reconcilertesting.StartDefaultJetStreamServer(natsPort)
+	log.Printf("NATS server with JetStream started %v", natsServer.ClientURL())
+
 	ens := &utils.TestEnsemble{
 		Ctx: ctx,
 		G:   g,
 		DefaultSubscriptionConfig: env.DefaultSubscriptionConfig{
 			MaxInFlightMessages: 1,
 		},
-		NatsServer: startJetStream(natsPort),
+		NatsServer: natsServer,
 		TestEnv: &envtest.Environment{
 			CRDDirectoryPaths: []string{
 				filepath.Join("../../../", "config", "crd", "bases"),
@@ -723,6 +730,7 @@ func setupTestEnsemble(ctx context.Context, eventTypePrefix string,
 
 	jsTestEnsemble := &utils.JetStreamTestEnsemble{
 		TestEnsemble: ens,
+		JSStreamName: fmt.Sprintf("%s%d", reconcilertesting.JSStreamName, natsPort),
 	}
 
 	utils.StartTestEnv(ens)
@@ -730,15 +738,6 @@ func setupTestEnsemble(ctx context.Context, eventTypePrefix string,
 	utils.StartSubscriberSvc(ens)
 
 	return jsTestEnsemble
-}
-
-func startJetStream(port int) *natsserver.Server {
-	natsServer := reconcilertesting.RunNatsServerOnPort(
-		reconcilertesting.WithPort(port),
-		reconcilertesting.WithJetStreamEnabled(),
-	)
-	log.Printf("NATS server with JetStream started %v", natsServer.ClientURL())
-	return natsServer
 }
 
 func startReconciler(eventTypePrefix string, ens *utils.JetStreamTestEnsemble) *utils.JetStreamTestEnsemble {
@@ -767,7 +766,8 @@ func startReconciler(eventTypePrefix string, ens *utils.JetStreamTestEnsemble) *
 		MaxReconnects:           10,
 		ReconnectWait:           time.Second,
 		EventTypePrefix:         eventTypePrefix,
-		JSStreamName:            reconcilertesting.JSStreamName,
+		JSStreamName:            ens.JSStreamName,
+		JSSubjectPrefix:         ens.JSStreamName,
 		JSStreamStorageType:     jetstreamv2.StorageTypeMemory,
 		JSStreamMaxBytes:        "-1",
 		JSStreamMaxMessages:     -1,

--- a/components/eventing-controller/controllers/subscription/testing/test_utils.go
+++ b/components/eventing-controller/controllers/subscription/testing/test_utils.go
@@ -9,7 +9,6 @@ import (
 
 	subscriptionjetstream "github.com/kyma-project/kyma/components/eventing-controller/controllers/subscription/jetstream"
 	backendjetstream "github.com/kyma-project/kyma/components/eventing-controller/pkg/backend/nats/jetstream"
-	v2 "github.com/kyma-project/kyma/components/eventing-controller/testing/v2"
 	"github.com/stretchr/testify/require"
 
 	"github.com/avast/retry-go/v3"
@@ -40,6 +39,7 @@ const (
 type JetStreamTestEnsemble struct {
 	Reconciler       *subscriptionjetstream.Reconciler
 	JetStreamBackend *backendjetstream.JetStream
+	JSStreamName     string
 	*TestEnsemble
 }
 
@@ -203,7 +203,9 @@ func CleanupResources(t *testing.T, ens *JetStreamTestEnsemble) {
 	StopTestEnv(ens.TestEnsemble)
 
 	jsCtx := ens.Reconciler.Backend.GetJetStreamContext()
-	require.NoError(t, jsCtx.DeleteStream(v2.JSStreamName))
+	require.NoError(t, jsCtx.DeleteStream(ens.JSStreamName))
+
+	reconcilertesting.ShutDownNATSServer(ens.NatsServer)
 }
 
 func StartSubscriberSvc(ens *TestEnsemble) {

--- a/components/eventing-controller/controllers/subscriptionv2/jetstream/reconciler_integration_test.go
+++ b/components/eventing-controller/controllers/subscriptionv2/jetstream/reconciler_integration_test.go
@@ -367,7 +367,8 @@ func TestChangeSubscription(t *testing.T) {
 						reconcilertestingv2.BeExistingSubscription(),
 						reconcilertestingv2.BeValidSubscription(),
 						reconcilertestingv2.BeJetStreamSubscriptionWithSubject(
-							testingv2.EventTypePrefix, reconcilertestingv2.NewCleanEventType("0"), eventingv1alpha2.TypeMatchingExact, ens.jetStreamBackend.Config,
+							testingv2.EventTypePrefix, reconcilertestingv2.NewCleanEventType("0"),
+							eventingv1alpha2.TypeMatchingExact, ens.jetStreamBackend.Config,
 						),
 					},
 				},

--- a/components/eventing-controller/controllers/subscriptionv2/jetstream/reconciler_integration_test.go
+++ b/components/eventing-controller/controllers/subscriptionv2/jetstream/reconciler_integration_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	reconcilertestingv2 "github.com/kyma-project/kyma/components/eventing-controller/controllers/subscriptionv2/reconcilertesting"
+	testingv1 "github.com/kyma-project/kyma/components/eventing-controller/testing"
 	testingv2 "github.com/kyma-project/kyma/components/eventing-controller/testing/v2"
 	"github.com/onsi/gomega"
 	gomegatypes "github.com/onsi/gomega/types"
@@ -128,7 +129,7 @@ func TestUnavailableNATSServer(t *testing.T) {
 	)
 
 	// should trigger the subscription become ready again
-	ens.NatsServer = startJetStream(ens.NatsPort)
+	ens.NatsServer = testingv1.StartDefaultJetStreamServer(ens.NatsPort)
 	reconcilertestingv2.TestSubscriptionOnK8s(ens.TestEnsemble, sub, testingv2.HaveSubscriptionReady())
 
 	t.Cleanup(ens.Cancel)
@@ -167,7 +168,7 @@ func TestIdempotency(t *testing.T) {
 			reconcilertestingv2.BeValidSubscription(),
 			reconcilertestingv2.BeNatsSubWithMaxPending(ens.DefaultSubscriptionConfig.MaxInFlightMessages),
 			reconcilertestingv2.BeJetStreamSubscriptionWithSubject(testingv2.EventSource,
-				testingv2.OrderCreatedEventType, eventingv1alpha2.TypeMatchingExact),
+				testingv2.OrderCreatedEventType, eventingv1alpha2.TypeMatchingExact, ens.jetStreamBackend.Config),
 		)
 	}
 	testNatsSub()
@@ -223,7 +224,8 @@ func TestCreateSubscription(t *testing.T) {
 						reconcilertestingv2.BeExistingSubscription(),
 						reconcilertestingv2.BeValidSubscription(),
 						reconcilertestingv2.BeJetStreamSubscriptionWithSubject(testingv2.EventSource,
-							testingv2.OrderCreatedEventType, eventingv1alpha2.TypeMatchingExact),
+							testingv2.OrderCreatedEventType, eventingv1alpha2.TypeMatchingExact,
+							ens.jetStreamBackend.Config),
 					},
 				},
 			},
@@ -283,6 +285,7 @@ func TestCreateSubscription(t *testing.T) {
 							testingv2.EventTypePrefixEmpty,
 							testingv2.OrderCreatedEventType,
 							eventingv1alpha2.TypeMatchingExact,
+							ens.jetStreamBackend.Config,
 						),
 					},
 				},
@@ -364,7 +367,7 @@ func TestChangeSubscription(t *testing.T) {
 						reconcilertestingv2.BeExistingSubscription(),
 						reconcilertestingv2.BeValidSubscription(),
 						reconcilertestingv2.BeJetStreamSubscriptionWithSubject(
-							testingv2.EventTypePrefix, reconcilertestingv2.NewCleanEventType("0"), eventingv1alpha2.TypeMatchingExact,
+							testingv2.EventTypePrefix, reconcilertestingv2.NewCleanEventType("0"), eventingv1alpha2.TypeMatchingExact, ens.jetStreamBackend.Config,
 						),
 					},
 				},
@@ -499,6 +502,7 @@ func TestChangeSubscription(t *testing.T) {
 						reconcilertestingv2.BeValidSubscription(),
 						reconcilertestingv2.BeJetStreamSubscriptionWithSubject(
 							testingv2.EventTypePrefix, testingv2.OrderCreatedEventType, eventingv1alpha2.TypeMatchingExact,
+							ens.jetStreamBackend.Config,
 						),
 						reconcilertestingv2.BeNatsSubWithMaxPending(101),
 					},
@@ -584,7 +588,7 @@ func TestEmptyEventTypePrefix(t *testing.T) {
 		reconcilertestingv2.BeExistingSubscription(),
 		reconcilertestingv2.BeValidSubscription(),
 		reconcilertestingv2.BeJetStreamSubscriptionWithSubject(testingv2.EventSource,
-			testingv2.OrderCreatedEventTypePrefixEmpty, eventingv1alpha2.TypeMatchingExact),
+			testingv2.OrderCreatedEventTypePrefixEmpty, eventingv1alpha2.TypeMatchingExact, ens.jetStreamBackend.Config),
 	}
 
 	testSubscriptionOnNATS(ens, sub, testingv2.OrderCreatedEventTypePrefixEmpty, expectedNatsSubscription...)

--- a/components/eventing-controller/controllers/subscriptionv2/reconcilertesting/jetstream_matchers.go
+++ b/components/eventing-controller/controllers/subscriptionv2/reconcilertesting/jetstream_matchers.go
@@ -3,6 +3,8 @@ package reconcilertesting
 import (
 	"fmt"
 
+	"github.com/kyma-project/kyma/components/eventing-controller/pkg/env"
+
 	eventingv1alpha2 "github.com/kyma-project/kyma/components/eventing-controller/api/v1alpha2"
 	"github.com/kyma-project/kyma/components/eventing-controller/pkg/backend/jetstreamv2"
 	"github.com/onsi/gomega"
@@ -26,13 +28,15 @@ func BeNatsSubWithMaxPending(expectedMaxAckPending int) gomegatypes.GomegaMatche
 }
 
 func BeJetStreamSubscriptionWithSubject(source, subject string,
-	typeMatching eventingv1alpha2.TypeMatching) gomegatypes.GomegaMatcher {
+	typeMatching eventingv1alpha2.TypeMatching, natsConfig env.NatsConfig) gomegatypes.GomegaMatcher {
 	return gomega.WithTransform(func(subscriber jetstreamv2.Subscriber) (bool, error) {
 		info, err := subscriber.ConsumerInfo()
 		if err != nil {
 			return false, err
 		}
-		js := jetstreamv2.JetStream{}
+		js := jetstreamv2.JetStream{
+			Config: natsConfig,
+		}
 		result := info.Config.FilterSubject == js.GetJetStreamSubject(source, subject, typeMatching)
 		if !result {
 			return false, fmt.Errorf(

--- a/components/eventing-controller/pkg/backend/jetstreamv2/jetstream.go
+++ b/components/eventing-controller/pkg/backend/jetstreamv2/jetstream.go
@@ -141,10 +141,10 @@ func (js *JetStream) GetJetStreamContext() nats.JetStreamContext {
 // GetJetStreamSubject appends the prefix and the cleaned source to subject.
 func (js *JetStream) GetJetStreamSubject(source, subject string, typeMatching eventingv1alpha2.TypeMatching) string {
 	if typeMatching == eventingv1alpha2.TypeMatchingExact {
-		return fmt.Sprintf("%s.%s", env.JetStreamSubjectPrefix, subject)
+		return fmt.Sprintf("%s.%s", js.Config.JSSubjectPrefix, subject)
 	}
 	cleanSource, _ := js.cleaner.CleanSource(source)
-	return fmt.Sprintf("%s.%s.%s", env.JetStreamSubjectPrefix, cleanSource, subject)
+	return fmt.Sprintf("%s.%s.%s", js.Config.JSSubjectPrefix, cleanSource, subject)
 }
 
 // DeleteInvalidConsumers deletes all JetStream consumers having no subscription event types in subscription resources.
@@ -185,10 +185,10 @@ func (js *JetStream) isConsumerUsedByKymaSub(consumerName string, subscriptions 
 // getJetStreamSubject appends the prefix and the cleaned source to subject.
 func (js *JetStream) getJetStreamSubject(source, subject string, typeMatching eventingv1alpha2.TypeMatching) string {
 	if typeMatching == eventingv1alpha2.TypeMatchingExact {
-		return fmt.Sprintf("%s.%s", env.JetStreamSubjectPrefix, subject)
+		return fmt.Sprintf("%s.%s", js.Config.JSSubjectPrefix, subject)
 	}
 	cleanSource, _ := js.cleaner.CleanSource(source)
-	return fmt.Sprintf("%s.%s.%s", env.JetStreamSubjectPrefix, cleanSource, subject)
+	return fmt.Sprintf("%s.%s.%s", js.Config.JSSubjectPrefix, cleanSource, subject)
 }
 
 func (js *JetStream) validateConfig() error {

--- a/components/eventing-controller/pkg/backend/jetstreamv2/jetstream_integration_test.go
+++ b/components/eventing-controller/pkg/backend/jetstreamv2/jetstream_integration_test.go
@@ -472,12 +472,14 @@ func TestJetStream_NATSSubscriptionCount(t *testing.T) {
 	}
 }
 
-func defaultNatsConfig(url string) env.NatsConfig {
+func defaultNatsConfig(url string, port int) env.NatsConfig {
+	streamName := fmt.Sprintf("%s%d", DefaultStreamName, port)
 	return env.NatsConfig{
 		URL:                     url,
 		MaxReconnects:           DefaultMaxReconnects,
 		ReconnectWait:           3 * time.Second,
-		JSStreamName:            DefaultStreamName,
+		JSStreamName:            streamName,
+		JSSubjectPrefix:         streamName,
 		JSStreamStorageType:     StorageTypeMemory,
 		JSStreamRetentionPolicy: RetentionPolicyInterest,
 		JSStreamDiscardPolicy:   DiscardPolicyNew,
@@ -505,7 +507,7 @@ func getJetStreamClient(t *testing.T, serverURL string) *jetStreamClient {
 func setupTestEnvironment(t *testing.T) *TestEnvironment {
 	natsServer, natsPort, err := natstesting.StartNATSServer(evtesting.WithJetStreamEnabled())
 	require.NoError(t, err)
-	natsConfig := defaultNatsConfig(natsServer.ClientURL())
+	natsConfig := defaultNatsConfig(natsServer.ClientURL(), natsPort)
 	defaultLogger, err := logger.New(string(kymalogger.JSON), string(kymalogger.INFO))
 	require.NoError(t, err)
 

--- a/components/eventing-controller/pkg/backend/jetstreamv2/test_helpers.go
+++ b/components/eventing-controller/pkg/backend/jetstreamv2/test_helpers.go
@@ -24,9 +24,10 @@ import (
 )
 
 const (
-	DefaultStreamName    = "kyma"
-	DefaultMaxReconnects = 10
-	DefaultMaxInFlights  = 10
+	DefaultStreamName             = "kyma"
+	DefaultJetStreamSubjectPrefix = "kyma"
+	DefaultMaxReconnects          = 10
+	DefaultMaxInFlights           = 10
 )
 
 // TestEnvironment provides mocked resources for tests.

--- a/components/eventing-controller/pkg/backend/jetstreamv2/utils.go
+++ b/components/eventing-controller/pkg/backend/jetstreamv2/utils.go
@@ -151,7 +151,7 @@ func getStreamConfig(natsConfig env.NatsConfig) (*nats.StreamConfig, error) {
 		// use a prefix. This prefix is handled only on the JetStream level (i.e. JetStream handler
 		// and EPP) and should not be exposed in the Kyma subscription. Any Kyma event type gets appended with the
 		// configured stream's subject prefix.
-		Subjects: []string{fmt.Sprintf("%s.>", env.JetStreamSubjectPrefix)},
+		Subjects: []string{fmt.Sprintf("%s.>", natsConfig.JSSubjectPrefix)},
 	}
 	return streamConfig, nil
 }

--- a/components/eventing-controller/pkg/backend/jetstreamv2/utils_unit_test.go
+++ b/components/eventing-controller/pkg/backend/jetstreamv2/utils_unit_test.go
@@ -130,6 +130,7 @@ func TestGetStreamConfig(t *testing.T) {
 			name: "Should return valid StreamConfig",
 			givenNatsConfig: env.NatsConfig{
 				JSStreamName:            DefaultStreamName,
+				JSSubjectPrefix:         DefaultJetStreamSubjectPrefix,
 				JSStreamStorageType:     StorageTypeMemory,
 				JSStreamRetentionPolicy: RetentionPolicyLimits,
 				JSStreamReplicas:        3,
@@ -145,7 +146,7 @@ func TestGetStreamConfig(t *testing.T) {
 				Retention: nats.LimitsPolicy,
 				MaxMsgs:   -1,
 				MaxBytes:  -1,
-				Subjects:  []string{fmt.Sprintf("%s.>", env.JetStreamSubjectPrefix)},
+				Subjects:  []string{fmt.Sprintf("%s.>", DefaultJetStreamSubjectPrefix)},
 			},
 			wantError: false,
 		},
@@ -153,6 +154,7 @@ func TestGetStreamConfig(t *testing.T) {
 			name: "Should parse MaxBytes correctly without unit",
 			givenNatsConfig: env.NatsConfig{
 				JSStreamName:            DefaultStreamName,
+				JSSubjectPrefix:         DefaultJetStreamSubjectPrefix,
 				JSStreamStorageType:     StorageTypeMemory,
 				JSStreamRetentionPolicy: RetentionPolicyLimits,
 				JSStreamDiscardPolicy:   DiscardPolicyNew,
@@ -168,7 +170,7 @@ func TestGetStreamConfig(t *testing.T) {
 				Retention: nats.LimitsPolicy,
 				MaxMsgs:   -1,
 				MaxBytes:  10485760,
-				Subjects:  []string{fmt.Sprintf("%s.>", env.JetStreamSubjectPrefix)},
+				Subjects:  []string{fmt.Sprintf("%s.>", DefaultJetStreamSubjectPrefix)},
 			},
 			wantError: false,
 		},
@@ -176,6 +178,7 @@ func TestGetStreamConfig(t *testing.T) {
 			name: "Should parse MaxBytes correctly with unit",
 			givenNatsConfig: env.NatsConfig{
 				JSStreamName:            DefaultStreamName,
+				JSSubjectPrefix:         DefaultJetStreamSubjectPrefix,
 				JSStreamStorageType:     StorageTypeMemory,
 				JSStreamDiscardPolicy:   DiscardPolicyNew,
 				JSStreamRetentionPolicy: RetentionPolicyLimits,
@@ -191,7 +194,7 @@ func TestGetStreamConfig(t *testing.T) {
 				Retention: nats.LimitsPolicy,
 				MaxMsgs:   -1,
 				MaxBytes:  10485760,
-				Subjects:  []string{fmt.Sprintf("%s.>", env.JetStreamSubjectPrefix)},
+				Subjects:  []string{fmt.Sprintf("%s.>", DefaultJetStreamSubjectPrefix)},
 			},
 			wantError: false,
 		},
@@ -308,7 +311,9 @@ func TestGetBackendJetStreamTypes(t *testing.T) {
 	t.Parallel()
 	jsCleaner := cleaner.NewJetStreamCleaner(nil)
 	defaultSub := evtestingv2.NewSubscription(subName, subNamespace)
-	js := NewJetStream(env.NatsConfig{}, nil, jsCleaner, env.DefaultSubscriptionConfig{}, nil)
+	js := NewJetStream(env.NatsConfig{
+		JSSubjectPrefix: DefaultJetStreamSubjectPrefix,
+	}, nil, jsCleaner, env.DefaultSubscriptionConfig{}, nil)
 	testCases := []struct {
 		name              string
 		givenSubscription *eventingv1alpha2.Subscription

--- a/components/eventing-controller/pkg/backend/nats/jetstream/jetstream.go
+++ b/components/eventing-controller/pkg/backend/nats/jetstream/jetstream.go
@@ -321,7 +321,7 @@ func (js *JetStream) GetJetStreamSubjects(subjects []string) []string {
 
 // GetJetStreamSubject appends the prefix to subject.
 func (js *JetStream) GetJetStreamSubject(subject string) string {
-	return fmt.Sprintf("%s.%s", env.JetStreamSubjectPrefix, subject)
+	return fmt.Sprintf("%s.%s", js.Config.JSSubjectPrefix, subject)
 }
 
 // GetJetStreamContext returns the current JetStreamContext.
@@ -457,7 +457,7 @@ func getStreamConfig(natsConfig env.NatsConfig) (*nats.StreamConfig, error) {
 		// use a prefix. This prefix is handled only on the JetStream level (i.e. JetStream handler
 		// and EPP) and should not be exposed in the Kyma subscription. Any Kyma event type gets appended with the
 		// configured stream's subject prefix.
-		Subjects: []string{fmt.Sprintf("%s.>", env.JetStreamSubjectPrefix)},
+		Subjects: []string{fmt.Sprintf("%s.>", natsConfig.JSSubjectPrefix)},
 	}
 	return streamConfig, nil
 }

--- a/components/eventing-controller/pkg/backend/nats/jetstream/jetstream_integration_test.go
+++ b/components/eventing-controller/pkg/backend/nats/jetstream/jetstream_integration_test.go
@@ -1636,7 +1636,7 @@ func startJetStream(t *testing.T, testEnv *TestEnvironment) {
 		evtesting.WithPort(testEnv.natsPort),
 		evtesting.WithJetStreamEnabled())
 	require.Eventually(t, func() bool {
-		info, streamErr := testEnv.jsClient.StreamInfo(defaultStreamName)
+		info, streamErr := testEnv.jsClient.StreamInfo(testEnv.natsConfig.JSStreamName)
 		require.NoError(t, streamErr)
 		return info != nil && streamErr == nil
 	}, 60*time.Second, 5*time.Second)
@@ -1660,5 +1660,5 @@ func assertNewSubscriptionReturnItsKey(t *testing.T,
 func cleanUpTestEnvironment(testEnvironment *TestEnvironment) {
 	defer testEnvironment.natsServer.Shutdown()
 	defer testEnvironment.jsClient.natsConn.Close()
-	defer func() { _ = testEnvironment.jsClient.DeleteStream(defaultStreamName) }()
+	defer func() { _ = testEnvironment.jsClient.DeleteStream(testEnvironment.natsConfig.JSStreamName) }()
 }

--- a/components/eventing-controller/pkg/backend/nats/jetstream/jetstream_integration_test.go
+++ b/components/eventing-controller/pkg/backend/nats/jetstream/jetstream_integration_test.go
@@ -997,12 +997,14 @@ func TestJSSubscriptionUsingCESDK(t *testing.T) {
 	require.NoError(t, jsBackend.DeleteSubscription(sub))
 }
 
-func defaultNatsConfig(url string) env.NatsConfig {
+func defaultNatsConfig(url string, natsPort int) env.NatsConfig {
+	streamName := fmt.Sprintf("%s%d", defaultStreamName, natsPort)
 	return env.NatsConfig{
 		URL:                     url,
 		MaxReconnects:           defaultMaxReconnects,
 		ReconnectWait:           3 * time.Second,
-		JSStreamName:            defaultStreamName,
+		JSStreamName:            streamName,
+		JSSubjectPrefix:         streamName,
 		JSStreamStorageType:     StorageTypeMemory,
 		JSStreamRetentionPolicy: RetentionPolicyInterest,
 		JSStreamDiscardPolicy:   DiscardPolicyNew,
@@ -1052,7 +1054,7 @@ type TestEnvironment struct {
 func setupTestEnvironment(t *testing.T, newCRD bool) *TestEnvironment {
 	natsServer, natsPort, err := natstesting.StartNATSServer(evtesting.WithJetStreamEnabled())
 	require.NoError(t, err)
-	natsConfig := defaultNatsConfig(natsServer.ClientURL())
+	natsConfig := defaultNatsConfig(natsServer.ClientURL(), natsPort)
 	defaultLogger, err := logger.New(string(kymalogger.JSON), string(kymalogger.INFO))
 	require.NoError(t, err)
 
@@ -1430,7 +1432,7 @@ func TestJetStreamSubAfterSync_ForExplicitlyBoundSubscriptionDeletion(t *testing
 	jsBackend := testEnvironment.jsBackend
 	defer testEnvironment.natsServer.Shutdown()
 	defer testEnvironment.jsClient.natsConn.Close()
-	defer func() { _ = testEnvironment.jsClient.DeleteStream(defaultStreamName) }()
+	defer func() { _ = testEnvironment.jsClient.DeleteStream(testEnvironment.natsConfig.JSStreamName) }()
 
 	testEnvironment.jsBackend.Config.JSStreamStorageType = StorageTypeFile
 	testEnvironment.jsBackend.Config.MaxReconnects = 0
@@ -1498,7 +1500,7 @@ func TestJetStreamSubAfterSync_ForExplicitlyBoundSubscriptionDeletion(t *testing
 	// the unacknowledged message must still be present in the stream
 
 	require.Eventually(t, func() bool {
-		info, streamErr := testEnvironment.jsClient.StreamInfo(defaultStreamName)
+		info, streamErr := testEnvironment.jsClient.StreamInfo(testEnvironment.natsConfig.JSStreamName)
 		require.NoError(t, streamErr)
 		return info != nil && streamErr == nil
 	}, 60*time.Second, 5*time.Second)

--- a/components/eventing-controller/pkg/backend/nats/jetstream/jetstream_v1v2_integration_test.go
+++ b/components/eventing-controller/pkg/backend/nats/jetstream/jetstream_v1v2_integration_test.go
@@ -90,7 +90,7 @@ func TestJetStream_ServerRestart(t *testing.T) { //nolint:gocognit
 			testEnvironment := setupTestEnvironment(t, tc.givenEnableCRDVersion)
 			defer testEnvironment.natsServer.Shutdown()
 			defer testEnvironment.jsClient.natsConn.Close()
-			defer func() { _ = testEnvironment.jsClient.DeleteStream(defaultStreamName) }()
+			defer func() { _ = testEnvironment.jsClient.DeleteStream(testEnvironment.natsConfig.JSStreamName) }()
 			var err error
 			if tc.givenEnableCRDVersion {
 				testEnvironment.jsBackendv2.Config.JSStreamStorageType = tc.givenStorageType
@@ -166,7 +166,7 @@ func TestJetStream_ServerRestart(t *testing.T) { //nolint:gocognit
 				}, 30*time.Second, 2*time.Second)
 			}
 
-			_, err = testEnvironment.jsClient.StreamInfo(defaultStreamName)
+			_, err = testEnvironment.jsClient.StreamInfo(testEnvironment.natsConfig.JSStreamName)
 			if tc.givenStorageType == StorageTypeMemory && tc.givenMaxReconnects == 0 {
 				// for memory storage with reconnects disabled
 				require.True(t, errors.Is(err, nats.ErrStreamNotFound))
@@ -186,7 +186,7 @@ func TestJetStream_ServerRestart(t *testing.T) { //nolint:gocognit
 			require.NoError(t, err)
 
 			// stream exists
-			_, err = testEnvironment.jsClient.StreamInfo(defaultStreamName)
+			_, err = testEnvironment.jsClient.StreamInfo(testEnvironment.natsConfig.JSStreamName)
 			require.NoError(t, err)
 
 			ev2data := fmt.Sprintf("%s%d", "newsampledata", id)
@@ -217,7 +217,7 @@ func TestJetStream_ServerAndSinkRestart(t *testing.T) {
 			testEnvironment := setupTestEnvironment(t, newCRD)
 			defer testEnvironment.natsServer.Shutdown()
 			defer testEnvironment.jsClient.natsConn.Close()
-			defer func() { _ = testEnvironment.jsClient.DeleteStream(defaultStreamName) }()
+			defer func() { _ = testEnvironment.jsClient.DeleteStream(testEnvironment.natsConfig.JSStreamName) }()
 
 			var err error
 			if newCRD {
@@ -282,7 +282,7 @@ func TestJetStream_ServerAndSinkRestart(t *testing.T) {
 			var info *nats.StreamInfo
 
 			require.Eventually(t, func() bool {
-				info, err = testEnvironment.jsClient.StreamInfo(defaultStreamName)
+				info, err = testEnvironment.jsClient.StreamInfo(testEnvironment.natsConfig.JSStreamName)
 				require.NoError(t, err)
 				return info.State.Msgs == expectedNotAcknowledgedMsgs
 			}, 60*time.Second, 5*time.Second)
@@ -303,7 +303,7 @@ func TestJetStream_ServerAndSinkRestart(t *testing.T) {
 				evtesting.WithJetStreamEnabled())
 			// the unacknowledged message must still be present in the stream
 			require.Eventually(t, func() bool {
-				info, err = testEnvironment.jsClient.StreamInfo(defaultStreamName)
+				info, err = testEnvironment.jsClient.StreamInfo(testEnvironment.natsConfig.JSStreamName)
 				require.NoError(t, err)
 				return info.State.Msgs == expectedNotAcknowledgedMsgs
 			}, 60*time.Second, 5*time.Second)
@@ -324,7 +324,7 @@ func TestJetStream_ServerAndSinkRestart(t *testing.T) {
 			// then
 			// no messages should be present in the stream
 			require.Eventually(t, func() bool {
-				info, err = testEnvironment.jsClient.StreamInfo(defaultStreamName)
+				info, err = testEnvironment.jsClient.StreamInfo(testEnvironment.natsConfig.JSStreamName)
 				require.NoError(t, err)
 				return info.State.Msgs == uint64(0)
 			}, 60*time.Second, 5*time.Second)

--- a/components/eventing-controller/pkg/env/nats_config.go
+++ b/components/eventing-controller/pkg/env/nats_config.go
@@ -6,10 +6,6 @@ import (
 	"github.com/kelseyhightower/envconfig"
 )
 
-const (
-	JetStreamSubjectPrefix = "kyma"
-)
-
 // NatsConfig represents the environment config for the Eventing Controller with Nats.
 type NatsConfig struct {
 	// Following details are for eventing-controller to communicate to Nats
@@ -29,7 +25,8 @@ type NatsConfig struct {
 
 	// JetStream-specific configs
 	// Name of the JetStream stream where all events are stored.
-	JSStreamName string `envconfig:"JS_STREAM_NAME" required:"true"`
+	JSStreamName    string `envconfig:"JS_STREAM_NAME" required:"true"`
+	JSSubjectPrefix string `envconfig:"JS_STREAM_SUBJECT_PREFIX" required:"false" default:"kyma"`
 	// Storage type of the stream, memory or file.
 	JSStreamStorageType string `envconfig:"JS_STREAM_STORAGE_TYPE" default:"memory"`
 	// Number of replicas for the JetStream stream

--- a/components/eventing-controller/pkg/env/nats_config.go
+++ b/components/eventing-controller/pkg/env/nats_config.go
@@ -25,8 +25,9 @@ type NatsConfig struct {
 
 	// JetStream-specific configs
 	// Name of the JetStream stream where all events are stored.
-	JSStreamName    string `envconfig:"JS_STREAM_NAME" required:"true"`
-	JSSubjectPrefix string `envconfig:"JS_STREAM_SUBJECT_PREFIX" required:"false" default:"kyma"`
+	JSStreamName string `envconfig:"JS_STREAM_NAME" required:"true"`
+	// Prefix for the subjects in the stream
+	JSSubjectPrefix string `envconfig:"JS_STREAM_SUBJECT_PREFIX" required:"true"`
 	// Storage type of the stream, memory or file.
 	JSStreamStorageType string `envconfig:"JS_STREAM_STORAGE_TYPE" default:"memory"`
 	// Number of replicas for the JetStream stream

--- a/components/eventing-controller/pkg/env/nats_config_test.go
+++ b/components/eventing-controller/pkg/env/nats_config_test.go
@@ -43,6 +43,7 @@ func TestGetNatsConfig(t *testing.T) {
 				MaxIdleConnsPerHost:     50,
 				IdleConnTimeout:         10 * time.Second,
 				JSStreamName:            "jsn",
+				JSSubjectPrefix:         "kyma",
 				JSStreamStorageType:     "memory",
 				JSStreamReplicas:        1,
 				JSStreamRetentionPolicy: "interest",
@@ -59,6 +60,7 @@ func TestGetNatsConfig(t *testing.T) {
 				envs: map[string]string{
 					"EVENT_TYPE_PREFIX":          "etp",
 					"JS_STREAM_NAME":             "jsn",
+					"JS_STREAM_SUBJECT_PREFIX": "testjsn",
 					"NATS_URL":                   "natsurl",
 					"MAX_IDLE_CONNS":             "1",
 					"MAX_CONNS_PER_HOST":         "2",
@@ -86,6 +88,7 @@ func TestGetNatsConfig(t *testing.T) {
 				MaxIdleConnsPerHost:     3,
 				IdleConnTimeout:         1 * time.Second,
 				JSStreamName:            "jsn",
+				JSSubjectPrefix:         "testjsn",
 				JSStreamStorageType:     "jsst",
 				JSStreamReplicas:        4,
 				JSStreamRetentionPolicy: "jsrp",

--- a/components/eventing-controller/pkg/env/nats_config_test.go
+++ b/components/eventing-controller/pkg/env/nats_config_test.go
@@ -26,9 +26,10 @@ func TestGetNatsConfig(t *testing.T) {
 		{name: "Required values only gives valid config",
 			args: args{
 				envs: map[string]string{
-					"NATS_URL":          "natsurl",
-					"EVENT_TYPE_PREFIX": "etp",
-					"JS_STREAM_NAME":    "jsn",
+					"NATS_URL":                 "natsurl",
+					"EVENT_TYPE_PREFIX":        "etp",
+					"JS_STREAM_NAME":           "jsn",
+					"JS_STREAM_SUBJECT_PREFIX": "kma",
 				},
 				maxReconnects: 1,
 				reconnectWait: 1 * time.Second,
@@ -43,7 +44,7 @@ func TestGetNatsConfig(t *testing.T) {
 				MaxIdleConnsPerHost:     50,
 				IdleConnTimeout:         10 * time.Second,
 				JSStreamName:            "jsn",
-				JSSubjectPrefix:         "kyma",
+				JSSubjectPrefix:         "kma",
 				JSStreamStorageType:     "memory",
 				JSStreamReplicas:        1,
 				JSStreamRetentionPolicy: "interest",
@@ -60,7 +61,7 @@ func TestGetNatsConfig(t *testing.T) {
 				envs: map[string]string{
 					"EVENT_TYPE_PREFIX":          "etp",
 					"JS_STREAM_NAME":             "jsn",
-					"JS_STREAM_SUBJECT_PREFIX": "testjsn",
+					"JS_STREAM_SUBJECT_PREFIX":   "testjsn",
 					"NATS_URL":                   "natsurl",
 					"MAX_IDLE_CONNS":             "1",
 					"MAX_CONNS_PER_HOST":         "2",

--- a/components/eventing-controller/pkg/subscriptionmanager/jetstream/jetstream_test.go
+++ b/components/eventing-controller/pkg/subscriptionmanager/jetstream/jetstream_test.go
@@ -82,27 +82,19 @@ func getJetStreamClient(t *testing.T, natsURL string) nats.JetStreamContext {
 	return jsClient
 }
 
-func getNATSConf(natsURL string) env.NatsConfig {
+func getNATSConf(natsURL string, natsPort int) env.NatsConfig {
+	streamName := fmt.Sprintf("%s%d", controllertesting.JSStreamName, natsPort)
 	return env.NatsConfig{
 		URL:                     natsURL,
 		MaxReconnects:           10,
 		ReconnectWait:           time.Second,
 		EventTypePrefix:         controllertesting.EventTypePrefix,
-		JSStreamName:            controllertesting.EventTypePrefix,
+		JSStreamName:            streamName,
+		JSSubjectPrefix:         streamName,
 		JSStreamStorageType:     backendjetstream.StorageTypeMemory,
 		JSStreamRetentionPolicy: backendjetstream.RetentionPolicyInterest,
 		JSStreamDiscardPolicy:   backendjetstream.DiscardPolicyNew,
 	}
-}
-
-func setUpNATSServer(t *testing.T) *server.Server {
-	// create NATS Server with JetStream enabled
-	natsPort, err := controllertesting.GetFreePort()
-	require.NoError(t, err)
-	natsServer := controllertesting.RunNatsServerOnPort(
-		controllertesting.WithPort(natsPort),
-		controllertesting.WithJetStreamEnabled())
-	return natsServer
 }
 
 func createAndSyncSubscription(t *testing.T, sinkURL string, jsBackend *backendjetstream.JetStream) *eventingv1alpha1.Subscription {
@@ -165,12 +157,15 @@ func setUpTestEnvironment(t *testing.T) *TestEnvironment {
 	ctx := context.Background()
 	// create a test subscriber and natsServer
 	subscriber := controllertesting.NewSubscriber()
-	natsServer := setUpNATSServer(t)
+	// create NATS Server with JetStream enabled
+	natsPort, err := controllertesting.GetFreePort()
+	require.NoError(t, err)
+	natsServer := controllertesting.StartDefaultJetStreamServer(natsPort)
 
 	defaultLogger, err := logger.New(string(kymalogger.JSON), string(kymalogger.INFO))
 	require.NoError(t, err)
 
-	envConf := getNATSConf(natsServer.ClientURL())
+	envConf := getNATSConf(natsServer.ClientURL(), natsPort)
 	jsClient := getJetStreamClient(t, natsServer.ClientURL())
 
 	// init the metrics collector

--- a/components/eventing-controller/testing/nats.go
+++ b/components/eventing-controller/testing/nats.go
@@ -28,6 +28,15 @@ func RunNatsServerOnPort(opts ...NatsServerOpt) *server.Server {
 	return natstestserver.RunServer(serverOpts)
 }
 
+// StartDefaultJetStreamServer will run a server on the given port.
+func StartDefaultJetStreamServer(port int) *server.Server {
+	natsServer := RunNatsServerOnPort(
+		WithPort(port),
+		WithJetStreamEnabled(),
+	)
+	return natsServer
+}
+
 // ShutDownNATSServer shuts down test NATS server and waits until shutdown is complete.
 func ShutDownNATSServer(natsServer *server.Server) {
 	natsServer.Shutdown()

--- a/components/eventing-controller/testing/nats/matchers.go
+++ b/components/eventing-controller/testing/nats/matchers.go
@@ -1,6 +1,7 @@
 package nats
 
 import (
+	"github.com/kyma-project/kyma/components/eventing-controller/pkg/env"
 	"github.com/onsi/gomega"
 	gomegatypes "github.com/onsi/gomega/types"
 
@@ -20,13 +21,15 @@ func BeSubscriptionWithSubject(subject string) gomegatypes.GomegaMatcher {
 	}, gomega.BeTrue())
 }
 
-func BeJetStreamSubscriptionWithSubject(subject string) gomegatypes.GomegaMatcher {
+func BeJetStreamSubscriptionWithSubject(subject string, natsConfig env.NatsConfig) gomegatypes.GomegaMatcher {
 	return gomega.WithTransform(func(subscriber nats.Subscriber) bool {
 		info, err := subscriber.ConsumerInfo()
 		if err != nil {
 			return false
 		}
-		js := jetstream.JetStream{}
+		js := jetstream.JetStream{
+			Config: natsConfig,
+		}
 		return info.Config.FilterSubject == js.GetJetStreamSubject(subject)
 	}, gomega.BeTrue())
 }

--- a/resources/eventing/charts/controller/templates/deployment.yaml
+++ b/resources/eventing/charts/controller/templates/deployment.yaml
@@ -69,7 +69,7 @@ spec:
           - name: JS_STREAM_NAME
             value: {{ .Values.jetstream.streamName | quote }}
           - name: JS_STREAM_SUBJECT_PREFIX
-            value: { { .Values.jetstream.streamSubjectPrefix | quote } }
+            value: {{ .Values.jetstream.streamSubjectPrefix | quote }}
           - name: JS_STREAM_STORAGE_TYPE
             value: {{ .Values.global.jetstream.storage | quote }}
           - name: JS_STREAM_REPLICAS

--- a/resources/eventing/charts/controller/templates/deployment.yaml
+++ b/resources/eventing/charts/controller/templates/deployment.yaml
@@ -68,6 +68,8 @@ spec:
             value: {{ .Values.global.log.level | quote }}
           - name: JS_STREAM_NAME
             value: {{ .Values.jetstream.streamName | quote }}
+          - name: JS_STREAM_SUBJECT_PREFIX
+            value: { { .Values.jetstream.streamSubjectPrefix | quote } }
           - name: JS_STREAM_STORAGE_TYPE
             value: {{ .Values.global.jetstream.storage | quote }}
           - name: JS_STREAM_REPLICAS

--- a/resources/eventing/charts/controller/values.yaml
+++ b/resources/eventing/charts/controller/values.yaml
@@ -89,6 +89,8 @@ jetstream:
   # Configs for the stream used for storing events
   # Name of the JetStream stream where all events are stored.
   streamName: sap
+  # Prefix for the subjects in the stream
+  streamSubjectPrefix: kyma
   # Number of replicas for JetStream stream (max: 5)
   streamReplicas: 1
   # Retention policy determines when messages are deleted from the stream:

--- a/resources/eventing/values.yaml
+++ b/resources/eventing/values.yaml
@@ -5,7 +5,7 @@ global:
   images:
     eventing_controller:
       name: eventing-controller
-      version: PR-16352
+      version: PR-16358
       pullPolicy: "IfNotPresent"
     publisher_proxy:
       name: event-publisher-proxy


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Problem is that even if you run multiple NATS test servers on different ports, the underlying data conflicts and hence the test fails. Also, using unique `storeDir` for stream did not help. So, to keep the test environment isolated, we are now using unique stream names and subject prefixes in each test. (Because subjects cannot overlap with an existing stream, we have to use unique subject prefixes as well [`nats: subjects overlap with an existing stream`]).

- The `JetStreamSubjectPrefix` was a const before and could not be defined variably in the tests, so first this PR changes the `JetStreamSubjectPrefix` to NATS config variable.
- Second, this PR changes the JetStream tests to use unique stream name and subject prefixes.

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
- https://github.com/kyma-project/kyma/issues/16331