### PR TITLE
Generate `Sink` from `Service` in Subscription `v1alpha2` Busola extension.

### DIFF
--- a/resources/eventing/charts/controller/templates/busola-extension.yaml
+++ b/resources/eventing/charts/controller/templates/busola-extension.yaml
@@ -76,16 +76,6 @@ data:
       defaultExpanded: true
       children:
         - path: '[]'
-    - simple: true
-      type: string
-      var: service
-      name: Service
-      widget: Resource
-      resource:
-        kind: Service
-        version: v1
-        scope: namespace
-      trigger: [sink]
     - path: spec.sink
       name: spec.sink
       widget: Resource

--- a/resources/eventing/charts/controller/templates/busola-extension.yaml
+++ b/resources/eventing/charts/controller/templates/busola-extension.yaml
@@ -76,6 +76,7 @@ data:
       defaultExpanded: true
       children:
         - path: '[]'
+          simple: true
     - path: spec.sink
       name: spec.sink
       widget: Resource

--- a/resources/eventing/charts/controller/templates/busola-extension.yaml
+++ b/resources/eventing/charts/controller/templates/busola-extension.yaml
@@ -88,11 +88,17 @@ data:
       trigger: [sink]
     - path: spec.sink
       name: spec.sink
+      widget: Resource
+      resource:
+        kind: Service
+        version: v1
+        scope: namespace
       simple: true
       inputInfo: inputInfo.sink
       placeholder: placeholder.sink
+      trigger: [sink]
       subscribe:
-        sink: '"http://" & $service & "." & $root.metadata.namespace & ".svc.cluster.local"'
+        sink: '"http://" & spec.sink & "." & $root.metadata.namespace & ".svc.cluster.local"'
     - path: spec.typeMatching
       simple: true
       enum:

--- a/resources/eventing/charts/controller/templates/busola-extension.yaml
+++ b/resources/eventing/charts/controller/templates/busola-extension.yaml
@@ -89,7 +89,7 @@ data:
       placeholder: placeholder.sink
       trigger: [sink]
       subscribe:
-        sink: '"http://" & spec.sink & "." & $root.metadata.namespace & ".svc.cluster.local"'
+        sink: '"http://" & $sink & "." & $root.metadata.namespace & ".svc.cluster.loca"'
     - path: spec.typeMatching
       simple: true
       enum:


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

This PR removes the `Service` field from the subscription v1alpha2 creation form. Instead, the `Sink` dropdown will offer all possible sinks, containing all available services.

**Related issue(s)**
this is related to https://github.com/kyma-project/kyma-dashboard/issues/51