### PR TITLE
disable grafana external snapshot publish endpoint

### DIFF
--- a/resources/monitoring/charts/grafana/values.yaml
+++ b/resources/monitoring/charts/grafana/values.yaml
@@ -401,7 +401,9 @@ env:
   # https://grafana.com/docs/grafana/v7.5/administration/configuration/#dashboards
   GF_DASHBOARDS_MIN_REFRESH_INTERVAL: "10s"
   # https://grafana.com/docs/grafana/v7.5/administration/configuration/#snapshots
-  GF_SNAPSHOTS_EXTERNAL_ENABLED: "false"
+# https://grafana.com/docs/grafana/v7.5/administration/configuration/#snapshots
+GF_SNAPSHOTS_ENABLED: "false"
+GF_SNAPSHOTS_EXTERNAL_ENABLED: "false"
 
 ## "valueFrom" environment variable references that will be added to deployment pods
 ## ref: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.17/#envvarsource-v1-core

--- a/resources/monitoring/charts/grafana/values.yaml
+++ b/resources/monitoring/charts/grafana/values.yaml
@@ -401,7 +401,6 @@ env:
   # https://grafana.com/docs/grafana/v7.5/administration/configuration/#dashboards
   GF_DASHBOARDS_MIN_REFRESH_INTERVAL: "10s"
   # https://grafana.com/docs/grafana/v7.5/administration/configuration/#snapshots
-# https://grafana.com/docs/grafana/v7.5/administration/configuration/#snapshots
   GF_SNAPSHOTS_EXTERNAL_ENABLED: "false"
 
 ## "valueFrom" environment variable references that will be added to deployment pods

--- a/resources/monitoring/charts/grafana/values.yaml
+++ b/resources/monitoring/charts/grafana/values.yaml
@@ -402,7 +402,6 @@ env:
   GF_DASHBOARDS_MIN_REFRESH_INTERVAL: "10s"
   # https://grafana.com/docs/grafana/v7.5/administration/configuration/#snapshots
 # https://grafana.com/docs/grafana/v7.5/administration/configuration/#snapshots
-GF_SNAPSHOTS_ENABLED: "false"
 GF_SNAPSHOTS_EXTERNAL_ENABLED: "false"
 
 ## "valueFrom" environment variable references that will be added to deployment pods

--- a/resources/monitoring/charts/grafana/values.yaml
+++ b/resources/monitoring/charts/grafana/values.yaml
@@ -402,7 +402,7 @@ env:
   GF_DASHBOARDS_MIN_REFRESH_INTERVAL: "10s"
   # https://grafana.com/docs/grafana/v7.5/administration/configuration/#snapshots
 # https://grafana.com/docs/grafana/v7.5/administration/configuration/#snapshots
-GF_SNAPSHOTS_EXTERNAL_ENABLED: "false"
+  GF_SNAPSHOTS_EXTERNAL_ENABLED: "false"
 
 ## "valueFrom" environment variable references that will be added to deployment pods
 ## ref: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.17/#envvarsource-v1-core

--- a/resources/monitoring/charts/grafana/values.yaml
+++ b/resources/monitoring/charts/grafana/values.yaml
@@ -367,12 +367,12 @@ admin:
 
 ## Extra environment variables that will be pass onto deployment pods
 env:
-  # https://grafana.com/docs/grafana/latest/installation/configuration/#users
+  # https://grafana.com/docs/grafana/v7.5/installation/configuration/#users
   GF_USERS_AUTO_ASSIGN_ORG: "true"
   GF_USERS_AUTO_ASSIGN_ORG_ROLE: Editor
   GF_USERS_DEFAULT_THEME: "dark"
   GF_USERS_VIEWERS_CAN_EDIT: "true"
-  # https://grafana.com/docs/grafana/latest/auth/overview/
+  # https://grafana.com/docs/grafana/v7.5/auth/overview/
   GF_AUTH_ANONYMOUS_ENABLED: "true"
   GF_AUTH_ANONYMOUS_ORG_ROLE: "Editor"
   GF_AUTH_ANONYMOUS_HIDE_VERSION: "true"
@@ -381,9 +381,9 @@ env:
   GF_AUTH_PROXY_ENABLED: "false"
   GF_AUTH_PROXY_HEADER_NAME: X-AUTH-EMAIL
   GF_AUTH_PROXY_HEADER_PROPERTY: "email"
-  # https://grafana.com/docs/grafana/latest/installation/configuration/#server
+  # https://grafana.com/docs/grafana/v7.5/installation/configuration/#server
   GF_SERVER_ROOT_URL: ""
-  # https://grafana.com/docs/grafana/latest/auth/generic-oauth/
+  # https://grafana.com/docs/grafana/v7.5/auth/generic-oauth/
   GF_AUTH_GENERIC_OAUTH_CLIENT_ID: "grafana"
   GF_AUTH_GENERIC_OAUTH_CLIENT_SECRET: "apie4eeX6hiC9ainieli"
   GF_AUTH_GENERIC_OAUTH_ENABLED: "false"
@@ -393,13 +393,15 @@ env:
   GF_AUTH_GENERIC_OAUTH_API_URL: ""
   GF_AUTH_GENERIC_OAUTH_ALLOWED_DOMAINS: ""
   GF_AUTH_GENERIC_OAUTH_ALLOW_SIGN_UP: "true"
-  # https://grafana.com/docs/grafana/latest/installation/configuration/#log
+  # https://grafana.com/docs/grafana/v7.5/installation/configuration/#log
   GF_LOG_MODE: "console"
   GF_LOG_LEVEL: "warn"
-  # https://grafana.com/docs/grafana/latest/administration/configuration/#alerting
+  # https://grafana.com/docs/grafana/v7.5/administration/configuration/#alerting
   GF_ALERTING_ENABLED: "true"
-  # https://grafana.com/docs/grafana/latest/administration/configuration/#dashboards
+  # https://grafana.com/docs/grafana/v7.5/administration/configuration/#dashboards
   GF_DASHBOARDS_MIN_REFRESH_INTERVAL: "10s"
+  # https://grafana.com/docs/grafana/v7.5/administration/configuration/#snapshots
+  GF_SNAPSHOTS_EXTERNAL_ENABLED: "false"
 
 ## "valueFrom" environment variable references that will be added to deployment pods
 ## ref: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.17/#envvarsource-v1-core


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- disable grafana external snapshot publish endpoint to avoid unnecessary integration with a 3party service
- enabling the feature is only useful when configuring an own snapshot provider target
- ...

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
