### PR TITLE
Release 2.10

### DIFF
--- a/components/event-publisher-proxy/pkg/handler/handler.go
+++ b/components/event-publisher-proxy/pkg/handler/handler.go
@@ -128,7 +128,7 @@ func (h *Handler) maxBytes(f http.HandlerFunc) http.HandlerFunc {
 	}
 }
 
-// handlePublishLegacyEventV1alpha1 handles the publishing of metrics.
+// handleSendEventAndRecordMetricsLegacy handles the publishing of metrics.
 // It writes to the user request if any error occurs.
 // Otherwise, returns the result.
 func (h *Handler) handleSendEventAndRecordMetricsLegacy(writer http.ResponseWriter, request *http.Request, event *cev2event.Event) (sender.PublishResult, error) {
@@ -148,10 +148,10 @@ func (h *Handler) handleSendEventAndRecordMetricsLegacy(writer http.ResponseWrit
 	return result, nil
 }
 
-// handlePublishLegacyEventV1alpha2 handles the publishing of events for Subscription v1alpha2 CRD.
+// handlePublishLegacyEvent handles the publishing of events for Subscription v1alpha2 CRD.
 // It writes to the user request if any error occurs.
 // Otherwise, return the published event.
-func (h *Handler) handlePublishLegacyEventV1alpha2(writer http.ResponseWriter, publishData *api.PublishRequestData, request *http.Request) (sender.PublishResult, *cev2event.Event) {
+func (h *Handler) handlePublishLegacyEvent(writer http.ResponseWriter, publishData *api.PublishRequestData, request *http.Request) (sender.PublishResult, *cev2event.Event) {
 	ceEvent, err := h.LegacyTransformer.TransformPublishRequestToCloudEvent(publishData)
 	if err != nil {
 		legacy.WriteJSONResponse(writer, legacy.ErrorResponse(http.StatusInternalServerError, err))
@@ -209,7 +209,7 @@ func (h *Handler) publishLegacyEventsAsCE(writer http.ResponseWriter, request *h
 
 	// publish event for Subscription v1alpha2
 	if h.Options.EnableNewCRDVersion {
-		successResult, publishedEvent = h.handlePublishLegacyEventV1alpha2(writer, publishRequestData, request)
+		successResult, publishedEvent = h.handlePublishLegacyEvent(writer, publishRequestData, request)
 		// if publishedEvent is nil, then it means that the publishing failed
 		// and the response is already returned to the user
 		if publishedEvent == nil {

--- a/components/event-publisher-proxy/pkg/legacy/legacy.go
+++ b/components/event-publisher-proxy/pkg/legacy/legacy.go
@@ -108,13 +108,7 @@ func (t *Transformer) ExtractPublishRequestData(request *http.Request) (*apiv1.P
 		return nil, checkResp, errors.New(checkResp.Error.Message)
 	}
 
-	// validate the application name
 	appName := ParseApplicationNameFromPath(request.URL.Path)
-	if !application.IsCleanName(appName) {
-		err := errors.New("application name should be cleaned from non-alphanumeric characters")
-		return nil, ErrorResponse(http.StatusInternalServerError, err), err
-	}
-
 	publishRequestData := &apiv1.PublishRequestData{
 		PublishEventParameters: parameters,
 		ApplicationName:        appName,


### PR DESCRIPTION
**Description**
Fix legacy event publish not clean app name issue. 

Changes proposed in this pull request:
- Don't validate app name while extracting request data, as it is checked during CE conversion

**Related issue(s)**
#16528