### PR TITLE
Factor memory operations on a python dictionary

### DIFF
--- a/components/function-runtimes/python39/kubeless/ce.py
+++ b/components/function-runtimes/python39/kubeless/ce.py
@@ -26,13 +26,10 @@ class PicklableBottleRequest(bottle.BaseRequest):
         env = self.environ.copy()
 
         # File-like objects are not picklable.
-        del env['wsgi.errors']
-        del env['wsgi.input']
+        del env['wsgi.errors'], env['wsgi.input']
 
         # bottle.ConfigDict is not picklable because it contains a lambda function.
-        del env['bottle.app']
-        del env['bottle.route']
-        del env['route.handle']
+        del env['bottle.app'], env['bottle.route'], env['route.handle']
 
         return env
 


### PR DESCRIPTION
**Description**

Small cpu optimization for serverless fuctions using the python runtime.

Changes proposed in this pull request:

- Group several consecutive **del** statements on a single line. Because here the number of elements is small, it doesn't impact readability.


This test show about 7% faster with 4 deletes are on a single line.

```
docker run python:3.9-alpine python3 -m timeit -n 4000000 "d=dict(a=1,b=2,c=3,d=4,e=5,f=6,g=7,h=8)
del d['b'],d['d'], d['f'], d['h']"
4000000 loops, best of 5: 367 nsec per loop
```

```
docker run python:3.9-alpine python3 -m timeit -n 4000000 "d=dict(a=1,b=2,c=3,d=4,e=5,f=6,g=7,h=8)
dquote> del d['b']                        
del d['d']
del d['f']
del d['h']"
4000000 loops, best of 5: 395 nsec per loop
```