### PR TITLE
Add PeerAuthentication to scrape Fluent Bit via plain http

### DIFF
--- a/resources/telemetry/charts/fluent-bit/templates/peerauthentication.yaml
+++ b/resources/telemetry/charts/fluent-bit/templates/peerauthentication.yaml
@@ -8,6 +8,8 @@ metadata:
     {{- toYaml . | nindent 4 }}
     {{- end }}
 spec:
+  mtls:
+    mode: STRICT
   portLevelMtls:
     2021:
       mode: PERMISSIVE
@@ -15,4 +17,4 @@ spec:
       mode: PERMISSIVE
   selector:
     matchLabels:
-      {{- include "fluent-bit.selectorLabels" . | nindent 4 }}
+      {{- include "fluent-bit.selectorLabels" . | nindent 6 }}

--- a/resources/telemetry/charts/fluent-bit/templates/peerauthentication.yaml
+++ b/resources/telemetry/charts/fluent-bit/templates/peerauthentication.yaml
@@ -1,0 +1,15 @@
+apiVersion: security.istio.io/v1beta1
+kind: PeerAuthentication
+metadata:
+  name: {{ include "fluent-bit.fullname" . }}-metrics
+  labels:
+    {{- include "fluent-bit.labels" . | nindent 4 }}
+    {{- with .Values.service.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  mtls:
+    mode: PERMISSIVE
+  selector:
+    matchLabels:
+      {{- include "fluent-bit.selectorLabels" . | nindent 4 }}

--- a/resources/telemetry/charts/fluent-bit/templates/peerauthentication.yaml
+++ b/resources/telemetry/charts/fluent-bit/templates/peerauthentication.yaml
@@ -9,7 +9,12 @@ metadata:
     {{- end }}
 spec:
   mtls:
-    mode: PERMISSIVE
+    mode: STRICT
+  portLevelMtls:
+    2020:
+      mode: PERMISSIVE
+    2021:
+      mode: PERMISSIVE
   selector:
     matchLabels:
       {{- include "fluent-bit.selectorLabels" . | nindent 4 }}

--- a/resources/telemetry/charts/fluent-bit/templates/peerauthentication.yaml
+++ b/resources/telemetry/charts/fluent-bit/templates/peerauthentication.yaml
@@ -8,8 +8,6 @@ metadata:
     {{- toYaml . | nindent 4 }}
     {{- end }}
 spec:
-  mtls:
-    mode: STRICT
   portLevelMtls:
     2021:
       mode: PERMISSIVE

--- a/resources/telemetry/charts/fluent-bit/templates/peerauthentication.yaml
+++ b/resources/telemetry/charts/fluent-bit/templates/peerauthentication.yaml
@@ -11,9 +11,9 @@ spec:
   mtls:
     mode: STRICT
   portLevelMtls:
-    2020:
-      mode: PERMISSIVE
     2021:
+      mode: PERMISSIVE
+    2020:
       mode: PERMISSIVE
   selector:
     matchLabels:

--- a/resources/telemetry/charts/fluent-bit/templates/servicemonitor.yaml
+++ b/resources/telemetry/charts/fluent-bit/templates/servicemonitor.yaml
@@ -36,25 +36,12 @@ spec:
       relabelings:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      ## scheme: HTTP scheme to use for scraping. Can be used with `tlsConfig` for example if using istio mTLS.
-      scheme: https
-      ## tlsConfig: TLS configuration to use when scraping the endpoint. For example if using istio mTLS.
-      ## Of type: https://github.com/coreos/prometheus-operator/blob/master/Documentation/api.md#tlsconfig
-      tlsConfig:
-        caFile: /etc/prometheus/secrets/istio.default/root-cert.pem
-        certFile: /etc/prometheus/secrets/istio.default/cert-chain.pem
-        keyFile: /etc/prometheus/secrets/istio.default/key.pem
-        insecureSkipVerify: true  # Prometheus does not support Istio security naming, thus skip verifying target pod ceritifcate
+      scheme: http
     {{- if .Values.serviceMonitor.serviceMonitorPorts }}
     {{- range .Values.serviceMonitor.serviceMonitorPorts }}
     - port: {{ .port }}
       path: {{ .path }}
-      scheme: {{ .scheme }}
-      tlsConfig:
-        caFile: {{ .tlsConfig.caFile }}
-        certFile: {{ .tlsConfig.certFile }}
-        keyFile: {{ .tlsConfig.keyFile }}
-        insecureSkipVerify: {{ .tlsConfig.insecureSkipVerify }}
+      scheme: http
     {{- end }}
     {{- end }}
   namespaceSelector:

--- a/resources/telemetry/charts/fluent-bit/values.yaml
+++ b/resources/telemetry/charts/fluent-bit/values.yaml
@@ -90,12 +90,6 @@ serviceMonitor:
   serviceMonitorPorts:
     - port: http-metrics
       path: /metrics
-      scheme: https
-      tlsConfig:
-        caFile: /etc/prometheus/secrets/istio.default/root-cert.pem
-        certFile: /etc/prometheus/secrets/istio.default/cert-chain.pem
-        keyFile: /etc/prometheus/secrets/istio.default/key.pem
-        insecureSkipVerify: true
 
 #   namespace: monitoring
 #   interval: 10s


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- The peer authentication will allow scraping via HTTP. The metrics do not contain sensitive data, so it is acceptable from the security point of view
- Modify the service monitor to scrape via HTTP

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
