### PR TITLE
Revert "improve epp metrics (#16298)"

### DIFF
--- a/components/event-publisher-proxy/pkg/handler/handler.go
+++ b/components/event-publisher-proxy/pkg/handler/handler.go
@@ -78,7 +78,6 @@ func NewHandler(receiver *receiver.HTTPMessageReceiver, sender sender.GenericSen
 // setupMux configures the request router for all required endpoints.
 func (h *Handler) setupMux() {
 	router := mux.NewRouter()
-	router.Use(h.collector.MetricsMiddleware())
 	router.HandleFunc(PublishEndpoint, h.maxBytes(h.publishCloudEvents)).Methods(http.MethodPost)
 	router.HandleFunc(LegacyEndpointPattern, h.maxBytes(h.publishLegacyEventsAsCE)).Methods(http.MethodPost)
 	if h.Options.EnableNewCRDVersion {
@@ -209,12 +208,12 @@ func (h *Handler) sendEventAndRecordMetrics(ctx context.Context, event *cev2even
 	result, err := h.Sender.Send(ctx, event)
 	duration := time.Since(start)
 	if err != nil {
-		h.collector.RecordBackendError()
+		h.collector.RecordError()
 		return nil, err
 	}
 	h.collector.RecordEventType(event.Type(), event.Source(), result.HTTPStatus())
-	h.collector.RecordBackendLatency(duration, result.HTTPStatus(), host)
-	h.collector.RecordBackendRequests(result.HTTPStatus(), host)
+	h.collector.RecordLatency(duration, result.HTTPStatus(), host)
+	h.collector.RecordRequests(result.HTTPStatus(), host)
 	return result, nil
 }
 

--- a/components/event-publisher-proxy/pkg/handler/handler_test.go
+++ b/components/event-publisher-proxy/pkg/handler/handler_test.go
@@ -201,27 +201,28 @@ func TestHandler_publishCloudEvents(t *testing.T) {
 			},
 			wantStatus: 204,
 			wantTEF: `
-				# HELP eventing_epp_event_type_published_total The total number of events published for a given eventTypeLabel
-				# TYPE eventing_epp_event_type_published_total counter
-				eventing_epp_event_type_published_total{code="204",event_source="/default/sap.kyma/id",event_type=""} 1
-				# HELP eventing_epp_backend_duration_milliseconds The duration of sending events to the messaging server in milliseconds
-				# TYPE eventing_epp_backend_duration_milliseconds histogram
-				eventing_epp_backend_duration_milliseconds_bucket{code="204",destination_service="FOO",le="0.005"} 1
-				eventing_epp_backend_duration_milliseconds_bucket{code="204",destination_service="FOO",le="0.01"} 1
-				eventing_epp_backend_duration_milliseconds_bucket{code="204",destination_service="FOO",le="0.025"} 1
-				eventing_epp_backend_duration_milliseconds_bucket{code="204",destination_service="FOO",le="0.05"} 1
-				eventing_epp_backend_duration_milliseconds_bucket{code="204",destination_service="FOO",le="0.1"} 1
-				eventing_epp_backend_duration_milliseconds_bucket{code="204",destination_service="FOO",le="0.25"} 1
-				eventing_epp_backend_duration_milliseconds_bucket{code="204",destination_service="FOO",le="0.5"} 1
-				eventing_epp_backend_duration_milliseconds_bucket{code="204",destination_service="FOO",le="1"} 1
-				eventing_epp_backend_duration_milliseconds_bucket{code="204",destination_service="FOO",le="2.5"} 1
-				eventing_epp_backend_duration_milliseconds_bucket{code="204",destination_service="FOO",le="5"} 1
-				eventing_epp_backend_duration_milliseconds_bucket{code="204",destination_service="FOO",le="10"} 1
-				eventing_epp_backend_duration_milliseconds_bucket{code="204",destination_service="FOO",le="+Inf"} 1
-				eventing_epp_backend_duration_milliseconds_count{code="204",destination_service="FOO"} 1
-				# HELP eventing_epp_backend_requests_total The total number of backend requests
-				# TYPE eventing_epp_backend_requests_total counter
-				eventing_epp_backend_requests_total{code="204",destination_service="FOO"} 1
+				# HELP epp_event_type_published_total The total number of events published for a given eventTypeLabel
+				# TYPE epp_event_type_published_total counter
+				epp_event_type_published_total{event_source="/default/sap.kyma/id",event_type="",response_code="204"} 1
+				# HELP eventing_epp_messaging_server_latency_duration_milliseconds The duration of sending events to the messaging server in milliseconds
+				# TYPE eventing_epp_messaging_server_latency_duration_milliseconds histogram
+				eventing_epp_messaging_server_latency_duration_milliseconds_bucket{destination_service="FOO",response_code="204",le="0.005"} 1
+				eventing_epp_messaging_server_latency_duration_milliseconds_bucket{destination_service="FOO",response_code="204",le="0.01"} 1
+				eventing_epp_messaging_server_latency_duration_milliseconds_bucket{destination_service="FOO",response_code="204",le="0.025"} 1
+				eventing_epp_messaging_server_latency_duration_milliseconds_bucket{destination_service="FOO",response_code="204",le="0.05"} 1
+				eventing_epp_messaging_server_latency_duration_milliseconds_bucket{destination_service="FOO",response_code="204",le="0.1"} 1
+				eventing_epp_messaging_server_latency_duration_milliseconds_bucket{destination_service="FOO",response_code="204",le="0.25"} 1
+				eventing_epp_messaging_server_latency_duration_milliseconds_bucket{destination_service="FOO",response_code="204",le="0.5"} 1
+				eventing_epp_messaging_server_latency_duration_milliseconds_bucket{destination_service="FOO",response_code="204",le="1"} 1
+				eventing_epp_messaging_server_latency_duration_milliseconds_bucket{destination_service="FOO",response_code="204",le="2.5"} 1
+				eventing_epp_messaging_server_latency_duration_milliseconds_bucket{destination_service="FOO",response_code="204",le="5"} 1
+				eventing_epp_messaging_server_latency_duration_milliseconds_bucket{destination_service="FOO",response_code="204",le="10"} 1
+				eventing_epp_messaging_server_latency_duration_milliseconds_bucket{destination_service="FOO",response_code="204",le="+Inf"} 1
+				eventing_epp_messaging_server_latency_duration_milliseconds_sum{destination_service="FOO",response_code="204"} 0
+				eventing_epp_messaging_server_latency_duration_milliseconds_count{destination_service="FOO",response_code="204"} 1
+				# HELP eventing_epp_requests_total The total number of event requests
+				# TYPE eventing_epp_requests_total counter
+				eventing_epp_requests_total{destination_service="FOO",response_code="204"} 1
 			`,
 		},
 		{
@@ -243,28 +244,28 @@ func TestHandler_publishCloudEvents(t *testing.T) {
 			},
 			wantStatus: 204,
 			wantTEF: `
-				# HELP eventing_epp_event_type_published_total The total number of events published for a given eventTypeLabel
-				# TYPE eventing_epp_event_type_published_total counter
-				eventing_epp_event_type_published_total{code="204",event_source="/default/sap.kyma/id",event_type=""} 1
-				# HELP eventing_epp_backend_duration_milliseconds The duration of sending events to the messaging server in milliseconds
-				# TYPE eventing_epp_backend_duration_milliseconds histogram
-				eventing_epp_backend_duration_milliseconds_bucket{code="204",destination_service="FOO",le="0.005"} 1
-				eventing_epp_backend_duration_milliseconds_bucket{code="204",destination_service="FOO",le="0.01"} 1
-				eventing_epp_backend_duration_milliseconds_bucket{code="204",destination_service="FOO",le="0.025"} 1
-				eventing_epp_backend_duration_milliseconds_bucket{code="204",destination_service="FOO",le="0.05"} 1
-				eventing_epp_backend_duration_milliseconds_bucket{code="204",destination_service="FOO",le="0.1"} 1
-				eventing_epp_backend_duration_milliseconds_bucket{code="204",destination_service="FOO",le="0.25"} 1
-				eventing_epp_backend_duration_milliseconds_bucket{code="204",destination_service="FOO",le="0.5"} 1
-				eventing_epp_backend_duration_milliseconds_bucket{code="204",destination_service="FOO",le="1"} 1
-				eventing_epp_backend_duration_milliseconds_bucket{code="204",destination_service="FOO",le="2.5"} 1
-				eventing_epp_backend_duration_milliseconds_bucket{code="204",destination_service="FOO",le="5"} 1
-				eventing_epp_backend_duration_milliseconds_bucket{code="204",destination_service="FOO",le="10"} 1
-				eventing_epp_backend_duration_milliseconds_bucket{code="204",destination_service="FOO",le="+Inf"} 1
-				eventing_epp_backend_duration_milliseconds_sum{destination_service="FOO",code="204"} 0
-				eventing_epp_backend_duration_milliseconds_count{destination_service="FOO",code="204"} 1
-				# HELP eventing_epp_backend_requests_total The total number of backend requests
-				# TYPE eventing_epp_backend_requests_total counter
-				eventing_epp_backend_requests_total{code="204",destination_service="FOO"} 1
+				# HELP epp_event_type_published_total The total number of events published for a given eventTypeLabel
+				# TYPE epp_event_type_published_total counter
+				epp_event_type_published_total{event_source="/default/sap.kyma/id",event_type="",response_code="204"} 1
+				# HELP eventing_epp_messaging_server_latency_duration_milliseconds The duration of sending events to the messaging server in milliseconds
+				# TYPE eventing_epp_messaging_server_latency_duration_milliseconds histogram
+				eventing_epp_messaging_server_latency_duration_milliseconds_bucket{destination_service="FOO",response_code="204",le="0.005"} 1
+				eventing_epp_messaging_server_latency_duration_milliseconds_bucket{destination_service="FOO",response_code="204",le="0.01"} 1
+				eventing_epp_messaging_server_latency_duration_milliseconds_bucket{destination_service="FOO",response_code="204",le="0.025"} 1
+				eventing_epp_messaging_server_latency_duration_milliseconds_bucket{destination_service="FOO",response_code="204",le="0.05"} 1
+				eventing_epp_messaging_server_latency_duration_milliseconds_bucket{destination_service="FOO",response_code="204",le="0.1"} 1
+				eventing_epp_messaging_server_latency_duration_milliseconds_bucket{destination_service="FOO",response_code="204",le="0.25"} 1
+				eventing_epp_messaging_server_latency_duration_milliseconds_bucket{destination_service="FOO",response_code="204",le="0.5"} 1
+				eventing_epp_messaging_server_latency_duration_milliseconds_bucket{destination_service="FOO",response_code="204",le="1"} 1
+				eventing_epp_messaging_server_latency_duration_milliseconds_bucket{destination_service="FOO",response_code="204",le="2.5"} 1
+				eventing_epp_messaging_server_latency_duration_milliseconds_bucket{destination_service="FOO",response_code="204",le="5"} 1
+				eventing_epp_messaging_server_latency_duration_milliseconds_bucket{destination_service="FOO",response_code="204",le="10"} 1
+				eventing_epp_messaging_server_latency_duration_milliseconds_bucket{destination_service="FOO",response_code="204",le="+Inf"} 1
+				eventing_epp_messaging_server_latency_duration_milliseconds_sum{destination_service="FOO",response_code="204"} 0
+				eventing_epp_messaging_server_latency_duration_milliseconds_count{destination_service="FOO",response_code="204"} 1
+				# HELP eventing_epp_requests_total The total number of event requests
+				# TYPE eventing_epp_requests_total counter
+				eventing_epp_requests_total{destination_service="FOO",response_code="204"} 1
 			`,
 		},
 		{
@@ -323,9 +324,9 @@ func TestHandler_publishCloudEvents(t *testing.T) {
 			},
 			wantStatus: 500,
 			wantTEF: `
-				# HELP eventing_epp_backend_errors_total The total number of backend errors while sending events to the messaging server
-				# TYPE eventing_epp_backend_errors_total counter
-				eventing_epp_backend_errors_total 1
+				# HELP eventing_epp_errors_total The total number of errors while sending events to the messaging server
+				# TYPE eventing_epp_errors_total counter
+				eventing_epp_errors_total 1
 			`,
 		},
 		{
@@ -342,9 +343,9 @@ func TestHandler_publishCloudEvents(t *testing.T) {
 			},
 			wantStatus: 507,
 			wantTEF: `
-				# HELP eventing_epp_backend_errors_total The total number of backend errors while sending events to the messaging server
-				# TYPE eventing_epp_backend_errors_total counter
-				eventing_epp_backend_errors_total 1
+				# HELP eventing_epp_errors_total The total number of errors while sending events to the messaging server
+				# TYPE eventing_epp_errors_total counter
+				eventing_epp_errors_total 1
 			`,
 		},
 	}
@@ -421,30 +422,30 @@ func TestHandler_publishLegacyEventsAsCE(t *testing.T) {
 			wantStatus: 200,
 			wantOk:     true,
 			wantTEF: `
-					# HELP eventing_epp_event_type_published_total The total number of events published for a given eventTypeLabel
-					# TYPE eventing_epp_event_type_published_total counter
-					eventing_epp_event_type_published_total{code="204",event_source="namespace",event_type="im.a.prefix.testapp.object.created.v1"} 1
+					# HELP epp_event_type_published_total The total number of events published for a given eventTypeLabel
+					# TYPE epp_event_type_published_total counter
+					epp_event_type_published_total{event_source="namespace",event_type="im.a.prefix.testapp.object.created.v1",response_code="204"} 1
 
-					# HELP eventing_epp_backend_duration_milliseconds The duration of sending events to the messaging server in milliseconds
-					# TYPE eventing_epp_backend_duration_milliseconds histogram
-					eventing_epp_backend_duration_milliseconds_bucket{code="204",destination_service="FOO",le="0.005"} 1
-					eventing_epp_backend_duration_milliseconds_bucket{code="204",destination_service="FOO",le="0.01"} 1
-					eventing_epp_backend_duration_milliseconds_bucket{code="204",destination_service="FOO",le="0.025"} 1
-					eventing_epp_backend_duration_milliseconds_bucket{code="204",destination_service="FOO",le="0.05"} 1
-					eventing_epp_backend_duration_milliseconds_bucket{code="204",destination_service="FOO",le="0.1"} 1
-					eventing_epp_backend_duration_milliseconds_bucket{code="204",destination_service="FOO",le="0.25"} 1
-					eventing_epp_backend_duration_milliseconds_bucket{code="204",destination_service="FOO",le="0.5"} 1
-					eventing_epp_backend_duration_milliseconds_bucket{code="204",destination_service="FOO",le="1"} 1
-					eventing_epp_backend_duration_milliseconds_bucket{code="204",destination_service="FOO",le="2.5"} 1
-					eventing_epp_backend_duration_milliseconds_bucket{code="204",destination_service="FOO",le="5"} 1
-					eventing_epp_backend_duration_milliseconds_bucket{code="204",destination_service="FOO",le="10"} 1
-					eventing_epp_backend_duration_milliseconds_bucket{code="204",destination_service="FOO",le="+Inf"} 1
-					eventing_epp_backend_duration_milliseconds_sum{destination_service="FOO",code="204"} 0
-					eventing_epp_backend_duration_milliseconds_count{code="204",destination_service="FOO"} 1
+					# HELP eventing_epp_messaging_server_latency_duration_milliseconds The duration of sending events to the messaging server in milliseconds
+					# TYPE eventing_epp_messaging_server_latency_duration_milliseconds histogram
+					eventing_epp_messaging_server_latency_duration_milliseconds_bucket{destination_service="FOO",response_code="204",le="0.005"} 1
+					eventing_epp_messaging_server_latency_duration_milliseconds_bucket{destination_service="FOO",response_code="204",le="0.01"} 1
+					eventing_epp_messaging_server_latency_duration_milliseconds_bucket{destination_service="FOO",response_code="204",le="0.025"} 1
+					eventing_epp_messaging_server_latency_duration_milliseconds_bucket{destination_service="FOO",response_code="204",le="0.05"} 1
+					eventing_epp_messaging_server_latency_duration_milliseconds_bucket{destination_service="FOO",response_code="204",le="0.1"} 1
+					eventing_epp_messaging_server_latency_duration_milliseconds_bucket{destination_service="FOO",response_code="204",le="0.25"} 1
+					eventing_epp_messaging_server_latency_duration_milliseconds_bucket{destination_service="FOO",response_code="204",le="0.5"} 1
+					eventing_epp_messaging_server_latency_duration_milliseconds_bucket{destination_service="FOO",response_code="204",le="1"} 1
+					eventing_epp_messaging_server_latency_duration_milliseconds_bucket{destination_service="FOO",response_code="204",le="2.5"} 1
+					eventing_epp_messaging_server_latency_duration_milliseconds_bucket{destination_service="FOO",response_code="204",le="5"} 1
+					eventing_epp_messaging_server_latency_duration_milliseconds_bucket{destination_service="FOO",response_code="204",le="10"} 1
+					eventing_epp_messaging_server_latency_duration_milliseconds_bucket{destination_service="FOO",response_code="204",le="+Inf"} 1
+					eventing_epp_messaging_server_latency_duration_milliseconds_sum{destination_service="FOO",response_code="204"} 0
+					eventing_epp_messaging_server_latency_duration_milliseconds_count{destination_service="FOO",response_code="204"} 1
 
-					# HELP eventing_epp_backend_requests_total The total number of backend requests
-					# TYPE eventing_epp_backend_requests_total counter
-					eventing_epp_backend_requests_total{code="204",destination_service="FOO"} 1
+					# HELP eventing_epp_requests_total The total number of event requests
+					# TYPE eventing_epp_requests_total counter
+					eventing_epp_requests_total{destination_service="FOO",response_code="204"} 1
 				`,
 		},
 		{
@@ -464,9 +465,9 @@ func TestHandler_publishLegacyEventsAsCE(t *testing.T) {
 			wantStatus: http.StatusBadGateway,
 			wantOk:     false,
 			wantTEF: `
-					# HELP eventing_epp_backend_errors_total The total number of backend errors while sending events to the messaging server
-					# TYPE eventing_epp_backend_errors_total counter
-					eventing_epp_backend_errors_total 1
+					# HELP eventing_epp_errors_total The total number of errors while sending events to the messaging server
+					# TYPE eventing_epp_errors_total counter
+					eventing_epp_errors_total 1
 				`,
 		},
 		{
@@ -486,9 +487,9 @@ func TestHandler_publishLegacyEventsAsCE(t *testing.T) {
 			wantStatus: 507,
 			wantOk:     false,
 			wantTEF: `
-					# HELP eventing_epp_backend_errors_total The total number of backend errors while sending events to the messaging server
-					# TYPE eventing_epp_backend_errors_total counter
-					eventing_epp_backend_errors_total 1
+					# HELP eventing_epp_errors_total The total number of errors while sending events to the messaging server
+					# TYPE eventing_epp_errors_total counter
+					eventing_epp_errors_total 1
 				`,
 		},
 		{
@@ -508,9 +509,9 @@ func TestHandler_publishLegacyEventsAsCE(t *testing.T) {
 			wantStatus: 500,
 			wantOk:     false,
 			wantTEF: `
-					# HELP eventing_epp_backend_errors_total The total number of backend errors while sending events to the messaging server
-					# TYPE eventing_epp_backend_errors_total counter
-					eventing_epp_backend_errors_total 1
+					# HELP eventing_epp_errors_total The total number of errors while sending events to the messaging server
+					# TYPE eventing_epp_errors_total counter
+					eventing_epp_errors_total 1
 				`,
 		},
 		{
@@ -690,22 +691,22 @@ func TestHandler_sendEventAndRecordMetrics(t *testing.T) {
 				metricLatency:   1,
 				metricPublished: 1,
 				metricLatencyTEF: `
-					# HELP eventing_epp_backend_duration_milliseconds The duration of sending events to the messaging server in milliseconds
-					# TYPE eventing_epp_backend_duration_milliseconds histogram
-					eventing_epp_backend_duration_milliseconds_bucket{code="204",destination_service="foo",le="0.005"} 1
-					eventing_epp_backend_duration_milliseconds_bucket{code="204",destination_service="foo",le="0.01"} 1
-					eventing_epp_backend_duration_milliseconds_bucket{code="204",destination_service="foo",le="0.025"} 1
-					eventing_epp_backend_duration_milliseconds_bucket{code="204",destination_service="foo",le="0.05"} 1
-					eventing_epp_backend_duration_milliseconds_bucket{code="204",destination_service="foo",le="0.1"} 1
-					eventing_epp_backend_duration_milliseconds_bucket{code="204",destination_service="foo",le="0.25"} 1
-					eventing_epp_backend_duration_milliseconds_bucket{code="204",destination_service="foo",le="0.5"} 1
-					eventing_epp_backend_duration_milliseconds_bucket{code="204",destination_service="foo",le="1"} 1
-					eventing_epp_backend_duration_milliseconds_bucket{code="204",destination_service="foo",le="2.5"} 1
-					eventing_epp_backend_duration_milliseconds_bucket{code="204",destination_service="foo",le="5"} 1
-					eventing_epp_backend_duration_milliseconds_bucket{code="204",destination_service="foo",le="10"} 1
-					eventing_epp_backend_duration_milliseconds_bucket{code="204",destination_service="foo",le="+Inf"} 1
-					eventing_epp_backend_duration_milliseconds_sum{code="204",destination_service="foo"} 0
-					eventing_epp_backend_duration_milliseconds_count{code="204",destination_service="foo"} 1
+# HELP eventing_epp_messaging_server_latency_duration_milliseconds The duration of sending events to the messaging server in milliseconds
+# TYPE eventing_epp_messaging_server_latency_duration_milliseconds histogram
+eventing_epp_messaging_server_latency_duration_milliseconds_bucket{destination_service="foo",response_code="204",le="0.005"} 1
+eventing_epp_messaging_server_latency_duration_milliseconds_bucket{destination_service="foo",response_code="204",le="0.01"} 1
+eventing_epp_messaging_server_latency_duration_milliseconds_bucket{destination_service="foo",response_code="204",le="0.025"} 1
+eventing_epp_messaging_server_latency_duration_milliseconds_bucket{destination_service="foo",response_code="204",le="0.05"} 1
+eventing_epp_messaging_server_latency_duration_milliseconds_bucket{destination_service="foo",response_code="204",le="0.1"} 1
+eventing_epp_messaging_server_latency_duration_milliseconds_bucket{destination_service="foo",response_code="204",le="0.25"} 1
+eventing_epp_messaging_server_latency_duration_milliseconds_bucket{destination_service="foo",response_code="204",le="0.5"} 1
+eventing_epp_messaging_server_latency_duration_milliseconds_bucket{destination_service="foo",response_code="204",le="1"} 1
+eventing_epp_messaging_server_latency_duration_milliseconds_bucket{destination_service="foo",response_code="204",le="2.5"} 1
+eventing_epp_messaging_server_latency_duration_milliseconds_bucket{destination_service="foo",response_code="204",le="5"} 1
+eventing_epp_messaging_server_latency_duration_milliseconds_bucket{destination_service="foo",response_code="204",le="10"} 1
+eventing_epp_messaging_server_latency_duration_milliseconds_bucket{destination_service="foo",response_code="204",le="+Inf"} 1
+eventing_epp_messaging_server_latency_duration_milliseconds_sum{destination_service="foo",response_code="204"} 0
+eventing_epp_messaging_server_latency_duration_milliseconds_count{destination_service="foo",response_code="204"} 1
 `,
 			},
 		},
@@ -755,7 +756,7 @@ func TestHandler_sendEventAndRecordMetrics(t *testing.T) {
 			metricstest.EnsureMetricTotalRequests(t, h.collector, tt.wants.metricTotal)
 			metricstest.EnsureMetricLatency(t, h.collector, tt.wants.metricLatency)
 			metricstest.EnsureMetricEventTypePublished(t, h.collector, tt.wants.metricPublished)
-			metricstest.EnsureMetricMatchesTextExpositionFormat(t, h.collector, tt.wants.metricLatencyTEF, "eventing_epp_backend_duration_milliseconds")
+			metricstest.EnsureMetricMatchesTextExpositionFormat(t, h.collector, tt.wants.metricLatencyTEF, "eventing_epp_messaging_server_latency_duration_milliseconds")
 		})
 	}
 }

--- a/components/event-publisher-proxy/pkg/metrics/collector.go
+++ b/components/event-publisher-proxy/pkg/metrics/collector.go
@@ -2,53 +2,32 @@ package metrics
 
 import (
 	"fmt"
-	"net/http"
 	"time"
 
-	"github.com/gorilla/mux"
 	"github.com/prometheus/client_golang/prometheus"
-	"github.com/prometheus/client_golang/prometheus/promhttp"
 
 	"github.com/kyma-project/kyma/components/event-publisher-proxy/pkg/metrics/histogram"
 )
 
 const (
-	// BackendErrorsKey name of the backendErrors metric
-	BackendErrorsKey = "eventing_epp_backend_errors_total"
-	// backendErrorsHelp help text for the backendErrors metric
-	backendErrorsHelp = "The total number of backend errors while sending events to the messaging server"
-
-	// BackendLatencyKey name of the backendLatencyHelp metric
-	BackendLatencyKey = "eventing_epp_backend_duration_milliseconds"
-	// backendLatencyHelp help text for the backendLatencyHelp metric
-	backendLatencyHelp = "The duration of sending events to the messaging server in milliseconds"
-
-	// BackendRequestsKey name of the eventRequests metric
-	BackendRequestsKey = "eventing_epp_backend_requests_total"
-	// backendRequestsHelp help text for event backendRequests metric
-	backendRequestsHelp = "The total number of backend requests"
-
-	// durationKey name of the duration metric
-	durationKey = "eventing_epp_requests_duration_milliseconds"
-	// durationHelp help text for the duration metric
-	durationHelp = "The duration of processing an incoming request (includes sending to the backend)"
-
-	// RequestsKey name of the Requests metric
-	RequestsKey = "eventing_epp_requests_total"
-	// requestsHelp help text for event requests metric
-	requestsHelp = "The total number of requests"
-
+	// ErrorsKey name of the errors metric
+	ErrorsKey = "eventing_epp_errors_total"
+	// LatencyKey name of the latency metric
+	LatencyKey = "eventing_epp_messaging_server_latency_duration_milliseconds"
 	// EventTypePublishedMetricKey name of the eventTypeLabel metric
-	EventTypePublishedMetricKey = "eventing_epp_event_type_published_total"
+	EventTypePublishedMetricKey = "epp_event_type_published_total"
+	// EventRequestsKey name of the eventRequests metric
+	EventRequestsKey = "eventing_epp_requests_total"
+	// errorsHelp help text for the errors metric
+	errorsHelp = "The total number of errors while sending events to the messaging server"
+	// latencyHelp help text for the latency metric
+	latencyHelp = "The duration of sending events to the messaging server in milliseconds"
 	// eventTypePublishedMetricHelp help text for the eventTypeLabel metric
 	eventTypePublishedMetricHelp = "The total number of events published for a given eventTypeLabel"
-	// methodLabel label for the method used in the http request
-
-	methodLabel = "method"
+	// eventRequestsHelp help text for event requests metric
+	eventRequestsHelp = "The total number of event requests"
 	// responseCodeLabel name of the status code labels used by multiple metrics
-	responseCodeLabel = "code"
-	// pathLabel name of the path service label
-	pathLabel = "path"
+	responseCodeLabel = "response_code"
 	// destSvcLabel name of the destination service label used by multiple metrics
 	destSvcLabel = "destination_service"
 	// eventTypeLabel name of the event type label used by metrics
@@ -61,53 +40,40 @@ const (
 // for recording epp specific metrics.
 type PublishingMetricsCollector interface {
 	prometheus.Collector
-	RecordBackendError()
-	RecordBackendLatency(duration time.Duration, statusCode int, destSvc string)
+	RecordError()
+	RecordLatency(duration time.Duration, statusCode int, destSvc string)
 	RecordEventType(eventType, eventSource string, statusCode int)
-	RecordBackendRequests(statusCode int, destSvc string)
-	MetricsMiddleware() mux.MiddlewareFunc
+	RecordRequests(statusCode int, destSvc string)
 }
 
 var _ PublishingMetricsCollector = &Collector{}
 
 // Collector implements the prometheus.Collector interface
 type Collector struct {
-	backendErrors   *prometheus.CounterVec
-	backendLatency  *prometheus.HistogramVec
-	backendRequests *prometheus.CounterVec
-
-	duration *prometheus.HistogramVec
-	requests *prometheus.CounterVec
-
+	errors    *prometheus.CounterVec
+	latency   *prometheus.HistogramVec
 	eventType *prometheus.CounterVec
+	requests  *prometheus.CounterVec
 }
 
 // NewCollector a new instance of Collector
 func NewCollector(latency histogram.BucketsProvider) *Collector {
 	return &Collector{
-		backendErrors: prometheus.NewCounterVec(
+		errors: prometheus.NewCounterVec(
 			prometheus.CounterOpts{
-				Name: BackendErrorsKey,
-				Help: backendErrorsHelp,
+				Name: ErrorsKey,
+				Help: errorsHelp,
 			},
 			[]string{},
 		),
-		backendLatency: prometheus.NewHistogramVec(
+		latency: prometheus.NewHistogramVec(
 			prometheus.HistogramOpts{
-				Name:    BackendLatencyKey,
-				Help:    backendLatencyHelp,
+				Name:    LatencyKey,
+				Help:    latencyHelp,
 				Buckets: latency.Buckets(),
 			},
 			[]string{responseCodeLabel, destSvcLabel},
 		),
-		backendRequests: prometheus.NewCounterVec(
-			prometheus.CounterOpts{
-				Name: BackendRequestsKey,
-				Help: backendRequestsHelp,
-			},
-			[]string{responseCodeLabel, destSvcLabel},
-		),
-
 		eventType: prometheus.NewCounterVec(
 			prometheus.CounterOpts{
 				Name: EventTypePublishedMetricKey,
@@ -115,52 +81,40 @@ func NewCollector(latency histogram.BucketsProvider) *Collector {
 			},
 			[]string{eventTypeLabel, eventSourceLabel, responseCodeLabel},
 		),
-
-		duration: prometheus.NewHistogramVec(
-			prometheus.HistogramOpts{
-				Name:    durationKey,
-				Help:    durationHelp,
-				Buckets: latency.Buckets(),
-			},
-			[]string{responseCodeLabel, methodLabel, pathLabel},
-		),
 		requests: prometheus.NewCounterVec(
 			prometheus.CounterOpts{
-				Name: RequestsKey,
-				Help: requestsHelp,
+				Name: EventRequestsKey,
+				Help: eventRequestsHelp,
 			},
-			[]string{responseCodeLabel, methodLabel, pathLabel}),
+			[]string{responseCodeLabel, destSvcLabel},
+		),
 	}
 }
 
 // Describe implements the prometheus.Collector interface Describe method
 func (c *Collector) Describe(ch chan<- *prometheus.Desc) {
-	c.backendErrors.Describe(ch)
-	c.backendLatency.Describe(ch)
-	c.backendRequests.Describe(ch)
+	c.errors.Describe(ch)
+	c.latency.Describe(ch)
 	c.eventType.Describe(ch)
 	c.requests.Describe(ch)
-	c.duration.Describe(ch)
 }
 
 // Collect implements the prometheus.Collector interface Collect method
 func (c *Collector) Collect(ch chan<- prometheus.Metric) {
-	c.backendErrors.Collect(ch)
-	c.backendLatency.Collect(ch)
-	c.backendRequests.Collect(ch)
+	c.errors.Collect(ch)
+	c.latency.Collect(ch)
 	c.eventType.Collect(ch)
 	c.requests.Collect(ch)
-	c.duration.Collect(ch)
 }
 
 // RecordError records an error metric
-func (c *Collector) RecordBackendError() {
-	c.backendErrors.WithLabelValues().Inc()
+func (c *Collector) RecordError() {
+	c.errors.WithLabelValues().Inc()
 }
 
-// RecordLatency records a backendLatencyHelp metric
-func (c *Collector) RecordBackendLatency(duration time.Duration, statusCode int, destSvc string) {
-	c.backendLatency.WithLabelValues(fmt.Sprint(statusCode), destSvc).Observe(float64(duration.Milliseconds()))
+// RecordLatency records a latency metric
+func (c *Collector) RecordLatency(duration time.Duration, statusCode int, destSvc string) {
+	c.latency.WithLabelValues(fmt.Sprint(statusCode), destSvc).Observe(float64(duration.Milliseconds()))
 }
 
 // RecordEventType records an eventType metric
@@ -169,21 +123,6 @@ func (c *Collector) RecordEventType(eventType, eventSource string, statusCode in
 }
 
 // RecordRequests records an eventRequests metric
-func (c *Collector) RecordBackendRequests(statusCode int, destSvc string) {
-	c.backendRequests.WithLabelValues(fmt.Sprint(statusCode), destSvc).Inc()
-}
-
-// MetricsMiddleware returns a http.Handler that can be used as middleware in gorilla.mux to track latencies for all handled paths in the gorilla router
-func (c *Collector) MetricsMiddleware() mux.MiddlewareFunc {
-	return func(next http.Handler) http.Handler {
-		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			route := mux.CurrentRoute(r)
-			path, _ := route.GetPathTemplate()
-			promhttp.InstrumentHandlerDuration(
-				c.duration.MustCurryWith(prometheus.Labels{pathLabel: path}),
-				promhttp.InstrumentHandlerCounter(c.requests.MustCurryWith(prometheus.Labels{pathLabel: path}), next),
-			).ServeHTTP(w, r)
-		})
-
-	}
+func (c *Collector) RecordRequests(statusCode int, destSvc string) {
+	c.requests.WithLabelValues(fmt.Sprint(statusCode), destSvc).Inc()
 }

--- a/components/event-publisher-proxy/pkg/metrics/collector_test.go
+++ b/components/event-publisher-proxy/pkg/metrics/collector_test.go
@@ -10,21 +10,25 @@ import (
 
 func TestNewCollector(t *testing.T) {
 	// given
+	const bucketsFunc = "Buckets"
 	latency := new(mocks.BucketsProvider)
-	latency.On("Buckets").Return(nil)
+	latency.On(bucketsFunc).Return(nil)
+	latency.Test(t)
 
 	// when
 	collector := NewCollector(latency)
 
 	// then
 	assert.NotNil(t, collector)
-	assert.NotNil(t, collector.backendErrors)
-	assert.NotNil(t, collector.backendErrors.MetricVec)
-	assert.NotNil(t, collector.backendLatency)
-	assert.NotNil(t, collector.backendLatency.MetricVec)
+	assert.NotNil(t, collector.errors)
+	assert.NotNil(t, collector.errors.MetricVec)
+	assert.NotNil(t, collector.latency)
+	assert.NotNil(t, collector.latency.MetricVec)
 	assert.NotNil(t, collector.eventType)
 	assert.NotNil(t, collector.eventType.MetricVec)
-	assert.NotNil(t, collector.backendRequests)
-	assert.NotNil(t, collector.backendRequests.MetricVec)
+	assert.NotNil(t, collector.requests)
+	assert.NotNil(t, collector.requests.MetricVec)
+	latency.AssertCalled(t, bucketsFunc)
+	latency.AssertNumberOfCalls(t, bucketsFunc, 1)
 	latency.AssertExpectations(t)
 }

--- a/components/event-publisher-proxy/pkg/metrics/metricstest/metricstest.go
+++ b/components/event-publisher-proxy/pkg/metrics/metricstest/metricstest.go
@@ -12,24 +12,24 @@ import (
 	"github.com/kyma-project/kyma/components/event-publisher-proxy/pkg/metrics"
 )
 
-// EnsureMetricErrors ensures metric eventing_epp_backend_errors_total exists.
+// EnsureMetricErrors ensures metric eventing_epp_errors_total exists.
 func EnsureMetricErrors(t *testing.T, collector metrics.PublishingMetricsCollector, count int) {
-	ensureMetricCount(t, collector, metrics.BackendErrorsKey, count)
+	ensureMetricCount(t, collector, metrics.ErrorsKey, count)
 }
 
-// EnsureMetricLatency ensures metric eventing_epp_backend_duration_seconds exists.
+// EnsureMetricLatency ensures metric eventing_epp_messaging_server_latency_duration_milliseconds exists.
 func EnsureMetricLatency(t *testing.T, collector metrics.PublishingMetricsCollector, count int) {
-	ensureMetricCount(t, collector, metrics.BackendLatencyKey, count)
+	ensureMetricCount(t, collector, metrics.LatencyKey, count)
 }
 
-// EnsureMetricEventTypePublished ensures metric eventing_epp_event_type_published_total exists.
+// EnsureMetricEventTypePublished ensures metric epp_event_type_published_total exists.
 func EnsureMetricEventTypePublished(t *testing.T, collector metrics.PublishingMetricsCollector, count int) {
 	ensureMetricCount(t, collector, metrics.EventTypePublishedMetricKey, count)
 }
 
-// EnsureMetricTotalRequests ensures metric eventing_epp_backend_requests_total exists.
+// EnsureMetricTotalRequests ensures metric eventing_epp_requests_total exists.
 func EnsureMetricTotalRequests(t *testing.T, collector metrics.PublishingMetricsCollector, count int) {
-	ensureMetricCount(t, collector, metrics.BackendRequestsKey, count)
+	ensureMetricCount(t, collector, metrics.EventRequestsKey, count)
 }
 
 func ensureMetricCount(t *testing.T, collector metrics.PublishingMetricsCollector, metric string, expectedCount int) {

--- a/resources/eventing/charts/dashboards/templates/delivery.yaml
+++ b/resources/eventing/charts/dashboards/templates/delivery.yaml
@@ -74,7 +74,7 @@ data:
             "targets": [
               {
                 "exemplar": true,
-                "expr": "sum by (event_type) (rate(eventing_epp_event_type_published_total{code=~\"[5].*\", event_type=~\"$eventType\"}[5m]))",
+                "expr": "sum by (event_type) (rate(epp_event_type_published_total{response_code=~\"[5].*\", event_type=~\"$eventType\"}[5m]))",
                 "hide": false,
                 "interval": "",
                 "legendFormat": "{{event_type}} 5xx",
@@ -82,7 +82,7 @@ data:
               },
               {
                 "exemplar": true,
-                "expr": "sum by (event_type) (rate(eventing_epp_event_type_published_total{code=~\"[4].*\", event_type=~\"$eventType\"}[5m]))",
+                "expr": "sum by (event_type) (rate(epp_event_type_published_total{response_code=~\"[4].*\", event_type=~\"$eventType\"}[5m]))",
                 "hide": false,
                 "interval": "",
                 "legendFormat": "{{event_type}} 4xx",
@@ -303,7 +303,7 @@ data:
             "targets": [
               {
                 "exemplar": true,
-                "expr": "sum by (event_type) (rate(eventing_epp_event_type_published_total{code=~\"[2].*\", event_type=~\"$eventType\"}[5m]))",
+                "expr": "sum by (event_type) (rate(epp_event_type_published_total{response_code=~\"[2].*\", event_type=~\"$eventType\"}[5m]))",
                 "hide": false,
                 "interval": "",
                 "legendFormat": "{{event_type}} 2xx",
@@ -815,7 +815,7 @@ data:
             "targets": [
               {
                 "exemplar": true,
-                "expr": "count(nats_consumer_ack_floor_consumer_seq * on(consumer_name) group_left(event_type, subscription_name, subscription_namespace) nats_ec_event_type_subscribed_total) by (event_type, subscription_name, subscription_namespace) * on(event_type) group_left() sum(eventing_epp_event_type_published_total{event_type=~\"$eventType\"}) by (event_type)",
+                "expr": "count(nats_consumer_ack_floor_consumer_seq * on(consumer_name) group_left(event_type, subscription_name, subscription_namespace) nats_ec_event_type_subscribed_total) by (event_type, subscription_name, subscription_namespace) * on(event_type) group_left() sum(epp_event_type_published_total{event_type=~\"$eventType\"}) by (event_type)",
                 "format": "table",
                 "instant": false,
                 "interval": "",
@@ -919,7 +919,7 @@ data:
             "targets": [
               {
                 "exemplar": true,
-                "expr": "sum(eventing_epp_event_type_published_total{event_type=~\"$eventType\"}) by (event_type) unless (count(eventing_epp_event_type_published_total * on(event_type) group_left() sum(nats_consumer_ack_floor_consumer_seq * on(consumer_name) group_left(event_type) nats_ec_event_type_subscribed_total) by (event_type)) by (event_type))",
+                "expr": "sum(epp_event_type_published_total{event_type=~\"$eventType\"}) by (event_type) unless (count(epp_event_type_published_total * on(event_type) group_left() sum(nats_consumer_ack_floor_consumer_seq * on(consumer_name) group_left(event_type) nats_ec_event_type_subscribed_total) by (event_type)) by (event_type))",
                 "format": "table",
                 "instant": false,
                 "interval": "",
@@ -1033,7 +1033,7 @@ data:
             "targets": [
               {
                 "exemplar": true,
-                "expr": "sum(nats_consumer_ack_floor_consumer_seq * on(consumer_name) group_left(event_type, subscription_name, subscription_namespace) nats_ec_event_type_subscribed_total) by (event_type, subscription_name, subscription_namespace) unless count(nats_consumer_ack_floor_consumer_seq * on(consumer_name) group_left(event_type, subscription_name, subscription_namespace) nats_ec_event_type_subscribed_total) by (event_type, subscription_name, subscription_namespace) * on(event_type) group_left() sum(rate(eventing_epp_event_type_published_total{}[$__range])) by (event_type)",
+                "expr": "sum(nats_consumer_ack_floor_consumer_seq * on(consumer_name) group_left(event_type, subscription_name, subscription_namespace) nats_ec_event_type_subscribed_total) by (event_type, subscription_name, subscription_namespace) unless count(nats_consumer_ack_floor_consumer_seq * on(consumer_name) group_left(event_type, subscription_name, subscription_namespace) nats_ec_event_type_subscribed_total) by (event_type, subscription_name, subscription_namespace) * on(event_type) group_left() sum(rate(epp_event_type_published_total{}[$__range])) by (event_type)",
                 "format": "table",
                 "instant": true,
                 "interval": "",
@@ -1096,7 +1096,7 @@ data:
                 ]
               },
               "datasource": null,
-              "definition": "label_values(eventing_epp_event_type_published_total, event_type)",
+              "definition": "label_values(epp_event_type_published_total, event_type)",
               "description": null,
               "error": null,
               "hide": 0,
@@ -1106,7 +1106,7 @@ data:
               "name": "eventType",
               "options": [],
               "query": {
-                "query": "label_values(eventing_epp_event_type_published_total, event_type)",
+                "query": "label_values(epp_event_type_published_total, event_type)",
                 "refId": "StandardVariableQuery"
               },
               "refresh": 2,

--- a/resources/eventing/charts/dashboards/templates/latency.yaml
+++ b/resources/eventing/charts/dashboards/templates/latency.yaml
@@ -180,7 +180,7 @@ data:
           "steppedLine": false,
           "targets": [
             {
-              "expr": "histogram_quantile(0.99999, sum(rate(eventing_epp_backend_duration_milliseconds_bucket{namespace=\"kyma-system\"}[5m])) by (le,pod,namespace,service))",
+              "expr": "histogram_quantile(0.99999, sum(rate(eventing_epp_messaging_server_latency_duration_milliseconds_bucket{namespace=\"kyma-system\"}[5m])) by (le,pod,namespace,service))",
               "hide": false,
               "interval": "",
               "legendFormat": "{{ `{{namespace}}/{{pod}} -> Messaging Server (99.999%)`}}",

--- a/resources/eventing/values.yaml
+++ b/resources/eventing/values.yaml
@@ -9,7 +9,7 @@ global:
       pullPolicy: "IfNotPresent"
     publisher_proxy:
       name: event-publisher-proxy
-      version: PR-16298
+      version: PR-16275
     nats:
       name: nats
       version: 2.9.6-alpine3.16

--- a/tests/fast-integration/eventing-test/metric-test.js
+++ b/tests/fast-integration/eventing-test/metric-test.js
@@ -63,7 +63,7 @@ const dashboards = {
   },
   latency_eventPublisherToMessagingServer: {
     title: 'Latency of Event Publisher -> Messaging Server',
-    query: 'histogram_quantile(0.99999, sum(rate(eventing_epp_backend_duration_milliseconds_bucket{namespace="kyma-system"}[5m])) by (le,pod,namespace,service))',
+    query: 'histogram_quantile(0.99999, sum(rate(eventing_epp_messaging_server_latency_duration_milliseconds_bucket{namespace="kyma-system"}[5m])) by (le,pod,namespace,service))',
     backends: ['nats', 'beb'],
     assert: function(result) {
       const foundMetric = result.find((res) =>


### PR DESCRIPTION
This reverts commit d9a237e9ad4f65e9803c6c23c8db0fa76fcafb37.

<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- Seems the PR #16298 broke the fast-integration tests. This was possible because the jobs were made optional (without an approval from the eventing team): https://github.com/kyma-project/test-infra/pull/6437/files
  - Reverting the changes until our eventing jobs are required again. Currently eventing tests are failing after this merge.



**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
