### PR TITLE
Revert pod preset cleanup guide (#16867)

### DIFF
--- a/docs/assets/2.11-2.12-cleanup-podpreset.bash
+++ b/docs/assets/2.11-2.12-cleanup-podpreset.bash
@@ -1,9 +1,0 @@
-#!/usr/bin/env bash
-
-kubectl delete mutatingwebhookconfiguration cluster-essentials-pod-preset-webhook
-kubectl delete -nkyma-system secret cluster-essentials-pod-preset-webhook-cert
-kubectl delete -nkyma-system serviceaccount cluster-essentials-pod-preset-webhook
-kubectl delete clusterrole cluster-essentials-pod-preset-webhook
-kubectl delete clusterrolebinding cluster-essentials-pod-preset-webhook
-kubectl delete -nkyma-system service cluster-essentials-pod-preset-webhook
-kubectl delete -nkyma-system deployment cluster-essentials-pod-preset-webhook

--- a/docs/migration-guide-2.11-2.12.md
+++ b/docs/migration-guide-2.11-2.12.md
@@ -10,12 +10,6 @@ Once you upgrade to Kyma 2.12, perform the manual steps described in the Migrati
 
 In preparation for the upcoming modularization and having a reduced set of dependencies on a module, Kyma switched to an annotation-based scraping of metrics for system components. With that, the ServiceMonitors of the components must be cleaned up. When you upgrade from Kyma 2.11 to 2.12, either run the script [cleanup.sh](https://github.com/kyma-project/kyma/blob/main/docs/assets/2.11-2.12-cleanup-servicemonitors.sh) or run the commands from the script manually.
 
-## Service Management
-
-### PodPreset cleanup
-
-The PodPreset component was deprecated in [Kyma 2.4](https://kyma-project.io/blog/2022/6/30/release-notes-24#pod-preset-deprecation-note) and removed from [Kyma 2.10](https://github.com/kyma-project/kyma/pull/16647). Run the [cleanup script](https://github.com/kyma-project/kyma/blob/main/docs/assets/2.11-2.12-cleanup-podpreset.bash) to remove any residual resources related to PodPresets. Follow [the guide](https://kyma-project.io/blog/2022/6/30/release-notes-24#pod-preset-deprecation-note) to transform the usage of `Secrets` from Kyma `Functions` manually.
-
 ## Application Connectivity
 
 ### Removal of the `compass-system` Namespace


### PR DESCRIPTION
reverting #16867 in favor of https://github.com/kyma-project/kyma/pull/16885, the guide is supposed to go to release branch for 2.11, not `main`.

see also: https://github.com/kyma-project/kyma/issues/16862#issuecomment-1441371255