### PR TITLE
Adapt Istio default values for HPA autoscaling/v2

### DIFF
--- a/resources/istio/values.yaml
+++ b/resources/istio/values.yaml
@@ -97,11 +97,15 @@ components:
         metrics:
           - resource:
               name: cpu
-              targetAverageUtilization: 80
+              target:
+                type: Utilization
+                averageUtilization: 80
             type: Resource
           - resource:
               name: memory
-              targetAverageUtilization: 80
+              target:
+                type: Utilization
+                averageUtilization: 80
             type: Resource
       securityContext:
         seccompProfile:

--- a/resources/monitoring/charts/grafana/values.yaml
+++ b/resources/monitoring/charts/grafana/values.yaml
@@ -36,11 +36,15 @@ autoscaling:
 #   - type: Resource
 #     resource:
 #       name: cpu
-#       targetAverageUtilization: 60
+#       target:
+#          type: Utilization
+#          averageUtilization: 60
 #   - type: Resource
 #     resource:
 #       name: memory
-#       targetAverageUtilization: 60
+#       target:
+#          type: Utilization
+#          averageUtilization: 60
 
 ## See `kubectl explain poddisruptionbudget.spec` for more
 ## ref: https://kubernetes.io/docs/tasks/run-application/configure-pdb/


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- Adapts default values for Istio ig-gw for autoscaling/v2
- https://kubernetes.io/docs/reference/using-api/deprecation-guide/#horizontalpodautoscaler-v125

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
https://github.com/kyma-project/kyma/issues/16847