### PR TITLE
Add pprof profiling to telemetry-operator

### DIFF
--- a/components/telemetry-operator/controller/tracepipeline/controller.go
+++ b/components/telemetry-operator/controller/tracepipeline/controller.go
@@ -212,7 +212,9 @@ func (r *Reconciler) createLock(ctx context.Context, name types.NamespacedName, 
 			Namespace: name.Namespace,
 		},
 	}
-	controllerutil.SetControllerReference(owner, &lock, r.Scheme)
+	if err := controllerutil.SetControllerReference(owner, &lock, r.Scheme); err != nil {
+		return fmt.Errorf("failed to set owner reference: %v", err)
+	}
 	if err := r.Create(ctx, &lock); err != nil {
 		return fmt.Errorf("failed to create lock: %v", err)
 	}

--- a/resources/telemetry/charts/operator/templates/networkpolicy.yaml
+++ b/resources/telemetry/charts/operator/templates/networkpolicy.yaml
@@ -1,0 +1,24 @@
+{{- if .Values.networkPolicy.enabled }}
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: telemetry-operator-pprof-deny-ingress
+spec:
+  podSelector:
+    matchLabels:
+      {{- include "operator.selectorLabels" . | nindent 6 }}
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+        - ipBlock:
+            cidr: 0.0.0.0/0
+      ports:
+        - protocol: TCP
+          port: 8080
+        - protocol: TCP
+          port: 8081
+        - protocol: TCP
+          port: 9443
+{{- end }}

--- a/resources/telemetry/charts/operator/values.yaml
+++ b/resources/telemetry/charts/operator/values.yaml
@@ -119,6 +119,9 @@ controllers:
   tracing:
     enabled: true
 
+networkPolicy:
+  enabled: true
+
 syncPeriod: 1h
 maxLogPipelines: 3
 

--- a/resources/telemetry/values.yaml
+++ b/resources/telemetry/values.yaml
@@ -7,7 +7,7 @@ global:
       version: "PR-16573"
     telemetry_operator:
       name: "telemetry-operator"
-      version: "PR-16592"
+      version: "PR-16485"
     telemetry_webhook_cert_init:
       name: "webhook-cert-init"
       version: "PR-16573"


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- Enable pprof profiling for telemetry-operator and make http endpoint configurable

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
