### PR TITLE
Fix missing field check for machineType update test

### DIFF
--- a/tests/fast-integration/skr-test/machine-type/index.js
+++ b/tests/fast-integration/skr-test/machine-type/index.js
@@ -42,7 +42,7 @@ function machineTypeE2ETest(getShootOptionsFunc, getShootInfoFunc) {
           }
           const si = p.schemas.service_instance;
           console.log(`catalog plan update ${si.update !== undefined}`);
-          if (si.update === undefined) {
+          if (si.update === undefined || si.update.parameters.properties.machineType === undefined) {
             continue;
           }
           const mt = si.update.parameters.properties.machineType.enum;


### PR DESCRIPTION
After #16919 merged, `skr-free-aws-integration-dev` started failing with
```
  1) SKR test
       Machine type update test
         Should figure out next machine type to update to:
     TypeError: Cannot read property 'enum' of undefined
      at Context.<anonymous> (skr-test/machine-type/index.js:48:66)
      at processTicksAndRejections (internal/process/task_queues.js:95:5)
```
The `free-aws` plan contains `update` section in the catalog but is missing `machineType` in the `update` section.