### PR TITLE
Use latest patch version for nodejs function runtimes

### DIFF
--- a/components/function-runtimes/nodejs14/Dockerfile
+++ b/components/function-runtimes/nodejs14/Dockerfile
@@ -29,7 +29,7 @@
 # image base on alpine:3.17.0
 FROM alpine@sha256:c0d488a800e4127c334ad20d61d7bc21b4097540327217dfab52262adc02380c
 
-ENV NODE_VERSION 14.21.1
+ENV NODE_VERSION 14.21.2
 
 SHELL ["/bin/ash", "-o", "pipefail", "-c"]
 
@@ -45,7 +45,7 @@ RUN addgroup -g 1000 node \
       && case "${alpineArch}" in \
         x86_64) \
           ARCH='x64' \
-          CHECKSUM="0fc7c18a1fa7aa6b39ac7b11ba2e56fa12ab1c4d3b4bb32f9c4ac3f7178d613c" \
+          CHECKSUM="069d9b0f9c01fa269dfe71e0b65f04a151c233c81bd998b59894c5f717f79877" \
           ;; \
         *) ;; \
       esac \

--- a/components/function-runtimes/nodejs16/Dockerfile
+++ b/components/function-runtimes/nodejs16/Dockerfile
@@ -1,5 +1,5 @@
-# image base on 16.18.1-alpine3.16
-FROM node@sha256:34d5b3bc90f9beb47e7eb14c17837c9d393eb2524b34c9421b1d675ba05b69b2
+# image base on 16.19.0-alpine3.17
+FROM node@sha256:e427ffd1ba7915ca8d8aeba45806ef3f1f1e6b65ce152b363645cd7428f8d75a
 
 ARG NODE_ENV
 ENV NODE_ENV $NODE_ENV

--- a/resources/serverless/values.yaml
+++ b/resources/serverless/values.yaml
@@ -89,7 +89,7 @@ global:
       version: "PR-16334"
     function_runtime_nodejs14:
       name: "function-runtime-nodejs14"
-      version: "PR-16274"
+      version: "PR-16398"
     function_runtime_nodejs16:
       name: "function-runtime-nodejs16"
       version: "PR-16309"

--- a/resources/serverless/values.yaml
+++ b/resources/serverless/values.yaml
@@ -92,7 +92,7 @@ global:
       version: "PR-16398"
     function_runtime_nodejs16:
       name: "function-runtime-nodejs16"
-      version: "PR-16309"
+      version: "PR-16398"
     function_runtime_python39:
       name: "function-runtime-python39"
       version: "PR-16309"


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- bump to nodejs 14.21.2
- bump to nodejs 16.19.0

