### PR TITLE
Display KEB events in SKR tests

### DIFF
--- a/tests/fast-integration/kcp/client.js
+++ b/tests/fast-integration/kcp/client.js
@@ -195,6 +195,11 @@ class KCPWrapper {
     return JSON.stringify(reconciliationsInfo, null, '\t');
   }
 
+  async getRuntimeEvents(instanceID) {
+    await this.login();
+    return this.exec(['runtimes', '--instance-id', instanceID, '--events']);
+  }
+
   async getRuntimeStatusOperations(instanceID) {
     await this.login();
     const runtimeStatus = await this.runtimes({instanceID: instanceID, ops: true});

--- a/tests/fast-integration/kyma-environment-broker/helpers.js
+++ b/tests/fast-integration/kyma-environment-broker/helpers.js
@@ -101,7 +101,9 @@ async function ensureOperationSucceeded(keb, kcp, instanceID, operationID, timeo
       1000 * 30, // 30 seconds
   ).catch(async (err) => {
     const runtimeStatus = await kcp.getRuntimeStatusOperations(instanceID);
-    throw new Error(`${err}\nError thrown by ensureOperationSucceeded: Runtime status: ${runtimeStatus}`);
+    const events = await kcp.getRuntimeEvents(instanceID);
+    const msg = `${err}\nError thrown by ensureOperationSucceeded: Runtime status: ${runtimeStatus}\nEvents: ${events}`;
+    throw new Error(msg);
   });
 
   if (res.state !== 'succeeded') {

--- a/tests/fast-integration/skr-aws-upgrade-integration/upgrade/upgrade-skr.js
+++ b/tests/fast-integration/skr-aws-upgrade-integration/upgrade/upgrade-skr.js
@@ -8,7 +8,8 @@ async function upgradeSKRInstance(options, kymaUpgradeVersion, timeout) {
     throw new Error(`Upgrade failed: ${e.toString()}`);
   } finally {
     const runtimeStatus = await kcp.getRuntimeStatusOperations(options.instanceID);
-    console.log(`\nRuntime status after upgrade: ${runtimeStatus}`);
+    const events = await kcp.getRuntimeEvents(options.instanceID);
+    console.log(`\nRuntime status after upgrade: ${runtimeStatus}\nEvents: ${events}`);
     await kcp.reconcileInformationLog(runtimeStatus);
   }
 }

--- a/tests/fast-integration/skr-nightly/provision/provision-skr-nightly.js
+++ b/tests/fast-integration/skr-nightly/provision/provision-skr-nightly.js
@@ -81,7 +81,8 @@ describe('SKR nightly', function() {
           provisioningTimeout);
 
       const runtimeStatus = await kcp.getRuntimeStatusOperations(options.instanceID);
-      console.log(`\nRuntime status after provisioning: ${runtimeStatus}`);
+      const events = await kcp.getRuntimeEvents(options.instanceID);
+      console.log(`\nRuntime status after provisioning: ${runtimeStatus}\nEvents: ${events}`);
 
       shoot = skr.shoot;
       initializeK8sClient({kubeconfig: shoot.kubeconfig});

--- a/tests/fast-integration/skr-test/provision/deprovision-skr.js
+++ b/tests/fast-integration/skr-test/provision/deprovision-skr.js
@@ -16,7 +16,8 @@ async function deprovisionSKRInstance(options, timeout, ensureSuccess=true) {
     throw new Error(`De-provisioning failed: ${e.toString()}`);
   } finally {
     const runtimeStatus = await kcp.getRuntimeStatusOperations(options.instanceID);
-    console.log(`\nRuntime status after de-provisioning: ${runtimeStatus}`);
+    const events = await kcp.getRuntimeEvents(options.instanceID);
+    console.log(`\nRuntime status after de-provisioning: ${runtimeStatus}\nEvents: ${events}`);
     await kcp.reconcileInformationLog(runtimeStatus);
   }
 }

--- a/tests/fast-integration/skr-test/provision/provision-skr.js
+++ b/tests/fast-integration/skr-test/provision/provision-skr.js
@@ -68,7 +68,8 @@ async function provisionSKRInstance(options, timeout) {
   } finally {
     debug('Fetching runtime status...');
     const runtimeStatus = await kcp.getRuntimeStatusOperations(options.instanceID);
-    console.log(`\nRuntime status after provisioning: ${runtimeStatus}`);
+    const events = await kcp.getRuntimeEvents(options.instanceID);
+    console.log(`\nRuntime status after provisioning: ${runtimeStatus}\nEvents: ${events}`);
     await kcp.reconcileInformationLog(runtimeStatus);
   }
 }


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

depends on: https://github.com/kyma-project/test-infra/pull/6606
closes: https://github.com/kyma-project/kyma/issues/16179

