### PR TITLE
Cosmetic improvement for fast-integration tests events

### DIFF
--- a/tests/fast-integration/kyma-environment-broker/helpers.js
+++ b/tests/fast-integration/kyma-environment-broker/helpers.js
@@ -102,8 +102,8 @@ async function ensureOperationSucceeded(keb, kcp, instanceID, operationID, timeo
   ).catch(async (err) => {
     const runtimeStatus = await kcp.getRuntimeStatusOperations(instanceID);
     const events = await kcp.getRuntimeEvents(instanceID);
-    const msg = `${err}\nError thrown by ensureOperationSucceeded: Runtime status: ${runtimeStatus}\nEvents: ${events}`;
-    throw new Error(msg);
+    const msg = `${err}\nError thrown by ensureOperationSucceeded: Runtime status: ${runtimeStatus}`;
+    throw new Error(`${msg}\nEvents:\n${events}`);
   });
 
   if (res.state !== 'succeeded') {

--- a/tests/fast-integration/skr-aws-upgrade-integration/upgrade/upgrade-skr.js
+++ b/tests/fast-integration/skr-aws-upgrade-integration/upgrade/upgrade-skr.js
@@ -9,7 +9,7 @@ async function upgradeSKRInstance(options, kymaUpgradeVersion, timeout) {
   } finally {
     const runtimeStatus = await kcp.getRuntimeStatusOperations(options.instanceID);
     const events = await kcp.getRuntimeEvents(options.instanceID);
-    console.log(`\nRuntime status after upgrade: ${runtimeStatus}\nEvents: ${events}`);
+    console.log(`\nRuntime status after upgrade: ${runtimeStatus}\nEvents:\n${events}`);
     await kcp.reconcileInformationLog(runtimeStatus);
   }
 }

--- a/tests/fast-integration/skr-nightly/provision/provision-skr-nightly.js
+++ b/tests/fast-integration/skr-nightly/provision/provision-skr-nightly.js
@@ -82,7 +82,7 @@ describe('SKR nightly', function() {
 
       const runtimeStatus = await kcp.getRuntimeStatusOperations(options.instanceID);
       const events = await kcp.getRuntimeEvents(options.instanceID);
-      console.log(`\nRuntime status after provisioning: ${runtimeStatus}\nEvents: ${events}`);
+      console.log(`\nRuntime status after provisioning: ${runtimeStatus}\nEvents:\n${events}`);
 
       shoot = skr.shoot;
       initializeK8sClient({kubeconfig: shoot.kubeconfig});

--- a/tests/fast-integration/skr-test/provision/deprovision-skr.js
+++ b/tests/fast-integration/skr-test/provision/deprovision-skr.js
@@ -17,7 +17,7 @@ async function deprovisionSKRInstance(options, timeout, ensureSuccess=true) {
   } finally {
     const runtimeStatus = await kcp.getRuntimeStatusOperations(options.instanceID);
     const events = await kcp.getRuntimeEvents(options.instanceID);
-    console.log(`\nRuntime status after de-provisioning: ${runtimeStatus}\nEvents: ${events}`);
+    console.log(`\nRuntime status after de-provisioning: ${runtimeStatus}\nEvents:\n${events}`);
     await kcp.reconcileInformationLog(runtimeStatus);
   }
 }

--- a/tests/fast-integration/skr-test/provision/provision-skr.js
+++ b/tests/fast-integration/skr-test/provision/provision-skr.js
@@ -69,7 +69,7 @@ async function provisionSKRInstance(options, timeout) {
     debug('Fetching runtime status...');
     const runtimeStatus = await kcp.getRuntimeStatusOperations(options.instanceID);
     const events = await kcp.getRuntimeEvents(options.instanceID);
-    console.log(`\nRuntime status after provisioning: ${runtimeStatus}\nEvents: ${events}`);
+    console.log(`\nRuntime status after provisioning: ${runtimeStatus}\nEvents:\n${events}`);
     await kcp.reconcileInformationLog(runtimeStatus);
   }
 }


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

followup to https://github.com/kyma-project/kyma/pull/16370, the header for runtime table is a little off
```
Events: GLOBALACCOUNT ID                       SUBACCOUNT ID          SHOOT       REGION         PLAN   CREATED AT            STATE       KYMA VERSION   
e449f875-b5b2-4485-b7c0-98725c0571bf   prow-keb-integration   c-432e772   eu-central-1   aws    2022/12/21 01:05:29   succeeded   2.9.1          
 ˫provision operation d1554a21-ce7e-434a-b4ed-2eaad8a54b74: succeeded
  ˫info   14m                           processing step: Starting                                 
  ˫info   14m                           processing step: Provision_Initialization                 
  ˫info   14m                           processing step: Init_Kyma_Template                       
...
```

this change proposes cosmetic update to
```
Events:
GLOBALACCOUNT ID                       SUBACCOUNT ID          SHOOT       REGION         PLAN   CREATED AT            STATE       KYMA VERSION   
e449f875-b5b2-4485-b7c0-98725c0571bf   prow-keb-integration   c-432e772   eu-central-1   aws    2022/12/21 01:05:29   succeeded   2.9.1          
 ˫provision operation d1554a21-ce7e-434a-b4ed-2eaad8a54b74: succeeded
  ˫info   14m                           processing step: Starting                                 
  ˫info   14m                           processing step: Provision_Initialization                 
  ˫info   14m                           processing step: Init_Kyma_Template                       
...
```