### PR TITLE
rename `beb` to `eventmesh` in epp/pkg/sender

### DIFF
--- a/components/event-publisher-proxy/pkg/commander/beb/beb.go
+++ b/components/event-publisher-proxy/pkg/commander/beb/beb.go
@@ -28,7 +28,7 @@ import (
 	"github.com/kyma-project/kyma/components/event-publisher-proxy/pkg/oauth"
 	"github.com/kyma-project/kyma/components/event-publisher-proxy/pkg/options"
 	"github.com/kyma-project/kyma/components/event-publisher-proxy/pkg/receiver"
-	"github.com/kyma-project/kyma/components/event-publisher-proxy/pkg/sender/beb"
+	"github.com/kyma-project/kyma/components/event-publisher-proxy/pkg/sender/eventmesh"
 	"github.com/kyma-project/kyma/components/event-publisher-proxy/pkg/signals"
 	"github.com/kyma-project/kyma/components/event-publisher-proxy/pkg/subscribed"
 )
@@ -81,7 +81,7 @@ func (c *Commander) Start() error {
 	defer client.CloseIdleConnections()
 
 	// configure message sender
-	messageSender := beb.NewSender(c.envCfg.EmsPublishURL, client)
+	messageSender := eventmesh.NewSender(c.envCfg.EmsPublishURL, client)
 
 	// cluster config
 	k8sConfig := config.GetConfigOrDie()

--- a/components/event-publisher-proxy/pkg/handler/handler_test.go
+++ b/components/event-publisher-proxy/pkg/handler/handler_test.go
@@ -31,7 +31,7 @@ import (
 	"github.com/kyma-project/kyma/components/event-publisher-proxy/pkg/metrics/metricstest"
 	"github.com/kyma-project/kyma/components/event-publisher-proxy/pkg/options"
 	"github.com/kyma-project/kyma/components/event-publisher-proxy/pkg/sender"
-	"github.com/kyma-project/kyma/components/event-publisher-proxy/pkg/sender/beb"
+	"github.com/kyma-project/kyma/components/event-publisher-proxy/pkg/sender/eventmesh"
 	testingutils "github.com/kyma-project/kyma/components/event-publisher-proxy/testing"
 )
 
@@ -193,7 +193,7 @@ func TestHandler_publishCloudEvents(t *testing.T) {
 			fields: fields{
 				Sender: &GenericSenderStub{
 					Err: nil,
-					Result: beb.HTTPPublishResult{
+					Result: eventmesh.HTTPPublishResult{
 						Status: 204,
 						Body:   []byte(""),
 					},
@@ -235,7 +235,7 @@ func TestHandler_publishCloudEvents(t *testing.T) {
 			fields: fields{
 				Sender: &GenericSenderStub{
 					Err: nil,
-					Result: beb.HTTPPublishResult{
+					Result: eventmesh.HTTPPublishResult{
 						Status: 204,
 						Body:   []byte(""),
 					},
@@ -413,7 +413,7 @@ func TestHandler_publishLegacyEventsAsCE(t *testing.T) {
 			name: "Send valid legacy event",
 			fields: fields{
 				Sender: &GenericSenderStub{
-					Result: beb.HTTPPublishResult{
+					Result: eventmesh.HTTPPublishResult{
 						Status: 204,
 					},
 					BackendURL: "FOO",
@@ -524,7 +524,7 @@ func TestHandler_publishLegacyEventsAsCE(t *testing.T) {
 			name: "Send invalid legacy event",
 			fields: fields{
 				Sender: &GenericSenderStub{
-					Result: beb.HTTPPublishResult{
+					Result: eventmesh.HTTPPublishResult{
 						Status: 204,
 					},
 					BackendURL: "FOO",
@@ -673,7 +673,7 @@ func TestHandler_sendEventAndRecordMetrics(t *testing.T) {
 				Sender: &GenericSenderStub{
 					Err:           nil,
 					SleepDuration: 0,
-					Result: beb.HTTPPublishResult{
+					Result: eventmesh.HTTPPublishResult{
 						Status: 204,
 						Body:   nil,
 					},
@@ -687,7 +687,7 @@ func TestHandler_sendEventAndRecordMetrics(t *testing.T) {
 				event: &cev2event.Event{},
 			},
 			wants: wants{
-				result: beb.HTTPPublishResult{
+				result: eventmesh.HTTPPublishResult{
 					Status: 204,
 					Body:   nil,
 				},
@@ -772,7 +772,7 @@ func TestHandler_sendEventAndRecordMetrics_TracingAndDefaults(t *testing.T) {
 	stub := &GenericSenderStub{
 		Err:           nil,
 		SleepDuration: 0,
-		Result:        beb.HTTPPublishResult{Status: http.StatusInternalServerError},
+		Result:        eventmesh.HTTPPublishResult{Status: http.StatusInternalServerError},
 	}
 
 	const bucketsFunc = "Buckets"

--- a/components/event-publisher-proxy/pkg/handler/handler_v1alpha2_test.go
+++ b/components/event-publisher-proxy/pkg/handler/handler_v1alpha2_test.go
@@ -23,7 +23,7 @@ import (
 	"github.com/kyma-project/kyma/components/event-publisher-proxy/pkg/metrics/metricstest"
 	"github.com/kyma-project/kyma/components/event-publisher-proxy/pkg/options"
 	"github.com/kyma-project/kyma/components/event-publisher-proxy/pkg/sender"
-	"github.com/kyma-project/kyma/components/event-publisher-proxy/pkg/sender/beb"
+	"github.com/kyma-project/kyma/components/event-publisher-proxy/pkg/sender/eventmesh"
 )
 
 func TestHandler_publishCloudEventsV1Alpha2(t *testing.T) {
@@ -54,7 +54,7 @@ func TestHandler_publishCloudEventsV1Alpha2(t *testing.T) {
 			fields: fields{
 				Sender: &GenericSenderStub{
 					Err: nil,
-					Result: beb.HTTPPublishResult{
+					Result: eventmesh.HTTPPublishResult{
 						Status: 204,
 						Body:   []byte(""),
 					},
@@ -96,7 +96,7 @@ func TestHandler_publishCloudEventsV1Alpha2(t *testing.T) {
 			fields: fields{
 				Sender: &GenericSenderStub{
 					Err: nil,
-					Result: beb.HTTPPublishResult{
+					Result: eventmesh.HTTPPublishResult{
 						Status: 204,
 						Body:   []byte(""),
 					},
@@ -139,7 +139,7 @@ func TestHandler_publishCloudEventsV1Alpha2(t *testing.T) {
 			fields: fields{
 				Sender: &GenericSenderStub{
 					Err: nil,
-					Result: beb.HTTPPublishResult{
+					Result: eventmesh.HTTPPublishResult{
 						Status: 204,
 						Body:   []byte(""),
 					},
@@ -181,7 +181,7 @@ func TestHandler_publishCloudEventsV1Alpha2(t *testing.T) {
 			fields: fields{
 				Sender: &GenericSenderStub{
 					Err: nil,
-					Result: beb.HTTPPublishResult{
+					Result: eventmesh.HTTPPublishResult{
 						Status: 204,
 						Body:   []byte(""),
 					},

--- a/components/event-publisher-proxy/pkg/sender/eventmesh/eventmesh.go
+++ b/components/event-publisher-proxy/pkg/sender/eventmesh/eventmesh.go
@@ -1,4 +1,4 @@
-package beb
+package eventmesh
 
 import (
 	"context"

--- a/components/event-publisher-proxy/pkg/sender/eventmesh/eventmesh_test.go
+++ b/components/event-publisher-proxy/pkg/sender/eventmesh/eventmesh_test.go
@@ -1,4 +1,4 @@
-package beb
+package eventmesh
 
 import (
 	"context"

--- a/components/event-publisher-proxy/pkg/sender/jetstream/jetstream.go
+++ b/components/event-publisher-proxy/pkg/sender/jetstream/jetstream.go
@@ -19,7 +19,7 @@ import (
 	"github.com/kyma-project/kyma/components/event-publisher-proxy/pkg/env"
 	"github.com/kyma-project/kyma/components/event-publisher-proxy/pkg/handler/health"
 	"github.com/kyma-project/kyma/components/event-publisher-proxy/pkg/sender"
-	"github.com/kyma-project/kyma/components/event-publisher-proxy/pkg/sender/beb"
+	"github.com/kyma-project/kyma/components/event-publisher-proxy/pkg/sender/eventmesh"
 
 	"github.com/nats-io/nats.go"
 )
@@ -99,7 +99,7 @@ func (s *Sender) Send(_ context.Context, event *event.Event) (sender.PublishResu
 		}
 		return nil, fmt.Errorf("%w : %v", sender.ErrInternalBackendError, fmt.Errorf("%w, %v", ErrCannotSendToStream, err))
 	}
-	return beb.HTTPPublishResult{Status: http.StatusNoContent}, nil
+	return eventmesh.HTTPPublishResult{Status: http.StatusNoContent}, nil
 }
 
 // eventToNATSMsg translates cloud event into the NATS Msg.

--- a/resources/eventing/values.yaml
+++ b/resources/eventing/values.yaml
@@ -9,7 +9,7 @@ global:
       pullPolicy: "IfNotPresent"
     publisher_proxy:
       name: event-publisher-proxy
-      version: PR-16456
+      version: PR-16466
     nats:
       name: nats
       version: 2.9.6-alpine3.16


### PR DESCRIPTION
This PR changes filename and package from `beb` to `eventmesh` in the `sender` package.
No functional changes here.

before
```
sender
|-- eventmesh
|   |-- beb.go
|   `-- beb_test.go
...
```
after
```
sender
|-- eventmesh
|   |-- eventmesh.go
|   `-- eventmesh_test.go
...
```