### PR TITLE
Change JetStream maxBytes to be 70% of the total file storage

### DIFF
--- a/resources/eventing/profile-evaluation.yaml
+++ b/resources/eventing/profile-evaluation.yaml
@@ -1,7 +1,7 @@
 global:
   jetstream:
     storage: file
-    maxBytes: 900Mi
+    maxBytes: 700Mi
     fileStorage:
       size: 1Gi
 

--- a/resources/eventing/profile-production.yaml
+++ b/resources/eventing/profile-production.yaml
@@ -1,7 +1,7 @@
 global:
   jetstream:
     storage: file
-    maxBytes: 900Mi
+    maxBytes: 700Mi
     fileStorage:
       size: 1Gi
 

--- a/resources/eventing/values.yaml
+++ b/resources/eventing/values.yaml
@@ -28,7 +28,7 @@ global:
     storage: file
     fileStorage:
       size: 1Gi
-    maxBytes: 900Mi
+    maxBytes: 700Mi
     discardPolicy: new
 
   # secretName defines optionally another name than the default secret name


### PR DESCRIPTION
**Description**

As part of this [ticket](https://github.com/kyma-project/kyma/issues/16346), we discovered that the max-bytes value of 900Mi of the stream size 1G is not suitable and causes the NATS cluster to break beyond repair. The root cause of this is not yet decided, but we suspect that NATS needs more storage buffer to store extra stream meta-data. This PR changes the max-bytes value to be 70% of the stream size to give more room for NATS meta storage.

**Related issue(s)**

- https://github.com/kyma-project/kyma/issues/16346
