### PR TITLE
Always disable scraping for kube-state-metrics service

### DIFF
--- a/resources/monitoring/charts/kube-state-metrics/templates/service.yaml
+++ b/resources/monitoring/charts/kube-state-metrics/templates/service.yaml
@@ -6,9 +6,7 @@ metadata:
   labels:
     {{- include "kube-state-metrics.labels" . | indent 4 }}
   annotations:
-    {{- if .Values.prometheusScrape }}
     prometheus.io/scrape: '{{ .Values.prometheusScrape }}'
-    {{- end }}
     {{- if .Values.service.annotations }}
     {{- toYaml .Values.service.annotations | nindent 4 }}
     {{- end }}


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- Fix a problem with upgrading introduced in [this PR](https://github.com/kyma-project/kyma/pull/16740). Since the reconciler does not remove annotations, we need to always set scraping to false

**Related issue(s)**
https://github.com/kyma-project/kyma/issues/11300
