### PR TITLE
Fix Eventing Metrics for new CRD

### DIFF
--- a/components/event-publisher-proxy/pkg/handler/handler_test.go
+++ b/components/event-publisher-proxy/pkg/handler/handler_test.go
@@ -794,7 +794,7 @@ func TestHandler_sendEventAndRecordMetrics(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			// given
-			logger, err := eclogger.New("text", "debug")
+			logger, _ := eclogger.New("text", "debug")
 			h := &Handler{
 				Sender:    tt.fields.Sender,
 				Defaulter: tt.fields.Defaulter,
@@ -832,7 +832,7 @@ func TestHandler_sendEventAndRecordMetrics_TracingAndDefaults(t *testing.T) {
 	latency := new(mocks.BucketsProvider)
 	latency.On(bucketsFunc).Return(nil)
 	latency.Test(t)
-	logger, err := eclogger.New("text", "debug")
+	logger, _ := eclogger.New("text", "debug")
 	h := &Handler{
 		Sender:    stub,
 		Defaulter: nil,
@@ -854,7 +854,7 @@ func TestHandler_sendEventAndRecordMetrics_TracingAndDefaults(t *testing.T) {
 		"b3flags":        "X-B3-Flags",
 	}
 	// when
-	_, err = h.sendEventAndRecordMetrics(context.Background(), CreateCloudEvent(t), "", header)
+	_, err := h.sendEventAndRecordMetrics(context.Background(), CreateCloudEvent(t), "", header)
 
 	// then
 	assert.NoError(t, err)

--- a/components/event-publisher-proxy/pkg/handler/handler_v1alpha2_test.go
+++ b/components/event-publisher-proxy/pkg/handler/handler_v1alpha2_test.go
@@ -162,7 +162,7 @@ func TestHandler_publishCloudEventsV1Alpha2(t *testing.T) {
 			wantTEF: `
 				# HELP eventing_epp_event_type_published_total The total number of events published for a given eventTypeLabel
 				# TYPE eventing_epp_event_type_published_total counter
-				eventing_epp_event_type_published_total{code="204",event_source="testapp1023",event_type="prefix.testapp1023.order.created.v1"} 1
+				eventing_epp_event_type_published_total{code="204",event_source="testapp1023",event_type="order.created.v1"} 1
 				# HELP eventing_epp_backend_duration_milliseconds The duration of sending events to the messaging server in milliseconds
 				# TYPE eventing_epp_backend_duration_milliseconds histogram
 				eventing_epp_backend_duration_milliseconds_bucket{code="204",destination_service="FOO",le="0.005"} 1
@@ -204,7 +204,7 @@ func TestHandler_publishCloudEventsV1Alpha2(t *testing.T) {
 			wantTEF: `
 				# HELP eventing_epp_event_type_published_total The total number of events published for a given eventTypeLabel
 				# TYPE eventing_epp_event_type_published_total counter
-				eventing_epp_event_type_published_total{code="204",event_source="testapp1023",event_type="prefix.testapp1023.order.created.v1"} 1
+				eventing_epp_event_type_published_total{code="204",event_source="testapp1023",event_type="order.created.v1"} 1
 				# HELP eventing_epp_backend_duration_milliseconds The duration of sending events to the messaging server in milliseconds
 				# TYPE eventing_epp_backend_duration_milliseconds histogram
 				eventing_epp_backend_duration_milliseconds_bucket{code="204",destination_service="FOO",le="0.005"} 1
@@ -362,7 +362,7 @@ func TestHandler_publishLegacyEventsAsCEV1alpha2(t *testing.T) {
 			wantTEF: `
 					# HELP eventing_epp_event_type_published_total The total number of events published for a given eventTypeLabel
 					# TYPE eventing_epp_event_type_published_total counter
-					eventing_epp_event_type_published_total{code="204",event_source="testapp",event_type="prefix.testapp.object.created.v1"} 1
+					eventing_epp_event_type_published_total{code="204",event_source="testapp",event_type="object.created.v1"} 1
 
 					# HELP eventing_epp_backend_duration_milliseconds The duration of sending events to the messaging server in milliseconds
 					# TYPE eventing_epp_backend_duration_milliseconds histogram

--- a/resources/eventing/values.yaml
+++ b/resources/eventing/values.yaml
@@ -9,7 +9,7 @@ global:
       pullPolicy: "IfNotPresent"
     publisher_proxy:
       name: event-publisher-proxy
-      version: v20230130-a1f2356f
+      version: PR-16720
     nats:
       name: nats
       version: 2.9.11-alpine3.17


### PR DESCRIPTION
**Description**
Use original event type without event type prefix for EPP published event total metric

**Related issue(s)**
#16664