### PR TITLE
Validate otel collector restart in telemetry test

### DIFF
--- a/resources/telemetry/charts/operator/templates/deployment.yaml
+++ b/resources/telemetry/charts/operator/templates/deployment.yaml
@@ -38,7 +38,6 @@ spec:
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           name: telemetry-webhook-cert-init
           resources:
-          resources:
             {{- toYaml .Values.initContainers.webhookInit.resources | nindent 12 }}
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}

--- a/tests/fast-integration/telemetry-test/suite.js
+++ b/tests/fast-integration/telemetry-test/suite.js
@@ -353,11 +353,32 @@ describe('Telemetry Operator', function() {
           assert.equal(secret.data.OTLP_ENDPOINT, 'aHR0cDovL25vLWVuZHBvaW50');
         });
 
-        it(`Should reflect secret ref change in telemetry-trace-collector secret`, async function() {
+        it(`Should reflect secret ref change in telemetry-trace-collector secret and pod restart`, async function() {
+           const podRes = await k8sCoreV1Api.listNamespacedPod(
+            'kyma-system',
+            'true',
+            undefined,
+            undefined,
+            undefined,
+            'app.kubernetes.io/name=telemetry-trace-collector',
+          );
+          const podList = podRes.body.items;
+
           await k8sApply(loadTestData('secret-patched-trace-endpoint.yaml'), 'default');
           await sleep(5*1000);
           const secret = await getSecret('telemetry-trace-collector', 'kyma-system');
           assert.equal(secret.data.OTLP_ENDPOINT, 'aHR0cDovL2Fub3RoZXItZW5kcG9pbnQ=');
+
+          const newPodRes = await k8sCoreV1Api.listNamespacedPod(
+            'kyma-system',
+            'true',
+            undefined,
+            undefined,
+            undefined,
+            'app.kubernetes.io/name=telemetry-trace-collector',
+          );
+          const newPodList = newPodRes.body.items;
+          assert.notDeepEqual(newPodList, podList, "telemetry-trace-collector has not been  restarted after Secret change");
         });
 
         const secondPipeline = loadTestData('tracepipeline-output-otlp-secret-ref-2.yaml');


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changing a TracePipeline or the referenced secret should restart the telemetry-trace-collector Pod. This PR adds a test to validate that the restart actually happens.

Changes proposed in this pull request:

- Enhance telemetry test to validate otel collector restart

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
