### PR TITLE
Remove k3s-tests from srvls chart definition

### DIFF
--- a/resources/serverless/Chart.yaml
+++ b/resources/serverless/Chart.yaml
@@ -9,5 +9,3 @@ dependencies:
     condition: dockerRegistry.enableInternal
   - name: webhook
     condition: webhook.enabled
-  - name: k3s-tests
-    condition: k3s-tests.enabled # this chart is installed manually


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- remove absent `k3s-tests` subchart from servelress Chart.yaml definition - it casues installation [failure](https://status.build.kyma-project.io/job-history/gs/kyma-prow-logs/logs/post-main-serverless-manager-verify) via serverless operator
```
{"level":"warn","timestamp":"Mar 28 08:05:52.330017413","caller":"state/state_functions.go:98","msg":"error while installing resource kyma-system/serverless-k3d: found in Chart.yaml, but missing in charts/ directory: k3s-tests","request":"kyma-system/serverless-k3d"}
```


**Related issue(s)**
https://github.com/kyma-project/serverless-manager/issues/44
