### PR TITLE
Write Tests for Missing Important Eventing Cases

### DIFF
--- a/tests/fast-integration/eventing-test/eventing-test-prep.js
+++ b/tests/fast-integration/eventing-test/eventing-test-prep.js
@@ -132,10 +132,14 @@ describe('Eventing tests preparation', function() {
     // we can verify that the stream was not affected/recreated
     debug('Creating eventing test data configmap with JetStream stream info');
     const streamInfo = await getJetStreamStreamData(natsApiRuleVSHost);
-    await createK8sConfigMap(
-        streamInfo,
-        testDataConfigMapName,
-    );
+    if (streamInfo) {
+      await createK8sConfigMap(
+          streamInfo,
+          testDataConfigMapName,
+      );
+    } else {
+      debug('Skipping creating eventing test data configmap due to missing stream');
+    }
   });
 
   it('Prepare assets without Compass flow', async function() {

--- a/tests/fast-integration/eventing-test/eventing-test-prep.js
+++ b/tests/fast-integration/eventing-test/eventing-test-prep.js
@@ -44,7 +44,7 @@ const {
   ensureCommerceMockLocalTestFixture,
   setEventMeshSourceNamespace,
   ensureCommerceMockWithCompassTestFixture,
-  eventTypeOrderReceivedHash,
+  orderReceivedSubName,
 } = require('../test/fixtures/commerce-mock');
 const {
   info,
@@ -54,6 +54,7 @@ const {
   createK8sConfigMap,
   createApiRuleForService,
   deleteApiRule, getConfigMap,
+  getSubscriptionConsumerName,
 } = require('../utils');
 const {
   addScenarioInCompass,
@@ -148,7 +149,7 @@ describe('Eventing tests preparation', function() {
     // Deploy Commerce mock application, function and subscriptions for tests
     await prepareAssetsWithoutCompassFlow();
 
-    await addConsumerToConfigMap(eventTypeOrderReceivedHash);
+    await addOrderReceivedConsumerToConfigMap();
   });
 
   it('Prepare assets with Compass flow', async function() {
@@ -162,7 +163,7 @@ describe('Eventing tests preparation', function() {
 
     debug('Adding JetStream consumer info to eventing test data configmap');
 
-    await addConsumerToConfigMap(eventTypeOrderReceivedHash);
+    await addOrderReceivedConsumerToConfigMap();
   });
 
   it('Prepare eventing-sink function', async function() {
@@ -253,7 +254,8 @@ describe('Eventing tests preparation', function() {
     );
   }
 
-  async function addConsumerToConfigMap(consumerName) {
+  async function addOrderReceivedConsumerToConfigMap() {
+    const consumerName = await getSubscriptionConsumerName(orderReceivedSubName, testNamespace, subCRDVersion);
     debug('Adding JetStream consumer info to eventing test data configmap');
     const consumerInfo = await getJetStreamConsumerData(consumerName, natsApiRuleVSHost);
     const testDataConfigMap = await getConfigMap(testDataConfigMapName);

--- a/tests/fast-integration/eventing-test/eventing-test-prep.js
+++ b/tests/fast-integration/eventing-test/eventing-test-prep.js
@@ -26,7 +26,6 @@ const {
   gardener,
   director,
   shootName,
-  getJetStreamConsumerData,
   cleanupTestingResources,
   eventingSinkName,
   getClusterHost,

--- a/tests/fast-integration/eventing-test/eventing-test-prep.js
+++ b/tests/fast-integration/eventing-test/eventing-test-prep.js
@@ -44,7 +44,6 @@ const {
   ensureCommerceMockLocalTestFixture,
   setEventMeshSourceNamespace,
   ensureCommerceMockWithCompassTestFixture,
-  orderReceivedSubName,
 } = require('../test/fixtures/commerce-mock');
 const {
   info,
@@ -53,8 +52,7 @@ const {
   createEventingBackendK8sSecret,
   createK8sConfigMap,
   createApiRuleForService,
-  deleteApiRule, getConfigMap,
-  getSubscriptionConsumerName,
+  deleteApiRule,
 } = require('../utils');
 const {
   addScenarioInCompass,
@@ -148,8 +146,6 @@ describe('Eventing tests preparation', function() {
 
     // Deploy Commerce mock application, function and subscriptions for tests
     await prepareAssetsWithoutCompassFlow();
-
-    await addOrderReceivedConsumerToConfigMap();
   });
 
   it('Prepare assets with Compass flow', async function() {
@@ -160,10 +156,6 @@ describe('Eventing tests preparation', function() {
 
     // Deploy Commerce mock application, function and subscriptions for tests (includes compass flow)
     await prepareAssetsWithCompassFlow();
-
-    debug('Adding JetStream consumer info to eventing test data configmap');
-
-    await addOrderReceivedConsumerToConfigMap();
   });
 
   it('Prepare eventing-sink function', async function() {
@@ -251,20 +243,6 @@ describe('Eventing tests preparation', function() {
         mockNamespace,
         testNamespace,
         compassScenarioAlreadyExist,
-    );
-  }
-
-  async function addOrderReceivedConsumerToConfigMap() {
-    const consumerName = await getSubscriptionConsumerName(orderReceivedSubName, testNamespace, subCRDVersion);
-    debug('Adding JetStream consumer info to eventing test data configmap');
-    const consumerInfo = await getJetStreamConsumerData(consumerName, natsApiRuleVSHost);
-    const testDataConfigMap = await getConfigMap(testDataConfigMapName);
-    await createK8sConfigMap(
-        {
-          ...testDataConfigMap.data,
-          ...consumerInfo,
-        },
-        testDataConfigMapName,
     );
   }
 });

--- a/tests/fast-integration/eventing-test/eventing-test.js
+++ b/tests/fast-integration/eventing-test/eventing-test.js
@@ -34,7 +34,6 @@ const {
   k8sApply,
   deleteK8sPod,
   createK8sConfigMap,
-  getSubscriptionConsumerName,
   waitForFunction,
   eventingSubscription,
   waitForEndpoint,
@@ -615,7 +614,8 @@ describe('Eventing tests', function() {
           testDataConfigMapName,
       );
     } else {
-      debug('Skipping adding consumer info to the eventing data CM due to missing consumer');
+      throw Error(`Couldn't add consumer info to the eventing data CM due to` +
+          `missing consumer ${consumerName} in NATS JetStream`);
     }
   });
 

--- a/tests/fast-integration/eventing-test/eventing-test.js
+++ b/tests/fast-integration/eventing-test/eventing-test.js
@@ -10,6 +10,7 @@ const {
   sendCloudEventStructuredModeAndCheckResponse,
   sendCloudEventBinaryModeAndCheckResponse,
   checkInClusterEventDelivery,
+  checkBEBFullyQualifiedTypeWithExactSub,
   waitForSubscriptionsTillReady,
   waitForSubscriptions,
   checkInClusterEventTracing,
@@ -491,6 +492,13 @@ describe('Eventing tests', function() {
 
     it('Run Eventing Monitoring tests', async function() {
       await eventingMonitoringTest(bebBackend, isSKR);
+    });
+
+    it('check subscription with full qualified event type and exact type matching', async function() {
+      if (!testSubscriptionV1Alpha2) {
+        this.skip();
+      }
+      await checkBEBFullyQualifiedTypeWithExactSub(testNamespace);
     });
   });
 

--- a/tests/fast-integration/eventing-test/eventing-test.js
+++ b/tests/fast-integration/eventing-test/eventing-test.js
@@ -473,20 +473,6 @@ describe('Eventing tests', function() {
     });
   }
 
-  async function recordOrderReceivedConsumerDataToConfigMap() {
-    const consumerName = await getSubscriptionConsumerName(orderReceivedSubName, testNamespace, subCRDVersion);
-    debug('Adding JetStream consumer info to eventing test data configmap');
-    const consumerInfo = await getJetStreamConsumerData(consumerName, natsApiRuleVSHost);
-    const testDataConfigMap = await getConfigMap(testDataConfigMapName);
-    await createK8sConfigMap(
-        {
-          ...testDataConfigMap.data,
-          ...consumerInfo,
-        },
-        testDataConfigMapName,
-    );
-  }
-
   // runs after each test in every block
   afterEach(async function() {
     // if the test is failed, then printing some debug logs
@@ -596,8 +582,25 @@ describe('Eventing tests', function() {
     if (currentBackend && currentBackend.toLowerCase() !== natsBackend) {
       this.skip();
     }
+
+    let testDataConfigMap;
+    try {
+      testDataConfigMap = await getConfigMap(testDataConfigMapName);
+    } catch (err) {
+      console.log('Skipping the recording consumer data due to missing configmap!');
+      this.skip();
+    }
+
     debug('Adding JetStream consumer info to eventing test data configmap');
-    await recordOrderReceivedConsumerDataToConfigMap();
+    const consumerName = await getSubscriptionConsumerName(orderReceivedSubName, testNamespace, subCRDVersion);
+    const consumerInfo = await getJetStreamConsumerData(consumerName, natsApiRuleVSHost);
+    await createK8sConfigMap(
+        {
+          ...testDataConfigMap.data,
+          ...consumerInfo,
+        },
+        testDataConfigMapName,
+    );
   });
 
   after('Delete the created APIRule', async function() {

--- a/tests/fast-integration/eventing-test/eventing-test.js
+++ b/tests/fast-integration/eventing-test/eventing-test.js
@@ -18,6 +18,7 @@ const {
   getVirtualServiceHost,
   sendInClusterEventWithRetry,
   ensureInClusterEventReceivedWithRetry,
+  eventTypeOrderReceivedHash,
 } = require('../test/fixtures/commerce-mock');
 const {
   getEventingBackend,
@@ -59,10 +60,12 @@ const {
   getStreamConfigForJetStream,
   skipAtLeastOnceDeliveryTest,
   isStreamCreationTimeMissing,
+  isConsumerCreationTimeMissing,
   getJetStreamStreamData,
-  streamDataConfigMapName,
+  testDataConfigMapName,
   eventingNatsSvcName,
   eventingNatsApiRuleAName,
+  getJetStreamConsumerData,
   subscriptionNames,
   eventingSinkName,
   v1alpha1SubscriptionsTypes,
@@ -276,7 +279,7 @@ describe('Eventing tests', function() {
     }
 
     if (backend === natsBackend) {
-      testStreamNotReCreated();
+      testStreamAndConsumerNotReCreated();
       testJetStreamAtLeastOnceDelivery();
     }
   }
@@ -296,22 +299,26 @@ describe('Eventing tests', function() {
     });
   }
 
-  // testStreamNotReCreated - compares the stream creation timestamp before and after upgrade
-  // and if the timestamp is the same, we conclude that the stream is not re created.
-  function testStreamNotReCreated() {
-    context('stream check with JetStream backend', function() {
-      let wantStreamData = null;
+  // testStreamAndConsumerNotReCreated - compares the stream and consumer creation timestamp before and after upgrade
+  // and if the timestamp is the same, we conclude that the stream is not re-created.
+  function testStreamAndConsumerNotReCreated() {
+    context('stream and consumer check with JetStream backend', function() {
+      let wantStreamName = null;
+      let wantStreamCreationTime = null;
+      let wantConsumerName = null;
+      let wantConsumerCreationTime = null;
       let gotStreamData = null;
-      before('check if stream creation timestamp is available', async function() {
+      let gotConsumerData = null;
+      let cm;
+      before('check if stream and consumer creation timestamp is available', async function() {
         try {
-          const cm = await getConfigMap(streamDataConfigMapName);
-          wantStreamData = cm.data;
+          cm = await getConfigMap(testDataConfigMapName);
+          wantStreamName = cm.data.streamName;
+          wantStreamCreationTime = cm.data.streamCreationTime;
+          wantConsumerName = cm.data.consumerName;
+          wantConsumerCreationTime = cm.data.consumerCreationTime;
         } catch (err) {
           console.log('Skipping the stream recreation check due to missing configmap!');
-          this.skip();
-        }
-        if (isStreamCreationTimeMissing(wantStreamData)) {
-          console.log('Skipping the stream recreation check as the stream creation timestamp is missing!');
           this.skip();
         }
       });
@@ -323,13 +330,26 @@ describe('Eventing tests', function() {
             8222);
         const vsHost = vs.spec.hosts[0];
         gotStreamData = await getJetStreamStreamData(vsHost);
+        gotConsumerData = await getJetStreamConsumerData(eventTypeOrderReceivedHash, vsHost);
       });
 
       it('Compare the stream creation timestamp', async function() {
-        assert.equal(gotStreamData.streamName, wantStreamData.streamName);
-        assert.equal(gotStreamData.streamCreationTime, wantStreamData.streamCreationTime);
+        if (isStreamCreationTimeMissing(cm.data)) {
+          console.log('Skipping the stream recreation check as the stream creation timestamp is missing!');
+          this.skip();
+        }
+        assert.equal(gotStreamData.streamName, wantStreamName);
+        assert.equal(gotStreamData.streamCreationTime, wantStreamCreationTime);
       });
 
+      it('Compare the consumer creation timestamp', async function() {
+        if (isConsumerCreationTimeMissing(cm.data)) {
+          console.log('Skipping the consumer recreation check as the stream creation timestamp is missing!');
+          this.skip();
+        }
+        assert.equal(gotConsumerData.consumerName, wantConsumerName);
+        assert.equal(gotConsumerData.consumerCreationTime, wantConsumerCreationTime);
+      });
 
       it('Delete the created APIRule', async function() {
         await deleteApiRule(eventingNatsApiRuleAName, kymaSystem);

--- a/tests/fast-integration/eventing-test/eventing-test.js
+++ b/tests/fast-integration/eventing-test/eventing-test.js
@@ -588,15 +588,19 @@ describe('Eventing tests', function() {
   after('Record order.received.v1 consumer data to ConfigMap', async () => {
     const currentBackend = await getEventingBackend();
     if (currentBackend && currentBackend.toLowerCase() !== natsBackend) {
-      this.skip();
+      debug('Skipping the recording consumer data for non NATS backend!');
+      return;
     }
 
     let testDataConfigMap;
     try {
       testDataConfigMap = await getConfigMap(testDataConfigMapName);
     } catch (err) {
-      console.log('Skipping the recording consumer data due to missing configmap!');
-      this.skip();
+      if (err.statusCode === 404) {
+        debug('Skipping the recording consumer data due to missing configmap!');
+        return;
+      }
+      throw err;
     }
 
     debug('Adding JetStream consumer info to eventing test data configmap');

--- a/tests/fast-integration/eventing-test/utils.js
+++ b/tests/fast-integration/eventing-test/utils.js
@@ -1,5 +1,6 @@
 const {
   cleanMockTestFixture,
+  eventTypeOrderReceivedHash,
   cleanCompassResourcesSKR,
   generateTraceParentHeader,
   checkTrace,
@@ -13,6 +14,7 @@ const {
   getShootNameFromK8sServerUrl,
   listPods,
   retryPromise,
+  getSubscription,
   waitForVirtualService,
   k8sApply,
   waitForFunction,
@@ -185,6 +187,17 @@ async function getJetStreamStreamData(host) {
     streamName: streamName,
     streamCreationTime: streamCreationTime,
   };
+}
+
+async function getSubscriptionConsumerName(subscriptionName, namespace='default', crdVersion='v1alpha1') {
+  const sub = await getSubscription(subscriptionName, namespace, crdVersion);
+  if (crdVersion === 'v1alpha1') {
+    // the logic is temporary because consumer name is missing in the v1alpha1 subscription
+    // will be deleted as we will upgrade to v1alpha2
+    return eventTypeOrderReceivedHash;
+  } else {
+    return sub.status.backend.types[0].consumerName;
+  }
 }
 
 async function getJetStreamConsumerData(consumerName, host) {
@@ -585,6 +598,7 @@ module.exports = {
   isConsumerCreationTimeMissing,
   eppInClusterUrl,
   subscriptionNames,
+  getSubscriptionConsumerName,
   eventingSinkName,
   v1alpha1SubscriptionsTypes,
   subscriptionsTypes,

--- a/tests/fast-integration/eventing-test/utils.js
+++ b/tests/fast-integration/eventing-test/utils.js
@@ -37,6 +37,7 @@ const {expect} = require('chai');
 
 // Variables
 const kymaVersion = process.env.KYMA_VERSION || '';
+const kymaStreamName = 'sap';
 const isSKR = process.env.KYMA_TYPE === 'SKR';
 const skrInstanceId = process.env.INSTANCE_ID || '';
 const testCompassFlow = process.env.TEST_COMPASS_FLOW || false;
@@ -180,22 +181,24 @@ async function getStreamConfigForJetStream() {
 
 async function getJetStreamStreamData(host) {
   const responseJson = await retryPromise(async () => await axios.get(`https://${host}/jsz?streams=true`), 5, 1000);
-  const streamName = responseJson.data.account_details[0].stream_detail[0].name;
-  const streamCreationTime = responseJson.data.account_details[0].stream_detail[0].created;
-
-  return {
-    streamName: streamName,
-    streamCreationTime: streamCreationTime,
-  };
+  const streams = responseJson.data.account_details[0].stream_detail;
+  for (const stream of streams) {
+    if (stream.name === kymaStreamName) {
+      return {
+        streamName: kymaStreamName,
+        streamCreationTime: stream.created,
+      };
+    }
+  }
 }
 
 async function getSubscriptionConsumerName(subscriptionName, namespace='default', crdVersion='v1alpha1') {
-  const sub = await getSubscription(subscriptionName, namespace, crdVersion);
   if (crdVersion === 'v1alpha1') {
     // the logic is temporary because consumer name is missing in the v1alpha1 subscription
     // will be deleted as we will upgrade to v1alpha2
     return eventTypeOrderReceivedHash;
   } else {
+    const sub = await getSubscription(subscriptionName, namespace, crdVersion);
     return sub.status.backend.types[0].consumerName;
   }
 }

--- a/tests/fast-integration/test/fixtures/commerce-mock/index.js
+++ b/tests/fast-integration/test/fixtures/commerce-mock/index.js
@@ -79,6 +79,9 @@ const lastorderFunctionYaml = fs.readFileSync(
 const eventTypeOrderCompleted = 'order.completed.v1';
 const uncleanEventType = 'Order-äöüÄÖÜβ.Final.R-e-c-e-i-v-e-d.v1';
 const fullyQualifiedEventType = 'sap.kyma.custom.inapp.order.completed.v2';
+const eventTypeOrderReceived = 'sap.kyma.custom.inapp.order.received.v1';
+// the following is the consumer name of 'sap.kyma.custom.inapp.order.received.v1'
+const eventTypeOrderReceivedHash = 'f8a4e1486659bb2647b07bb167c9ee95';
 const eventSourceInApp = 'inapp';
 const uncleanSource = 'test-app';
 const applicationObjs = k8s.loadAllYaml(applicationMockYaml);
@@ -610,7 +613,7 @@ async function ensureCommerceMockWithCompassTestFixture(
   await waitForApplicationCr(`mp-${appName}`);
 
   await k8sApply([eventingSubscription(
-      `sap.kyma.custom.inapp.order.received.v1`,
+      eventTypeOrderReceived,
       `http://lastorder.${targetNamespace}.svc.cluster.local`,
       'order-received',
       targetNamespace)]);
@@ -1028,6 +1031,7 @@ module.exports = {
   sendInClusterEventWithRetry,
   ensureInClusterEventReceivedWithRetry,
   prepareFunction,
+  eventTypeOrderReceivedHash,
   generateTraceParentHeader,
   checkTrace,
 };

--- a/tests/fast-integration/test/fixtures/commerce-mock/index.js
+++ b/tests/fast-integration/test/fixtures/commerce-mock/index.js
@@ -1029,6 +1029,7 @@ module.exports = {
   ensureInClusterEventReceivedWithRetry,
   prepareFunction,
   eventTypeOrderReceivedHash,
+  eventTypeOrderReceived,
   orderReceivedSubName,
   generateTraceParentHeader,
   checkTrace,

--- a/tests/fast-integration/test/fixtures/commerce-mock/index.js
+++ b/tests/fast-integration/test/fixtures/commerce-mock/index.js
@@ -77,8 +77,9 @@ const lastorderFunctionYaml = fs.readFileSync(
 );
 
 const eventTypeOrderCompleted = 'order.completed.v1';
-const uncleanEventType = 'Order-äöüÄÖÜβ.Final.R-e-c-e-i-v-e-d.v1';
+const uncleanEventType = 'Order-$.Final.R-e-c-e-i-v-e-d.v1';
 const fullyQualifiedEventType = 'sap.kyma.custom.inapp.order.completed.v2';
+const orderReceivedSubName = 'order-received';
 const eventTypeOrderReceived = 'sap.kyma.custom.inapp.order.received.v1';
 // the following is the consumer name of 'sap.kyma.custom.inapp.order.received.v1'
 const eventTypeOrderReceivedHash = 'f8a4e1486659bb2647b07bb167c9ee95';
@@ -615,9 +616,9 @@ async function ensureCommerceMockWithCompassTestFixture(
   await k8sApply([eventingSubscription(
       eventTypeOrderReceived,
       `http://lastorder.${targetNamespace}.svc.cluster.local`,
-      'order-received',
+      orderReceivedSubName,
       targetNamespace)]);
-  await waitForSubscription('order-received', targetNamespace);
+  await waitForSubscription(orderReceivedSubName, targetNamespace);
   await waitForSubscription('order-created', targetNamespace);
   return mockHost;
 }
@@ -663,11 +664,11 @@ async function ensureCommerceMockLocalTestFixture(mockNamespace, targetNamespace
 
   const sink = `http://lastorder.${targetNamespace}.svc.cluster.local`;
   await k8sApply([eventingSubscription(
-      `sap.kyma.custom.inapp.order.received.v1`,
+      eventTypeOrderReceived,
       sink,
-      'order-received',
+      orderReceivedSubName,
       targetNamespace)]);
-  await waitForSubscription('order-received', targetNamespace);
+  await waitForSubscription(orderReceivedSubName, targetNamespace);
   await waitForSubscription('order-created', targetNamespace);
 
   if (testSubscriptionV1Alpha2) {
@@ -789,7 +790,7 @@ async function waitForSubscriptions(subscriptions) {
 }
 
 async function waitForSubscriptionsTillReady(targetNamespace) {
-  await waitForSubscription('order-received', targetNamespace);
+  await waitForSubscription(orderReceivedSubName, targetNamespace);
   await waitForSubscription('order-created', targetNamespace);
 }
 
@@ -797,13 +798,23 @@ async function checkInClusterEventDelivery(targetNamespace, testSubscriptionV1Al
   await checkInClusterEventDeliveryHelper(targetNamespace, 'structured', testSubscriptionV1Alpha2);
   await checkInClusterEventDeliveryHelper(targetNamespace, 'binary', testSubscriptionV1Alpha2);
   if (testSubscriptionV1Alpha2) {
-    await checkInClusterEventDeliveryHelper(targetNamespace, 'structured', true, uncleanEventType, uncleanSource);
-    await checkInClusterLegacyEvent(targetNamespace, true, uncleanEventType, uncleanSource);
+    await checkInClusterEventDeliveryHelper(targetNamespace, 'structured', true,
+        eventTypeOrderCompleted, eventSourceInApp);
+    await checkInClusterEventDeliveryHelper(targetNamespace, 'binary', true,
+        eventTypeOrderCompleted, eventSourceInApp);
+    // test CE with unclean event type
+    await checkInClusterEventDeliveryHelper(targetNamespace, 'structured', true,
+        uncleanEventType, uncleanSource);
+    await checkInClusterLegacyEvent(targetNamespace, true,
+        eventTypeOrderCompleted.replace('.v1', ''), eventSourceInApp);
+    // test legacy event with unclean event type
+    await checkInClusterLegacyEvent(targetNamespace, true,
+        uncleanEventType.replace('.v1', ''), uncleanSource);
   }
   await checkInClusterLegacyEvent(targetNamespace, testSubscriptionV1Alpha2);
 }
 
-async function checkBEBFullyQualifiedTypeWithExactSub(targetNamespace, eventType=fullyQualifiedEventType) {
+async function checkFullyQualifiedTypeWithExactSub(targetNamespace, eventType=fullyQualifiedEventType) {
   await checkInClusterEventDeliveryHelper(targetNamespace, 'structured', true,
       eventType, eventMeshSourceNamespace);
 }
@@ -964,12 +975,6 @@ async function getVirtualServiceHost(targetNamespace, funcName) {
 async function checkInClusterEventDeliveryHelper(targetNamespace, encoding, testSubscriptionV1Alpha2=false,
     eventType='', eventSource='') {
   const eventId = getRandomEventId(encoding);
-  if (!eventType) {
-    eventType = testSubscriptionV1Alpha2 ? eventTypeOrderCompleted : '';
-  }
-  if (!eventSource) {
-    eventSource = testSubscriptionV1Alpha2 ? eventSourceInApp : '';
-  }
   const mockHost = await getVirtualServiceHost(targetNamespace, 'lastorder');
 
   if (isDebugEnabled()) {
@@ -990,14 +995,6 @@ async function checkInClusterLegacyEvent(targetNamespace, testSubscriptionV1Alph
   }
 
   const eventData = {'id': eventId, 'legacyOrder': '987'};
-  if (!eventType) {
-    eventType = testSubscriptionV1Alpha2 ? eventTypeOrderCompleted.replace('.v1', '') : '';
-  } else {
-    eventType = testSubscriptionV1Alpha2 ? uncleanEventType.replace('.v1', '') : '';
-  }
-  if (!eventSource) {
-    eventSource = testSubscriptionV1Alpha2 ? eventSourceInApp : '';
-  }
 
   await sendInClusterLegacyEventWithRetry(mockHost, eventData, eventType, eventSource);
   return ensureInClusterLegacyEventReceivedWithRetry(mockHost, eventId, eventType);
@@ -1017,7 +1014,7 @@ module.exports = {
   deleteService,
   checkFunctionResponse,
   checkInClusterEventDelivery,
-  checkBEBFullyQualifiedTypeWithExactSub,
+  checkFullyQualifiedTypeWithExactSub,
   checkInClusterEventTracing,
   cleanMockTestFixture,
   deleteMockTestFixture,
@@ -1032,6 +1029,7 @@ module.exports = {
   ensureInClusterEventReceivedWithRetry,
   prepareFunction,
   eventTypeOrderReceivedHash,
+  orderReceivedSubName,
   generateTraceParentHeader,
   checkTrace,
 };

--- a/tests/fast-integration/test/fixtures/commerce-mock/lastorder-function.yaml
+++ b/tests/fast-integration/test/fixtures/commerce-mock/lastorder-function.yaml
@@ -143,7 +143,8 @@ spec:
           console.log("Printing event data: ", event.data);
           console.log("Printing event header: ", event.headers);
           return {event:inAppEvent[event.extensions.request.query.inappevent], podName: process.env.HOSTNAME};
-        } else if (event["ce-type"] && (event["ce-type"].includes("order.received") || event["ce-type"].includes("order.completed"))){
+        } else if (event["ce-type"] && (event["ce-type"].includes("order.received") || event["ce-type"].includes("order.completed") 
+               || event["ce-type"].includes("Final.R-e-c-e-i-v-e-d.v1") || event["ce-type"].includes("Final.Received.v1"))){
           console.log("Got in-app event:", event.data);
           inAppEvent[event.data.id] = { ...cloudEventHeaders(event), shipped:true, ...event.data, headers:event.extensions.request.headers };
         } else if (event["ce-type"] && event["ce-type"].includes("order.created")) {

--- a/tests/fast-integration/utils/index.js
+++ b/tests/fast-integration/utils/index.js
@@ -4,7 +4,6 @@ const fs = require('fs');
 const {join} = require('path');
 const {expect} = require('chai');
 const execa = require('execa');
-const {eventTypeOrderReceivedHash} = require('../test/fixtures/commerce-mock');
 
 const kc = new k8s.KubeConfig();
 let k8sDynamicApi;
@@ -411,19 +410,6 @@ function waitForFunction(name, namespace = 'default', timeout = 90_000) {
       timeout,
       `Waiting for ${name} function timeout (${timeout} ms)`,
   );
-}
-
-async function getSubscriptionConsumerName(subscriptionName, namespace='default', crdVersion='v1alpha1') {
-  const sub = await getSubscription(subscriptionName, namespace, crdVersion);
-  let consumerName;
-  if (crdVersion === 'v1alpha1') {
-    // the logic is temporary because consumer name is missing in the v1alpha1 subscription
-    // will be deleted as we will upgrade to v1alpha2
-    return eventTypeOrderReceivedHash;
-  } else {
-    consumerName = sub.status.backend.types[0].consumerName;
-  }
-  return consumerName;
 }
 
 async function getSubscription(name, namespace = 'default', crdVersion='v1alpha1') {
@@ -1925,5 +1911,5 @@ module.exports = {
   waitForEndpoint,
   waitForPodWithLabelAndCondition,
   waitForDeploymentWithLabel,
-  getSubscriptionConsumerName,
+  getSubscription,
 };

--- a/tests/fast-integration/utils/index.js
+++ b/tests/fast-integration/utils/index.js
@@ -4,6 +4,7 @@ const fs = require('fs');
 const {join} = require('path');
 const {expect} = require('chai');
 const execa = require('execa');
+const {eventTypeOrderReceivedHash} = require('../test/fixtures/commerce-mock');
 
 const kc = new k8s.KubeConfig();
 let k8sDynamicApi;
@@ -410,6 +411,38 @@ function waitForFunction(name, namespace = 'default', timeout = 90_000) {
       timeout,
       `Waiting for ${name} function timeout (${timeout} ms)`,
   );
+}
+
+async function getSubscriptionConsumerName(subscriptionName, namespace='default', crdVersion='v1alpha1') {
+  const sub = await getSubscription(subscriptionName, namespace, crdVersion);
+  let consumerName;
+  if (crdVersion === 'v1alpha1') {
+    // the logic is temporary because consumer name is missing in the v1alpha1 subscription
+    // will be deleted as we will upgrade to v1alpha2
+    return eventTypeOrderReceivedHash;
+  } else {
+    consumerName = sub.status.backend.types[0].consumerName;
+  }
+  return consumerName;
+}
+
+async function getSubscription(name, namespace = 'default', crdVersion='v1alpha1') {
+  try {
+    const path = `/apis/eventing.kyma-project.io/${crdVersion}/namespaces/${namespace}/subscriptions/${name}`;
+    const response = await k8sDynamicApi.requestPromise({
+      url: k8sDynamicApi.basePath + path,
+      qs: {limit: 500},
+    });
+    const body = JSON.parse(response.body);
+    return body;
+  } catch (e) {
+    if (e.statusCode === 404 || e.statusCode === 405) {
+      // do nothing
+    } else {
+      error(e);
+      throw e;
+    }
+  }
 }
 
 async function getAllSubscriptions(namespace = 'default', crdVersion='v1alpha1') {
@@ -1892,4 +1925,5 @@ module.exports = {
   waitForEndpoint,
   waitForPodWithLabelAndCondition,
   waitForDeploymentWithLabel,
+  getSubscriptionConsumerName,
 };


### PR DESCRIPTION
**Description**
Write tests for missing scenarios of v1alpha2

Changes proposed in this pull request:

- Write test for unclean event type and source tests for v1alpha2
- Write test for event mesh with fully qualified event and exact type matching
- Writes test for testing a consumer is not recreated after eventing upgrade

**Related issue(s)**
#16738