### PR TITLE
enable startup healthcheck for nats in production profile

### DIFF
--- a/resources/eventing/profile-production.yaml
+++ b/resources/eventing/profile-production.yaml
@@ -48,3 +48,6 @@ nats:
     logging:
       debug: false
       trace: false
+    healthcheck:
+      startup:
+        enabled: true


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Startup probe checks that the JS server is enabled, is current with the meta leader, and that all streams and consumers assigned to this JS server are current. It must be enabled when nats clustering is enabled.

[_Source_](https://github.com/nats-io/k8s/blob/977343b835fcca19d1e2d583ba6778d7ed59aad1/helm/charts/nats/templates/statefulset.yaml#L480)

Changes proposed in this pull request:

- Enabled startup probe for while using production profile

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
