### PR TITLE
Allow input of event types in busolas subscription form in the simple - Rel 2.12

### DIFF
--- a/resources/eventing/charts/controller/templates/busola-extension.yaml
+++ b/resources/eventing/charts/controller/templates/busola-extension.yaml
@@ -76,6 +76,7 @@ data:
       defaultExpanded: true
       children:
         - path: '[]'
+          simple: true
     - simple: true
       type: string
       var: service


### PR DESCRIPTION
… view. (#17041)

* Allow input of event types in busolas subscription form in the simple view.

* Fix broken indentation.

<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- Cherry picked https://github.com/kyma-project/kyma/pull/17041

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
