### PR TITLE
Cherry-pick Eventing FI tests refactoring to release-2.11 branch

### DIFF
--- a/tests/fast-integration/eventing-test/assets/eventing-function.yaml
+++ b/tests/fast-integration/eventing-test/assets/eventing-function.yaml
@@ -1,0 +1,121 @@
+apiVersion: serverless.kyma-project.io/v1alpha2
+kind: Function
+metadata:
+  labels:
+    serverless.kyma-project.io/build-resources-preset: local-dev
+    serverless.kyma-project.io/function-resources-preset: S
+    serverless.kyma-project.io/replicas-preset: S
+  name: eventing-sink
+spec:
+  scaleConfig:
+    minReplicas: 1
+    maxReplicas: 1
+  runtime: nodejs16
+  resourceConfiguration:
+    function:
+      resources:
+        limits:
+          cpu: 1
+          memory: 1Gi
+        requests:
+          cpu: 500m
+          memory: 500Mi
+    build:
+      resources:
+        limits:
+          cpu: 1
+          memory: 1Gi
+        requests:
+          cpu: 500m
+          memory: 500Mi
+  source:
+    inline:
+      dependencies: |
+        {
+          "name": "orders",
+          "version": "1.0.0",
+          "dependencies": {
+            "axios": "^0.19.2"
+          }
+        }
+      source: |
+        let receviedEvents = {};
+        const axios = require('axios');
+        function sendEvent(url, headers, payload) {
+            console.log("Forwarding event to EPP: " + url)
+            console.log("Payload: ", payload)
+            console.log("Headers: ", headers)
+            return axios.post(url, payload, {headers:headers})
+            return response
+        }
+        function cloudEventHeaders(event) {
+          return Object.keys(event).reduce((accumulator, current) => {
+            if (current.startsWith('ce-')) {
+              accumulator[current] = event[current]
+            }
+            return accumulator;
+          }, {});
+        }
+        function dump(obj) {
+          console.dir(obj, {depth: null});
+        }
+        module.exports = {
+          main: async function (event, context) {
+            var metadata = { podName: process.env.HOSTNAME }
+
+            if (event.extensions.request.query.send) {
+              // Send a request with param send=true to publish event to EPP.
+              try {
+                const reqBody = event.data
+                const response = await sendEvent(reqBody.url, reqBody.data.headers, reqBody.data.payload);
+                console.log(`In-app event sent. Publisher proxy response: ${response.status}`);
+                return { success: true, status: response.status, metadata: metadata }
+              } catch (e) {
+                console.dir(e);
+                return { success: false, errorMessage: e.message, error: JSON.stringify(e), metadata: metadata }
+              }
+            } else if (event.extensions.request.query.eventid) {
+              // Send a request with param eventid=<id> to fetch an received event.
+              console.log("Searching and returing event with id: ", event.extensions.request.query.eventid);
+              result = receviedEvents[event.extensions.request.query.eventid]
+              if (result) {
+                console.log("event found with id: ", event.extensions.request.query.eventid);
+                return { success: true, event:result, metadata: metadata};
+              }
+              console.log("event NOT found with id: ", event.extensions.request.query.eventid);
+              return { success: false, metadata: metadata};
+            } else if (event["ce-type"]){
+              // Store all valid received events.
+              console.log("Got in-app event:", event["ce-type"], ", id: ", event["ce-id"]);
+              savedFormat = { ceHeaders: cloudEventHeaders(event), payload: event.data, headers: event.extensions.request.headers }
+              receviedEvents[event["ce-id"]] = savedFormat;
+              return { success: true }
+            } else {
+              console.log("Discarding event with ce-type:", event["ce-type"])
+              console.log("Discarding event with data:", event.data)
+            }
+            return {metadata: metadata};
+          }
+        }
+---
+apiVersion: gateway.kyma-project.io/v1alpha1
+kind: APIRule
+metadata:
+  name: eventing-sink
+spec:
+  gateway: kyma-gateway.kyma-system.svc.cluster.local
+  rules:
+    - path: /function
+      methods: ["GET", "POST"]
+      accessStrategies:
+        - handler: allow
+          config: {}
+    - path: /.*
+      methods: ["GET", "POST"]
+      accessStrategies:
+        - handler: allow
+          config: {}
+  service:
+    host: eventing-sink
+    name: eventing-sink
+    port: 80

--- a/tests/fast-integration/eventing-test/eventing-test.js
+++ b/tests/fast-integration/eventing-test/eventing-test.js
@@ -50,6 +50,7 @@ const {
   eventingSinkName,
   v1alpha1SubscriptionsTypes,
   subscriptionsTypes,
+  subscriptionsExactTypeMatching,
   getClusterHost,
   checkFunctionReachable,
   checkEventDelivery,
@@ -213,6 +214,20 @@ describe('Eventing tests', function() {
       }
       for (let i=0; i < subscriptionsTypes.length; i++) {
         await checkEventDelivery(clusterHost, 'legacy', subscriptionsTypes[i].type, subscriptionsTypes[i].source);
+      }
+    });
+
+    it('Cloud Events with subscription (exact) should be delivered to eventing-sink ', async function() {
+      if (!isEventingSinkDeployed || !testSubscriptionV1Alpha2 || backend !== bebBackend) {
+        this.skip();
+      }
+
+      let eventSource = 'eventing-test';
+      if (backend === bebBackend) {
+        eventSource = getEventMeshNamespace();
+      }
+      for (let i=0; i < subscriptionsExactTypeMatching.length; i++) {
+        await checkEventDelivery(clusterHost, 'binary', subscriptionsExactTypeMatching[i].type, eventSource);
       }
     });
   }

