### PR TITLE
Prevent Fast integration test log print out http Authorization header

### DIFF
--- a/tests/fast-integration/utils/index.js
+++ b/tests/fast-integration/utils/index.js
@@ -1167,12 +1167,22 @@ function log(prefix, ...args) {
   if (args.length === 0) {
     return;
   }
-
-  args = [...args];
+  args = filterSensitiveLog(args);
   const fmt = `[${prefix}] ` + args[0];
   args = args.slice(1);
   console.log.apply(console, [fmt, ...args]);
 }
+
+function filterSensitiveLog(args) {
+  args.forEach((o, i, a) => {
+    if (typeof o === 'object') {
+      a[i] = JSON.stringify(o);
+    }
+    a[i] = a[i].replace(/"Authorization".*",/, '');
+  });
+  return args;
+}
+
 
 function isDebugEnabled() {
   return DEBUG;

--- a/tests/fast-integration/utils/index.js
+++ b/tests/fast-integration/utils/index.js
@@ -1183,7 +1183,6 @@ function filterSensitiveLog(args) {
   return args;
 }
 
-
 function isDebugEnabled() {
   return DEBUG;
 }


### PR DESCRIPTION
… currently only filter Authorization bear token in http response

<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

This PR adds a function to prevent sensitive information like HTTP Authorization header info print out in fast integration test logs, to improve the secure infrastructure implementation concern.

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
