### PR TITLE
Temporarily re-add FluentBit ServiceMonitor

### DIFF
--- a/resources/telemetry/charts/operator/templates/fluent-bit/service-monitor.yaml
+++ b/resources/telemetry/charts/operator/templates/fluent-bit/service-monitor.yaml
@@ -1,0 +1,53 @@
+{{- if .Values.fluentbit.serviceMonitor.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ template "fluent-bit.fullname" . }}
+  {{- with .Values.fluentbit.serviceMonitor.namespace }}
+  namespace: {{ . }}
+  {{- end }}
+  labels:
+    {{- include "fluent-bit.labels" . | nindent 4 }}
+    {{- with .Values.fluentbit.serviceMonitor.selector }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  {{- if .Values.fluentbit.serviceMonitor.jobLabel }}
+  jobLabel: {{ .Values.fluentbit.serviceMonitor.jobLabel }}
+  {{- end }}
+  endpoints:
+    - port: http
+      path: /api/v1/metrics/prometheus
+      {{- with .Values.fluentbit.serviceMonitor.interval }}
+      interval: {{ . }}
+      {{- end }}
+      {{- with .Values.fluentbit.serviceMonitor.scrapeTimeout }}
+      scrapeTimeout: {{ . }}
+      {{- end }}
+      {{- with .Values.fluentbit.serviceMonitor.metricRelabelings }}
+      metricRelabelings:
+      {{- if kindIs "string" . }}
+        {{- tpl . $ | nindent 8 }}
+      {{- else }}
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- end }}
+      {{- with .Values.fluentbit.serviceMonitor.relabelings }}
+      relabelings:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      scheme: http
+    {{- if .Values.fluentbit.serviceMonitor.serviceMonitorPorts }}
+    {{- range .Values.fluentbit.serviceMonitor.serviceMonitorPorts }}
+    - port: {{ .port }}
+      path: {{ .path }}
+      scheme: http
+    {{- end }}
+    {{- end }}
+  namespaceSelector:
+    matchNames:
+      - {{ .Release.Namespace }}
+  selector:
+    matchLabels:
+      {{- include "fluent-bit.selectorLabels" . | nindent 6 }}
+{{- end }}

--- a/resources/telemetry/charts/operator/values.yaml
+++ b/resources/telemetry/charts/operator/values.yaml
@@ -67,6 +67,11 @@ fluentbit:
     create: true
   podSecurityPolicy:
     create: true
+  serviceMonitor:
+    enabled: true
+    serviceMonitorPorts:
+      - port: http-metrics
+        path: /metrics
 
 resources:
   limits:


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- https://github.com/kyma-project/kyma/pull/16740 removes the FluentBit ServiceMonitor, which breaks some jobs that upgrade from Kyma 2.10 to main. The PR temporarily fixes the jobs and must be reverted after Kyma 2.11 is released. Upgrade from 2.11 to main should work just fine 

**Related issue(s)**
https://github.com/kyma-project/kyma/issues/11300
