### PR TITLE
Set Istio cni namespace

### DIFF
--- a/resources/istio/templates/istio-operator.yaml
+++ b/resources/istio/templates/istio-operator.yaml
@@ -10,6 +10,7 @@ spec:
   profile: default
   components:
     cni:
+      namespace: {{ .Release.Namespace }}
       enabled: {{ .Values.components.cni.enabled }}
       k8s:
 {{- toYaml .Values.components.cni.config | nindent 8}}


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**
In Istio 1.16 an  auto-detection of [GKE specific installation steps](https://istio.io/latest/docs/setup/additional-setup/cni/#hosted-kubernetes-settings) was added. This leads to the issue that istio-cni resources are installed in the `kube-system` namespace on GKE clusters like mps.

Changes proposed in this pull request:

- Set the istio cni namespace to override the default.

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
