### PR TITLE
Fix time comparisons for NATS in Eventing FI tests

### DIFF
--- a/tests/fast-integration/eventing-test/eventing-test.js
+++ b/tests/fast-integration/eventing-test/eventing-test.js
@@ -61,6 +61,7 @@ const {
   waitForV1Alpha1Subscriptions,
   waitForV1Alpha2Subscriptions,
   checkEventTracing,
+  getTimeStampsWithZeroMilliSeconds,
 } = require('./utils');
 const {
   bebBackend,
@@ -339,7 +340,10 @@ describe('Eventing tests', function() {
 
       it('Compare the stream creation timestamp', async function() {
         assert.equal(gotStreamData.streamName, wantStreamName);
-        assert.equal(gotStreamData.streamCreationTime, wantStreamCreationTime);
+        assert.equal(
+            getTimeStampsWithZeroMilliSeconds(gotStreamData.streamCreationTime),
+            getTimeStampsWithZeroMilliSeconds(wantStreamCreationTime),
+        );
       });
     });
   }
@@ -378,7 +382,10 @@ describe('Eventing tests', function() {
 
       it('Compare the consumer creation timestamp', async function() {
         assert.equal(gotConsumerData.consumerName, wantConsumerName);
-        assert.equal(gotConsumerData.consumerCreationTime, wantConsumerCreationTime);
+        assert.equal(
+            getTimeStampsWithZeroMilliSeconds(gotConsumerData.consumerCreationTime),
+            getTimeStampsWithZeroMilliSeconds(wantConsumerCreationTime),
+        );
       });
     });
   }

--- a/tests/fast-integration/eventing-test/utils.js
+++ b/tests/fast-integration/eventing-test/utils.js
@@ -555,6 +555,12 @@ function createLegacyEventRequestBody(proxyHost, eventId, eventType, eventSource
   return reqBody;
 }
 
+function getTimeStampsWithZeroMilliSeconds(timestamp) {
+  // set milliseconds to zero
+  const ts = (new Date(timestamp)).setMilliseconds(0);
+  return (new Date(ts)).toISOString();
+}
+
 module.exports = {
   appName,
   scenarioName,
@@ -600,4 +606,5 @@ module.exports = {
   waitForV1Alpha1Subscriptions,
   waitForV1Alpha2Subscriptions,
   checkEventTracing,
+  getTimeStampsWithZeroMilliSeconds,
 };


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- Fix time comparisons for NATS in Eventing FI tests
- The problem was that we were comparing the whole timestamp string, and in the new NATS version the milliseconds part is slightly different, so the comparison was failing.
```
consumer creation timestamp:
      AssertionError: expected '2023-02-24T10:04:46.621219086Z' to equal '2023-02-24T10:04:46.621016282Z' 
```
- Now, we compare the timestamps excluding milliseconds.

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
