### PR TITLE
Change v1alpha1 to v1alpha2 serverless fast integration

### DIFF
--- a/tests/fast-integration/test/fixtures/commerce-mock/index.js
+++ b/tests/fast-integration/test/fixtures/commerce-mock/index.js
@@ -744,7 +744,7 @@ async function provisionCommerceMockResources(appName, mockNamespace, targetName
 
 function getResourcePaths(namespace) {
   return [
-    `/apis/serverless.kyma-project.io/v1alpha1/namespaces/${namespace}/functions`,
+    `/apis/serverless.kyma-project.io/v1alpha2/namespaces/${namespace}/functions`,
     `/apis/addons.kyma-project.io/v1alpha1/namespaces/${namespace}/addonsconfigurations`,
     `/apis/gateway.kyma-project.io/v1alpha1/namespaces/${namespace}/apirules`,
     `/apis/apps/v1/namespaces/${namespace}/deployments`,

--- a/tests/fast-integration/test/fixtures/getting-started-guide/index.js
+++ b/tests/fast-integration/test/fixtures/getting-started-guide/index.js
@@ -149,7 +149,7 @@ async function ensureGettingStartedTestFixture() {
 
 function getResourcePaths(namespace) {
   return [
-    `/apis/serverless.kyma-project.io/v1alpha1/namespaces/${namespace}/functions`,
+    `/apis/serverless.kyma-project.io/v1alpha2/namespaces/${namespace}/functions`,
     `/apis/addons.kyma-project.io/v1alpha1/namespaces/${namespace}/addonsconfigurations`,
     `/apis/gateway.kyma-project.io/v1alpha1/namespaces/${namespace}/apirules`,
     `/apis/apps/v1/namespaces/${namespace}/deployments`,

--- a/tests/fast-integration/utils/index.js
+++ b/tests/fast-integration/utils/index.js
@@ -245,7 +245,7 @@ async function getSecret(name, namespace) {
 }
 
 async function getFunction(name, namespace) {
-  const path = `/apis/serverless.kyma-project.io/v1alpha1/namespaces/${namespace}/functions/${name}`;
+  const path = `/apis/serverless.kyma-project.io/v1alpha2/namespaces/${namespace}/functions/${name}`;
   const response = await k8sDynamicApi.requestPromise({
     url: k8sDynamicApi.basePath + path,
   });

--- a/tests/fast-integration/utils/index.js
+++ b/tests/fast-integration/utils/index.js
@@ -396,7 +396,7 @@ function waitForEndpoint(name, namespace = 'default', timeout = 300_000) {
 
 function waitForFunction(name, namespace = 'default', timeout = 90_000) {
   return waitForK8sObject(
-      `/apis/serverless.kyma-project.io/v1alpha1/namespaces/${namespace}/functions`,
+      `/apis/serverless.kyma-project.io/v1alpha2/namespaces/${namespace}/functions`,
       {},
       (_type, _apiObj, watchObj) => {
         return (


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- use v1alpha2 API

**Related issue(s)**
https://github.com/kyma-project/kyma/issues/16974
