### PR TITLE
Move function profile overrides from the test-infra scripts

### DIFF
--- a/resources/serverless/values.yaml
+++ b/resources/serverless/values.yaml
@@ -114,7 +114,7 @@ global:
   testImages:
     function_controller_test:
       name: "function-controller-test"
-      version: "v20221230-38609347"
+      version: "PR-16925"
     git_server:
       name: "gitserver"
       version: "708f6a87"

--- a/tests/function-controller/testsuite/gitops/function.go
+++ b/tests/function-controller/testsuite/gitops/function.go
@@ -35,5 +35,10 @@ func GitopsFunction(repoURL, baseDir, reference string, rtm serverlessv1alpha2.R
 			MinReplicas: &minReplicas,
 			MaxReplicas: &maxReplicas,
 		},
+		ResourceConfiguration: &serverlessv1alpha2.ResourceConfiguration{
+			Function: &serverlessv1alpha2.ResourceRequirements{
+				Profile: "M",
+			},
+		},
 	}
 }

--- a/tests/function-controller/testsuite/runtimes/nodejs.go
+++ b/tests/function-controller/testsuite/runtimes/nodejs.go
@@ -16,6 +16,11 @@ func BasicNodeJSFunction(msg string, rtm serverlessv1alpha2.Runtime) serverlessv
 				Dependencies: `{ "name": "hellobasic", "version": "0.0.1", "dependencies": {} }`,
 			},
 		},
+		ResourceConfiguration: &serverlessv1alpha2.ResourceConfiguration{
+			Function: &serverlessv1alpha2.ResourceRequirements{
+				Profile: "M",
+			},
+		},
 	}
 }
 
@@ -26,6 +31,11 @@ func BasicNodeJSFunctionWithCustomDependency(msg string, rtm serverlessv1alpha2.
 			Inline: &serverlessv1alpha2.InlineSource{
 				Source:       fmt.Sprintf(`module.exports = { main: function(event, context) { return "%s" } }`, msg),
 				Dependencies: `{ "name": "hellobasic", "version": "0.0.1", "dependencies": { "camelcase": "^7.0.0" } }`,
+			},
+		},
+		ResourceConfiguration: &serverlessv1alpha2.ResourceConfiguration{
+			Function: &serverlessv1alpha2.ResourceRequirements{
+				Profile: "M",
 			},
 		},
 	}
@@ -68,6 +78,11 @@ func NodeJSFunctionWithEnvFromConfigMapAndSecret(configMapName, cmEnvKey, secret
 						Key: secretEnvKey,
 					},
 				},
+			},
+		},
+		ResourceConfiguration: &serverlessv1alpha2.ResourceConfiguration{
+			Function: &serverlessv1alpha2.ResourceRequirements{
+				Profile: "M",
 			},
 		},
 	}

--- a/tests/function-controller/testsuite/runtimes/python.go
+++ b/tests/function-controller/testsuite/runtimes/python.go
@@ -22,6 +22,11 @@ arrow==0.15.8`
 				Dependencies: dpd,
 			},
 		},
+		ResourceConfiguration: &serverlessv1alpha2.ResourceConfiguration{
+			Function: &serverlessv1alpha2.ResourceRequirements{
+				Profile: "M",
+			},
+		},
 	}
 }
 
@@ -41,6 +46,11 @@ kyma-pypi-test==1.0.0`
 			Inline: &serverlessv1alpha2.InlineSource{
 				Source:       src,
 				Dependencies: dpd,
+			},
+		},
+		ResourceConfiguration: &serverlessv1alpha2.ResourceConfiguration{
+			Function: &serverlessv1alpha2.ResourceRequirements{
+				Profile: "M",
 			},
 		},
 	}


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- Some serverless overrides [that we use](https://github.com/kyma-project/test-infra/blob/main/prow/scripts/cluster-integration/serverless-integration-k3s.sh#L39) in tests are set on the installation level which may be problematic when we want to run these tests to check serverless module integration because serverless-manager does not allow to use of such logic

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
https://github.com/kyma-project/serverless-manager/issues/22