### PR TITLE
Restore validatingwebhook creation in telemetry chart

### DIFF
--- a/resources/telemetry/charts/operator/templates/validation_webhook.yaml
+++ b/resources/telemetry/charts/operator/templates/validation_webhook.yaml
@@ -1,0 +1,58 @@
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  labels:
+    {{- include "operator.labels" . | nindent 4 }}
+    {{- toYaml .Values.extraLabels | nindent 4 }}
+  name: {{ .Values.webhook.name }}
+webhooks:
+- admissionReviewVersions:
+  - v1beta1
+  - v1
+  clientConfig:
+    service:
+      name: {{ include "operator.fullname" . }}-webhook
+      namespace: {{ .Release.Namespace }}
+      path: /validate-logpipeline
+      port: 443
+  failurePolicy: Fail
+  matchPolicy: Exact
+  name: validation.logpipelines.telemetry.kyma-project.io
+  rules:
+  - apiGroups:
+    - telemetry.kyma-project.io
+    apiVersions:
+    - v1alpha1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - logpipelines
+    scope: '*'
+  sideEffects: None
+  timeoutSeconds: {{ .Values.webhook.timeout }}
+- admissionReviewVersions:
+  - v1beta1
+  - v1
+  clientConfig:
+    service:
+      name: {{ include "operator.fullname" . }}-webhook
+      namespace: {{ .Release.Namespace }}
+      path: /validate-logparser
+      port: 443
+  failurePolicy: Fail
+  matchPolicy: Exact
+  name: validation.logparsers.telemetry.kyma-project.io
+  rules:
+  - apiGroups:
+    - telemetry.kyma-project.io
+    apiVersions:
+    - v1alpha1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - logparsers
+    scope: '*'
+  sideEffects: None
+  timeoutSeconds: {{ .Values.webhook.timeout }}

--- a/resources/telemetry/charts/operator/values.yaml
+++ b/resources/telemetry/charts/operator/values.yaml
@@ -89,6 +89,8 @@ service:
 
 webhook:
   enabled: true
+  name: validation.webhook.telemetry.kyma-project.io
+  timeout: 15
   service:
     portName: https-webhook
     port: 443


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

PR #16879 moved the creation of the ValidatingWebhookConfiguration for LogPipeliens and LogParsers from the Helm chart to the operator. This might result in a deadlock situation when removing Kyma since the webhook is not deleted by the reconciler anymore. This PR adds the webhook creation back to the chart to have it removed by a `kyma undeploy`. The operator will still update the webhook with a generated certificate.

Changes proposed in this pull request:

- Restore validatingwebhook creation in telemetry chart

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
#16879 