### PR TITLE
Conform serverless webhooks with gardener hibernation constaints

### DIFF
--- a/resources/serverless/charts/webhook/templates/webhooks.yaml
+++ b/resources/serverless/charts/webhook/templates/webhooks.yaml
@@ -14,9 +14,15 @@ webhooks:
     failurePolicy: Fail
     sideEffects: None
     matchPolicy: Exact
-    timeoutSeconds: 15
+    timeoutSeconds: 10
     admissionReviewVersions: ["v1beta1", "v1"]
     name: validation.webhook.serverless.kyma-project.io
+    namespaceSelector:
+      matchExpressions:
+      - key: gardener.cloud/purpose
+        operator: NotIn
+        values:
+        - kube-system
 ---
 apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingWebhookConfiguration
@@ -32,9 +38,15 @@ webhooks:
     failurePolicy: Fail
     sideEffects: None
     matchPolicy: Exact
-    timeoutSeconds: 15
+    timeoutSeconds: 10
     admissionReviewVersions: ["v1beta1", "v1"]
     name: defaulting.webhook.serverless.kyma-project.io
+    namespaceSelector:
+      matchExpressions:
+      - key: gardener.cloud/purpose
+        operator: NotIn
+        values:
+        - kube-system
   - clientConfig:
       service:
         name: {{ template "webhook.fullname" . }}
@@ -42,6 +54,12 @@ webhooks:
     failurePolicy: Fail
     sideEffects: None
     matchPolicy: Exact
-    timeoutSeconds: 15
+    timeoutSeconds: 10
     admissionReviewVersions: ["v1beta1", "v1"]
     name: mutating.secret.webhook.serverless.kyma-project.io
+    namespaceSelector:
+      matchExpressions:
+      - key: gardener.cloud/purpose
+        operator: NotIn
+        values:
+        - kube-system

--- a/resources/serverless/values.yaml
+++ b/resources/serverless/values.yaml
@@ -83,7 +83,7 @@ global:
       version: "v20230125-28a4267b"
     function_webhook:
       name: "function-webhook"
-      version: "v20230125-28a4267b"
+      version: "PR-16709"
     function_build_init:
       name: "function-build-init"
       version: "v20230125-28a4267b"


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- fix shoot clusters not meeting gardener hibernation constraints 

```
Your hibernation schedule may not have any effect: MutatingWebhookConfiguration "defaulting.webhook.serverless.kyma-project.io" is problematic: webhook "mutating.secret.webhook.serverless.kyma-project.io" with failurePolicy "Fail" and 15s timeout might prevent worker nodes from properly joining the shoot cluster
```

**Related issue(s)**
https://github.com/gardener/gardener/blob/master/docs/usage/shoot_status.md#constraints