### PR TITLE
Serialise in json non primitive types as string

### DIFF
--- a/components/function-runtimes/python39/kubeless/ce.py
+++ b/components/function-runtimes/python39/kubeless/ce.py
@@ -72,7 +72,7 @@ class Event:
     def publishCloudEvent(self, data):
         return requests.post(
             publisher_proxy_address,
-            data = json.dumps(data),
+            data = json.dumps(data, default=str),
             headers = {"Content-Type": "application/cloudevents+json"}
             )
     

--- a/resources/serverless/values.yaml
+++ b/resources/serverless/values.yaml
@@ -98,7 +98,7 @@ global:
       version: "v20230302-a6a85f47"
     function_runtime_python39:
       name: "function-runtime-python39"
-      version: "v20230308-446d093a"
+      version: "PR-17125"
     kaniko_executor:
       name: "kaniko-executor"
       version: "1.9.1-d4dfc177"


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- When events contain non primitive types like dates or uuid, the user must explicitely convert them to a primitive type, typically by casting each field to a string. This change makes casting as string the default for all non primitive types.
It is no longer required to change event data and cast attributes as string
This avoids several TypeError during developement

**Related issue(s)**
Resolves https://github.com/kyma-project/kyma/issues/16843