### PR TITLE
Remove Fluent Bit dummy pipeline creation

### DIFF
--- a/components/directory-size-exporter/Dockerfile
+++ b/components/directory-size-exporter/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.19.4 AS build
+FROM golang:1.19.5 AS build
 
 WORKDIR /src/
 COPY main.go go.* /src/

--- a/components/telemetry-operator/Dockerfile
+++ b/components/telemetry-operator/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM golang:1.18 as builder
+FROM golang:1.19.5 as builder
 
 WORKDIR /workspace
 # Copy the Go Modules manifests

--- a/components/telemetry-operator/internal/resources/logpipeline/resources.go
+++ b/components/telemetry-operator/internal/resources/logpipeline/resources.go
@@ -2,6 +2,7 @@ package logpipeline
 
 import (
 	"fmt"
+
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -309,12 +310,6 @@ func MakeConfigMap(name types.NamespacedName) *corev1.ConfigMap {
     DB /data/flb_kube.db
     storage.type  filesystem
 
-[INPUT]
-    Name tail
-    Path /null.log
-    Tag null.*
-    Alias null-tail
-
 [FILTER]
     Name kubernetes
     Match tele.*
@@ -322,11 +317,6 @@ func MakeConfigMap(name types.NamespacedName) *corev1.ConfigMap {
     K8S-Logging.Parser On
     K8S-Logging.Exclude On
     Buffer_Size 1MB
-
-[OUTPUT]
-    Name null
-    Match null.*
-    Alias null-null
 
 @INCLUDE dynamic/*.conf
 `

--- a/components/webhook-cert-init/Dockerfile
+++ b/components/webhook-cert-init/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.19.3 AS build
+FROM golang:1.19.5 AS build
 
 WORKDIR /src/
 COPY main.go go.* /src/

--- a/resources/telemetry/values.yaml
+++ b/resources/telemetry/values.yaml
@@ -4,13 +4,13 @@ global:
   images:
     directory_size_exporter:
       name: "directory-size-exporter"
-      version: "v20230102-4a803570"
+      version: "PR-16573"
     telemetry_operator:
       name: "telemetry-operator"
-      version: "PR-16517"
+      version: "PR-16573"
     telemetry_webhook_cert_init:
       name: "webhook-cert-init"
-      version: "v20221122-200937b4"
+      version: "PR-16573"
     telemetry_otel_collector:
       name: "otel-collector"
       version: "0.66.0-a80d981f"


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

The telemetry component uses a dummy Fluent Bit input and output to make the application starting even without an existing LogPipeline. This PR removes the creation of this configuration for the case that the Fluent Bit ConfigMap that is created by the telemetry-operator.

Changes proposed in this pull request:

- Remove dummy pipeline from Fluent Bit configuration
- Bump Golang version for telemetry-operator and related images

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
