### PR TITLE
Allow input of event types in busolas subscription form in the simple view.

### DIFF
--- a/resources/eventing/charts/controller/templates/busola-extension.yaml
+++ b/resources/eventing/charts/controller/templates/busola-extension.yaml
@@ -76,7 +76,7 @@ data:
       defaultExpanded: true
       children:
         - path: '[]'
-        simple: true
+          simple: true
     - simple: true
       type: string
       var: service

--- a/resources/eventing/charts/controller/templates/busola-extension.yaml
+++ b/resources/eventing/charts/controller/templates/busola-extension.yaml
@@ -76,6 +76,7 @@ data:
       defaultExpanded: true
       children:
         - path: '[]'
+        simple: true
     - simple: true
       type: string
       var: service


### PR DESCRIPTION

<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

The internals of Busola have changed, and now also Child Widgets need the `simple: true` property to work in the simple view.
 
This PR allows the input of event types in Busola's Subscription v1alpha2 form in the simple view by adding `simple: true`.


**Related issue(s)**
https://github.com/kyma-project/kyma/issues/16929