### PR TITLE
Upgrade the NATS-Server image to `v2.9.9-alpine3.17`.

### DIFF
--- a/resources/eventing/values.yaml
+++ b/resources/eventing/values.yaml
@@ -12,7 +12,7 @@ global:
       version: PR-16472
     nats:
       name: nats
-      version: 2.9.6-alpine3.16
+      version: 2.9.9-alpine3.17
       directory: external
     nats_config_reloader:
       name: natsio/nats-server-config-reloader


### PR DESCRIPTION
This PR upgrades the image of NATS Server used in eventing to `v2.9.9-alpine3.17`.

See the [release notes `NATS v2.9.9-alpine3.17`](https://github.com/nats-io/nats-server/releases/tag/v2.9.9).