### PR TITLE
SKR machineType update e2e test

### DIFF
--- a/tests/fast-integration/kyma-environment-broker/client.js
+++ b/tests/fast-integration/kyma-environment-broker/client.js
@@ -88,6 +88,15 @@ class KEBClient {
     }
   }
 
+  async getCatalog() {
+    const endpoint = `catalog`;
+    try {
+      return await this.callKEB({}, endpoint, 'get');
+    } catch (err) {
+      throw new Error(`error while getting catalog: ${err.toString()}`);
+    }
+  }
+
   async provisionSKR(name, instanceID, platformCreds, btpOperatorCreds, customParams) {
     const payload = {
       service_id: KYMA_SERVICE_ID,

--- a/tests/fast-integration/kyma-environment-broker/helpers.js
+++ b/tests/fast-integration/kyma-environment-broker/helpers.js
@@ -124,6 +124,10 @@ async function getShootName(keb, instanceID) {
   return resp.data[0].shootName;
 }
 
+async function getCatalog(keb) {
+  return keb.getCatalog();
+}
+
 async function ensureValidOIDCConfigInCustomerFacingKubeconfig(keb, instanceID, oidcConfig) {
   let kubeconfigContent;
   try {
@@ -156,4 +160,5 @@ module.exports = {
   getShootName,
   ensureValidShootOIDCConfig,
   ensureValidOIDCConfigInCustomerFacingKubeconfig,
+  getCatalog,
 };

--- a/tests/fast-integration/package.json
+++ b/tests/fast-integration/package.json
@@ -18,7 +18,7 @@
     "test-certificate": "mocha --timeout 150000 --inline-diffs --check-leaks --reporter mocha-multi-reporters --reporter-options configFile=mocha-reporter-config.json ./certificate-test/",
     "test-getting-started": "mocha --inline-diffs --check-leaks --reporter mocha-multi-reporters --reporter-options configFile=mocha-reporter-config.json ./test/3-getting-started-guides.js",
     "test-compass": "mocha --inline-diffs --check-leaks --reporter mocha-multi-reporters --reporter-options configFile=mocha-reporter-config.json ./compass-test/",
-    "test-skr": "DEBUG=false mocha --timeout 15000 --inline-diffs --check-leaks --reporter mocha-multi-reporters --reporter-options configFile=mocha-reporter-config.json ./skr-test/test.js",
+    "test-skr": "DEBUG=true mocha --timeout 15000 --inline-diffs --check-leaks --reporter mocha-multi-reporters --reporter-options configFile=mocha-reporter-config.json ./skr-test/test.js",
     "test-skr-own-cluster": "DEBUG=false mocha --timeout 15000 --inline-diffs --check-leaks --reporter mocha-multi-reporters --reporter-options configFile=mocha-reporter-config.json ./skr-test/test-own-cluster.js",
     "test-skr-provision": "DEBUG=false mocha --timeout 15000 --inline-diffs --check-leaks --reporter mocha-multi-reporters --reporter-options configFile=mocha-reporter-config.json ./skr-test/provision-skr.js",
     "test-skr-deprovision": "DEBUG=false mocha --timeout 15000 --inline-diffs --check-leaks --reporter mocha-multi-reporters --reporter-options configFile=mocha-reporter-config.json ./skr-test/deprovision-skr.js",

--- a/tests/fast-integration/skr-test/index.js
+++ b/tests/fast-integration/skr-test/index.js
@@ -2,4 +2,5 @@ module.exports = {
   ...require('./helpers'),
   ...require('./provision/provision-skr'),
   ...require('./oidc/index'),
+  ...require('./machine-type/index'),
 };

--- a/tests/fast-integration/skr-test/machine-type/index.js
+++ b/tests/fast-integration/skr-test/machine-type/index.js
@@ -1,5 +1,5 @@
 const {expect} = require('chai');
-const {updateSKR} = require('../../kyma-environment-broker');
+const {updateSKR, getCatalog} = require('../../kyma-environment-broker');
 const {keb, kcp} = require('../helpers');
 const {GardenerClient, GardenerConfig} = require('../../gardener');
 const {getEnvOrThrow} = require('../../utils');
@@ -10,8 +10,10 @@ function machineTypeE2ETest(getShootOptionsFunc, getShootInfoFunc) {
   describe('Machine type update test', function() {
     let shoot = undefined;
     let options = undefined;
+    let updateMachineType = undefined;
+    let defaultMachineType = undefined;
+    const planID = getEnvOrThrow('KEB_PLAN_ID');
     const gardener = new GardenerClient(GardenerConfig.fromEnv());
-    const updateMachineType = getEnvOrThrow('MACHINE_TYPE_UPDATE');
 
     before('Get provisioned Shoot Info', async function() {
       shoot = getShootInfoFunc();
@@ -19,11 +21,57 @@ function machineTypeE2ETest(getShootOptionsFunc, getShootInfoFunc) {
     });
 
     it('Should check default machine type after provisioning', async function() {
-      const machineType = await getMachineType(gardener, shoot.name);
-      console.log(`Default machine type ${machineType}`);
+      defaultMachineType = await getMachineType(gardener, shoot.name);
+      console.log(`Default machine type ${defaultMachineType}`);
     });
 
-    it('Should update SKR service instance with machine type', async function() {
+    it('Should figure out next machine type to update to', async function() {
+      const catalog = await getCatalog(keb);
+      console.log(`catalog services ${catalog.services.length}`);
+      for (let i = 0; i < catalog.services.length; i++) {
+        const s = catalog.services[i];
+        console.log(`checking catalog service ${s.id}`);
+        if (s.id !== '47c9dcbf-ff30-448e-ab36-d3bad66ba281') {
+          continue;
+        }
+        for (let j = 0; j < s.plans.length; j++) {
+          const p = s.plans[j];
+          console.log(`checking catalog plan ${p.id}, looking for ${planID}`);
+          if (p.id !== planID) {
+            continue;
+          }
+          const si = p.schemas.service_instance;
+          console.log(`catalog plan update ${si.update !== undefined}`);
+          if (si.update === undefined) {
+            continue;
+          }
+          const mt = si.update.parameters.properties.machineType.enum;
+          console.log(`catalog plan update machine types ${mt}`);
+          if (mt.length < 2) {
+            continue;
+          }
+          for (let i = 0; i < mt.length; i++) {
+            console.log(`checking catalog plan update machine type comp ${mt[i]}, looking for ${defaultMachineType}`);
+            if (mt[i] === defaultMachineType) {
+              console.log(`catalog plan update machine type ${mt[i]} === ${defaultMachineType}`);
+              updateMachineType = mt[(i+1) % mt.length];
+              break;
+            }
+          }
+          if (updateMachineType !== undefined) {
+            break;
+          }
+        }
+      }
+      console.log(`determined machine type to update: ${updateMachineType}`);
+    });
+
+    it('Should update SKR service instance machine type', async function() {
+      if (updateMachineType === undefined) {
+        console.log('skipping machine type update');
+        return;
+      }
+      console.log(`updating ${defaultMachineType} => ${updateMachineType}`);
       this.timeout(updateTimeout);
       const customParams = {
         machineType: updateMachineType,
@@ -41,6 +89,10 @@ function machineTypeE2ETest(getShootOptionsFunc, getShootInfoFunc) {
     });
 
     it('Should check machine type after update', async function() {
+      if (updateMachineType === undefined) {
+        console.log('skipping machine type update');
+        return;
+      }
       const machineType = await getMachineType(gardener, shoot.name);
       expect(machineType).to.equal(updateMachineType);
     });

--- a/tests/fast-integration/skr-test/machine-type/index.js
+++ b/tests/fast-integration/skr-test/machine-type/index.js
@@ -1,0 +1,58 @@
+const {expect} = require('chai');
+const {updateSKR} = require('../../kyma-environment-broker');
+const {keb, kcp} = require('../helpers');
+const {GardenerClient, GardenerConfig} = require('../../gardener');
+const {getEnvOrThrow} = require('../../utils');
+
+const updateTimeout = 1000 * 60 * 30; // 30m
+
+function machineTypeE2ETest(getShootOptionsFunc, getShootInfoFunc) {
+  describe('Machine type update test', function() {
+    let shoot = undefined;
+    let options = undefined;
+    const gardener = new GardenerClient(GardenerConfig.fromEnv());
+    const updateMachineType = getEnvOrThrow('MACHINE_TYPE_UPDATE');
+
+    before('Get provisioned Shoot Info', async function() {
+      shoot = getShootInfoFunc();
+      options = getShootOptionsFunc();
+    });
+
+    it('Should check default machine type after provisioning', async function() {
+      const machineType = await getMachineType(gardener, shoot.name);
+      console.log(`Default machine type ${machineType}`);
+    });
+
+    it('Should update SKR service instance with machine type', async function() {
+      this.timeout(updateTimeout);
+      const customParams = {
+        machineType: updateMachineType,
+      };
+      const skr = await updateSKR(keb,
+          kcp,
+          gardener,
+          options.instanceID,
+          shoot.name,
+          customParams,
+          updateTimeout,
+          null,
+          false);
+      shoot = skr.shoot;
+    });
+
+    it('Should check machine type after update', async function() {
+      const machineType = await getMachineType(gardener, shoot.name);
+      expect(machineType).to.equal(updateMachineType);
+    });
+  });
+}
+
+async function getMachineType(gardener, shoot) {
+  await gardener.waitForShoot(shoot, 'Reconcile');
+  const sh = await gardener.getShoot(shoot);
+  return sh.spec.provider.workers[0].machine.type;
+}
+
+module.exports = {
+  machineTypeE2ETest,
+};

--- a/tests/fast-integration/skr-test/test.js
+++ b/tests/fast-integration/skr-test/test.js
@@ -52,11 +52,7 @@ describe('SKR test', function() {
 
   // Run the OIDC and machine type tests
   oidcE2ETest(getShootOptionsFunc, getShootInfoFunc);
-  if (process.env.MACHINE_TYPE_UPDATE) {
-    machineTypeE2ETest(getShootOptionsFunc, getShootInfoFunc);
-  } else {
-    console.log('no machine type update defined');
-  }
+  machineTypeE2ETest(getShootOptionsFunc, getShootInfoFunc);
 
   after('Cleanup the resources', async function() {
     this.timeout(deprovisioningTimeout);

--- a/tests/fast-integration/skr-test/test.js
+++ b/tests/fast-integration/skr-test/test.js
@@ -1,6 +1,7 @@
 const {
   gatherOptions,
   oidcE2ETest,
+  machineTypeE2ETest,
 } = require('./index');
 const {getOrProvisionSKR} = require('./provision/provision-skr');
 const {deprovisionAndUnregisterSKR} = require('./provision/deprovision-skr');
@@ -49,8 +50,13 @@ describe('SKR test', function() {
   });
 
 
-  // Run the OIDC tests
+  // Run the OIDC and machine type tests
   oidcE2ETest(getShootOptionsFunc, getShootInfoFunc);
+  if (process.env.MACHINE_TYPE_UPDATE) {
+    machineTypeE2ETest(getShootOptionsFunc, getShootInfoFunc);
+  } else {
+    console.log('no machine type update defined');
+  }
 
   after('Cleanup the resources', async function() {
     this.timeout(deprovisioningTimeout);


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

~Running machineType update as part of SKR tests. Env variables defined in https://github.com/kyma-project/test-infra/pull/7117.~

Querying `/catalog` endpoint to determine whether the plan has an updateable machine type and then running the update if possible to the next machine type after the default.

pjtester: https://status.build.kyma-project.io/log?container=test&id=1632732358094360576&job=wozniakjan_test_of_prowjob_skr-aws-integration-dev

<details>
  <summary>log excerpt</summary>

```
...
    Machine type update test
[DEBUG] waiting for /apis/core.gardener.cloud/v1beta1/namespaces/garden-kyma-dev/shoots
[DEBUG] Skipping object from watch c-91f95f3 != ba83ca5
[DEBUG] Waiting for ba83ca5 shoot
[DEBUG] Check object state Reconcile == Reconcile && Succeeded == 'Succeeded'
[DEBUG] Last operation status: {"description":"Shoot cluster has been successfully reconciled.","lastUpdateTime":"2023-03-06T13:40:00Z","progress":100,"state":"Succeeded","type":"Reconcile"}
[DEBUG] finished waiting for  /apis/core.gardener.cloud/v1beta1/namespaces/garden-kyma-dev/shoots
[DEBUG] Fetching shoot: ba83ca5 from gardener namespace: garden-kyma-dev
Default machine type m5.xlarge
      ✓ Should check default machine type after provisioning
catalog services 1
checking catalog service 47c9dcbf-ff30-448e-ab36-d3bad66ba281
checking catalog plan 4deee563-e5ec-4731-b9b1-53b42d855f0c, looking for 361c511f-f939-4621-b228-d0fb79a1fe15
checking catalog plan 8cb22518-aa26-44c5-91a0-e669ec9bf443, looking for 361c511f-f939-4621-b228-d0fb79a1fe15
checking catalog plan b1a5764e-2ea1-4f95-94c0-2b4538b37b55, looking for 361c511f-f939-4621-b228-d0fb79a1fe15
checking catalog plan 5cb3d976-b85c-42ea-a636-79cadda109a9, looking for 361c511f-f939-4621-b228-d0fb79a1fe15
checking catalog plan ca6e5357-707f-4565-bbbd-b3ab732597c6, looking for 361c511f-f939-4621-b228-d0fb79a1fe15
checking catalog plan 03b812ac-c991-4528-b5bd-08b303523a63, looking for 361c511f-f939-4621-b228-d0fb79a1fe15
checking catalog plan 7d55d31d-35ae-4438-bf13-6ffdfa107d9f, looking for 361c511f-f939-4621-b228-d0fb79a1fe15
checking catalog plan 03e3cb66-a4c6-4c6a-b4b0-5d42224debea, looking for 361c511f-f939-4621-b228-d0fb79a1fe15
checking catalog plan 361c511f-f939-4621-b228-d0fb79a1fe15, looking for 361c511f-f939-4621-b228-d0fb79a1fe15
catalog plan update true
catalog plan update machine types m5.xlarge,m5.2xlarge,m5.4xlarge,m5.8xlarge,m5.12xlarge,m6i.xlarge,m6i.2xlarge,m6i.4xlarge,m6i.8xlarge,m6i.12xlarge
checking catalog plan update machine type comp m5.xlarge, looking for m5.xlarge
catalog plan update machine type m5.xlarge === m5.xlarge
determined machine type to update: m5.2xlarge
      ✓ Should figure out next machine type to update to
updating m5.xlarge => m5.2xlarge
[DEBUG] Operation ID 0f058245-0bd3-4813-a898-1226908072e7
Operation 0f058245-0bd3-4813-a898-1226908072e7 finished with state succeeded
[DEBUG] Fetching shoot: ba83ca5 from gardener namespace: garden-kyma-dev
      ✓ Should update SKR service instance machine type (450562ms)
[DEBUG] waiting for /apis/core.gardener.cloud/v1beta1/namespaces/garden-kyma-dev/shoots
[DEBUG] Skipping object from watch c-10b4a17 != ba83ca5
[DEBUG] Skipping object from watch c-5ea60c9 != ba83ca5
[DEBUG] Skipping object from watch c-919eb9a != ba83ca5
[DEBUG] Skipping object from watch c-64e07cc != ba83ca5
[DEBUG] Skipping object from watch a21336d != ba83ca5
[DEBUG] Skipping object from watch e1cca07 != ba83ca5
[DEBUG] Skipping object from watch d34bab1 != ba83ca5
[DEBUG] Skipping object from watch c21a34e != ba83ca5
[DEBUG] Waiting for ba83ca5 shoot
[DEBUG] Check object state Reconcile == Reconcile && Succeeded == 'Succeeded'
[DEBUG] Last operation status: {"description":"Shoot cluster has been successfully reconciled.","lastUpdateTime":"2023-03-06T13:47:06Z","progress":100,"state":"Succeeded","type":"Reconcile"}
[DEBUG] finished waiting for  /apis/core.gardener.cloud/v1beta1/namespaces/garden-kyma-dev/shoots
[DEBUG] Fetching shoot: ba83ca5 from gardener namespace: garden-kyma-dev
      ✓ Should check machine type after update
...
```

</details>

closes: https://github.com/kyma-project/control-plane/issues/2497