--- a/tests/fast-integration/eventing-test/eventing-test.js
+++ b/tests/fast-integration/eventing-test/eventing-test.js
@@ -31,8 +31,14 @@ const {
   isDebugEnabled,
   k8sApply,
   deleteK8sPod,
-  eventingSubscription, waitForEndpoint, waitForPodStatusWithLabel, waitForPodWithLabelAndCondition,
-  createApiRuleForService, getConfigMap, deleteApiRule,
+  waitForFunction,
+  eventingSubscription,
+  waitForEndpoint,
+  waitForPodStatusWithLabel,
+  waitForPodWithLabelAndCondition,
+  createApiRuleForService,
+  getConfigMap,
+  deleteApiRule,
 } = require('../utils');
 const {
   eventingMonitoringTest,
@@ -57,19 +63,37 @@ const {
   eventingNatsSvcName,
   eventingNatsApiRuleAName,
   subscriptionNames,
+  eventingSinkName,
+  v1alpha1SubscriptionsTypes,
+  subscriptionsTypes,
+  getClusterHost,
+  checkFunctionReachable,
+  checkEventDelivery,
+  waitForV1Alpha1Subscriptions,
+  waitForV1Alpha2Subscriptions,
+  checkEventTracing,
 } = require('./utils');
 const {
   bebBackend,
-  natsBackend, getEventMeshNamespace,
-  kymaSystem, telemetryOperatorLabel, conditionReady, jaegerLabel, jaegerEndpoint,
+  natsBackend,
+  getEventMeshNamespace,
+  kymaSystem,
+  telemetryOperatorLabel,
+  conditionReady,
+  jaegerLabel,
+  jaegerEndpoint,
 } = require('./common/common');
 const {
   assert,
+  expect,
 } = require('chai');
 const {
   exposeGrafana,
   unexposeGrafana,
 } = require('../monitoring');
+
+let clusterHost = '';
+let isEventingSinkDeployed = false;
 
 describe('Eventing tests', function() {
   this.timeout(timeoutTime);
@@ -96,6 +120,135 @@ describe('Eventing tests', function() {
     const success = await getStreamConfigForJetStream();
     assert.isTrue(success);
   });
+
+  before('Check if eventing-sink is deployed', async function() {
+    try {
+      await waitForFunction(eventingSinkName, testNamespace, 30*1000);
+      isEventingSinkDeployed = true;
+    } catch (e) {
+      debug('Eventing Sink is not deployed');
+      debug(e);
+      isEventingSinkDeployed = false;
+    }
+  });
+
+  before('Get cluster host name from Virtual Services', async function() {
+    if (!isEventingSinkDeployed) {
+      return;
+    }
+
+    this.test.retries(5);
+
+    clusterHost = await getClusterHost(eventingSinkName, testNamespace);
+    expect(clusterHost).to.not.empty;
+    debug(`host name fetched: ${clusterHost}`);
+  });
+
+  // eventDeliveryTestSuite - Runs Eventing tests for event delivery
+  function eventDeliveryTestSuite(backend) {
+    it('Wait for subscriptions to be ready', async function() {
+      // important for upgrade tests
+      if (!isEventingSinkDeployed) {
+        return;
+      }
+
+      // waiting for v1alpha1 subscriptions
+      await waitForV1Alpha1Subscriptions();
+
+      if (testSubscriptionV1Alpha2) {
+        // waiting for v1alpha2 subscriptions
+        await waitForV1Alpha2Subscriptions();
+      }
+    });
+
+    it('Eventing-sink function should be reachable through API Rule', async function() {
+      if (!isEventingSinkDeployed) {
+        this.skip();
+      }
+      await checkFunctionReachable(eventingSinkName, testNamespace, clusterHost);
+    });
+
+    it('Cloud Events [binary] with v1alpha1 subscription should be delivered to eventing-sink ', async function() {
+      if (!isEventingSinkDeployed) {
+        this.skip();
+      }
+
+      let eventSource = 'eventing-test';
+      if (backend === bebBackend) {
+        eventSource = getEventMeshNamespace();
+      }
+      for (let i=0; i < v1alpha1SubscriptionsTypes.length; i++) {
+        await checkEventDelivery(clusterHost, 'binary', v1alpha1SubscriptionsTypes[i], eventSource, true);
+      }
+    });
+
+    it('Cloud Events [structured] with v1alpha1 subscription should be delivered to eventing-sink ', async function() {
+      if (!isEventingSinkDeployed) {
+        this.skip();
+      }
+
+      let eventSource = 'eventing-test';
+      if (backend === bebBackend) {
+        eventSource = getEventMeshNamespace();
+      }
+      for (let i=0; i < v1alpha1SubscriptionsTypes.length; i++) {
+        await checkEventDelivery(clusterHost, 'structured', v1alpha1SubscriptionsTypes[i], eventSource, true);
+      }
+    });
+
+    it('Legacy Events with v1alpha1 subscription should be delivered to eventing-sink ', async function() {
+      if (!isEventingSinkDeployed) {
+        this.skip();
+      }
+      for (let i=0; i < v1alpha1SubscriptionsTypes.length; i++) {
+        await checkEventDelivery(clusterHost, 'legacy', v1alpha1SubscriptionsTypes[i], 'test', true);
+      }
+    });
+
+    it('Cloud Events [binary] with v1alpha2 subscription should be delivered to eventing-sink ', async function() {
+      if (!isEventingSinkDeployed || !testSubscriptionV1Alpha2) {
+        this.skip();
+      }
+      for (let i=0; i < subscriptionsTypes.length; i++) {
+        await checkEventDelivery(clusterHost, 'binary', subscriptionsTypes[i].type, subscriptionsTypes[i].source);
+      }
+    });
+
+    it('Cloud Events [structured] with v1alpha2 subscription should be delivered to eventing-sink ', async function() {
+      if (!isEventingSinkDeployed || !testSubscriptionV1Alpha2) {
+        this.skip();
+      }
+      for (let i=0; i < subscriptionsTypes.length; i++) {
+        await checkEventDelivery(clusterHost, 'structured', subscriptionsTypes[i].type, subscriptionsTypes[i].source);
+      }
+    });
+
+    it('Legacy Events with v1alpha2 subscription should be delivered to eventing-sink ', async function() {
+      if (!isEventingSinkDeployed || !testSubscriptionV1Alpha2) {
+        this.skip();
+      }
+      for (let i=0; i < subscriptionsTypes.length; i++) {
+        await checkEventDelivery(clusterHost, 'legacy', subscriptionsTypes[i].type, subscriptionsTypes[i].source);
+      }
+    });
+  }
+
+  // eventingTracingTestSuite - Runs Eventing tracing tests
+  function eventingTracingTestSuiteV2(isSKR) {
+    // Only run tracing tests on OSS
+    if (isSKR) {
+      debug('Skipping eventing tracing tests on SKR');
+      return;
+    }
+
+    it('In-cluster event should have correct tracing spans [v2]', async function() {
+      if (!isEventingSinkDeployed || !testSubscriptionV1Alpha2) {
+        this.skip();
+      }
+
+      await checkEventTracing(clusterHost, subscriptionsTypes[0].type, subscriptionsTypes[0].source, testNamespace);
+    });
+  }
 
   // eventingTestSuite - Runs Eventing tests
   function eventingTestSuite(backend, isSKR, testCompassFlow=false) {
@@ -291,9 +444,17 @@ describe('Eventing tests', function() {
     it('Wait until subscriptions are ready', async function() {
       await waitForSubscriptionsTillReady(testNamespace);
     });
-    // Running Eventing end-to-end tests
+
+    // Running Eventing end-to-end event delivery tests
+    eventDeliveryTestSuite(natsBackend);
+
+    // Running Eventing end-to-end tests - deprecated (will be removed)
     eventingTestSuite(natsBackend, isSKR, testCompassFlow);
-    // Running Eventing tracing tests
+
+    // Running Eventing tracing tests [v2]
+    eventingTracingTestSuiteV2(isSKR);
+
+    // Running Eventing tracing tests - deprecated (will be removed)
     eventingTracingTestSuite(isSKR);
 
     it('Run Eventing Monitoring tests', async function() {
@@ -320,7 +481,11 @@ describe('Eventing tests', function() {
         await printAllSubscriptions(testNamespace, subCRDVersion);
       }
     });
-    // Running Eventing end-to-end tests
+
+    // Running Eventing end-to-end event delivery tests
+    eventDeliveryTestSuite(bebBackend);
+
+    // Running Eventing end-to-end tests - deprecated (will be removed)
     eventingTestSuite(bebBackend, isSKR, testCompassFlow);
 
     it('Run Eventing Monitoring tests', async function() {
@@ -339,9 +504,17 @@ describe('Eventing tests', function() {
     it('Wait until subscriptions are ready', async function() {
       await waitForSubscriptionsTillReady(testNamespace);
     });
-    // Running Eventing end-to-end tests
+
+    // Running Eventing end-to-end event delivery tests
+    eventDeliveryTestSuite(natsBackend);
+
+    // Running Eventing end-to-end tests - deprecated (will be removed)
     eventingTestSuite(natsBackend, isSKR, testCompassFlow);
-    // Running Eventing tracing tests
+
+    // Running Eventing tracing tests [v2]
+    eventingTracingTestSuiteV2(isSKR);
+
+    // Running Eventing tracing tests - deprecated (will be removed)
     eventingTracingTestSuite(isSKR);
 
     it('Run Eventing Monitoring tests', async function() {

--- a/tests/fast-integration/eventing-test/eventing-test.js
+++ b/tests/fast-integration/eventing-test/eventing-test.js
@@ -11,30 +11,17 @@ const {
   sendCloudEventBinaryModeAndCheckResponse,
   checkInClusterEventDelivery,
   waitForSubscriptionsTillReady,
-  waitForSubscriptions,
   checkInClusterEventTracing,
-  getRandomEventId,
-  getVirtualServiceHost,
-  sendInClusterEventWithRetry,
-  ensureInClusterEventReceivedWithRetry,
 } = require('../test/fixtures/commerce-mock');
 const {
   getEventingBackend,
   waitForNamespace,
   switchEventingBackend,
-  waitForEventingBackendToReady,
   printAllSubscriptions,
-  printEventingControllerLogs,
-  printEventingPublisherProxyLogs,
-  k8sDelete,
   debug,
   isDebugEnabled,
-  k8sApply,
-  deleteK8sPod,
   waitForFunction,
-  eventingSubscription,
   waitForEndpoint,
-  waitForPodStatusWithLabel,
   waitForPodWithLabelAndCondition,
   createApiRuleForService,
   getConfigMap,
@@ -54,15 +41,12 @@ const {
   testCompassFlow,
   testSubscriptionV1Alpha2,
   subCRDVersion,
-  getNatsPods,
   getStreamConfigForJetStream,
-  skipAtLeastOnceDeliveryTest,
   isStreamCreationTimeMissing,
   getJetStreamStreamData,
   streamDataConfigMapName,
   eventingNatsSvcName,
   eventingNatsApiRuleAName,
-  subscriptionNames,
   eventingSinkName,
   v1alpha1SubscriptionsTypes,
   subscriptionsTypes,
@@ -287,7 +271,6 @@ describe('Eventing tests', function() {
 
     if (backend === natsBackend) {
       testStreamNotReCreated();
-      testJetStreamAtLeastOnceDelivery();
     }
   }
 
@@ -348,79 +331,6 @@ describe('Eventing tests', function() {
   }
 
 
-  function testJetStreamAtLeastOnceDelivery() {
-    context('with JetStream file storage', function() {
-      const minute = 60 * 1000;
-      const funcName = 'lastorder';
-      const encodingBinary = 'binary';
-      const encodingStructured = 'structured';
-      const eventIdBinary = getRandomEventId(encodingBinary);
-      const eventIdStructured = getRandomEventId(encodingStructured);
-      const sink = `http://lastorder.${testNamespace}.svc.cluster.local`;
-      const subscriptions = [
-        eventingSubscription(`sap.kyma.custom.inapp.order.received.v1`,
-            sink, subscriptionNames.orderReceived, testNamespace),
-        eventingSubscription(`sap.kyma.custom.commerce.order.created.v1`,
-            sink, subscriptionNames.orderCreated, testNamespace),
-      ];
-
-      before('check if at least once delivery tests need to be skipped', async function() {
-        if (skipAtLeastOnceDeliveryTest()) {
-          console.log('Skipping the at least once delivery tests for NATS JetStream');
-          this.skip();
-        }
-      });
-
-      it('Delete subscriptions', async function() {
-        await k8sDelete(subscriptions);
-      });
-
-      it('Publish events', async function() {
-        const host = await getVirtualServiceHost(testNamespace, funcName);
-        assert.isNotEmpty(host);
-
-        await sendInClusterEventWithRetry(host, eventIdBinary, encodingBinary);
-        await sendInClusterEventWithRetry(host, eventIdStructured, encodingStructured);
-      });
-
-      it('Delete all Nats pods', async function() {
-        const natsPods = await getNatsPods();
-        for (let i = 0; i < natsPods.body.items.length; i++) {
-          const pod = natsPods.body.items[i];
-          await deleteK8sPod(pod);
-        }
-      });
-
-      it('Wait until all Nats pods are deleted', async function() {
-        // Assuming that Nats pods had the status.phase equals to "Running", so if it changed to "Pending"
-        // this means that they were successfully deleted and recreated.
-        await waitForPodStatusWithLabel('app.kubernetes.io/name', 'nats', 'kyma-system', 'Pending', 5 * minute);
-      });
-
-      it('Wait until any Nats pod is ready', async function() {
-        // When the status.phase changes from "Pending" to "Running" this means that Nats pod containers are starting.
-        await waitForPodStatusWithLabel('app.kubernetes.io/name', 'nats', 'kyma-system', 'Running', 5 * minute);
-      });
-
-      it('Wait until eventing backend is ready', async function() {
-        await waitForEventingBackendToReady(natsBackend, 'eventing-backend', 'kyma-system', 5 * minute);
-      });
-
-      it('Recreate subscriptions', async function() {
-        await k8sApply(subscriptions);
-        await waitForSubscriptions(subscriptions);
-      });
-
-      it('Wait for events to be delivered', async function() {
-        const host = await getVirtualServiceHost(testNamespace, funcName);
-        assert.isNotEmpty(host);
-
-        await ensureInClusterEventReceivedWithRetry(host, eventIdBinary);
-        await ensureInClusterEventReceivedWithRetry(host, eventIdStructured);
-      });
-    });
-  }
-
   // eventingTracingTestSuite - Runs Eventing tracing tests
   function eventingTracingTestSuite(isSKR) {
     // Only run tracing tests on OSS
@@ -433,16 +343,6 @@ describe('Eventing tests', function() {
       await checkInClusterEventTracing(testNamespace);
     });
   }
-
-  // runs after each test in every block
-  afterEach(async function() {
-    // if the test is failed, then printing some debug logs
-    if (this.currentTest.state === 'failed' && isDebugEnabled()) {
-      await printAllSubscriptions(testNamespace, subCRDVersion);
-      await printEventingControllerLogs();
-      await printEventingPublisherProxyLogs();
-    }
-  });
 
   // Tests
   context('with Nats backend', function() {

--- a/tests/fast-integration/eventing-test/eventing-test.js
+++ b/tests/fast-integration/eventing-test/eventing-test.js
@@ -233,6 +233,18 @@ describe('Eventing tests', function() {
     });
   }
 
+  // eventingMonitoringTestSuite - Runs Eventing tests for monitoring
+  function eventingMonitoringTestSuite(backend, isSKR) {
+    it('Run Eventing Monitoring tests', async function() {
+      if (isEventingSinkDeployed && testSubscriptionV1Alpha2) {
+        await eventingMonitoringTest(backend, isSKR, true);
+        return;
+      }
+      // run old monitoring tests - deprecated - will be removed
+      await eventingMonitoringTest(backend, isSKR);
+    });
+  }
+
   // eventingTracingTestSuite - Runs Eventing tracing tests
   function eventingTracingTestSuiteV2(isSKR) {
     // Only run tracing tests on OSS
@@ -457,9 +469,8 @@ describe('Eventing tests', function() {
     // Running Eventing tracing tests - deprecated (will be removed)
     eventingTracingTestSuite(isSKR);
 
-    it('Run Eventing Monitoring tests', async function() {
-      await eventingMonitoringTest(natsBackend, isSKR);
-    });
+    // Running Eventing monitoring tests.
+    eventingMonitoringTestSuite(natsBackend, isSKR);
   });
 
   context('with BEB backend', function() {
@@ -488,9 +499,8 @@ describe('Eventing tests', function() {
     // Running Eventing end-to-end tests - deprecated (will be removed)
     eventingTestSuite(bebBackend, isSKR, testCompassFlow);
 
-    it('Run Eventing Monitoring tests', async function() {
-      await eventingMonitoringTest(bebBackend, isSKR);
-    });
+    // Running Eventing monitoring tests.
+    eventingMonitoringTestSuite(bebBackend, isSKR);
   });
 
   context('with Nats backend switched back from BEB', async function() {
@@ -517,9 +527,8 @@ describe('Eventing tests', function() {
     // Running Eventing tracing tests - deprecated (will be removed)
     eventingTracingTestSuite(isSKR);
 
-    it('Run Eventing Monitoring tests', async function() {
-      await eventingMonitoringTest(natsBackend, isSKR);
-    });
+    // Running Eventing monitoring tests.
+    eventingMonitoringTestSuite(natsBackend, isSKR);
   });
 
   after('Unexpose Grafana', async function() {

--- a/tests/fast-integration/eventing-test/utils.js
+++ b/tests/fast-integration/eventing-test/utils.js
@@ -1,6 +1,8 @@
 const {
   cleanMockTestFixture,
   cleanCompassResourcesSKR,
+  generateTraceParentHeader,
+  checkTrace,
 } = require('../test/fixtures/commerce-mock');
 
 const {
@@ -11,12 +13,27 @@ const {
   getShootNameFromK8sServerUrl,
   listPods,
   retryPromise,
+  waitForVirtualService,
+  k8sApply,
+  waitForFunction,
+  eventingSubscription,
+  waitForSubscription,
+  eventingSubscriptionV1Alpha2,
+  convertAxiosError,
+  sleep,
 } = require('../utils');
 
 const {DirectorClient, DirectorConfig, getAlreadyAssignedScenarios} = require('../compass');
 const {GardenerClient, GardenerConfig} = require('../gardener');
 const {eventMeshSecretFilePath} = require('./common/common');
 const axios = require('axios');
+const {v4: uuidv4} = require('uuid');
+const fs = require('fs');
+const path = require('path');
+const k8s = require('@kubernetes/client-node');
+const {expect} = require('chai');
+
+// Variables
 const kymaVersion = process.env.KYMA_VERSION || '';
 const isSKR = process.env.KYMA_TYPE === 'SKR';
 const skrInstanceId = process.env.INSTANCE_ID || '';
@@ -37,10 +54,37 @@ const eventingNatsApiRuleAName = `${eventingNatsSvcName}-apirule`;
 const timeoutTime = 10 * 60 * 1000;
 const slowTime = 5000;
 const streamConfig = { };
+const eppInClusterUrl = 'eventing-event-publisher-proxy.kyma-system';
 const subscriptionNames = {
   orderCreated: 'order-created',
   orderReceived: 'order-received',
 };
+const eventingSinkName = 'eventing-sink';
+
+// ****** Event types to test ***********//
+const v1alpha1SubscriptionsTypes = [
+  'sap.kyma.custom.noapp.order.tested.v1',
+  'sap.kyma.custom.connected-app.order.tested.v1',
+  'sap.kyma.custom.test-app.order-$.second.R-e-c-e-i-v-e-d.v1',
+  'sap.kyma.custom.connected-app2.or-der.crea-ted.one.two.three.v4',
+];
+
+const subscriptionsTypes = [
+  {
+    type: 'order.modified.v1',
+    source: 'myapp',
+  },
+  {
+    type: 'or-der.crea-ted.one.two.three.four.v4',
+    source: 'test-app',
+  },
+  {
+    type: 'Order-$.third.R-e-c-e-i-v-e-d.v1',
+    source: 'test-app',
+  },
+];
+
+// ****** ************* ***********//
 
 // SKR related constants
 let gardener = null;
@@ -152,6 +196,345 @@ function isStreamCreationTimeMissing(streamData) {
   return streamData.streamCreationTime === undefined;
 }
 
+async function getClusterHost(apiRuleName, namespace) {
+  const vs = await waitForVirtualService(namespace, apiRuleName);
+  const mockHost = vs.spec.hosts[0];
+  return mockHost.split('.').slice(1).join('.');
+}
+
+function createNewEventId() {
+  return uuidv4();
+}
+
+async function deployEventingSinkFunction() {
+  const functionYaml = fs.readFileSync(
+      path.join(__dirname, './assets/eventing-function.yaml'),
+      {
+        encoding: 'utf8',
+      },
+  );
+
+  const k8sObjs = k8s.loadAllYaml(functionYaml);
+  await k8sApply(k8sObjs, testNamespace, true);
+}
+
+async function waitForEventingSinkFunction() {
+  await waitForFunction(eventingSinkName, testNamespace);
+}
+
+async function deployV1Alpha1Subscriptions() {
+  const sink = `http://${eventingSinkName}.${testNamespace}.svc.cluster.local`;
+  debug(`Using sink: ${sink}`);
+
+  // creating v1alpha1 subscriptions
+  for (let i=0; i < v1alpha1SubscriptionsTypes.length; i++) {
+    const subName = `fi-test-sub-${i}`;
+    const eventType = v1alpha1SubscriptionsTypes[i];
+
+    debug(`Creating subscription: ${subName} with type: ${eventType}`);
+    await k8sApply([eventingSubscription(eventType, sink, subName, testNamespace)]);
+    debug(`Waiting for subscription: ${subName} with type: ${eventType}`);
+    await waitForSubscription(subName, testNamespace);
+  }
+}
+
+async function deployV1Alpha2Subscriptions() {
+  const sink = `http://${eventingSinkName}.${testNamespace}.svc.cluster.local`;
+  debug(`Using sink: ${sink}`);
+
+  // creating v1alpha2 subscriptions
+  for (let i=0; i < subscriptionsTypes.length; i++) {
+    const subName = `fi-test-sub-v2-${i}`;
+    const eventType = subscriptionsTypes[i].type;
+    const eventSource = subscriptionsTypes[i].source;
+
+    debug(`Creating subscription: ${subName} with type: ${eventType}, source: ${eventSource}`);
+    // eventingSubscriptionV1Alpha2(eventType, source, sink, name, namespace, typeMatching='standard')
+    await k8sApply([eventingSubscriptionV1Alpha2(eventType, eventSource, sink, subName, testNamespace)]);
+    debug(`Waiting for subscription: ${subName} with type: ${eventType}, source: ${eventSource}`);
+    await waitForSubscription(subName, testNamespace);
+  }
+}
+
+async function waitForV1Alpha1Subscriptions() {
+  // waiting for v1alpha1 subscriptions
+  for (let i=0; i < v1alpha1SubscriptionsTypes.length; i++) {
+    const subName = `fi-test-sub-${i}`;
+    debug(`Waiting for subscription: ${subName} with type: ${v1alpha1SubscriptionsTypes[i]}`);
+    await waitForSubscription(subName, testNamespace);
+  }
+}
+
+async function waitForV1Alpha2Subscriptions() {
+  // waiting for v1alpha2 subscriptions
+  for (let i=0; i < subscriptionsTypes.length; i++) {
+    const subName = `fi-test-sub-v2-${i}`;
+    debug(`Waiting for subscription: ${subName} with type: ${subscriptionsTypes[i].type}`);
+    await waitForSubscription(subName, testNamespace);
+  }
+}
+
+async function checkFunctionReachable(name, namespace, host) {
+  // the function should be reachable.
+  const res = await retryPromise(
+      () => axios.post(`https://${name}.${host}/function`, {orderCode: '789'}, {
+        timeout: 5000,
+      }),
+      45,
+      2000,
+  ).catch((err) => {
+    debug(`Error when trying to reach the function: ${name}`);
+    debug(err);
+    throw convertAxiosError(err, `Function ${name} responded with error`);
+  });
+
+  // the request should be authorized and successful
+  expect(res.status).to.be.equal(200);
+}
+
+async function checkEventTracing(proxyHost, eventType, eventSource, namespace) {
+  // first send an event and verify if it was delivered
+  const result = await checkEventDelivery(proxyHost, 'binary', eventType, eventSource);
+  expect(result).to.have.nested.property('traceParentId');
+  expect(result.traceParentId).to.not.be.empty;
+  expect(result.response).to.have.nested.property('data.metadata.podName');
+  expect(result.response.data.metadata.podName).to.not.be.empty;
+
+  // Define expected trace data
+  const podName = result.response.data.metadata.podName;
+  const correctTraceProcessSequence = [
+    // We are sending the in-cluster event from inside the eventing sink pod
+    'istio-ingressgateway.istio-system',
+    `${eventingSinkName}-${podName.split('-')[2]}.${namespace}`,
+    'eventing-publisher-proxy.kyma-system',
+    'eventing-controller.kyma-system',
+    `${eventingSinkName}-${podName.split('-')[2]}.${namespace}`,
+  ];
+
+  // wait sometime for jaeger to complete tracing data.
+  // Arrival of traces might be delayed by otel-collectors batch timeout.
+  const traceId = result.traceParentId.split('-')[1];
+  debug(`Checking the tracing with traceId: ${traceId}, traceParentId: ${result.traceParentId}`);
+  await sleep(20_000);
+  await checkTrace(traceId, correctTraceProcessSequence);
+}
+
+// checks if the event publish and receive is working.
+// Possible values for encoding are [binary, structured, legacy].
+async function checkEventDelivery(proxyHost, encoding, eventType, eventSource, isSubV1Alpha1 = false) {
+  const eventId = createNewEventId();
+
+  debug(`Publishing event with id:${eventId}, type: ${eventType}, source: ${eventSource}...`);
+  const result = await publishEventWithRetry(proxyHost, encoding, eventId, eventType, eventSource, isSubV1Alpha1);
+
+  debug(`Verifying if event with id:${eventId}, type: ${eventType}, source: ${eventSource} was received by sink...`);
+  const result2 = await ensureEventReceivedWithRetry(proxyHost, encoding, eventId, eventType, eventSource);
+  return {
+    eventId,
+    traceParentId: result.traceParentId,
+    response: result2.response,
+  };
+}
+
+// send event using function query parameter send=true
+async function publishEventWithRetry(proxyHost, encoding, eventId, eventType, eventSource,
+    isSubV1Alpha1 = false, retriesLeft = 10) {
+  return retryPromise(async () => {
+    let reqBody = {};
+    const traceParentId = await generateTraceParentHeader();
+
+    if (encoding === 'binary') { // binary CE
+      reqBody = createBinaryCloudEventRequestBody(proxyHost, eventId, eventType, eventSource, traceParentId);
+    } else if (encoding === 'structured') { // structured CE
+      reqBody = createStructuredCloudEventRequestBody(proxyHost, eventId, eventType, eventSource, traceParentId);
+    } else if (encoding === 'legacy') {
+      reqBody = createLegacyEventRequestBody(proxyHost, eventId, eventType, eventSource, isSubV1Alpha1);
+    } else {
+      throw new Error('Invalid encoding. Possible values are [binary, structured, legacy]');
+    }
+
+    // console out information
+    debug(`Sending Event request to ${eventingSinkName}:`, reqBody);
+
+    // send request
+    const response = await axios.post(`https://${eventingSinkName}.${proxyHost}`, reqBody, {
+      params: {
+        send: true,
+      },
+      headers: {
+        'traceparent': traceParentId,
+      },
+    });
+
+    debug(`Response from ${eventingSinkName} for sending event:`, {
+      status: response.status,
+      data: response.data,
+    });
+
+    if (response.data.success !== true) {
+      throw convertAxiosError(response.data.errorMessage);
+    }
+    expect(response.status).to.be.equal(200);
+    // EPP response should be 204 (or 200 for legacy)
+    expect(response.data.status).to.be.oneOf([200, 204]);
+
+    return {
+      traceParentId,
+      response,
+    };
+  }, retriesLeft, 1000);
+}
+
+// verify if event was received using function
+async function ensureEventReceivedWithRetry(proxyHost, encoding, eventId, eventType, eventSource, retriesLeft = 10) {
+  return await retryPromise(async () => {
+    debug(`Waiting to receive CE event "${eventId}"`);
+
+    const response = await axios.get(`https://${eventingSinkName}.${proxyHost}`,
+        {params: {eventid: eventId}});
+
+    debug('Received response:', {
+      status: response.status,
+      statusText: response.statusText,
+      data: response.data,
+    });
+
+    if (response.data && response.data.event) {
+      debug('Received event data:', {
+        payload: response.data.event.payload,
+        headers: response.data.event.headers,
+        ceHeaders: response.data.event.ceHeaders,
+      });
+    }
+
+    expect(response.data.success).to.be.equal(true);
+
+    if (encoding === 'binary' || encoding === 'legacy') {
+      expect(response.data).to.have.nested.property('event.payload.eventId',
+          eventId, 'The same event id expected in the result');
+
+      // comparing the unclean event type from payload.
+      // In headers the event type would be clean one, so comparison may fail.
+      expect(response.data).to.have.nested.property(
+          'event.payload.eventType', eventType, 'The same event type expected in the result');
+    } else if (encoding === 'structured') {
+      expect(response.data).to.have.nested.property('event.headers.ce-eventid',
+          eventId, 'The same event id expected in the result');
+
+      expect(response.data).to.have.nested.property(
+          'event.headers.ce-eventtype', eventType, 'The same event type expected in the result');
+    } else {
+      throw new Error('Invalid encoding. Possible values are [binary, structured, legacy]');
+    }
+
+    return {
+      response,
+    };
+  }, retriesLeft, 2 * 1000)
+      .catch((err) => {
+        throw convertAxiosError(err, 'Fetching published event responded with error');
+      });
+}
+
+function createBinaryCloudEventRequestBody(proxyHost, eventId, eventType, eventSource, traceparent) {
+  debug('setting headers and payload for binary cloud event');
+  const reqBody = {
+    url: `http://${eppInClusterUrl}/publish`,
+    data: {},
+  };
+
+  reqBody.data.headers = {
+    'ce-source': eventSource,
+    'ce-specversion': '1.0',
+    'ce-eventtypeversion': 'v1',
+    'ce-id': eventId,
+    'ce-type': eventType,
+    'Content-Type': 'application/json',
+    'traceparent': traceparent,
+  };
+
+  reqBody.data.payload = {
+    eventId: eventId,
+    eventType: eventType, // passing unclean event type as payload
+  };
+  return reqBody;
+}
+
+function createStructuredCloudEventRequestBody(proxyHost, eventId, eventType, eventSource, traceparent) {
+  debug('setting headers and payload for structured cloud event');
+  const reqBody = {
+    url: `http://${eppInClusterUrl}/publish`,
+    data: {},
+  };
+
+  reqBody.data.headers = {
+    'Content-Type': 'application/cloudevents+json',
+    'traceparent': traceparent,
+  };
+
+  reqBody.data.payload = {
+    source: eventSource,
+    specversion: '1.0',
+    eventtypeversion: 'v1',
+    datacontenttype: 'application/json',
+    id: eventId,
+    type: eventType,
+    eventId: eventId,
+    eventType: eventType, // passing unclean event type as payload
+  };
+  return reqBody;
+}
+
+function createLegacyEventRequestBody(proxyHost, eventId, eventType, eventSource, isSubV1Alpha1 = true) {
+  debug('setting url, headers and payload for legacy event');
+  // event types are different between subscription v1alpha1 and v1alpha2.
+  // so extracting the appropriate types for legacy format.
+  let legacyVersion; let legacySource; let legacyType;
+  if (isSubV1Alpha1) {
+    // e.g. type: sap.kyma.custom.noapp.order.created.v1
+    const typeSegments = eventType.replace('sap.kyma.custom.', '').split('.');
+    // extract source (e.g. noapp)
+    legacySource = typeSegments[0];
+    // extract last version info (e.g. v1)
+    legacyVersion = typeSegments[typeSegments.length-1];
+    // remove last version (e.g. order.created)
+    legacyType = typeSegments.slice(1, typeSegments.length-1).join('.');
+  } else {
+    // e.g. type: order.created.v1
+    const typeSegments = eventType.split('.');
+
+    // extract last version info (e.g. v1)
+    legacyVersion = typeSegments[typeSegments.length-1];
+    // remove last version (e.g. order.created)
+    legacyType = typeSegments.slice(0, typeSegments.length-1).join('.');
+    legacySource = eventSource;
+  }
+
+  // Now, create the request body
+  // Note that EPP publish URL is different for legacy events
+  const reqBody = {
+    url: `http://${eppInClusterUrl}/${legacySource}/v1/events`,
+    data: {},
+  };
+
+  reqBody.data.headers = {
+    'Content-Type': 'application/json',
+  };
+
+  reqBody.data.payload = {
+    'event-id': eventId,
+    'event-type': legacyType,
+    'event-source': legacySource,
+    'event-type-version': legacyVersion,
+    'event-time': '2020-09-28T14:47:16.491Z',
+    'data': {
+      eventId: eventId,
+      eventType: eventType, // passing unclean event type as payload
+    },
+  };
+  return reqBody;
+}
+
 module.exports = {
   appName,
   scenarioName,
@@ -181,5 +564,19 @@ module.exports = {
   skipAtLeastOnceDeliveryTest,
   getJetStreamStreamData,
   isStreamCreationTimeMissing,
+  eppInClusterUrl,
   subscriptionNames,
+  eventingSinkName,
+  v1alpha1SubscriptionsTypes,
+  subscriptionsTypes,
+  getClusterHost,
+  checkFunctionReachable,
+  checkEventDelivery,
+  deployEventingSinkFunction,
+  waitForEventingSinkFunction,
+  deployV1Alpha1Subscriptions,
+  deployV1Alpha2Subscriptions,
+  waitForV1Alpha1Subscriptions,
+  waitForV1Alpha2Subscriptions,
+  checkEventTracing,
 };

--- a/tests/fast-integration/eventing-test/utils.js
+++ b/tests/fast-integration/eventing-test/utils.js
@@ -170,7 +170,7 @@ async function getStreamConfigForJetStream() {
   const res = await listPods(labelSelector, 'kyma-system');
   let envsCount = 0;
   res.body?.items[0]?.spec.containers.find((container) =>
-      container.name === 'controller',
+    container.name === 'controller',
   ).env.forEach((env) => {
     if (env.name === 'JS_STREAM_RETENTION_POLICY') {
       streamConfig['retention_policy'] = env.value;

--- a/tests/fast-integration/eventing-test/utils.js
+++ b/tests/fast-integration/eventing-test/utils.js
@@ -53,6 +53,7 @@ const eventingNatsSvcName = 'eventing-nats';
 const eventingNatsApiRuleAName = `${eventingNatsSvcName}-apirule`;
 const timeoutTime = 10 * 60 * 1000;
 const slowTime = 5000;
+const streamConfig = { };
 const eppInClusterUrl = 'eventing-event-publisher-proxy.kyma-system';
 const subscriptionNames = {
   orderCreated: 'order-created',
@@ -162,6 +163,28 @@ async function getNatsPods() {
   return await listPods(labelSelector, 'kyma-system');
 }
 
+// getStreamConfigForJetStream gets the stream retention policy and the consumer deliver policy env variables
+// from the eventing controller pod and also checks if these env variables exist on the pod.
+async function getStreamConfigForJetStream() {
+  const labelSelector = 'app.kubernetes.io/instance=eventing,app.kubernetes.io/name=controller';
+  const res = await listPods(labelSelector, 'kyma-system');
+  let envsCount = 0;
+  res.body?.items[0]?.spec.containers.find((container) =>
+      container.name === 'controller',
+  ).env.forEach((env) => {
+    if (env.name === 'JS_STREAM_RETENTION_POLICY') {
+      streamConfig['retention_policy'] = env.value;
+      envsCount++;
+    }
+    if (env.name === 'JS_CONSUMER_DELIVER_POLICY') {
+      streamConfig['consumer_deliver_policy'] = env.value;
+      envsCount++;
+    }
+  });
+  // check to make sure the environment variables exist
+  return envsCount === 2;
+}
+
 async function getJetStreamStreamData(host) {
   const responseJson = await retryPromise(async () => await axios.get(`https://${host}/jsz?streams=true`), 5, 1000);
   const streamName = responseJson.data.account_details[0].stream_detail[0].name;
@@ -171,6 +194,11 @@ async function getJetStreamStreamData(host) {
     streamName: streamName,
     streamCreationTime: streamCreationTime,
   };
+}
+
+function skipAtLeastOnceDeliveryTest() {
+  return !(streamConfig['retention_policy'] === 'limits' &&
+      streamConfig['consumer_deliver_policy'] === 'all');
 }
 
 function isStreamCreationTimeMissing(streamData) {
@@ -562,6 +590,8 @@ module.exports = {
   cleanupTestingResources,
   getRegisteredCompassScenarios,
   getNatsPods,
+  getStreamConfigForJetStream,
+  skipAtLeastOnceDeliveryTest,
   getJetStreamStreamData,
   isStreamCreationTimeMissing,
   eppInClusterUrl,

--- a/tests/fast-integration/eventing-test/utils.js
+++ b/tests/fast-integration/eventing-test/utils.js
@@ -25,7 +25,7 @@ const {
 
 const {DirectorClient, DirectorConfig, getAlreadyAssignedScenarios} = require('../compass');
 const {GardenerClient, GardenerConfig} = require('../gardener');
-const {eventMeshSecretFilePath} = require('./common/common');
+const {eventMeshSecretFilePath, getEventMeshNamespace} = require('./common/common');
 const axios = require('axios');
 const {v4: uuidv4} = require('uuid');
 const fs = require('fs');
@@ -80,6 +80,15 @@ const subscriptionsTypes = [
   {
     type: 'Order-$.third.R-e-c-e-i-v-e-d.v1',
     source: 'test-app',
+  },
+];
+
+const subscriptionsExactTypeMatching = [
+  {
+    name: 'fi-test-sub-v2-exact-0',
+    type: 'sap.kyma.custom.exact.order.completed.v2',
+    source: undefined,
+    typeMatching: 'exact',
   },
 ];
 
@@ -214,15 +223,29 @@ async function deployV1Alpha2Subscriptions() {
   const sink = `http://${eventingSinkName}.${testNamespace}.svc.cluster.local`;
   debug(`Using sink: ${sink}`);
 
-  // creating v1alpha2 subscriptions
+  // creating v1alpha2 subscriptions - standard type matching
   for (let i=0; i < subscriptionsTypes.length; i++) {
     const subName = `fi-test-sub-v2-${i}`;
     const eventType = subscriptionsTypes[i].type;
     const eventSource = subscriptionsTypes[i].source;
 
     debug(`Creating subscription: ${subName} with type: ${eventType}, source: ${eventSource}`);
-    // eventingSubscriptionV1Alpha2(eventType, source, sink, name, namespace, typeMatching='standard')
     await k8sApply([eventingSubscriptionV1Alpha2(eventType, eventSource, sink, subName, testNamespace)]);
+    debug(`Waiting for subscription: ${subName} with type: ${eventType}, source: ${eventSource}`);
+    await waitForSubscription(subName, testNamespace);
+  }
+
+  // creating v1alpha2 subscriptions - exact type matching
+  for (let i=0; i < subscriptionsExactTypeMatching.length; i++) {
+    const subName = subscriptionsExactTypeMatching[i].name;
+    const eventType = subscriptionsExactTypeMatching[i].type;
+    let eventSource = subscriptionsExactTypeMatching[i].source;
+    if (!subscriptionsTypes[i].source) {
+      eventSource = getEventMeshNamespace();
+    }
+
+    debug(`Creating subscription (TypeMatching: exact): ${subName} with type: ${eventType}, source: ${eventSource}`);
+    await k8sApply([eventingSubscriptionV1Alpha2(eventType, eventSource, sink, subName, testNamespace, 'exact')]);
     debug(`Waiting for subscription: ${subName} with type: ${eventType}, source: ${eventSource}`);
     await waitForSubscription(subName, testNamespace);
   }
@@ -242,6 +265,13 @@ async function waitForV1Alpha2Subscriptions() {
   for (let i=0; i < subscriptionsTypes.length; i++) {
     const subName = `fi-test-sub-v2-${i}`;
     debug(`Waiting for subscription: ${subName} with type: ${subscriptionsTypes[i].type}`);
+    await waitForSubscription(subName, testNamespace);
+  }
+
+  // waiting for v1alpha2 subscriptions - exact type matching
+  for (let i=0; i < subscriptionsExactTypeMatching.length; i++) {
+    const subName = subscriptionsExactTypeMatching[i].name;
+    debug(`Waiting for subscription: ${subName} with type: ${subscriptionsExactTypeMatching[i].type}`);
     await waitForSubscription(subName, testNamespace);
   }
 }
@@ -539,6 +569,7 @@ module.exports = {
   eventingSinkName,
   v1alpha1SubscriptionsTypes,
   subscriptionsTypes,
+  subscriptionsExactTypeMatching,
   getClusterHost,
   checkFunctionReachable,
   checkEventDelivery,

--- a/tests/fast-integration/test/fixtures/commerce-mock/index.js
+++ b/tests/fast-integration/test/fixtures/commerce-mock/index.js
@@ -976,4 +976,6 @@ module.exports = {
   sendInClusterEventWithRetry,
   ensureInClusterEventReceivedWithRetry,
   prepareFunction,
+  generateTraceParentHeader,
+  checkTrace,
 };


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Cherry-picked the following PRs to Eventing FI tests refactoring from main:

- Get rid of the last-order function for event delivery and tracing tests. PR: https://github.com/kyma-project/kyma/pull/16832
- Refactor the monitoring tests to use new event delivery tests. PR: https://github.com/kyma-project/kyma/pull/16861
- Get rid of the last-order function in JetStream at-least once delivery check test. (i.e. `testJetStreamAtLeastOnceDelivery()`) PR: https://github.com/kyma-project/kyma/pull/16896
- Add tests for `exact` type matching in eventing-sink flow. PR: https://github.com/kyma-project/kyma/pull/16921

**Test runs:**
- `pre-main-kyma-gardener-gcp-eventing-upgrade` - [sample run](https://status.build.kyma-project.io/view/gs/kyma-prow-logs/pr-logs/pull/kyma-project_kyma/16933/mfaizanse_test_of_prowjob_pre-main-kyma-gardener-gcp-eventing-u/1630215196284817408)

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
- https://github.com/kyma-project/kyma/issues/16840