### PR TITLE
Correct `make` calls in conn validator tests README

### DIFF
--- a/tests/components/application-connector/docs/application-connectivity-validator-tests.md
+++ b/tests/components/application-connector/docs/application-connectivity-validator-tests.md
@@ -59,7 +59,7 @@ Pipelines run the tests using the **test-validator** target from the `Makefile`.
 ### Run the tests
 
 ``` sh
-make test-validator
+make -f Makefile.test-application-conn-validator test-validator
 ```
 
 By default, the tests clean up after themselves, removing all the previously created resources and the `test` Namespace.
@@ -75,11 +75,11 @@ To run the tests without removing all the created resources afterwards, run them
 1. To start the tests in the debugging mode, run:
 
    ``` shell
-   make test-validator-debug
+   make -f Makefile.test-application-conn-validator test-validator-debug
    ```
 
 2. Once you've finished debugging, run:
 
    ``` shell
-   make clean-validator-test
+   make -f Makefile.test-application-conn-validator clean-validator-test
    ```


### PR DESCRIPTION
They were missing makefile specification

<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Connectivity validator tests had incorrect `make` calls in README.
This PR fixes that.

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
#15380