### PR TITLE
remove init container from fluentbit

### DIFF
--- a/components/telemetry-operator/internal/resources/logpipeline/resources.go
+++ b/components/telemetry-operator/internal/resources/logpipeline/resources.go
@@ -161,7 +161,7 @@ func MakeDaemonSet(name types.NamespacedName, checksum string, dsConfig DaemonSe
 								{MountPath: "/fluent-bit/etc", Name: "shared-fluent-bit-config"},
 								{MountPath: "/fluent-bit/etc/fluent-bit.conf", Name: "config", SubPath: "fluent-bit.conf"},
 								{MountPath: "/fluent-bit/etc/dynamic/", Name: "dynamic-config"},
-								{MountPath: "/fluent-bit/etc/dynamic-parsers/parsers.conf", Name: "dynamic-parsers-config"},
+								{MountPath: "/fluent-bit/etc/dynamic-parsers/", Name: "dynamic-parsers-config"},
 								{MountPath: "/fluent-bit/etc/custom_parsers.conf", Name: "config", SubPath: "custom_parsers.conf"},
 								{MountPath: "/fluent-bit/etc/loki-labelmap.json", Name: "config", SubPath: "loki-labelmap.json"},
 								{MountPath: "/fluent-bit/scripts/filter-script.lua", Name: "luascripts", SubPath: "filter-script.lua"},

--- a/components/telemetry-operator/internal/resources/logpipeline/resources.go
+++ b/components/telemetry-operator/internal/resources/logpipeline/resources.go
@@ -111,30 +111,6 @@ func MakeDaemonSet(name types.NamespacedName, checksum string, dsConfig DaemonSe
 						RunAsNonRoot:   pointer.Bool(false),
 						SeccompProfile: &corev1.SeccompProfile{Type: "RuntimeDefault"},
 					},
-					InitContainers: []corev1.Container{
-						{
-							Name:  "prep-fluent-bit-config",
-							Image: dsConfig.FluentBitConfigPrepperImage,
-							Command: []string{
-								"sh", "-c",
-								"cp /main/* /fluent-bit/etc/ && mkdir -p /fluent-bit/etc/dynamic/ && cp /dynamic/* /fluent-bit/etc/dynamic && mkdir -p /fluent-bit/etc/dynamic-parsers/ && cp /dynamic-parsers/* /fluent-bit/etc/dynamic-parsers || touch /fluent-bit/etc/dynamic/empty.conf",
-							},
-							SecurityContext: &corev1.SecurityContext{
-								AllowPrivilegeEscalation: pointer.Bool(false),
-								Privileged:               pointer.Bool(false),
-								ReadOnlyRootFilesystem:   pointer.Bool(true),
-								Capabilities: &corev1.Capabilities{
-									Drop: []corev1.Capability{"ALL"},
-								},
-							},
-							VolumeMounts: []corev1.VolumeMount{
-								{Name: "shared-fluent-bit-config", MountPath: "/fluent-bit/etc/"},
-								{Name: "config", MountPath: "/main/fluent-bit.conf", SubPath: "fluent-bit.conf"},
-								{Name: "dynamic-config", MountPath: "/dynamic"},
-								{Name: "dynamic-parsers-config", MountPath: "/dynamic-parsers"},
-							},
-						},
-					},
 					Containers: []corev1.Container{
 						{
 							Name: "fluent-bit",
@@ -184,6 +160,8 @@ func MakeDaemonSet(name types.NamespacedName, checksum string, dsConfig DaemonSe
 							VolumeMounts: []corev1.VolumeMount{
 								{MountPath: "/fluent-bit/etc", Name: "shared-fluent-bit-config"},
 								{MountPath: "/fluent-bit/etc/fluent-bit.conf", Name: "config", SubPath: "fluent-bit.conf"},
+								{MountPath: "/fluent-bit/etc/dynamic/", Name: "dynamic-config"},
+								{MountPath: "/fluent-bit/etc/dynamic-parsers/parsers.conf", Name: "dynamic-parsers-config"},
 								{MountPath: "/fluent-bit/etc/custom_parsers.conf", Name: "config", SubPath: "custom_parsers.conf"},
 								{MountPath: "/fluent-bit/etc/loki-labelmap.json", Name: "config", SubPath: "loki-labelmap.json"},
 								{MountPath: "/fluent-bit/scripts/filter-script.lua", Name: "luascripts", SubPath: "filter-script.lua"},

--- a/components/telemetry-operator/main.go
+++ b/components/telemetry-operator/main.go
@@ -116,11 +116,10 @@ var (
 )
 
 const (
-	otelImage                   = "eu.gcr.io/kyma-project/tpi/otel-collector:0.70.0-723b551a"
-	overrideConfigMapName       = "telemetry-override-config"
-	fluentBitImage              = "eu.gcr.io/kyma-project/tpi/fluent-bit:2.0.8-723b551a"
-	fluentBitConfigPrepperImage = "eu.gcr.io/kyma-project/external/busybox:1.34.1"
-	fluentBitExporterImage      = "eu.gcr.io/kyma-project/directory-size-exporter:v20221020-e314a071"
+	otelImage              = "eu.gcr.io/kyma-project/tpi/otel-collector:0.70.0-723b551a"
+	overrideConfigMapName  = "telemetry-override-config"
+	fluentBitImage         = "eu.gcr.io/kyma-project/tpi/fluent-bit:2.0.8-723b551a"
+	fluentBitExporterImage = "eu.gcr.io/kyma-project/directory-size-exporter:v20221020-e314a071"
 )
 
 //nolint:gochecknoinits
@@ -212,7 +211,6 @@ func main() {
 	flag.StringVar(&fluentBitCPURequest, "fluent-bit-cpu-request", "400m", "CPU request for fluent-bit")
 	flag.StringVar(&fluentBitMemoryRequest, "fluent-bit-memory-request", "256Mi", "Memory request for fluent-bit")
 	flag.StringVar(&fluentBitImageVersion, "fluent-bit-image", fluentBitImage, "Image for fluent-bit")
-	flag.StringVar(&fluentBitConfigPrepperImageVersion, "fluent-bit-config-prepper-image", fluentBitConfigPrepperImage, "Image for fluent-bit config preparation")
 	flag.StringVar(&fluentBitExporterVersion, "fluent-bit-exporter-image", fluentBitExporterImage, "Image for exporting fluent bit filesystem usage")
 	flag.StringVar(&fluentBitPriorityClassName, "fluent-bit-priority-class-name", "kyma-system-priority", "Name of the priority class of fluent bit ")
 

--- a/resources/telemetry/charts/operator/templates/deployment.yaml
+++ b/resources/telemetry/charts/operator/templates/deployment.yaml
@@ -67,7 +67,6 @@ spec:
             - --fluent-bit-denied-output-plugins={{ join "," .Values.deniedPlugins.output}}
             - --fluent-bit-max-pipelines={{.Values.maxLogPipelines}}
             - --fluent-bit-image={{ include "imageurl" (dict "reg" .Values.global.containerRegistry "img" .Values.global.images.fluent_bit) }}
-            - --fluent-bit-config-prepper-image={{ include "imageurl" (dict "reg" $.Values.global.containerRegistry "img" $.Values.global.images.busybox) }}
             - --fluent-bit-exporter-image={{ include "imageurl" (dict "reg" .Values.global.containerRegistry "img" .Values.global.images.directory_size_exporter) }}
 {{- if or .Values.priorityClassName .Values.global.highPriorityClassName }}
             - --fluent-bit-priority-class-name={{ coalesce .Values.priorityClassName .Values.global.highPriorityClassName }}

--- a/resources/telemetry/values.yaml
+++ b/resources/telemetry/values.yaml
@@ -7,7 +7,7 @@ global:
       version: "v20230117-64505a69"
     telemetry_operator:
       name: "telemetry-operator"
-      version: "PR-16767"
+      version: "PR-16781"
     telemetry_webhook_cert_init:
       name: "webhook-cert-init"
       version: "v20230117-64505a69"


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- Static parsers are already stored in `custom-parsers.conf`
- Remove init container
- Mount `dynamic` and `dynamic-parsers` directly onto the fluent-bit container
**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
https://github.com/kyma-project/kyma/issues/16733