### PR TITLE
Fix keda module name prefix

### DIFF
--- a/modules/alpha/moduletemplate-keda.yaml
+++ b/modules/alpha/moduletemplate-keda.yaml
@@ -41,7 +41,7 @@ spec:
   descriptor:
     component:
       componentReferences: []
-      name: kyma.project.io/module/keda
+      name: kyma-project.io/module/keda
       provider: internal
       repositoryContexts:
       - baseUrl: europe-docker.pkg.dev/kyma-project/prod/unsigned


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- keda component should be named with `kyma-project.io` prefix