[pjtester](https://status.build.kyma-project.io/log?container=test&id=1604825979539165184&job=wozniakjan_test_of_prowjob_skr-aws-integration-dev)
<details>
  <summary>sample excerpt from pjtester</summary>

```
InstanceID 1adc12b5-e85d-4bbe-b496-1f6a1cc7de47 Runtime kyma-6gdr Application app-6gdr Suffix 6gdr
[DEBUG] Operation ID 96d12dce-6374-477d-923f-052facf0ce30
Operation 96d12dce-6374-477d-923f-052facf0ce30 finished with state succeeded
[DEBUG] Fetching runtime operation status...
[DEBUG] Fetching shoot info from gardener...
[DEBUG] Fetching shoot: c-7f1a0e1 from gardener namespace: garden-kyma-dev
[DEBUG] Compass ID bd0c0547-26f9-4e29-8aff-aae4d945034e
[DEBUG] SKR is provisioned!
[DEBUG] Fetching runtime status...

Runtime status after provisioning: {
	"data": [
		{
			"instanceID": "1adc12b5-e85d-4bbe-b496-1f6a1cc7de47",
			"runtimeID": "bd0c0547-26f9-4e29-8aff-aae4d945034e",
			"globalAccountID": "e449f875-b5b2-4485-b7c0-98725c0571bf",
			"subscriptionGlobalAccountID": "",
			"subAccountID": "prow-keb-integration",
			"region": "eu-central-1",
			"subAccountRegion": "cf-eu10",
			"shootName": "c-7f1a0e1",
			"serviceClassID": "47c9dcbf-ff30-448e-ab36-d3bad66ba281",
			"serviceClassName": "kymaruntime",
			"servicePlanID": "361c511f-f939-4621-b228-d0fb79a1fe15",
			"servicePlanName": "aws",
			"provider": "AWS",
			"status": {
				"createdAt": "2022-12-19T13:08:43.789041Z",
				"modifiedAt": "2022-12-19T13:21:28.106714Z",
				"state": "succeeded",
				"provisioning": {
					"state": "succeeded",
					"description": "Operation created",
					"createdAt": "2022-12-19T13:08:43.785051Z",
					"updatedAt": "2022-12-19T13:21:28.106714Z",
					"operationID": "96d12dce-6374-477d-923f-052facf0ce30",
					"finishedStages": [
						"start",
						"create_runtime",
						"check_kyma",
						"create_kyma_resource",
						"post_actions"
					],
					"runtimeVersion": "2.9.1"
				}
			},
			"userID": "test@test.com",
			"avsInternalEvaluationID": 260761555,
			"kymaVersion": "2.9.1"
		}
	],
	"count": 1,
	"totalCount": 1
}
Events: GLOBALACCOUNT ID                       SUBACCOUNT ID          SHOOT       REGION         PLAN   CREATED AT            STATE       KYMA VERSION   
e449f875-b5b2-4485-b7c0-98725c0571bf   prow-keb-integration   c-7f1a0e1   eu-central-1   aws    2022/12/19 13:08:43   succeeded   2.9.1          
 ˫provision operation 96d12dce-6374-477d-923f-052facf0ce30: succeeded
  ˫info   13m                          processing step: Starting                                 
  ˫info   13m                          processing step: Provision_Initialization                 
  ˫info   13m                          processing step: Init_Kyma_Template                       
  ˫info   13m                          processing step: Resolve_Target_Secret                    
  ˫info   13m                          processing step: AVS_Create_Internal_Eval_Step            
  ˫info   13m                          processing step: EDP_Registration                         
  ˫info   12m                          step EDP_Registration sleeping for 1s                     
  ˫info   12m                          processing step: Overrides_From_Secrets_And_Config_Step   
  ˫info   12m                          processing step: BTPOperatorOverrides                     
  ˫info   12m                          processing step: Create_Runtime_Without_Kyma              
  ˫info   12m                          processing step: Check_Runtime                            
  ˫info   6m57s ago (4x in last 12m)   step Check_Runtime sleeping for 2m0s                      
  ˫info   4m57s                        processing step: Get_Kubeconfig                           
  ˫info   4m57s                        processing step: Inject_BTP_Operator_Credentials          
  ˫info   4m57s                        processing step: Sync_Kubeconfig                          
  ˫info   4m57s                        processing step: Create_Cluster_Configuration             
  ˫info   4m56s                        processing step: Check_Cluster_Configuration              
  ˫info   56s ago (9x in last 4m56s)   step Check_Cluster_Configuration sleeping for 30s         
  ˫info   26s                          processing step: AVS_Create_External_Eval_Step            
  ˪info   17s                          processing step: AVS_Tags    
```
</details>