### PR TITLE
Bump k8s-tools image in Kyma 2.11

### DIFF
--- a/docs/04-operation-guides/operations/10-backup-kyma.md
+++ b/docs/04-operation-guides/operations/10-backup-kyma.md
@@ -171,7 +171,7 @@ spec:
           serviceAccountName: volume-snapshotter
           containers:
           - name: job
-            image: eu.gcr.io/kyma-project/tpi/k8s-tools:v20230110-ce11007d
+            image: eu.gcr.io/kyma-project/tpi/k8s-tools:v20230214-a820b6b6
             command:
               - /bin/bash
               - -c

--- a/resources/ory/values.yaml
+++ b/resources/ory/values.yaml
@@ -30,7 +30,7 @@ global:
   images:
     k8s_tools:
       name: "k8s-tools"
-      version: "v20230110-ce11007d"
+      version: "v20230214-a820b6b6"
       directory: "tpi"
     ## Google Cloud SQL Proxy image
     ## ref: https://cloud.google.com/sql/docs/mysql/sql-proxy

--- a/resources/serverless/values.yaml
+++ b/resources/serverless/values.yaml
@@ -76,7 +76,7 @@ global:
   images:
     k8s_tools:
       name: "k8s-tools"
-      version: "v20230110-ce11007d"
+      version: "v20230214-a820b6b6"
       directory: "tpi"
     function_controller:
       name: "function-controller"


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- The same changes as #16806, for Kyma 2.11
- Bump k8s-tools image to one based on Alpine 3.17.2 and containing kubectl 1.24.10

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
- https://github.com/kyma-project/third-party-images/pull/309
- https://github.com/kyma-project/third-party-images/pull/310