### PR TITLE
Exclude default `request` auto-instrumentation in python functions

### DIFF
--- a/components/function-runtimes/python39/Dockerfile
+++ b/components/function-runtimes/python39/Dockerfile
@@ -164,5 +164,7 @@ COPY kubeless/ /
 WORKDIR /
 
 USER 1000
+# Tracing propagators are configured based on OTEL_PROPAGATORS env variable https://opentelemetry.io/docs/instrumentation/python/manual/#using-environment-variables
+ENV OTEL_PROPAGATORS=tracecontext,baggage,b3
 
 CMD ["python", "/kubeless.py"]

--- a/components/function-runtimes/python39/kubeless/kubeless.py
+++ b/components/function-runtimes/python39/kubeless/kubeless.py
@@ -14,6 +14,7 @@ from ce import Event
 from tracing import set_req_context
 
 
+
 def create_service_name(pod_name: str, service_namespace: str) -> str:
     # remove generated pods suffix ( two last sections )
     deployment_name = '-'.join(pod_name.split('-')[0:pod_name.count('-') - 1])
@@ -55,16 +56,13 @@ function_context = {
     'memory-limit': os.getenv('FUNC_MEMORY_LIMIT'),
 }
 
-tracecollector_endpoint = os.getenv('TRACE_COLLECTOR_ENDPOINT')
 pod_name = os.getenv('HOSTNAME')
 service_namespace = os.getenv('SERVICE_NAMESPACE')
 service_name = create_service_name(pod_name, service_namespace)
 
-tracer_provider = None
-# To not create several tracer providers, when the server start forking.
-if __name__ == "__main__":
-    tracer_provider = tracing.ServerlessTracerProvider(tracecollector_endpoint, service_name)
 
+if __name__ == "__main__":
+    tracer = tracing._setup_tracer(service_name)
 
 def func_with_context(e, function_context):
     ex = e.ceHeaders["extensions"]
@@ -91,7 +89,6 @@ def exception_handler():
 @app.route('/<:re:.*>', method=['GET', 'POST', 'PATCH', 'DELETE'])
 def handler():
     req = bottle.request
-    tracer = tracer_provider.get_tracer(req)
     event = Event(req, tracer)
 
     method = req.method

--- a/components/function-runtimes/python39/kubeless/requirements.txt
+++ b/components/function-runtimes/python39/kubeless/requirements.txt
@@ -4,8 +4,7 @@ bottle==0.12.21
 cherrypy==8.9.1
 wsgi-request-logger==0.4.6
 prometheus_client==0.8.0
-opentelemetry-api==1.9.1
-opentelemetry-sdk==1.9.1
-opentelemetry-exporter-otlp-proto-http==1.9.1
+opentelemetry-api==1.16.0
+opentelemetry-sdk==1.16.0
+opentelemetry-exporter-otlp-proto-http==1.16.0
 opentelemetry-propagator-b3==1.9.1
-opentelemetry-instrumentation-requests==0.28b1

--- a/components/function-runtimes/python39/kubeless/tracing.py
+++ b/components/function-runtimes/python39/kubeless/tracing.py
@@ -1,57 +1,45 @@
-import logging
 from contextlib import contextmanager
 from typing import Iterator
 
-import requests
 from opentelemetry import trace
-from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
-from opentelemetry.instrumentation.requests import RequestsInstrumentor
-from opentelemetry.propagate import extract
-from opentelemetry.propagate import set_global_textmap
-from opentelemetry.propagators.b3 import B3MultiFormat
-from opentelemetry.sdk.resources import SERVICE_NAME, Resource
 from opentelemetry.sdk.trace import TracerProvider, _Span
-from opentelemetry.sdk.trace.export import BatchSpanProcessor
+from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
+from opentelemetry.propagate import extract
+from opentelemetry.sdk.resources import (
+    SERVICE_NAME,
+    Resource
+)
+from opentelemetry.sdk.trace.export import (
+    SimpleSpanProcessor,
+)
+from opentelemetry.sdk.trace.sampling import ( 
+    DEFAULT_ON,
+)
+
 from opentelemetry.trace import context_api
 from opentelemetry.trace.propagation import _SPAN_KEY
 
-_TRACING_SAMPLE_HEADER = "x-b3-sampled"
+import os
 
+# Tracing propagators are configured based on OTEL_PROPAGATORS env variable set in deockerfile
+# https://opentelemetry.io/docs/instrumentation/python/manual/#using-environment-variables
+def _setup_tracer(service_name: str) -> trace.Tracer:
 
-class ServerlessTracerProvider:
-    def __init__(self, tracecollector_endpoint: str, service_name: str):
-        self.noop_tracer = trace.NoOpTracer()
-        if not tracecollector_endpoint:
-            self.tracer = trace.NoOpTracer()
-        else:
-            self.tracer = _get_tracer(tracecollector_endpoint, service_name)
-
-    def get_tracer(self, req):
-        val = req.get_header(_TRACING_SAMPLE_HEADER)
-        if val is not None and val == "1":
-            return self.tracer
-
-        return self.noop_tracer
-
-
-def _get_tracer(tracecollector_endpoint: str, service_name: str) -> trace.Tracer:
-    set_global_textmap(B3MultiFormat())
-    RequestsInstrumentor().instrument()
-
-    trace.set_tracer_provider(
-        TracerProvider(
-            resource=Resource.create({SERVICE_NAME: service_name})
-        )
+    provider = TracerProvider(
+        resource=Resource.create({SERVICE_NAME: service_name}),
+        sampler=DEFAULT_ON,
     )
+   
+    tracecollector_endpoint = os.getenv('TRACE_COLLECTOR_ENDPOINT')
 
-    otlp_exporter = OTLPSpanExporter(
-        endpoint=tracecollector_endpoint,
-    )
+    if tracecollector_endpoint:
+        span_processor = SimpleSpanProcessor(OTLPSpanExporter(endpoint=tracecollector_endpoint))
+        provider.add_span_processor(span_processor)
+ 
+    # Sets the global default tracer provider
+    trace.set_tracer_provider(provider)
 
-    span_processor = BatchSpanProcessor(otlp_exporter)
-
-    trace.get_tracer_provider().add_span_processor(span_processor)
-
+    # Creates a tracer from the global tracer provider
     return trace.get_tracer(__name__)
 
 
@@ -75,3 +63,4 @@ def set_req_context(req) -> Iterator[trace.Span]:
         yield span
     finally:
         context_api.detach(token)
+        

--- a/resources/serverless/values.yaml
+++ b/resources/serverless/values.yaml
@@ -98,7 +98,7 @@ global:
       version: "v20230302-a6a85f47"
     function_runtime_python39:
       name: "function-runtime-python39"
-      version: "v20230223-ec41ec1e"
+      version: "PR-16990"
     kaniko_executor:
       name: "kaniko-executor"
       version: "1.9.1-d4dfc177"


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Do not auto-instrument `request` library by default as it causes error logs in case trace pipeline is missing 
- Use latest opentelemetry SDK version for python
- configure sampling strategy

**Related issue(s)**
https://github.com/kyma-project/kyma/issues/16981