### PR TITLE
update images for telemetry/observabaility

### DIFF
--- a/resources/logging/values.yaml
+++ b/resources/logging/values.yaml
@@ -23,7 +23,7 @@ global:
   images:
     loki:
       name: loki
-      version: 2.2.1-791da1af
+      version: 2.2.1-a3475b24
       directory: tpi
     alpine:
       name: "alpine"

--- a/resources/monitoring/values.yaml
+++ b/resources/monitoring/values.yaml
@@ -145,12 +145,12 @@ global:
       directory: "tpi"
     kube_state_metrics:
       name: "kube-state-metrics"
-      version: "2.6.0-723b551a"
+      version: "2.8.1-a3475b24"
       directory: "tpi"
       sha: ""
     grafana:
       name: "grafana"
-      version: "7.5.17-791da1af"
+      version: "7.5.17-a3475b24"
       directory: "tpi"
       sha: ""
     busybox:
@@ -165,7 +165,7 @@ global:
       sha: ""
     oauth2_proxy:
       name: "oauth2-proxy"
-      version: "7.4.0-791da1af"
+      version: "7.4.0-a3475b24"
       directory: "tpi"
       sha: ""
 

--- a/resources/telemetry/values.yaml
+++ b/resources/telemetry/values.yaml
@@ -7,7 +7,7 @@ global:
       version: "v20230308-ff6cf204"
     telemetry_operator:
       name: "telemetry-manager"
-      version: "PR-71"
+      version: "v20230313-ce81d48e"
     telemetry_otel_collector:
       name: "otel-collector"
       version: "0.73.0-a3475b24"

--- a/resources/telemetry/values.yaml
+++ b/resources/telemetry/values.yaml
@@ -4,17 +4,17 @@ global:
   images:
     directory_size_exporter:
       name: "directory-size-exporter"
-      version: "v20230117-64505a69"
+      version: "v20230308-ff6cf204"
     telemetry_operator:
       name: "telemetry-manager"
-      version: "v20230310-0cbb4bb5"
+      version: "PR-71"
     telemetry_otel_collector:
       name: "otel-collector"
-      version: "0.72.0-734399a6"
+      version: "0.73.0-a3475b24"
       directory: "tpi"
     fluent_bit:
       name: "fluent-bit"
-      version: "2.0.9-f89e8b78"
+      version: "2.0.9-a3475b24"
       directory: "tpi"
   highPriorityClassName: "kyma-system-priority"
   log:

--- a/resources/tracing/values.yaml
+++ b/resources/tracing/values.yaml
@@ -181,7 +181,7 @@ global:
       directory: "external"
     oauth2_proxy:
       name: "oauth2-proxy"
-      version: "7.4.0-791da1af"
+      version: "7.4.0-a3475b24"
       directory: "tpi"
 virtualservice:
   enabled: true


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- updated otel-collector to 0.73.0
- updated kube-state-metrics to 2.8.1 (the upstream helm chart had several changes, but none of them was important for running the updated version. As we will drop it, I did not do the investment of updating the chart)
- updated golang version to 1.19
.7 or 1.20.2 for fluentbit, otel-collector, loki, grafana, oauth2-proxy
**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->

**Related**
https://github.com/kyma-project/telemetry-manager/pull/71
https://github.com/kyma-project/third-party-images/pull/318