### PR TITLE
Reorganise nats config and nats backend import paths

### DIFF
--- a/components/eventing-controller/cmd/eventing-controller/main.go
+++ b/components/eventing-controller/cmd/eventing-controller/main.go
@@ -52,7 +52,7 @@ func main() {
 
 	var natsSubMgr subscriptionmanager.Manager
 
-	natsConfig, err := backendnats.GetNatsConfig(opts.MaxReconnects, opts.ReconnectWait)
+	natsConfig, err := backendnats.GetNATSConfig(opts.MaxReconnects, opts.ReconnectWait)
 	if err != nil {
 		setupLogger.Fatalw("Failed to load configuration", "error", err)
 	}

--- a/components/eventing-controller/cmd/eventing-controller/main.go
+++ b/components/eventing-controller/cmd/eventing-controller/main.go
@@ -5,21 +5,20 @@ import (
 	"log"
 
 	"github.com/go-logr/zapr"
-	"k8s.io/apimachinery/pkg/runtime"
-	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
-	ctrl "sigs.k8s.io/controller-runtime"
-	"sigs.k8s.io/controller-runtime/pkg/healthz"
-
 	"github.com/kyma-project/kyma/components/eventing-controller/api/v1alpha1"
 	"github.com/kyma-project/kyma/components/eventing-controller/api/v1alpha2"
 	"github.com/kyma-project/kyma/components/eventing-controller/controllers/backend"
 	"github.com/kyma-project/kyma/components/eventing-controller/logger"
 	"github.com/kyma-project/kyma/components/eventing-controller/options"
 	backendmetrics "github.com/kyma-project/kyma/components/eventing-controller/pkg/backend/metrics"
-	"github.com/kyma-project/kyma/components/eventing-controller/pkg/env"
+	backendnats "github.com/kyma-project/kyma/components/eventing-controller/pkg/backend/nats"
 	"github.com/kyma-project/kyma/components/eventing-controller/pkg/subscriptionmanager"
 	"github.com/kyma-project/kyma/components/eventing-controller/pkg/subscriptionmanager/beb"
 	"github.com/kyma-project/kyma/components/eventing-controller/pkg/subscriptionmanager/jetstream"
+	"k8s.io/apimachinery/pkg/runtime"
+	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/healthz"
 )
 
 func main() {
@@ -52,7 +51,8 @@ func main() {
 	metricsCollector.RegisterMetrics()
 
 	var natsSubMgr subscriptionmanager.Manager
-	natsConfig, err := env.GetNatsConfig(opts.MaxReconnects, opts.ReconnectWait)
+
+	natsConfig, err := backendnats.GetNatsConfig(opts.MaxReconnects, opts.ReconnectWait)
 	if err != nil {
 		setupLogger.Fatalw("Failed to load configuration", "error", err)
 	}

--- a/components/eventing-controller/controllers/backend/reconciler.go
+++ b/components/eventing-controller/controllers/backend/reconciler.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"os"
 
+	backendnats "github.com/kyma-project/kyma/components/eventing-controller/pkg/backend/nats"
 	pkgerrors "github.com/kyma-project/kyma/components/eventing-controller/pkg/errors"
 	"golang.org/x/xerrors"
 
@@ -78,7 +79,7 @@ type Reconciler struct {
 	client.Client
 	ctx               context.Context
 	natsSubMgr        subscriptionmanager.Manager
-	natsConfig        env.NatsConfig
+	natsConfig        backendnats.Config
 	natsSubMgrStarted bool
 	bebSubMgr         subscriptionmanager.Manager
 	bebSubMgrStarted  bool
@@ -92,7 +93,9 @@ type Reconciler struct {
 	oauth2ClientSecret []byte
 }
 
-func NewReconciler(ctx context.Context, natsSubMgr subscriptionmanager.Manager, natsConfig env.NatsConfig, bebSubMgr subscriptionmanager.Manager, client client.Client, logger *logger.Logger, recorder record.EventRecorder) *Reconciler {
+func NewReconciler(ctx context.Context, natsSubMgr subscriptionmanager.Manager, natsConfig backendnats.Config,
+	bebSubMgr subscriptionmanager.Manager, client client.Client, logger *logger.Logger,
+	recorder record.EventRecorder) *Reconciler {
 	cfg := env.GetBackendConfig()
 	return &Reconciler{
 		ctx:        ctx,

--- a/components/eventing-controller/controllers/backend/reconciler_internal_integration_test.go
+++ b/components/eventing-controller/controllers/backend/reconciler_internal_integration_test.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/go-logr/zapr"
+	backendnats "github.com/kyma-project/kyma/components/eventing-controller/pkg/backend/nats"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
@@ -109,7 +110,7 @@ var _ = BeforeSuite(func(done Done) {
 	Expect(err).To(BeNil())
 
 	// populate with required env variables
-	natsConfig := env.NatsConfig{
+	natsConfig := backendnats.Config{
 		EventTypePrefix: reconcilertesting.EventTypePrefix,
 		JSStreamName:    reconcilertesting.JSStreamName,
 	}

--- a/components/eventing-controller/controllers/subscription/jetstream/reconciler_internal_integration_test.go
+++ b/components/eventing-controller/controllers/subscription/jetstream/reconciler_internal_integration_test.go
@@ -26,7 +26,7 @@ import (
 	"github.com/kyma-project/kyma/components/eventing-controller/pkg/application/fake"
 	"github.com/kyma-project/kyma/components/eventing-controller/pkg/backend/eventtype"
 	"github.com/kyma-project/kyma/components/eventing-controller/pkg/backend/metrics"
-	"github.com/kyma-project/kyma/components/eventing-controller/pkg/backend/nats"
+	backendnats "github.com/kyma-project/kyma/components/eventing-controller/pkg/backend/nats"
 	backendjetstream "github.com/kyma-project/kyma/components/eventing-controller/pkg/backend/nats/jetstream"
 	"github.com/kyma-project/kyma/components/eventing-controller/pkg/backend/sink"
 	"github.com/kyma-project/kyma/components/eventing-controller/pkg/env"
@@ -761,7 +761,7 @@ func startReconciler(eventTypePrefix string, ens *utils.JetStreamTestEnsemble) *
 	})
 	g.Expect(err).ToNot(gomega.HaveOccurred())
 
-	envConf := env.NatsConfig{
+	envConf := backendnats.Config{
 		URL:                     ens.NatsServer.ClientURL(),
 		MaxReconnects:           10,
 		ReconnectWait:           time.Second,
@@ -830,7 +830,7 @@ func getSubscriptionFromJetStream(ens *utils.JetStreamTestEnsemble,
 	subscription *eventingv1alpha1.Subscription, subject string) gomega.AsyncAssertion {
 	g := ens.G
 
-	return g.Eventually(func() nats.Subscriber {
+	return g.Eventually(func() backendnats.Subscriber {
 		subscriptions := ens.JetStreamBackend.GetAllSubscriptions()
 		subscriptionSubject := backendjetstream.NewSubscriptionSubjectIdentifier(subscription, subject)
 		for key, sub := range subscriptions {

--- a/components/eventing-controller/controllers/subscriptionv2/jetstream/test_utils.go
+++ b/components/eventing-controller/controllers/subscriptionv2/jetstream/test_utils.go
@@ -15,6 +15,7 @@ import (
 	cleanerv1alpha2 "github.com/kyma-project/kyma/components/eventing-controller/pkg/backend/cleaner"
 	"github.com/kyma-project/kyma/components/eventing-controller/pkg/backend/jetstreamv2"
 	"github.com/kyma-project/kyma/components/eventing-controller/pkg/backend/metrics"
+	backendnats "github.com/kyma-project/kyma/components/eventing-controller/pkg/backend/nats"
 	sinkv2 "github.com/kyma-project/kyma/components/eventing-controller/pkg/backend/sink/v2"
 	"github.com/kyma-project/kyma/components/eventing-controller/pkg/env"
 	v1 "github.com/kyma-project/kyma/components/eventing-controller/testing"
@@ -108,7 +109,7 @@ func startReconciler(ens *jetStreamTestEnsemble) *jetStreamTestEnsemble {
 	})
 	require.NoError(ens.T, err)
 
-	envConf := env.NatsConfig{
+	envConf := backendnats.Config{
 		URL:                     ens.NatsServer.ClientURL(),
 		MaxReconnects:           reconcilertestingv2.MaxReconnects,
 		ReconnectWait:           time.Second,

--- a/components/eventing-controller/controllers/subscriptionv2/reconcilertesting/jetstream_matchers.go
+++ b/components/eventing-controller/controllers/subscriptionv2/reconcilertesting/jetstream_matchers.go
@@ -3,10 +3,9 @@ package reconcilertesting
 import (
 	"fmt"
 
-	"github.com/kyma-project/kyma/components/eventing-controller/pkg/env"
-
 	eventingv1alpha2 "github.com/kyma-project/kyma/components/eventing-controller/api/v1alpha2"
 	"github.com/kyma-project/kyma/components/eventing-controller/pkg/backend/jetstreamv2"
+	backendnats "github.com/kyma-project/kyma/components/eventing-controller/pkg/backend/nats"
 	"github.com/onsi/gomega"
 	gomegatypes "github.com/onsi/gomega/types"
 )
@@ -28,7 +27,7 @@ func BeNatsSubWithMaxPending(expectedMaxAckPending int) gomegatypes.GomegaMatche
 }
 
 func BeJetStreamSubscriptionWithSubject(source, subject string,
-	typeMatching eventingv1alpha2.TypeMatching, natsConfig env.NatsConfig) gomegatypes.GomegaMatcher {
+	typeMatching eventingv1alpha2.TypeMatching, natsConfig backendnats.Config) gomegatypes.GomegaMatcher {
 	return gomega.WithTransform(func(subscriber jetstreamv2.Subscriber) (bool, error) {
 		info, err := subscriber.ConsumerInfo()
 		if err != nil {

--- a/components/eventing-controller/pkg/backend/jetstreamv2/config.go
+++ b/components/eventing-controller/pkg/backend/jetstreamv2/config.go
@@ -1,0 +1,26 @@
+package jetstreamv2
+
+import (
+	backendnats "github.com/kyma-project/kyma/components/eventing-controller/pkg/backend/nats"
+)
+
+// Validate ensures that the NatsConfig is valid and therefore can be used safely.
+// TODO: as soon as backend/nats is gone, make this method a function of backendnats.Config.
+func Validate(natsConfig backendnats.Config) error {
+	if natsConfig.JSStreamName == "" {
+		return ErrEmptyStreamName
+	}
+	if len(natsConfig.JSStreamName) > jsMaxStreamNameLength {
+		return ErrStreamNameTooLong
+	}
+	if _, err := toJetStreamStorageType(natsConfig.JSStreamStorageType); err != nil {
+		return err
+	}
+	if _, err := toJetStreamRetentionPolicy(natsConfig.JSStreamRetentionPolicy); err != nil {
+		return err
+	}
+	if _, err := toJetStreamDiscardPolicy(natsConfig.JSStreamDiscardPolicy); err != nil {
+		return err
+	}
+	return nil
+}

--- a/components/eventing-controller/pkg/backend/jetstreamv2/config_internal_unit_test.go
+++ b/components/eventing-controller/pkg/backend/jetstreamv2/config_internal_unit_test.go
@@ -1,4 +1,4 @@
-package env
+package jetstreamv2
 
 import (
 	"os"
@@ -6,8 +6,63 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	backendnats "github.com/kyma-project/kyma/components/eventing-controller/pkg/backend/nats"
+	"github.com/stretchr/testify/assert"
 )
 
+func TestUnitValidate_For_Errors(t *testing.T) {
+	tests := []struct {
+		name        string
+		givenConfig backendnats.Config
+		wantError   error
+	}{
+		{
+			name:        "ErrorEmptyStream",
+			givenConfig: backendnats.Config{JSStreamName: ""},
+			wantError:   ErrEmptyStreamName,
+		},
+		{
+			name:        "ErrorStreamToLong",
+			givenConfig: backendnats.Config{JSStreamName: fixtureStreamNameTooLong()},
+			wantError:   ErrStreamNameTooLong,
+		},
+		{
+			name: "ErrorStorageType",
+			givenConfig: backendnats.Config{
+				JSStreamName:        "not-empty",
+				JSStreamStorageType: "invalid-storage-type",
+			},
+			wantError: ErrInvalidStorageType.WithArg("invalid-storage-type"),
+		},
+		{
+			name: "ErrorRetentionPolicy",
+			givenConfig: backendnats.Config{
+				JSStreamName:            "not-empty",
+				JSStreamStorageType:     StorageTypeMemory,
+				JSStreamRetentionPolicy: "invalid-retention-policy",
+			},
+			wantError: ErrInvalidRetentionPolicy.WithArg("invalid-retention-policy"),
+		},
+		{
+			name: "ErrorDiscardPolicy",
+			givenConfig: backendnats.Config{
+				JSStreamName:            "not-empty",
+				JSStreamStorageType:     StorageTypeMemory,
+				JSStreamRetentionPolicy: RetentionPolicyInterest,
+				JSStreamDiscardPolicy:   "invalid-discard-policy",
+			},
+			wantError: ErrInvalidDiscardPolicy.WithArg("invalid-discard-policy"),
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := Validate(tc.givenConfig)
+			assert.ErrorIs(t, err, tc.wantError)
+		})
+	}
+}
 func TestGetNatsConfig(t *testing.T) {
 	type args struct {
 		maxReconnects int
@@ -17,7 +72,7 @@ func TestGetNatsConfig(t *testing.T) {
 	tests := []struct {
 		name    string
 		args    args
-		want    NatsConfig
+		want    backendnats.Config
 		wantErr bool
 	}{
 		{name: "Empty env triggers error",
@@ -34,7 +89,7 @@ func TestGetNatsConfig(t *testing.T) {
 				maxReconnects: 1,
 				reconnectWait: 1 * time.Second,
 			},
-			want: NatsConfig{
+			want: backendnats.Config{
 				URL:                     "natsurl",
 				MaxReconnects:           1,
 				ReconnectWait:           1 * time.Second,
@@ -79,7 +134,7 @@ func TestGetNatsConfig(t *testing.T) {
 				maxReconnects: 1,
 				reconnectWait: 1 * time.Second,
 			},
-			want: NatsConfig{
+			want: backendnats.Config{
 				URL:                     "natsurl",
 				MaxReconnects:           1,
 				ReconnectWait:           1 * time.Second,
@@ -110,7 +165,9 @@ func TestGetNatsConfig(t *testing.T) {
 			t.Cleanup(func() {
 				for _, e := range env {
 					s := strings.Split(e, "=")
-					os.Setenv(s[0], s[1])
+					if err := os.Setenv(s[0], s[1]); err != nil {
+						t.Log(err)
+					}
 				}
 			})
 
@@ -120,7 +177,7 @@ func TestGetNatsConfig(t *testing.T) {
 				t.Setenv(k, v)
 			}
 
-			got, err := GetNatsConfig(tt.args.maxReconnects, tt.args.reconnectWait)
+			got, err := backendnats.GetNatsConfig(tt.args.maxReconnects, tt.args.reconnectWait)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("GetNatsConfig() error = %v, wantErr %v", err, tt.wantErr)
 				return
@@ -130,4 +187,13 @@ func TestGetNatsConfig(t *testing.T) {
 			}
 		})
 	}
+}
+
+func fixtureStreamNameTooLong() string {
+	b := strings.Builder{}
+	for i := 0; i < (jsMaxStreamNameLength + 1); i++ {
+		b.WriteString("a")
+	}
+	streamName := b.String()
+	return streamName
 }

--- a/components/eventing-controller/pkg/backend/jetstreamv2/config_internal_unit_test.go
+++ b/components/eventing-controller/pkg/backend/jetstreamv2/config_internal_unit_test.go
@@ -63,7 +63,7 @@ func TestUnitValidate_For_Errors(t *testing.T) {
 		})
 	}
 }
-func TestGetNatsConfig(t *testing.T) {
+func Test_GetNATSConfig(t *testing.T) {
 	type args struct {
 		maxReconnects int
 		reconnectWait time.Duration
@@ -177,13 +177,13 @@ func TestGetNatsConfig(t *testing.T) {
 				t.Setenv(k, v)
 			}
 
-			got, err := backendnats.GetNatsConfig(tt.args.maxReconnects, tt.args.reconnectWait)
+			got, err := backendnats.GetNATSConfig(tt.args.maxReconnects, tt.args.reconnectWait)
 			if (err != nil) != tt.wantErr {
-				t.Errorf("GetNatsConfig() error = %v, wantErr %v", err, tt.wantErr)
+				t.Errorf("GetNATSConfig() error = %v, wantErr %v", err, tt.wantErr)
 				return
 			}
 			if !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("GetNatsConfig() got = %v, want %v", got, tt.want)
+				t.Errorf("GetNATSConfig() got = %v, want %v", got, tt.want)
 			}
 		})
 	}

--- a/components/eventing-controller/pkg/backend/jetstreamv2/errors.go
+++ b/components/eventing-controller/pkg/backend/jetstreamv2/errors.go
@@ -1,6 +1,10 @@
 package jetstreamv2
 
-import "github.com/pkg/errors"
+import (
+	"fmt"
+
+	"github.com/pkg/errors"
+)
 
 var (
 	ErrMissingSubscription = errors.New("failed to find a NATS subscription for a subject")
@@ -10,4 +14,7 @@ var (
 	ErrDeleteConsumer      = errors.New("failed to delete consumer")
 	ErrFailedSubscribe     = errors.New("failed to create NATS JetStream subscription")
 	ErrFailedUnsubscribe   = errors.New("failed to unsubscribe from NATS JetStream")
+
+	ErrEmptyStreamName   = errors.New("stream name cannot be empty")
+	ErrStreamNameTooLong = fmt.Errorf("stream name should be max %d characters long", jsMaxStreamNameLength)
 )

--- a/components/eventing-controller/pkg/backend/jetstreamv2/jetstream.go
+++ b/components/eventing-controller/pkg/backend/jetstreamv2/jetstream.go
@@ -7,6 +7,7 @@ import (
 	"reflect"
 	"time"
 
+	backendnats "github.com/kyma-project/kyma/components/eventing-controller/pkg/backend/nats"
 	backendutils "github.com/kyma-project/kyma/components/eventing-controller/pkg/backend/utils"
 	pkgerrors "github.com/kyma-project/kyma/components/eventing-controller/pkg/errors"
 
@@ -36,7 +37,7 @@ const (
 	jsConsumerAcKWait      = 30 * time.Second
 )
 
-func NewJetStream(config env.NatsConfig, metricsCollector *backendmetrics.Collector,
+func NewJetStream(config backendnats.Config, metricsCollector *backendmetrics.Collector,
 	cleaner cleaner.Cleaner, subsConfig env.DefaultSubscriptionConfig, logger *logger.Logger) *JetStream {
 	return &JetStream{
 		Config:           config,
@@ -285,7 +286,7 @@ func (js *JetStream) initJSContext() error {
 	return nil
 }
 
-func (js *JetStream) initCloudEventClient(config env.NatsConfig) error {
+func (js *JetStream) initCloudEventClient(config backendnats.Config) error {
 	if js.client != nil {
 		return nil
 	}

--- a/components/eventing-controller/pkg/backend/jetstreamv2/jetstream_integration_test.go
+++ b/components/eventing-controller/pkg/backend/jetstreamv2/jetstream_integration_test.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	backendnats "github.com/kyma-project/kyma/components/eventing-controller/pkg/backend/nats"
+	"github.com/nats-io/nats.go"
 	"github.com/stretchr/testify/assert"
 
 	kymalogger "github.com/kyma-project/kyma/common/logging/logger"

--- a/components/eventing-controller/pkg/backend/jetstreamv2/jetstream_integration_test.go
+++ b/components/eventing-controller/pkg/backend/jetstreamv2/jetstream_integration_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 	"time"
 
+	backendnats "github.com/kyma-project/kyma/components/eventing-controller/pkg/backend/nats"
 	"github.com/stretchr/testify/assert"
 
 	kymalogger "github.com/kyma-project/kyma/common/logging/logger"
@@ -472,9 +473,9 @@ func TestJetStream_NATSSubscriptionCount(t *testing.T) {
 	}
 }
 
-func defaultNatsConfig(url string, port int) env.NatsConfig {
+func defaultNatsConfig(url string, port int) backendnats.Config {
 	streamName := fmt.Sprintf("%s%d", DefaultStreamName, port)
-	return env.NatsConfig{
+	return backendnats.Config{
 		URL:                     url,
 		MaxReconnects:           DefaultMaxReconnects,
 		ReconnectWait:           3 * time.Second,

--- a/components/eventing-controller/pkg/backend/jetstreamv2/jetstream_integration_test.go
+++ b/components/eventing-controller/pkg/backend/jetstreamv2/jetstream_integration_test.go
@@ -9,7 +9,6 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	kymalogger "github.com/kyma-project/kyma/common/logging/logger"
-	"github.com/nats-io/nats.go"
 	"github.com/stretchr/testify/require"
 
 	eventingv1alpha2 "github.com/kyma-project/kyma/components/eventing-controller/api/v1alpha2"
@@ -473,7 +472,7 @@ func TestJetStream_NATSSubscriptionCount(t *testing.T) {
 	}
 }
 
-func defaultNatsConfig(url string, port int) backendnats.Config {
+func defaultNATSConfig(url string, port int) backendnats.Config {
 	streamName := fmt.Sprintf("%s%d", DefaultStreamName, port)
 	return backendnats.Config{
 		URL:                     url,
@@ -508,7 +507,7 @@ func getJetStreamClient(t *testing.T, serverURL string) *jetStreamClient {
 func setupTestEnvironment(t *testing.T) *TestEnvironment {
 	natsServer, natsPort, err := natstesting.StartNATSServer(evtesting.WithJetStreamEnabled())
 	require.NoError(t, err)
-	natsConfig := defaultNatsConfig(natsServer.ClientURL(), natsPort)
+	natsConfig := defaultNATSConfig(natsServer.ClientURL(), natsPort)
 	defaultLogger, err := logger.New(string(kymalogger.JSON), string(kymalogger.INFO))
 	require.NoError(t, err)
 

--- a/components/eventing-controller/pkg/backend/jetstreamv2/test_helpers.go
+++ b/components/eventing-controller/pkg/backend/jetstreamv2/test_helpers.go
@@ -7,8 +7,8 @@ import (
 	"time"
 
 	"github.com/kyma-project/kyma/components/eventing-controller/logger"
+	backendnats "github.com/kyma-project/kyma/components/eventing-controller/pkg/backend/nats"
 	natstesting "github.com/kyma-project/kyma/components/eventing-controller/pkg/backend/nats/testing"
-	"github.com/kyma-project/kyma/components/eventing-controller/pkg/env"
 	evtestingv2 "github.com/kyma-project/kyma/components/eventing-controller/testing/v2"
 	"github.com/nats-io/nats-server/v2/server"
 
@@ -36,7 +36,7 @@ type TestEnvironment struct {
 	logger     *logger.Logger
 	natsServer *server.Server
 	jsClient   *jetStreamClient
-	natsConfig env.NatsConfig
+	natsConfig backendnats.Config
 	cleaner    cleaner.Cleaner
 	natsPort   int
 }

--- a/components/eventing-controller/pkg/backend/jetstreamv2/types.go
+++ b/components/eventing-controller/pkg/backend/jetstreamv2/types.go
@@ -3,6 +3,7 @@ package jetstreamv2
 import (
 	"sync"
 
+	backendnats "github.com/kyma-project/kyma/components/eventing-controller/pkg/backend/nats"
 	backendutilsv2 "github.com/kyma-project/kyma/components/eventing-controller/pkg/backend/utils/v2"
 
 	cev2 "github.com/cloudevents/sdk-go/v2"
@@ -39,7 +40,7 @@ type Backend interface {
 }
 
 type JetStream struct {
-	Config        env.NatsConfig
+	Config        backendnats.Config
 	Conn          *nats.Conn
 	jsCtx         nats.JetStreamContext
 	client        cev2.Client

--- a/components/eventing-controller/pkg/backend/jetstreamv2/utils_unit_test.go
+++ b/components/eventing-controller/pkg/backend/jetstreamv2/utils_unit_test.go
@@ -6,8 +6,6 @@ import (
 	"testing"
 
 	backendnats "github.com/kyma-project/kyma/components/eventing-controller/pkg/backend/nats"
-	"github.com/nats-io/nats.go"
-
 	"github.com/kyma-project/kyma/components/eventing-controller/pkg/env"
 
 	kymalogger "github.com/kyma-project/kyma/common/logging/logger"
@@ -107,13 +105,13 @@ func TestGetStreamConfig(t *testing.T) {
 	t.Parallel()
 	testCases := []struct {
 		name             string
-		givenNatsConfig  backendnats.Config
+		givenNATSConfig  backendnats.Config
 		wantStreamConfig *nats.StreamConfig
 		wantError        bool
 	}{
 		{
 			name: "Should throw an error if storage type is invalid",
-			givenNatsConfig: backendnats.Config{
+			givenNATSConfig: backendnats.Config{
 				JSStreamStorageType: "invalid",
 			},
 			wantStreamConfig: nil,
@@ -121,7 +119,7 @@ func TestGetStreamConfig(t *testing.T) {
 		},
 		{
 			name: "Should throw an error if retention policy is invalid",
-			givenNatsConfig: backendnats.Config{
+			givenNATSConfig: backendnats.Config{
 				JSStreamRetentionPolicy: "invalid",
 			},
 			wantStreamConfig: nil,
@@ -129,7 +127,7 @@ func TestGetStreamConfig(t *testing.T) {
 		},
 		{
 			name: "Should return valid StreamConfig",
-			givenNatsConfig: backendnats.Config{
+			givenNATSConfig: backendnats.Config{
 				JSStreamName:            DefaultStreamName,
 				JSSubjectPrefix:         DefaultJetStreamSubjectPrefix,
 				JSStreamStorageType:     StorageTypeMemory,
@@ -153,7 +151,7 @@ func TestGetStreamConfig(t *testing.T) {
 		},
 		{
 			name: "Should parse MaxBytes correctly without unit",
-			givenNatsConfig: backendnats.Config{
+			givenNATSConfig: backendnats.Config{
 				JSStreamName:            DefaultStreamName,
 				JSSubjectPrefix:         DefaultJetStreamSubjectPrefix,
 				JSStreamStorageType:     StorageTypeMemory,
@@ -177,7 +175,7 @@ func TestGetStreamConfig(t *testing.T) {
 		},
 		{
 			name: "Should parse MaxBytes correctly with unit",
-			givenNatsConfig: backendnats.Config{
+			givenNATSConfig: backendnats.Config{
 				JSStreamName:            DefaultStreamName,
 				JSSubjectPrefix:         DefaultJetStreamSubjectPrefix,
 				JSStreamStorageType:     StorageTypeMemory,
@@ -204,7 +202,7 @@ func TestGetStreamConfig(t *testing.T) {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
-			streamConfig, err := getStreamConfig(tc.givenNatsConfig)
+			streamConfig, err := getStreamConfig(tc.givenNATSConfig)
 			if tc.wantError {
 				require.Error(t, err)
 			} else {

--- a/components/eventing-controller/pkg/backend/jetstreamv2/utils_unit_test.go
+++ b/components/eventing-controller/pkg/backend/jetstreamv2/utils_unit_test.go
@@ -7,6 +7,7 @@ import (
 
 	backendnats "github.com/kyma-project/kyma/components/eventing-controller/pkg/backend/nats"
 	"github.com/kyma-project/kyma/components/eventing-controller/pkg/env"
+	"github.com/nats-io/nats.go"
 
 	kymalogger "github.com/kyma-project/kyma/common/logging/logger"
 	"github.com/stretchr/testify/require"

--- a/components/eventing-controller/pkg/backend/jetstreamv2/utils_unit_test.go
+++ b/components/eventing-controller/pkg/backend/jetstreamv2/utils_unit_test.go
@@ -5,6 +5,7 @@ import (
 	"reflect"
 	"testing"
 
+	backendnats "github.com/kyma-project/kyma/components/eventing-controller/pkg/backend/nats"
 	"github.com/nats-io/nats.go"
 
 	"github.com/kyma-project/kyma/components/eventing-controller/pkg/env"
@@ -106,13 +107,13 @@ func TestGetStreamConfig(t *testing.T) {
 	t.Parallel()
 	testCases := []struct {
 		name             string
-		givenNatsConfig  env.NatsConfig
+		givenNatsConfig  backendnats.Config
 		wantStreamConfig *nats.StreamConfig
 		wantError        bool
 	}{
 		{
 			name: "Should throw an error if storage type is invalid",
-			givenNatsConfig: env.NatsConfig{
+			givenNatsConfig: backendnats.Config{
 				JSStreamStorageType: "invalid",
 			},
 			wantStreamConfig: nil,
@@ -120,7 +121,7 @@ func TestGetStreamConfig(t *testing.T) {
 		},
 		{
 			name: "Should throw an error if retention policy is invalid",
-			givenNatsConfig: env.NatsConfig{
+			givenNatsConfig: backendnats.Config{
 				JSStreamRetentionPolicy: "invalid",
 			},
 			wantStreamConfig: nil,
@@ -128,7 +129,7 @@ func TestGetStreamConfig(t *testing.T) {
 		},
 		{
 			name: "Should return valid StreamConfig",
-			givenNatsConfig: env.NatsConfig{
+			givenNatsConfig: backendnats.Config{
 				JSStreamName:            DefaultStreamName,
 				JSSubjectPrefix:         DefaultJetStreamSubjectPrefix,
 				JSStreamStorageType:     StorageTypeMemory,
@@ -152,7 +153,7 @@ func TestGetStreamConfig(t *testing.T) {
 		},
 		{
 			name: "Should parse MaxBytes correctly without unit",
-			givenNatsConfig: env.NatsConfig{
+			givenNatsConfig: backendnats.Config{
 				JSStreamName:            DefaultStreamName,
 				JSSubjectPrefix:         DefaultJetStreamSubjectPrefix,
 				JSStreamStorageType:     StorageTypeMemory,
@@ -176,7 +177,7 @@ func TestGetStreamConfig(t *testing.T) {
 		},
 		{
 			name: "Should parse MaxBytes correctly with unit",
-			givenNatsConfig: env.NatsConfig{
+			givenNatsConfig: backendnats.Config{
 				JSStreamName:            DefaultStreamName,
 				JSSubjectPrefix:         DefaultJetStreamSubjectPrefix,
 				JSStreamStorageType:     StorageTypeMemory,
@@ -311,7 +312,7 @@ func TestGetBackendJetStreamTypes(t *testing.T) {
 	t.Parallel()
 	jsCleaner := cleaner.NewJetStreamCleaner(nil)
 	defaultSub := evtestingv2.NewSubscription(subName, subNamespace)
-	js := NewJetStream(env.NatsConfig{
+	js := NewJetStream(backendnats.Config{
 		JSSubjectPrefix: DefaultJetStreamSubjectPrefix,
 	}, nil, jsCleaner, env.DefaultSubscriptionConfig{}, nil)
 	testCases := []struct {

--- a/components/eventing-controller/pkg/backend/nats/config.go
+++ b/components/eventing-controller/pkg/backend/nats/config.go
@@ -28,7 +28,8 @@ type Config struct {
 
 	// JetStream-specific configs
 	// Name of the JetStream stream where all events are stored.
-	JSStreamName    string `envconfig:"JS_STREAM_NAME" required:"true"`
+	JSStreamName string `envconfig:"JS_STREAM_NAME" required:"true"`
+	// Prefix for the subjects in the stream.
 	JSSubjectPrefix string `envconfig:"JS_STREAM_SUBJECT_PREFIX" required:"true"`
 	// Storage type of the stream, memory or file.
 	JSStreamStorageType string `envconfig:"JS_STREAM_STORAGE_TYPE" default:"memory"`

--- a/components/eventing-controller/pkg/backend/nats/config.go
+++ b/components/eventing-controller/pkg/backend/nats/config.go
@@ -61,7 +61,7 @@ type Config struct {
 	EnableNewCRDVersion bool `envconfig:"ENABLE_NEW_CRD_VERSION" default:"false"`
 }
 
-func GetNatsConfig(maxReconnects int, reconnectWait time.Duration) (Config, error) {
+func GetNATSConfig(maxReconnects int, reconnectWait time.Duration) (Config, error) {
 	cfg := Config{
 		MaxReconnects: maxReconnects,
 		ReconnectWait: reconnectWait,

--- a/components/eventing-controller/pkg/backend/nats/config.go
+++ b/components/eventing-controller/pkg/backend/nats/config.go
@@ -1,4 +1,4 @@
-package env
+package nats
 
 import (
 	"time"
@@ -6,8 +6,11 @@ import (
 	"github.com/kelseyhightower/envconfig"
 )
 
+// TODO(nils): move the content of this file to backend/jetstreamv2/config.go
+// as soon as jetstreamv2 is the only backend!
+
 // NatsConfig represents the environment config for the Eventing Controller with Nats.
-type NatsConfig struct {
+type Config struct {
 	// Following details are for eventing-controller to communicate to Nats
 	URL           string `envconfig:"NATS_URL" required:"true"`
 	MaxReconnects int
@@ -25,8 +28,7 @@ type NatsConfig struct {
 
 	// JetStream-specific configs
 	// Name of the JetStream stream where all events are stored.
-	JSStreamName string `envconfig:"JS_STREAM_NAME" required:"true"`
-	// Prefix for the subjects in the stream
+	JSStreamName    string `envconfig:"JS_STREAM_NAME" required:"true"`
 	JSSubjectPrefix string `envconfig:"JS_STREAM_SUBJECT_PREFIX" required:"true"`
 	// Storage type of the stream, memory or file.
 	JSStreamStorageType string `envconfig:"JS_STREAM_STORAGE_TYPE" default:"memory"`
@@ -59,13 +61,13 @@ type NatsConfig struct {
 	EnableNewCRDVersion bool `envconfig:"ENABLE_NEW_CRD_VERSION" default:"false"`
 }
 
-func GetNatsConfig(maxReconnects int, reconnectWait time.Duration) (NatsConfig, error) {
-	cfg := NatsConfig{
+func GetNatsConfig(maxReconnects int, reconnectWait time.Duration) (Config, error) {
+	cfg := Config{
 		MaxReconnects: maxReconnects,
 		ReconnectWait: reconnectWait,
 	}
 	if err := envconfig.Process("", &cfg); err != nil {
-		return NatsConfig{}, err
+		return Config{}, err
 	}
 	return cfg, nil
 }

--- a/components/eventing-controller/pkg/backend/nats/jetstream/jetstream.go
+++ b/components/eventing-controller/pkg/backend/nats/jetstream/jetstream.go
@@ -30,7 +30,6 @@ import (
 	"github.com/kyma-project/kyma/components/eventing-controller/logger"
 	backendmetrics "github.com/kyma-project/kyma/components/eventing-controller/pkg/backend/metrics"
 	backendnats "github.com/kyma-project/kyma/components/eventing-controller/pkg/backend/nats"
-	"github.com/kyma-project/kyma/components/eventing-controller/pkg/env"
 	"github.com/kyma-project/kyma/components/eventing-controller/pkg/tracing"
 )
 
@@ -106,7 +105,7 @@ func computeNamespacedSubjectName(subscription *eventingv1alpha1.Subscription, s
 }
 
 type JetStream struct {
-	Config        env.NatsConfig
+	Config        backendnats.Config
 	conn          *nats.Conn
 	jsCtx         nats.JetStreamContext
 	client        cev2.Client
@@ -119,7 +118,7 @@ type JetStream struct {
 	cleaner           eventtype.Cleaner
 }
 
-func NewJetStream(config env.NatsConfig, metricsCollector *backendmetrics.Collector, jsCleaner eventtype.Cleaner,
+func NewJetStream(config backendnats.Config, metricsCollector *backendmetrics.Collector, jsCleaner eventtype.Cleaner,
 	logger *logger.Logger) *JetStream {
 	return &JetStream{
 		Config:           config,
@@ -130,7 +129,7 @@ func NewJetStream(config env.NatsConfig, metricsCollector *backendmetrics.Collec
 	}
 }
 
-func (js *JetStream) initCloudEventClient(config env.NatsConfig) error {
+func (js *JetStream) initCloudEventClient(config backendnats.Config) error {
 	if js.client != nil {
 		return nil
 	}
@@ -422,7 +421,7 @@ func streamIsConfiguredCorrectly(got nats.StreamConfig, want nats.StreamConfig) 
 	return reflect.DeepEqual(got, want)
 }
 
-func getStreamConfig(natsConfig env.NatsConfig) (*nats.StreamConfig, error) {
+func getStreamConfig(natsConfig backendnats.Config) (*nats.StreamConfig, error) {
 	storage, err := toJetStreamStorageType(natsConfig.JSStreamStorageType)
 	if err != nil {
 		return nil, err

--- a/components/eventing-controller/pkg/backend/nats/jetstream/jetstream_integration_test.go
+++ b/components/eventing-controller/pkg/backend/nats/jetstream/jetstream_integration_test.go
@@ -997,9 +997,9 @@ func TestJSSubscriptionUsingCESDK(t *testing.T) {
 	require.NoError(t, jsBackend.DeleteSubscription(sub))
 }
 
-func defaultNatsConfig(url string, natsPort int) env.NatsConfig {
+func defaultNatsConfig(url string, natsPort int) backendnats.Config {
 	streamName := fmt.Sprintf("%s%d", defaultStreamName, natsPort)
-	return env.NatsConfig{
+	return backendnats.Config{
 		URL:                     url,
 		MaxReconnects:           defaultMaxReconnects,
 		ReconnectWait:           3 * time.Second,
@@ -1044,7 +1044,7 @@ type TestEnvironment struct {
 	logger      *logger.Logger
 	natsServer  *server.Server
 	jsClient    *jetStreamClient
-	natsConfig  env.NatsConfig
+	natsConfig  backendnats.Config
 	cleaner     eventtype.Cleaner
 	cleanerv2   cleanerv1alpha2.Cleaner
 	natsPort    int

--- a/components/eventing-controller/pkg/backend/nats/jetstream/jetstream_integration_test.go
+++ b/components/eventing-controller/pkg/backend/nats/jetstream/jetstream_integration_test.go
@@ -9,6 +9,7 @@ import (
 
 	kymalogger "github.com/kyma-project/kyma/common/logging/logger"
 	"github.com/nats-io/nats-server/v2/server"
+	"github.com/nats-io/nats.go"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 

--- a/components/eventing-controller/pkg/backend/nats/jetstream/jetstream_integration_test.go
+++ b/components/eventing-controller/pkg/backend/nats/jetstream/jetstream_integration_test.go
@@ -9,7 +9,6 @@ import (
 
 	kymalogger "github.com/kyma-project/kyma/common/logging/logger"
 	"github.com/nats-io/nats-server/v2/server"
-	"github.com/nats-io/nats.go"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -997,7 +996,7 @@ func TestJSSubscriptionUsingCESDK(t *testing.T) {
 	require.NoError(t, jsBackend.DeleteSubscription(sub))
 }
 
-func defaultNatsConfig(url string, natsPort int) backendnats.Config {
+func defaultNATSConfig(url string, natsPort int) backendnats.Config {
 	streamName := fmt.Sprintf("%s%d", defaultStreamName, natsPort)
 	return backendnats.Config{
 		URL:                     url,
@@ -1054,7 +1053,7 @@ type TestEnvironment struct {
 func setupTestEnvironment(t *testing.T, newCRD bool) *TestEnvironment {
 	natsServer, natsPort, err := natstesting.StartNATSServer(evtesting.WithJetStreamEnabled())
 	require.NoError(t, err)
-	natsConfig := defaultNatsConfig(natsServer.ClientURL(), natsPort)
+	natsConfig := defaultNATSConfig(natsServer.ClientURL(), natsPort)
 	defaultLogger, err := logger.New(string(kymalogger.JSON), string(kymalogger.INFO))
 	require.NoError(t, err)
 

--- a/components/eventing-controller/pkg/deployment/publisher_deployment.go
+++ b/components/eventing-controller/pkg/deployment/publisher_deployment.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/kyma-project/kyma/components/eventing-controller/api/v1alpha1"
+	backendnats "github.com/kyma-project/kyma/components/eventing-controller/pkg/backend/nats"
 	"github.com/kyma-project/kyma/components/eventing-controller/utils"
 
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -60,7 +61,7 @@ func NewBEBPublisherDeployment(publisherConfig env.PublisherConfig) *appsv1.Depl
 		WithLogEnvVars(publisherConfig),
 	)
 }
-func NewNATSPublisherDeployment(natsConfig env.NatsConfig, publisherConfig env.PublisherConfig) *appsv1.Deployment {
+func NewNATSPublisherDeployment(natsConfig backendnats.Config, publisherConfig env.PublisherConfig) *appsv1.Deployment {
 	return NewDeployment(
 		publisherConfig,
 		WithLabels(v1alpha1.NatsBackendType),
@@ -166,7 +167,7 @@ func WithLogEnvVars(publisherConfig env.PublisherConfig) DeployOpt {
 	}
 }
 
-func WithNATSEnvVars(natsConfig env.NatsConfig, publisherConfig env.PublisherConfig) DeployOpt {
+func WithNATSEnvVars(natsConfig backendnats.Config, publisherConfig env.PublisherConfig) DeployOpt {
 	return func(d *appsv1.Deployment) {
 		for i, container := range d.Spec.Template.Spec.Containers {
 			if strings.EqualFold(container.Name, PublisherName) {
@@ -323,7 +324,7 @@ func getBEBEnvVars(publisherConfig env.PublisherConfig) []v1.EnvVar {
 	}
 }
 
-func getNATSEnvVars(natsConfig env.NatsConfig, publisherConfig env.PublisherConfig) []v1.EnvVar {
+func getNATSEnvVars(natsConfig backendnats.Config, publisherConfig env.PublisherConfig) []v1.EnvVar {
 	return []v1.EnvVar{
 		{Name: "BACKEND", Value: "nats"},
 		{Name: "PORT", Value: strconv.Itoa(int(publisherPortNum))},

--- a/components/eventing-controller/pkg/deployment/publisher_deployment_integration_test.go
+++ b/components/eventing-controller/pkg/deployment/publisher_deployment_integration_test.go
@@ -86,7 +86,7 @@ func Test_GetNATSEnvVars(t *testing.T) {
 	testCases := []struct {
 		name            string
 		givenEnvs       map[string]string
-		givenNatsConfig backendnats.Config
+		givenNATSConfig backendnats.Config
 		wantEnvs        map[string]string
 	}{
 		{
@@ -96,7 +96,7 @@ func Test_GetNATSEnvVars(t *testing.T) {
 				"PUBLISHER_REQUESTS_MEMORY": "128Mi",
 				"PUBLISHER_REQUEST_TIMEOUT": "10s",
 			},
-			givenNatsConfig: backendnats.Config{},
+			givenNATSConfig: backendnats.Config{},
 			wantEnvs: map[string]string{
 				"REQUEST_TIMEOUT": "10s",
 				"JS_STREAM_NAME":  "",
@@ -107,7 +107,7 @@ func Test_GetNATSEnvVars(t *testing.T) {
 			givenEnvs: map[string]string{
 				"PUBLISHER_REQUEST_TIMEOUT": "10s",
 			},
-			givenNatsConfig: backendnats.Config{
+			givenNATSConfig: backendnats.Config{
 				JSStreamName: "kyma",
 			},
 			wantEnvs: map[string]string{
@@ -122,7 +122,7 @@ func Test_GetNATSEnvVars(t *testing.T) {
 				t.Setenv(k, v)
 			}
 			backendConfig := env.GetBackendConfig()
-			envVars := getNATSEnvVars(tc.givenNatsConfig, backendConfig.PublisherConfig)
+			envVars := getNATSEnvVars(tc.givenNATSConfig, backendConfig.PublisherConfig)
 
 			// ensure the right envs were set
 			for index, val := range tc.wantEnvs {

--- a/components/eventing-controller/pkg/deployment/publisher_deployment_integration_test.go
+++ b/components/eventing-controller/pkg/deployment/publisher_deployment_integration_test.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 	"testing"
 
+	backendnats "github.com/kyma-project/kyma/components/eventing-controller/pkg/backend/nats"
 	appsv1 "k8s.io/api/apps/v1"
 
 	"github.com/stretchr/testify/assert"
@@ -49,11 +50,11 @@ func TestNewDeployment(t *testing.T) {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			var deployment *appsv1.Deployment
-			var natsConfig env.NatsConfig
+			var natsConfig backendnats.Config
 
 			switch tc.givenBackend {
 			case "NATS":
-				natsConfig = env.NatsConfig{
+				natsConfig = backendnats.Config{
 					JSStreamName: "kyma",
 					URL:          natsURL,
 				}
@@ -85,7 +86,7 @@ func Test_GetNATSEnvVars(t *testing.T) {
 	testCases := []struct {
 		name            string
 		givenEnvs       map[string]string
-		givenNatsConfig env.NatsConfig
+		givenNatsConfig backendnats.Config
 		wantEnvs        map[string]string
 	}{
 		{
@@ -95,7 +96,7 @@ func Test_GetNATSEnvVars(t *testing.T) {
 				"PUBLISHER_REQUESTS_MEMORY": "128Mi",
 				"PUBLISHER_REQUEST_TIMEOUT": "10s",
 			},
-			givenNatsConfig: env.NatsConfig{},
+			givenNatsConfig: backendnats.Config{},
 			wantEnvs: map[string]string{
 				"REQUEST_TIMEOUT": "10s",
 				"JS_STREAM_NAME":  "",
@@ -106,7 +107,7 @@ func Test_GetNATSEnvVars(t *testing.T) {
 			givenEnvs: map[string]string{
 				"PUBLISHER_REQUEST_TIMEOUT": "10s",
 			},
-			givenNatsConfig: env.NatsConfig{
+			givenNatsConfig: backendnats.Config{
 				JSStreamName: "kyma",
 			},
 			wantEnvs: map[string]string{

--- a/components/eventing-controller/pkg/object/equality_test.go
+++ b/components/eventing-controller/pkg/object/equality_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	apigatewayv1beta1 "github.com/kyma-incubator/api-gateway/api/v1beta1"
+	backendnats "github.com/kyma-project/kyma/components/eventing-controller/pkg/backend/nats"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -453,7 +454,7 @@ func TestPublisherProxyDeploymentEqual(t *testing.T) {
 		LimitsCPU:      "64m",
 		LimitsMemory:   "128Mi",
 	}
-	natsConfig := env.NatsConfig{
+	natsConfig := backendnats.Config{
 		EventTypePrefix: "prefix",
 		JSStreamName:    "kyma",
 	}

--- a/components/eventing-controller/pkg/subscriptionmanager/jetstream/jetstream.go
+++ b/components/eventing-controller/pkg/subscriptionmanager/jetstream/jetstream.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 
+	backendnats "github.com/kyma-project/kyma/components/eventing-controller/pkg/backend/nats"
 	sinkv2 "github.com/kyma-project/kyma/components/eventing-controller/pkg/backend/sink/v2"
 	backendutilsv2 "github.com/kyma-project/kyma/components/eventing-controller/pkg/backend/utils/v2"
 
@@ -64,7 +65,7 @@ func AddV1Alpha2ToScheme(scheme *runtime.Scheme) error {
 
 type SubscriptionManager struct {
 	cancel           context.CancelFunc
-	envCfg           env.NatsConfig
+	envCfg           backendnats.Config
 	restCfg          *rest.Config
 	metricsAddr      string
 	metricsCollector *backendmetrics.Collector
@@ -75,7 +76,8 @@ type SubscriptionManager struct {
 }
 
 // NewSubscriptionManager creates the subscription manager for JetStream.
-func NewSubscriptionManager(restCfg *rest.Config, natsConfig env.NatsConfig, metricsAddr string, metricsCollector *backendmetrics.Collector, logger *logger.Logger) *SubscriptionManager {
+func NewSubscriptionManager(restCfg *rest.Config, natsConfig backendnats.Config, metricsAddr string,
+	metricsCollector *backendmetrics.Collector, logger *logger.Logger) *SubscriptionManager {
 	return &SubscriptionManager{
 		envCfg:           natsConfig,
 		restCfg:          restCfg,

--- a/components/eventing-controller/pkg/subscriptionmanager/jetstream/jetstream_test.go
+++ b/components/eventing-controller/pkg/subscriptionmanager/jetstream/jetstream_test.go
@@ -61,7 +61,7 @@ type TestEnvironment struct {
 	jsCtx         nats.JetStreamContext
 	natsServer    *server.Server
 	subscriber    *controllertesting.Subscriber
-	envConf       env.NatsConfig
+	envConf       backendnats.Config
 	defaultLogger *logger.Logger
 }
 
@@ -82,9 +82,9 @@ func getJetStreamClient(t *testing.T, natsURL string) nats.JetStreamContext {
 	return jsClient
 }
 
-func getNATSConf(natsURL string, natsPort int) env.NatsConfig {
+func getNATSConf(natsURL string, natsPort int) backendnats.Config {
 	streamName := fmt.Sprintf("%s%d", controllertesting.JSStreamName, natsPort)
-	return env.NatsConfig{
+	return backendnats.Config{
 		URL:                     natsURL,
 		MaxReconnects:           10,
 		ReconnectWait:           time.Second,

--- a/components/eventing-controller/testing/nats/matchers.go
+++ b/components/eventing-controller/testing/nats/matchers.go
@@ -1,28 +1,27 @@
 package nats
 
 import (
-	"github.com/kyma-project/kyma/components/eventing-controller/pkg/env"
 	"github.com/onsi/gomega"
 	gomegatypes "github.com/onsi/gomega/types"
 
-	"github.com/kyma-project/kyma/components/eventing-controller/pkg/backend/nats"
+	backendnats "github.com/kyma-project/kyma/components/eventing-controller/pkg/backend/nats"
 	"github.com/kyma-project/kyma/components/eventing-controller/pkg/backend/nats/jetstream"
 )
 
 func BeValidSubscription() gomegatypes.GomegaMatcher {
-	return gomega.WithTransform(func(subscriber nats.Subscriber) bool {
+	return gomega.WithTransform(func(subscriber backendnats.Subscriber) bool {
 		return subscriber.IsValid()
 	}, gomega.BeTrue())
 }
 
 func BeSubscriptionWithSubject(subject string) gomegatypes.GomegaMatcher {
-	return gomega.WithTransform(func(subscriber nats.Subscriber) bool {
+	return gomega.WithTransform(func(subscriber backendnats.Subscriber) bool {
 		return subscriber.SubscriptionSubject() == subject
 	}, gomega.BeTrue())
 }
 
-func BeJetStreamSubscriptionWithSubject(subject string, natsConfig env.NatsConfig) gomegatypes.GomegaMatcher {
-	return gomega.WithTransform(func(subscriber nats.Subscriber) bool {
+func BeJetStreamSubscriptionWithSubject(subject string, natsConfig backendnats.Config) gomegatypes.GomegaMatcher {
+	return gomega.WithTransform(func(subscriber backendnats.Subscriber) bool {
 		info, err := subscriber.ConsumerInfo()
 		if err != nil {
 			return false
@@ -35,7 +34,7 @@ func BeJetStreamSubscriptionWithSubject(subject string, natsConfig env.NatsConfi
 }
 
 func BeExistingSubscription() gomegatypes.GomegaMatcher {
-	return gomega.WithTransform(func(subscriber nats.Subscriber) bool {
+	return gomega.WithTransform(func(subscriber backendnats.Subscriber) bool {
 		return subscriber != nil
 	}, gomega.BeTrue())
 }

--- a/resources/eventing/values.yaml
+++ b/resources/eventing/values.yaml
@@ -5,7 +5,7 @@ global:
   images:
     eventing_controller:
       name: eventing-controller
-      version: PR-16460
+      version: PR-16468
       pullPolicy: "IfNotPresent"
     publisher_proxy:
       name: event-publisher-proxy


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

Preparation for PR https://github.com/kyma-project/kyma/issues/15705:

- Moves the `env.NatsConfig` to the `pkg/backend/nats` package as it is specific to the backend (nats in this case)
	- In the future we can host it under `pkg/backend/jetstreamv2` if `pkg/backend/nats` vanishes away
- For now we cannot host it directly under `pkg/backend/jetstreamv2` since it imports `pkg/backend/nats` (for the v1alpha1 -> v1alpha2 conversion). By moving it to `pkg/backend/nats` we make the config specific to the backend and avoid a cyclic import for now.
- Names the import path for `pkg/backend/nats` as `backendnats` in all files (makes it uniform)

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
See also https://github.com/kyma-project/kyma/issues/15705