### PR TITLE
Fullfill stub for webhooks

### DIFF
--- a/components/function-controller/hack/config.yaml
+++ b/components/function-controller/hack/config.yaml
@@ -1,0 +1,2 @@
+logLevel: info
+logFormat: text

--- a/components/function-controller/internal/webhook/resources/resources.go
+++ b/components/function-controller/internal/webhook/resources/resources.go
@@ -29,7 +29,7 @@ func SetupResourcesController(ctx context.Context, mgr ctrl.Manager, serviceName
 	}
 
 	webhookConfig := WebhookConfig{
-		CABundel:         certBytes,
+		CABundle:         certBytes,
 		ServiceName:      serviceName,
 		ServiceNamespace: serviceNamespace,
 	}

--- a/components/function-controller/internal/webhook/resources/resources.go
+++ b/components/function-controller/internal/webhook/resources/resources.go
@@ -43,12 +43,12 @@ func SetupResourcesController(ctx context.Context, mgr ctrl.Manager, serviceName
 	}
 
 	logger.Info("initializing the defaulting webhook configuration")
-	if err := EnsureWebhookConfigurationFor(ctx, serverClient, webhookConfig, MutatingWebhook); err != nil {
+	if err := InjectCABundleIntoWebhooks(ctx, serverClient, webhookConfig, MutatingWebhook); err != nil {
 		return errors.Wrap(err, "failed to ensure defaulting webhook configuration")
 	}
 
 	logger.Info("initializing the validation webhook configuration")
-	if err := EnsureWebhookConfigurationFor(ctx, serverClient, webhookConfig, ValidatingWebHook); err != nil {
+	if err := InjectCABundleIntoWebhooks(ctx, serverClient, webhookConfig, ValidatingWebHook); err != nil {
 		return errors.Wrap(err, "failed to ensure validating webhook configuration")
 	}
 	// watch over the configuration
@@ -117,13 +117,13 @@ func (r *resourceReconciler) Reconcile(ctx context.Context, request reconcile.Re
 func (r *resourceReconciler) reconcilerWebhooks(ctx context.Context, request reconcile.Request) error {
 	if request.Name == DefaultingWebhookName {
 		r.logger.Info("reconciling webhook defaulting webhook configuration")
-		if err := EnsureWebhookConfigurationFor(ctx, r.client, r.webhookConfig, MutatingWebhook); err != nil {
+		if err := InjectCABundleIntoWebhooks(ctx, r.client, r.webhookConfig, MutatingWebhook); err != nil {
 			return errors.Wrap(err, "failed to ensure defaulting webhook configuration")
 		}
 	}
 	if request.Name == ValidationWebhookName {
 		r.logger.Info("reconciling webhook validating webhook configuration")
-		if err := EnsureWebhookConfigurationFor(ctx, r.client, r.webhookConfig, ValidatingWebHook); err != nil {
+		if err := InjectCABundleIntoWebhooks(ctx, r.client, r.webhookConfig, ValidatingWebHook); err != nil {
 			return errors.Wrap(err, "failed to ensure validating webhook configuration")
 		}
 	}

--- a/components/function-controller/internal/webhook/resources/resources.go
+++ b/components/function-controller/internal/webhook/resources/resources.go
@@ -25,7 +25,7 @@ func SetupResourcesController(ctx context.Context, mgr ctrl.Manager, serviceName
 	certPath := path.Join(DefaultCertDir, CertFile)
 	certBytes, err := ioutil.ReadFile(certPath)
 	if err != nil {
-		return errors.Wrapf(err, "failed to read caBundel file: %s", certPath)
+		return errors.Wrapf(err, "failed to read caBundle file: %s", certPath)
 	}
 
 	webhookConfig := WebhookConfig{

--- a/components/function-controller/internal/webhook/resources/webhook_config.go
+++ b/components/function-controller/internal/webhook/resources/webhook_config.go
@@ -52,8 +52,8 @@ func injectCAIntoMutatingWebhook(ctx context.Context, client ctlrclient.Client, 
 			webhook.ClientConfig.CABundle = CABundle
 			updatedWebhooks = append(updatedWebhooks, webhook)
 		}
-
 	}
+
 	if shouldBeUpdated {
 		mwhc.Webhooks = updatedWebhooks
 		return errors.Wrap(client.Update(ctx, mwhc), "while  injecting CA Bundle into mutation webhook configuration")
@@ -77,6 +77,7 @@ func injectCAIntoValidationWebhook(ctx context.Context, client ctlrclient.Client
 		}
 
 	}
+
 	if shouldBeUpdated {
 		vwhc.Webhooks = updatedWebhooks
 		return errors.Wrap(client.Update(ctx, vwhc), "while injecting CA Bundle into validation webhook configuration")

--- a/components/function-controller/internal/webhook/resources/webhook_config.go
+++ b/components/function-controller/internal/webhook/resources/webhook_config.go
@@ -90,15 +90,18 @@ func injectCaBundleIntoValidationWebhook(ctx context.Context, client ctlrclient.
 		return errors.Wrapf(err, "failed to get validation ValidatingWebhookConfiguration: %s", ValidationWebhookName)
 	}
 
+	updatedWebhooks := []admissionregistrationv1.ValidatingWebhook{}
 	shouldBeUpdated := false
-	for _, webhooks := range vwhc.Webhooks {
-		if !bytes.Equal(webhooks.ClientConfig.CABundle, config.CABundel) {
+	for _, webhook := range vwhc.Webhooks {
+		if !bytes.Equal(webhook.ClientConfig.CABundle, config.CABundel) {
 			shouldBeUpdated = true
-			webhooks.ClientConfig.CABundle = config.CABundel
+			webhook.ClientConfig.CABundle = config.CABundel
+			updatedWebhooks = append(updatedWebhooks, webhook)
 		}
 
 	}
 	if shouldBeUpdated {
+		vwhc.Webhooks = updatedWebhooks
 		return errors.Wrap(client.Update(ctx, vwhc), "while updating webhook mutation configuration")
 	}
 	return nil

--- a/components/function-controller/internal/webhook/resources/webhook_config.go
+++ b/components/function-controller/internal/webhook/resources/webhook_config.go
@@ -3,21 +3,14 @@ package resources
 import (
 	"bytes"
 	"context"
-	"reflect"
-
-	serverlessv1alpha2 "github.com/kyma-project/kyma/components/function-controller/pkg/apis/serverless/v1alpha2"
-
 	"github.com/pkg/errors"
 	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
-	apiErrors "k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/utils/pointer"
 	ctlrclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 type WebhookConfig struct {
-	CABundel         []byte
+	CABundle         []byte
 	ServiceName      string
 	ServiceNamespace string
 }
@@ -27,177 +20,66 @@ const (
 	MutatingWebhook   WebHookType = "Mutating"
 	ValidatingWebHook WebHookType = "Validating"
 
-	serverlessAPIGroup          = "serverless.kyma-project.io"
-	ServerlessCurrentAPIVersion = serverlessv1alpha2.FunctionVersion
-
-	DefaultingWebhookName     = "defaulting.webhook.serverless.kyma-project.io"
-	SecretMutationWebhookName = "mutating.secret.webhook.serverless.kyma-project.io"
-	ValidationWebhookName     = "validation.webhook.serverless.kyma-project.io"
-
-	WebhookTimeout = 10
+	DefaultingWebhookName = "defaulting.webhook.serverless.kyma-project.io"
+	ValidationWebhookName = "validation.webhook.serverless.kyma-project.io"
 
 	FunctionDefaultingWebhookPath       = "/defaulting/functions"
 	RegistryConfigDefaultingWebhookPath = "/defaulting/registry-config-secrets"
 	FunctionValidationWebhookPath       = "/validation/function"
-
-	RemoteRegistryLabelKey = "serverless.kyma-project.io/remote-registry"
 )
 
-func createExcludeKubeSystemNamespacesSelector() *metav1.LabelSelector {
-	return &metav1.LabelSelector{
-		MatchExpressions: []metav1.LabelSelectorRequirement{
-			{
-				Key:      "gardener.cloud/purpose",
-				Operator: metav1.LabelSelectorOpNotIn,
-				Values:   []string{"kube-system"},
-			},
-		},
-	}
-}
-
 func EnsureWebhookConfigurationFor(ctx context.Context, client ctlrclient.Client, config WebhookConfig, wt WebHookType) error {
-	if wt == MutatingWebhook {
-		return ensureMutatingWebhookConfigFor(ctx, client, config)
+	switch wt {
+	case MutatingWebhook:
+		return injectCAIntoMutatingWebhook(ctx, client, config.CABundle)
+	case ValidatingWebHook:
+		return injectCAIntoValidationWebhook(ctx, client, config.CABundle)
+	default:
+		return errors.Errorf("Unknow webhook type: %s", wt)
 	}
-	return injectCaBundleIntoValidationWebhook(ctx, client, config)
 }
 
-func ensureMutatingWebhookConfigFor(ctx context.Context, client ctlrclient.Client, config WebhookConfig) error {
+func injectCAIntoMutatingWebhook(ctx context.Context, client ctlrclient.Client, CABundle []byte) error {
 	mwhc := &admissionregistrationv1.MutatingWebhookConfiguration{}
 	if err := client.Get(ctx, types.NamespacedName{Name: DefaultingWebhookName}, mwhc); err != nil {
-		if apiErrors.IsNotFound(err) {
-			return errors.Wrap(client.Create(ctx, createMutatingWebhookConfiguration(config)), "while creating webhook mutation configuration")
-		}
 		return errors.Wrapf(err, "failed to get defaulting MutatingWebhookConfiguration: %s", DefaultingWebhookName)
 	}
-	ensuredMwhc := createMutatingWebhookConfiguration(config)
-	if !reflect.DeepEqual(ensuredMwhc.Webhooks, mwhc.Webhooks) {
-		ensuredMwhc.ObjectMeta = *mwhc.ObjectMeta.DeepCopy()
-		return errors.Wrap(client.Update(ctx, ensuredMwhc), "while updating webhook mutation configuration")
+	var updatedWebhooks []admissionregistrationv1.MutatingWebhook
+	shouldBeUpdated := false
+	for _, webhook := range mwhc.Webhooks {
+		if !bytes.Equal(webhook.ClientConfig.CABundle, CABundle) {
+			shouldBeUpdated = true
+			webhook.ClientConfig.CABundle = CABundle
+			updatedWebhooks = append(updatedWebhooks, webhook)
+		}
+
+	}
+	if shouldBeUpdated {
+		mwhc.Webhooks = updatedWebhooks
+		return errors.Wrap(client.Update(ctx, mwhc), "while  injecting CA Bundle into mutation webhook configuration")
 	}
 	return nil
 }
 
-func injectCaBundleIntoValidationWebhook(ctx context.Context, client ctlrclient.Client, config WebhookConfig) error {
+func injectCAIntoValidationWebhook(ctx context.Context, client ctlrclient.Client, CABundle []byte) error {
 	vwhc := &admissionregistrationv1.ValidatingWebhookConfiguration{}
 	if err := client.Get(ctx, types.NamespacedName{Name: ValidationWebhookName}, vwhc); err != nil {
 		return errors.Wrapf(err, "failed to get validation ValidatingWebhookConfiguration: %s", ValidationWebhookName)
 	}
 
-	updatedWebhooks := []admissionregistrationv1.ValidatingWebhook{}
+	var updatedWebhooks []admissionregistrationv1.ValidatingWebhook
 	shouldBeUpdated := false
 	for _, webhook := range vwhc.Webhooks {
-		if !bytes.Equal(webhook.ClientConfig.CABundle, config.CABundel) {
+		if !bytes.Equal(webhook.ClientConfig.CABundle, CABundle) {
 			shouldBeUpdated = true
-			webhook.ClientConfig.CABundle = config.CABundel
+			webhook.ClientConfig.CABundle = CABundle
 			updatedWebhooks = append(updatedWebhooks, webhook)
 		}
 
 	}
 	if shouldBeUpdated {
 		vwhc.Webhooks = updatedWebhooks
-		return errors.Wrap(client.Update(ctx, vwhc), "while updating webhook mutation configuration")
+		return errors.Wrap(client.Update(ctx, vwhc), "while injecting CA Bundle into validation webhook configuration")
 	}
 	return nil
-}
-
-func createMutatingWebhookConfiguration(config WebhookConfig) *admissionregistrationv1.MutatingWebhookConfiguration {
-	return &admissionregistrationv1.MutatingWebhookConfiguration{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: DefaultingWebhookName,
-		},
-		Webhooks: []admissionregistrationv1.MutatingWebhook{
-			getFunctionMutatingWebhookCfg(config),
-			getRegistryConfigSecretMutatingWebhook(config),
-		},
-	}
-}
-
-func getFunctionMutatingWebhookCfg(config WebhookConfig) admissionregistrationv1.MutatingWebhook {
-	failurePolicy := admissionregistrationv1.Fail
-	matchPolicy := admissionregistrationv1.Exact
-	reinvocationPolicy := admissionregistrationv1.NeverReinvocationPolicy
-	scope := admissionregistrationv1.AllScopes
-	sideEffects := admissionregistrationv1.SideEffectClassNone
-
-	return admissionregistrationv1.MutatingWebhook{
-		Name: DefaultingWebhookName,
-		AdmissionReviewVersions: []string{
-			"v1beta1",
-			"v1",
-		},
-		ClientConfig: admissionregistrationv1.WebhookClientConfig{
-			CABundle: config.CABundel,
-			Service: &admissionregistrationv1.ServiceReference{
-				Namespace: config.ServiceNamespace,
-				Name:      config.ServiceName,
-				Path:      pointer.String(FunctionDefaultingWebhookPath),
-				Port:      pointer.Int32(443),
-			},
-		},
-		FailurePolicy:      &failurePolicy,
-		MatchPolicy:        &matchPolicy,
-		ReinvocationPolicy: &reinvocationPolicy,
-		Rules: []admissionregistrationv1.RuleWithOperations{
-			{
-				Rule: admissionregistrationv1.Rule{
-					APIGroups:   []string{serverlessAPIGroup},
-					APIVersions: []string{ServerlessCurrentAPIVersion},
-					Resources:   []string{"functions", "functions/status"},
-					Scope:       &scope,
-				},
-				Operations: []admissionregistrationv1.OperationType{
-					admissionregistrationv1.Create,
-					admissionregistrationv1.Update,
-				},
-			},
-		},
-		SideEffects:       &sideEffects,
-		TimeoutSeconds:    pointer.Int32(WebhookTimeout),
-		NamespaceSelector: createExcludeKubeSystemNamespacesSelector(),
-	}
-}
-
-func getRegistryConfigSecretMutatingWebhook(config WebhookConfig) admissionregistrationv1.MutatingWebhook {
-	failurePolicy := admissionregistrationv1.Fail
-	matchPolicy := admissionregistrationv1.Exact
-	sideEffects := admissionregistrationv1.SideEffectClassNone
-	secretSelector := map[string]string{
-		RemoteRegistryLabelKey: "config",
-	}
-
-	return admissionregistrationv1.MutatingWebhook{
-		Name: SecretMutationWebhookName,
-		ClientConfig: admissionregistrationv1.WebhookClientConfig{
-			CABundle: config.CABundel,
-			Service: &admissionregistrationv1.ServiceReference{
-				Namespace: config.ServiceNamespace,
-				Name:      config.ServiceName,
-				Path:      pointer.String(RegistryConfigDefaultingWebhookPath),
-				Port:      pointer.Int32(443),
-			},
-		},
-		FailurePolicy:           &failurePolicy,
-		MatchPolicy:             &matchPolicy,
-		TimeoutSeconds:          pointer.Int32(WebhookTimeout),
-		NamespaceSelector:       createExcludeKubeSystemNamespacesSelector(),
-		SideEffects:             &sideEffects,
-		AdmissionReviewVersions: []string{"v1beta1", "v1"},
-		ObjectSelector: &metav1.LabelSelector{
-			MatchLabels: secretSelector,
-		},
-		Rules: []admissionregistrationv1.RuleWithOperations{
-			{
-				Rule: admissionregistrationv1.Rule{
-					APIGroups:   []string{""},
-					APIVersions: []string{"v1"},
-					Resources:   []string{"secrets"},
-				},
-				Operations: []admissionregistrationv1.OperationType{
-					admissionregistrationv1.Create,
-					admissionregistrationv1.Update,
-				},
-			},
-		},
-	}
 }

--- a/components/function-controller/internal/webhook/resources/webhook_config.go
+++ b/components/function-controller/internal/webhook/resources/webhook_config.go
@@ -28,7 +28,7 @@ const (
 	FunctionValidationWebhookPath       = "/validation/function"
 )
 
-func EnsureWebhookConfigurationFor(ctx context.Context, client ctlrclient.Client, config WebhookConfig, wt WebHookType) error {
+func InjectCABundleIntoWebhooks(ctx context.Context, client ctlrclient.Client, config WebhookConfig, wt WebHookType) error {
 	switch wt {
 	case MutatingWebhook:
 		return injectCAIntoMutatingWebhook(ctx, client, config.CABundle)

--- a/components/function-controller/internal/webhook/resources/webhook_config.go
+++ b/components/function-controller/internal/webhook/resources/webhook_config.go
@@ -33,15 +33,12 @@ const (
 	DefaultingWebhookName     = "defaulting.webhook.serverless.kyma-project.io"
 	SecretMutationWebhookName = "mutating.secret.webhook.serverless.kyma-project.io"
 	ValidationWebhookName     = "validation.webhook.serverless.kyma-project.io"
-	ConvertingWebHookName     = "converting.webhook.serverless.kyma-project.io"
 
 	WebhookTimeout = 10
 
 	FunctionDefaultingWebhookPath       = "/defaulting/functions"
 	RegistryConfigDefaultingWebhookPath = "/defaulting/registry-config-secrets"
 	FunctionValidationWebhookPath       = "/validation/function"
-
-	FunctionConvertWebhookPath = "/convert/functions"
 
 	RemoteRegistryLabelKey = "serverless.kyma-project.io/remote-registry"
 )
@@ -60,9 +57,6 @@ func createExcludeKubeSystemNamespacesSelector() *metav1.LabelSelector {
 
 func EnsureWebhookConfigurationFor(ctx context.Context, client ctlrclient.Client, config WebhookConfig, wt WebHookType) error {
 	if wt == MutatingWebhook {
-		if err := ensureConvertingWebhookConfigFor(ctx, client, config); err != nil {
-			return err
-		}
 		return ensureMutatingWebhookConfigFor(ctx, client, config)
 	}
 	return injectCaBundleIntoValidationWebhook(ctx, client, config)
@@ -206,62 +200,4 @@ func getRegistryConfigSecretMutatingWebhook(config WebhookConfig) admissionregis
 			},
 		},
 	}
-}
-
-func getFunctionConvertingWebhookCfg(config WebhookConfig) admissionregistrationv1.MutatingWebhook {
-	failurePolicy := admissionregistrationv1.Fail
-	matchPolicy := admissionregistrationv1.Equivalent
-	reinvocationPolicy := admissionregistrationv1.NeverReinvocationPolicy
-	sideEffects := admissionregistrationv1.SideEffectClassNone
-
-	return admissionregistrationv1.MutatingWebhook{
-		Name: ConvertingWebHookName,
-		AdmissionReviewVersions: []string{
-			"v1beta1",
-			"v1",
-		},
-		ClientConfig: admissionregistrationv1.WebhookClientConfig{
-			CABundle: config.CABundel,
-			Service: &admissionregistrationv1.ServiceReference{
-				Namespace: config.ServiceNamespace,
-				Name:      config.ServiceName,
-				Path:      pointer.String(FunctionConvertWebhookPath),
-				Port:      pointer.Int32(443),
-			},
-		},
-		FailurePolicy:      &failurePolicy,
-		MatchPolicy:        &matchPolicy,
-		ReinvocationPolicy: &reinvocationPolicy,
-		SideEffects:        &sideEffects,
-		TimeoutSeconds:     pointer.Int32(WebhookTimeout),
-		NamespaceSelector:  createExcludeKubeSystemNamespacesSelector(),
-	}
-}
-
-func createConvertingWebhookConfiguration(config WebhookConfig) *admissionregistrationv1.MutatingWebhookConfiguration {
-	return &admissionregistrationv1.MutatingWebhookConfiguration{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: ConvertingWebHookName,
-		},
-		Webhooks: []admissionregistrationv1.MutatingWebhook{
-
-			getFunctionConvertingWebhookCfg(config),
-		},
-	}
-}
-
-func ensureConvertingWebhookConfigFor(ctx context.Context, client ctlrclient.Client, config WebhookConfig) error {
-	mwhc := &admissionregistrationv1.MutatingWebhookConfiguration{}
-	if err := client.Get(ctx, types.NamespacedName{Name: ConvertingWebHookName}, mwhc); err != nil {
-		if apiErrors.IsNotFound(err) {
-			return client.Create(ctx, createConvertingWebhookConfiguration(config))
-		}
-		return errors.Wrapf(err, "failed to get converting MutatingWebhookConfiguration: %s", ConvertingWebHookName)
-	}
-	ensuredMwhc := createConvertingWebhookConfiguration(config)
-	if !reflect.DeepEqual(ensuredMwhc.Webhooks, mwhc.Webhooks) {
-		ensuredMwhc.ObjectMeta = *mwhc.ObjectMeta.DeepCopy()
-		return client.Update(ctx, ensuredMwhc)
-	}
-	return nil
 }

--- a/components/function-controller/internal/webhook/resources/webhook_config_test.go
+++ b/components/function-controller/internal/webhook/resources/webhook_config_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 var (
-	caBundel = []byte("LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUVEakNDQW5ZQ0NRRE5vZFh6bERqdk9qQU5CZ2txaGtpRzl3MEJBUXNGQURCSk1SVXdFd1lEVlFRS0RBeGoKWlhKMExXMWhibUZuWlhJeEZUQVRCZ05WQkFzTURHTmxjblF0YldGdVlXZGxjakVaTUJjR0ExVUVBd3dRYTNsdApZUzFsZUdGdGNHeGxMbU52YlRBZUZ3MHlNVEE1TWpreE5ERXhOVGRhRncweU1qQTVNamt4TkRFeE5UZGFNRWt4CkZUQVRCZ05WQkFvTURHTmxjblF0YldGdVlXZGxjakVWTUJNR0ExVUVDd3dNWTJWeWRDMXRZVzVoWjJWeU1Sa3cKRndZRFZRUUREQkJyZVcxaExXVjRZVzF3YkdVdVkyOXRNSUlCb2pBTkJna3Foa2lHOXcwQkFRRUZBQU9DQVk4QQpNSUlCaWdLQ0FZRUFvMHNzdEtYZ01sR0FvV0F6WmxCZVNHMTVJZ0VBRkZwbWFTcnArQ0Y1bGdjTXVSZFNBamlXCk1tS0F5OWlzdy9meTN3YmFWUWNoSWFLZXJvZzVFcnYyR1hlMmZaK0Q2anJpbFp4SG01ZURxZmtxdmQrcXh6K3IKN25Dd1JOS2t0Q093YmJqOWtMSWduQkdUVGZQL1NiVUMxd2R5R3BuYnpwVXo1b3RvbVJRMWlsWi9OZFl2T2UwYworK21zZ2xSUVpNWmNtZVI0RWJhZlNwRTdWT1M2L0srbTZpMzRZMzdmSTBhSUlUV2lVR1RuMzRVMEZhTG9DSTF5CjVNaFhSYUhyQTAyWVBsNmhUMlJFVVlRUTBuNUMxVnpQYm02VHkvUjdoOXI2RnoxQWxPQ0I5NnZtalNPemR2dmsKaHdMcVRqdHArbFNNcW1iRExEV2ZVY2JpVFIwbzliQ3Rxam1aUjQwcXhqa1hieW5hYU42TzFnbm9Fem50a1J3Sgo1cytZaVVtTHpvVFIyV2V1bHc5VVZaZXdiQm85Zk1FSFVRa1RJOEd0aWVjUDhNMGF4R1RSSVFCWUc0bTBYcEF1CmFrd2ZPNlRlZzR2T1FTQmpVanE0Rm1nYkZkVVZsUkZrVm95NXkra3JrV2FpT21hSFlqWHViMkduVWQ1WFBiamgKeG56a1R4UlE3UFh6QWdNQkFBRXdEUVlKS29aSWh2Y05BUUVMQlFBRGdnR0JBRCs5QlExWERXY0pkZ2Jma2ZJeApNa1ZLc3pXRWdvUC9GWWNmcVVEc1drcTNkR3M0Q1Z4ODRzTjNRd0hSY2JkV2trVTd1WXh3VmE0NVZWbVZrZjhmClZGN3ZiblhWWUoydHp5K2lTb0JDcVFjMUNHV1ZwQmdIOGlFVWdYb2hwdTczWjhtSkJhNUhQT1lXTHM5dEVlVTUKdy9VOG9HOUJZRHRsclBGSzZLWkJpYU8veERMQXlFOFRxUEc3U3oxUXJFdC9HbE1wS1RHakFUYXNNQ2hzT0IrMgpuc2xLdExuNXZoS3hOdkRIYjJ4Y1pGZHlOdGQ5Vk9mcFQvNXZ2VE4wb3ozcERJd2RhUkNyTTMwU0tCZVl1OFdGClJPb1NsNUE5dDl3S08vZ0xwcFJ1WW9IdzU4Z1VudWpCOUoyT1oxaUp2YUFLTXZMNGFFbTE4VjVCYkZaUVdPUFkKcWRYZGRnYk80R0VsUFRXdUxFb01HZTM5UnBITmVtMmcrNFdUcjl1K2FkSVN3MnBQbjFRYXhqbzJmb0ZiUUpUcgpXeXR5MnVLU2diU3RzNzEvOUZ4bUIvM3Z6Y21oOUhLdzJWb0FQSzY4ckdhUkhvTjdqZ0dCR3JtdDdHZ01UeGlqCmRuOEt1OHBhRERWSTFldUx6RlJwUlBvdVVwOEVDdmRHTkxoRTJrc0dsdEk3WEE9PQotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg==")
+	caBundle = []byte("LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUVEakNDQW5ZQ0NRRE5vZFh6bERqdk9qQU5CZ2txaGtpRzl3MEJBUXNGQURCSk1SVXdFd1lEVlFRS0RBeGoKWlhKMExXMWhibUZuWlhJeEZUQVRCZ05WQkFzTURHTmxjblF0YldGdVlXZGxjakVaTUJjR0ExVUVBd3dRYTNsdApZUzFsZUdGdGNHeGxMbU52YlRBZUZ3MHlNVEE1TWpreE5ERXhOVGRhRncweU1qQTVNamt4TkRFeE5UZGFNRWt4CkZUQVRCZ05WQkFvTURHTmxjblF0YldGdVlXZGxjakVWTUJNR0ExVUVDd3dNWTJWeWRDMXRZVzVoWjJWeU1Sa3cKRndZRFZRUUREQkJyZVcxaExXVjRZVzF3YkdVdVkyOXRNSUlCb2pBTkJna3Foa2lHOXcwQkFRRUZBQU9DQVk4QQpNSUlCaWdLQ0FZRUFvMHNzdEtYZ01sR0FvV0F6WmxCZVNHMTVJZ0VBRkZwbWFTcnArQ0Y1bGdjTXVSZFNBamlXCk1tS0F5OWlzdy9meTN3YmFWUWNoSWFLZXJvZzVFcnYyR1hlMmZaK0Q2anJpbFp4SG01ZURxZmtxdmQrcXh6K3IKN25Dd1JOS2t0Q093YmJqOWtMSWduQkdUVGZQL1NiVUMxd2R5R3BuYnpwVXo1b3RvbVJRMWlsWi9OZFl2T2UwYworK21zZ2xSUVpNWmNtZVI0RWJhZlNwRTdWT1M2L0srbTZpMzRZMzdmSTBhSUlUV2lVR1RuMzRVMEZhTG9DSTF5CjVNaFhSYUhyQTAyWVBsNmhUMlJFVVlRUTBuNUMxVnpQYm02VHkvUjdoOXI2RnoxQWxPQ0I5NnZtalNPemR2dmsKaHdMcVRqdHArbFNNcW1iRExEV2ZVY2JpVFIwbzliQ3Rxam1aUjQwcXhqa1hieW5hYU42TzFnbm9Fem50a1J3Sgo1cytZaVVtTHpvVFIyV2V1bHc5VVZaZXdiQm85Zk1FSFVRa1RJOEd0aWVjUDhNMGF4R1RSSVFCWUc0bTBYcEF1CmFrd2ZPNlRlZzR2T1FTQmpVanE0Rm1nYkZkVVZsUkZrVm95NXkra3JrV2FpT21hSFlqWHViMkduVWQ1WFBiamgKeG56a1R4UlE3UFh6QWdNQkFBRXdEUVlKS29aSWh2Y05BUUVMQlFBRGdnR0JBRCs5QlExWERXY0pkZ2Jma2ZJeApNa1ZLc3pXRWdvUC9GWWNmcVVEc1drcTNkR3M0Q1Z4ODRzTjNRd0hSY2JkV2trVTd1WXh3VmE0NVZWbVZrZjhmClZGN3ZiblhWWUoydHp5K2lTb0JDcVFjMUNHV1ZwQmdIOGlFVWdYb2hwdTczWjhtSkJhNUhQT1lXTHM5dEVlVTUKdy9VOG9HOUJZRHRsclBGSzZLWkJpYU8veERMQXlFOFRxUEc3U3oxUXJFdC9HbE1wS1RHakFUYXNNQ2hzT0IrMgpuc2xLdExuNXZoS3hOdkRIYjJ4Y1pGZHlOdGQ5Vk9mcFQvNXZ2VE4wb3ozcERJd2RhUkNyTTMwU0tCZVl1OFdGClJPb1NsNUE5dDl3S08vZ0xwcFJ1WW9IdzU4Z1VudWpCOUoyT1oxaUp2YUFLTXZMNGFFbTE4VjVCYkZaUVdPUFkKcWRYZGRnYk80R0VsUFRXdUxFb01HZTM5UnBITmVtMmcrNFdUcjl1K2FkSVN3MnBQbjFRYXhqbzJmb0ZiUUpUcgpXeXR5MnVLU2diU3RzNzEvOUZ4bUIvM3Z6Y21oOUhLdzJWb0FQSzY4ckdhUkhvTjdqZ0dCR3JtdDdHZ01UeGlqCmRuOEt1OHBhRERWSTFldUx6RlJwUlBvdVVwOEVDdmRHTkxoRTJrc0dsdEk3WEE9PQotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg==")
 )
 
 func TestEnsureWebhookConfigurationFor(t *testing.T) {
@@ -32,7 +32,45 @@ func TestEnsureWebhookConfigurationFor(t *testing.T) {
 		require.NoError(t, err)
 
 		wc := WebhookConfig{
-			CABundle:         caBundel,
+			CABundle:         caBundle,
+			ServiceName:      testServiceName,
+			ServiceNamespace: testNamespaceName,
+		}
+		err = EnsureWebhookConfigurationFor(ctx, client, wc, MutatingWebhook)
+		require.NoError(t, err)
+
+		updatedWh := &admissionregistrationv1.MutatingWebhookConfiguration{}
+		err = client.Get(ctx, types.NamespacedName{Name: DefaultingWebhookName}, updatedWh)
+
+		require.NoError(t, err)
+		require.NotNil(t, updatedWh)
+		require.Equal(t, updatedWh.Name, DefaultingWebhookName)
+		require.NotNil(t, updatedWh.Webhooks)
+		require.Contains(t, updatedWh.Labels, "dont-remove-me")
+		require.Len(t, updatedWh.Webhooks, 2)
+		require.Equal(t, wc.CABundle, updatedWh.Webhooks[0].ClientConfig.CABundle)
+		require.Equal(t, wc.CABundle, updatedWh.Webhooks[1].ClientConfig.CABundle)
+	})
+
+	t.Run("ca bundle is already present in mutating webhook's configs", func(t *testing.T) {
+		client := fake.NewClientBuilder().Build()
+		mwh := &admissionregistrationv1.MutatingWebhookConfiguration{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: DefaultingWebhookName,
+				Labels: map[string]string{
+					"dont-remove-me": "true",
+				},
+			},
+			Webhooks: []admissionregistrationv1.MutatingWebhook{
+				{ClientConfig: admissionregistrationv1.WebhookClientConfig{CABundle: caBundle}},
+				{ClientConfig: admissionregistrationv1.WebhookClientConfig{CABundle: caBundle}},
+			}}
+
+		err := client.Create(ctx, mwh)
+		require.NoError(t, err)
+
+		wc := WebhookConfig{
+			CABundle:         caBundle,
 			ServiceName:      testServiceName,
 			ServiceNamespace: testNamespaceName,
 		}
@@ -61,15 +99,13 @@ func TestEnsureWebhookConfigurationFor(t *testing.T) {
 					"dont-remove-me": "true",
 				},
 			},
-			Webhooks: []admissionregistrationv1.ValidatingWebhook{
-				{},
-			},
+			Webhooks: []admissionregistrationv1.ValidatingWebhook{{}, {}},
 		}
 		err := client.Create(ctx, vwh)
 		require.NoError(t, err)
 
 		wc := WebhookConfig{
-			CABundle:         caBundel,
+			CABundle:         caBundle,
 			ServiceName:      testServiceName,
 			ServiceNamespace: testNamespaceName,
 		}
@@ -80,7 +116,42 @@ func TestEnsureWebhookConfigurationFor(t *testing.T) {
 		err = client.Get(ctx, types.NamespacedName{Name: ValidationWebhookName}, updatedWh)
 
 		require.NoError(t, err)
-		require.Len(t, updatedWh.Webhooks, 1)
+		require.Len(t, updatedWh.Webhooks, 2)
 		require.Equal(t, wc.CABundle, updatedWh.Webhooks[0].ClientConfig.CABundle)
+		require.Equal(t, wc.CABundle, updatedWh.Webhooks[1].ClientConfig.CABundle)
+	})
+
+	t.Run("ca bundle is already present in validation webhook's configs", func(t *testing.T) {
+		client := fake.NewClientBuilder().Build()
+		vwh := &admissionregistrationv1.ValidatingWebhookConfiguration{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: ValidationWebhookName,
+				Labels: map[string]string{
+					"dont-remove-me": "true",
+				},
+			},
+			Webhooks: []admissionregistrationv1.ValidatingWebhook{{
+				ClientConfig: admissionregistrationv1.WebhookClientConfig{CABundle: caBundle}},
+				{ClientConfig: admissionregistrationv1.WebhookClientConfig{CABundle: caBundle}},
+			},
+		}
+		err := client.Create(ctx, vwh)
+		require.NoError(t, err)
+
+		wc := WebhookConfig{
+			CABundle:         caBundle,
+			ServiceName:      testServiceName,
+			ServiceNamespace: testNamespaceName,
+		}
+		err = EnsureWebhookConfigurationFor(ctx, client, wc, ValidatingWebHook)
+		require.NoError(t, err)
+
+		updatedWh := &admissionregistrationv1.ValidatingWebhookConfiguration{}
+		err = client.Get(ctx, types.NamespacedName{Name: ValidationWebhookName}, updatedWh)
+
+		require.NoError(t, err)
+		require.Len(t, updatedWh.Webhooks, 2)
+		require.Equal(t, wc.CABundle, updatedWh.Webhooks[0].ClientConfig.CABundle)
+		require.Equal(t, wc.CABundle, updatedWh.Webhooks[1].ClientConfig.CABundle)
 	})
 }

--- a/components/function-controller/internal/webhook/resources/webhook_config_test.go
+++ b/components/function-controller/internal/webhook/resources/webhook_config_test.go
@@ -15,143 +15,125 @@ var (
 	caBundle = []byte("LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUVEakNDQW5ZQ0NRRE5vZFh6bERqdk9qQU5CZ2txaGtpRzl3MEJBUXNGQURCSk1SVXdFd1lEVlFRS0RBeGoKWlhKMExXMWhibUZuWlhJeEZUQVRCZ05WQkFzTURHTmxjblF0YldGdVlXZGxjakVaTUJjR0ExVUVBd3dRYTNsdApZUzFsZUdGdGNHeGxMbU52YlRBZUZ3MHlNVEE1TWpreE5ERXhOVGRhRncweU1qQTVNamt4TkRFeE5UZGFNRWt4CkZUQVRCZ05WQkFvTURHTmxjblF0YldGdVlXZGxjakVWTUJNR0ExVUVDd3dNWTJWeWRDMXRZVzVoWjJWeU1Sa3cKRndZRFZRUUREQkJyZVcxaExXVjRZVzF3YkdVdVkyOXRNSUlCb2pBTkJna3Foa2lHOXcwQkFRRUZBQU9DQVk4QQpNSUlCaWdLQ0FZRUFvMHNzdEtYZ01sR0FvV0F6WmxCZVNHMTVJZ0VBRkZwbWFTcnArQ0Y1bGdjTXVSZFNBamlXCk1tS0F5OWlzdy9meTN3YmFWUWNoSWFLZXJvZzVFcnYyR1hlMmZaK0Q2anJpbFp4SG01ZURxZmtxdmQrcXh6K3IKN25Dd1JOS2t0Q093YmJqOWtMSWduQkdUVGZQL1NiVUMxd2R5R3BuYnpwVXo1b3RvbVJRMWlsWi9OZFl2T2UwYworK21zZ2xSUVpNWmNtZVI0RWJhZlNwRTdWT1M2L0srbTZpMzRZMzdmSTBhSUlUV2lVR1RuMzRVMEZhTG9DSTF5CjVNaFhSYUhyQTAyWVBsNmhUMlJFVVlRUTBuNUMxVnpQYm02VHkvUjdoOXI2RnoxQWxPQ0I5NnZtalNPemR2dmsKaHdMcVRqdHArbFNNcW1iRExEV2ZVY2JpVFIwbzliQ3Rxam1aUjQwcXhqa1hieW5hYU42TzFnbm9Fem50a1J3Sgo1cytZaVVtTHpvVFIyV2V1bHc5VVZaZXdiQm85Zk1FSFVRa1RJOEd0aWVjUDhNMGF4R1RSSVFCWUc0bTBYcEF1CmFrd2ZPNlRlZzR2T1FTQmpVanE0Rm1nYkZkVVZsUkZrVm95NXkra3JrV2FpT21hSFlqWHViMkduVWQ1WFBiamgKeG56a1R4UlE3UFh6QWdNQkFBRXdEUVlKS29aSWh2Y05BUUVMQlFBRGdnR0JBRCs5QlExWERXY0pkZ2Jma2ZJeApNa1ZLc3pXRWdvUC9GWWNmcVVEc1drcTNkR3M0Q1Z4ODRzTjNRd0hSY2JkV2trVTd1WXh3VmE0NVZWbVZrZjhmClZGN3ZiblhWWUoydHp5K2lTb0JDcVFjMUNHV1ZwQmdIOGlFVWdYb2hwdTczWjhtSkJhNUhQT1lXTHM5dEVlVTUKdy9VOG9HOUJZRHRsclBGSzZLWkJpYU8veERMQXlFOFRxUEc3U3oxUXJFdC9HbE1wS1RHakFUYXNNQ2hzT0IrMgpuc2xLdExuNXZoS3hOdkRIYjJ4Y1pGZHlOdGQ5Vk9mcFQvNXZ2VE4wb3ozcERJd2RhUkNyTTMwU0tCZVl1OFdGClJPb1NsNUE5dDl3S08vZ0xwcFJ1WW9IdzU4Z1VudWpCOUoyT1oxaUp2YUFLTXZMNGFFbTE4VjVCYkZaUVdPUFkKcWRYZGRnYk80R0VsUFRXdUxFb01HZTM5UnBITmVtMmcrNFdUcjl1K2FkSVN3MnBQbjFRYXhqbzJmb0ZiUUpUcgpXeXR5MnVLU2diU3RzNzEvOUZ4bUIvM3Z6Y21oOUhLdzJWb0FQSzY4ckdhUkhvTjdqZ0dCR3JtdDdHZ01UeGlqCmRuOEt1OHBhRERWSTFldUx6RlJwUlBvdVVwOEVDdmRHTkxoRTJrc0dsdEk3WEE9PQotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg==")
 )
 
-func TestEnsureWebhookConfigurationFor(t *testing.T) {
-	ctx := context.Background()
-	t.Run("ensure a Mutating Webhook CABundles are updated if empty", func(t *testing.T) {
-		client := fake.NewClientBuilder().Build()
-		mwh := &admissionregistrationv1.MutatingWebhookConfiguration{
-			ObjectMeta: metav1.ObjectMeta{
-				Name: DefaultingWebhookName,
-				Labels: map[string]string{
-					"dont-remove-me": "true",
-				},
-			},
-			Webhooks: []admissionregistrationv1.MutatingWebhook{{}, {}},
-		}
-		err := client.Create(ctx, mwh)
-		require.NoError(t, err)
-
-		wc := WebhookConfig{
-			CABundle:         caBundle,
-			ServiceName:      testServiceName,
-			ServiceNamespace: testNamespaceName,
-		}
-		err = EnsureWebhookConfigurationFor(ctx, client, wc, MutatingWebhook)
-		require.NoError(t, err)
-
-		updatedWh := &admissionregistrationv1.MutatingWebhookConfiguration{}
-		err = client.Get(ctx, types.NamespacedName{Name: DefaultingWebhookName}, updatedWh)
-
-		require.NoError(t, err)
-		require.NotNil(t, updatedWh)
-		require.Equal(t, updatedWh.Name, DefaultingWebhookName)
-		require.NotNil(t, updatedWh.Webhooks)
-		require.Contains(t, updatedWh.Labels, "dont-remove-me")
-		require.Len(t, updatedWh.Webhooks, 2)
-		require.Equal(t, wc.CABundle, updatedWh.Webhooks[0].ClientConfig.CABundle)
-		require.Equal(t, wc.CABundle, updatedWh.Webhooks[1].ClientConfig.CABundle)
-	})
-
-	t.Run("ca bundle is already present in mutating webhook's configs", func(t *testing.T) {
-		client := fake.NewClientBuilder().Build()
-		mwh := &admissionregistrationv1.MutatingWebhookConfiguration{
-			ObjectMeta: metav1.ObjectMeta{
-				Name: DefaultingWebhookName,
-				Labels: map[string]string{
-					"dont-remove-me": "true",
-				},
-			},
-			Webhooks: []admissionregistrationv1.MutatingWebhook{
+func TestInjectCABundleIntoMutatingWebhooks(t *testing.T) {
+	testCases := []struct {
+		name     string
+		webhooks []admissionregistrationv1.MutatingWebhook
+	}{
+		{
+			name:     "ensure a Mutating Webhook CABundles are updated if empty",
+			webhooks: []admissionregistrationv1.MutatingWebhook{{}, {}},
+		},
+		{
+			name: "ca bundle is already present in mutating webhook's configs",
+			webhooks: []admissionregistrationv1.MutatingWebhook{
 				{ClientConfig: admissionregistrationv1.WebhookClientConfig{CABundle: caBundle}},
 				{ClientConfig: admissionregistrationv1.WebhookClientConfig{CABundle: caBundle}},
-			}}
-
-		err := client.Create(ctx, mwh)
-		require.NoError(t, err)
-
-		wc := WebhookConfig{
-			CABundle:         caBundle,
-			ServiceName:      testServiceName,
-			ServiceNamespace: testNamespaceName,
-		}
-		err = EnsureWebhookConfigurationFor(ctx, client, wc, MutatingWebhook)
-		require.NoError(t, err)
-
-		updatedWh := &admissionregistrationv1.MutatingWebhookConfiguration{}
-		err = client.Get(ctx, types.NamespacedName{Name: DefaultingWebhookName}, updatedWh)
-
-		require.NoError(t, err)
-		require.NotNil(t, updatedWh)
-		require.Equal(t, updatedWh.Name, DefaultingWebhookName)
-		require.NotNil(t, updatedWh.Webhooks)
-		require.Contains(t, updatedWh.Labels, "dont-remove-me")
-		require.Len(t, updatedWh.Webhooks, 2)
-		require.Equal(t, wc.CABundle, updatedWh.Webhooks[0].ClientConfig.CABundle)
-		require.Equal(t, wc.CABundle, updatedWh.Webhooks[1].ClientConfig.CABundle)
-	})
-
-	t.Run("ensure a Validating Webhook CABundles are updated if empty", func(t *testing.T) {
-		client := fake.NewClientBuilder().Build()
-		vwh := &admissionregistrationv1.ValidatingWebhookConfiguration{
-			ObjectMeta: metav1.ObjectMeta{
-				Name: ValidationWebhookName,
-				Labels: map[string]string{
-					"dont-remove-me": "true",
-				},
 			},
-			Webhooks: []admissionregistrationv1.ValidatingWebhook{{}, {}},
-		}
-		err := client.Create(ctx, vwh)
-		require.NoError(t, err)
-
-		wc := WebhookConfig{
-			CABundle:         caBundle,
-			ServiceName:      testServiceName,
-			ServiceNamespace: testNamespaceName,
-		}
-		err = EnsureWebhookConfigurationFor(ctx, client, wc, ValidatingWebHook)
-		require.NoError(t, err)
-
-		updatedWh := &admissionregistrationv1.ValidatingWebhookConfiguration{}
-		err = client.Get(ctx, types.NamespacedName{Name: ValidationWebhookName}, updatedWh)
-
-		require.NoError(t, err)
-		require.Len(t, updatedWh.Webhooks, 2)
-		require.Equal(t, wc.CABundle, updatedWh.Webhooks[0].ClientConfig.CABundle)
-		require.Equal(t, wc.CABundle, updatedWh.Webhooks[1].ClientConfig.CABundle)
-	})
-
-	t.Run("ca bundle is already present in validation webhook's configs", func(t *testing.T) {
-		client := fake.NewClientBuilder().Build()
-		vwh := &admissionregistrationv1.ValidatingWebhookConfiguration{
-			ObjectMeta: metav1.ObjectMeta{
-				Name: ValidationWebhookName,
-				Labels: map[string]string{
-					"dont-remove-me": "true",
-				},
+		},
+		{
+			name: "ca bundle is different in mutating webhook's configs",
+			webhooks: []admissionregistrationv1.MutatingWebhook{
+				{ClientConfig: admissionregistrationv1.WebhookClientConfig{CABundle: []byte("aaaa")}},
+				{ClientConfig: admissionregistrationv1.WebhookClientConfig{CABundle: []byte("bbbb")}},
 			},
-			Webhooks: []admissionregistrationv1.ValidatingWebhook{{
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			ctx := context.TODO()
+			client := fake.NewClientBuilder().Build()
+			mwh := &admissionregistrationv1.MutatingWebhookConfiguration{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: DefaultingWebhookName,
+					Labels: map[string]string{
+						"dont-remove-me": "true",
+					},
+				},
+				Webhooks: testCase.webhooks,
+			}
+			err := client.Create(ctx, mwh)
+			require.NoError(t, err)
+
+			wc := WebhookConfig{
+				CABundle:         caBundle,
+				ServiceName:      testServiceName,
+				ServiceNamespace: testNamespaceName,
+			}
+			err = InjectCABundleIntoWebhooks(ctx, client, wc, MutatingWebhook)
+			require.NoError(t, err)
+
+			updatedWh := &admissionregistrationv1.MutatingWebhookConfiguration{}
+			err = client.Get(ctx, types.NamespacedName{Name: DefaultingWebhookName}, updatedWh)
+
+			require.NoError(t, err)
+			require.NotNil(t, updatedWh)
+			require.Equal(t, updatedWh.Name, DefaultingWebhookName)
+			require.NotNil(t, updatedWh.Webhooks)
+			require.Contains(t, updatedWh.Labels, "dont-remove-me")
+			require.Len(t, updatedWh.Webhooks, 2)
+			require.Equal(t, wc.CABundle, updatedWh.Webhooks[0].ClientConfig.CABundle)
+			require.Equal(t, wc.CABundle, updatedWh.Webhooks[1].ClientConfig.CABundle)
+		})
+	}
+}
+func TestInjectCABundleIntoValidationWebhooks(t *testing.T) {
+	testCases := []struct {
+		name     string
+		webhooks []admissionregistrationv1.ValidatingWebhook
+	}{
+		{
+			name:     "ensure a Validating Webhook CABundles are updated if empty",
+			webhooks: []admissionregistrationv1.ValidatingWebhook{{}, {}},
+		},
+		{
+			name: "ca bundle is already present in validation webhook's configs",
+			webhooks: []admissionregistrationv1.ValidatingWebhook{{
 				ClientConfig: admissionregistrationv1.WebhookClientConfig{CABundle: caBundle}},
 				{ClientConfig: admissionregistrationv1.WebhookClientConfig{CABundle: caBundle}},
 			},
-		}
-		err := client.Create(ctx, vwh)
-		require.NoError(t, err)
+		},
+		{
+			name: "ca bundle is different in validation webhook's configs",
+			webhooks: []admissionregistrationv1.ValidatingWebhook{{
+				ClientConfig: admissionregistrationv1.WebhookClientConfig{CABundle: []byte("cccc")}},
+				{ClientConfig: admissionregistrationv1.WebhookClientConfig{CABundle: []byte("dddd")}},
+			},
+		},
+	}
 
-		wc := WebhookConfig{
-			CABundle:         caBundle,
-			ServiceName:      testServiceName,
-			ServiceNamespace: testNamespaceName,
-		}
-		err = EnsureWebhookConfigurationFor(ctx, client, wc, ValidatingWebHook)
-		require.NoError(t, err)
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			ctx := context.TODO()
+			client := fake.NewClientBuilder().Build()
+			vwh := &admissionregistrationv1.ValidatingWebhookConfiguration{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: ValidationWebhookName,
+					Labels: map[string]string{
+						"dont-remove-me": "true",
+					},
+				},
+				Webhooks: testCase.webhooks,
+			}
+			err := client.Create(ctx, vwh)
+			require.NoError(t, err)
 
-		updatedWh := &admissionregistrationv1.ValidatingWebhookConfiguration{}
-		err = client.Get(ctx, types.NamespacedName{Name: ValidationWebhookName}, updatedWh)
+			wc := WebhookConfig{
+				CABundle:         caBundle,
+				ServiceName:      testServiceName,
+				ServiceNamespace: testNamespaceName,
+			}
+			err = InjectCABundleIntoWebhooks(ctx, client, wc, ValidatingWebHook)
+			require.NoError(t, err)
 
-		require.NoError(t, err)
-		require.Len(t, updatedWh.Webhooks, 2)
-		require.Equal(t, wc.CABundle, updatedWh.Webhooks[0].ClientConfig.CABundle)
-		require.Equal(t, wc.CABundle, updatedWh.Webhooks[1].ClientConfig.CABundle)
-	})
+			updatedWh := &admissionregistrationv1.ValidatingWebhookConfiguration{}
+			err = client.Get(ctx, types.NamespacedName{Name: ValidationWebhookName}, updatedWh)
+
+			require.NoError(t, err)
+			require.Len(t, updatedWh.Webhooks, 2)
+			require.Equal(t, wc.CABundle, updatedWh.Webhooks[0].ClientConfig.CABundle)
+			require.Equal(t, wc.CABundle, updatedWh.Webhooks[1].ClientConfig.CABundle)
+		})
+	}
 }

--- a/resources/serverless/charts/webhook/templates/webhooks.yaml
+++ b/resources/serverless/charts/webhook/templates/webhooks.yaml
@@ -11,6 +11,8 @@ webhooks:
       service:
         name: {{ template "webhook.fullname" . }}
         namespace: {{ .Release.Namespace }}
+        path:  "/validation/function"
+        port : {{ .Values.service.ports.httpsWebhook.port}}
     failurePolicy: Fail
     sideEffects: None
     matchPolicy: Exact

--- a/resources/serverless/charts/webhook/templates/webhooks.yaml
+++ b/resources/serverless/charts/webhook/templates/webhooks.yaml
@@ -49,6 +49,8 @@ webhooks:
       service:
         name: {{ template "webhook.fullname" . }}
         namespace: {{ .Release.Namespace }}
+        path: /defaulting/registry-config-secrets
+        port: {{ .Values.service.ports.httpsWebhook.port}}
     failurePolicy: Fail
     sideEffects: None
     matchPolicy: Exact
@@ -61,10 +63,23 @@ webhooks:
         operator: NotIn
         values:
         - kube-system
+    rules:
+      - apiGroups:
+          - ""
+        apiVersions:
+          - v1
+        operations:
+          - CREATE
+          - UPDATE
+        resources:
+          - secrets
+        scope: '*'
   - clientConfig:
       service:
         name: {{ template "webhook.fullname" . }}
         namespace: {{ .Release.Namespace }}
+        path: "/defaulting/functions"
+        port: {{ .Values.service.ports.httpsWebhook.port}}
     failurePolicy: Fail
     sideEffects: None
     matchPolicy: Exact

--- a/resources/serverless/charts/webhook/templates/webhooks.yaml
+++ b/resources/serverless/charts/webhook/templates/webhooks.yaml
@@ -23,6 +23,18 @@ webhooks:
         operator: NotIn
         values:
         - kube-system
+    rules:
+      - apiGroups:
+          - serverless.kyma-project.io
+        apiVersions:
+          - v1alpha2
+        operations:
+          - CREATE
+          - UPDATE
+        resources:
+          - functions
+          - functions/status
+        scope: '*'
 ---
 apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingWebhookConfiguration
@@ -63,3 +75,15 @@ webhooks:
         operator: NotIn
         values:
         - kube-system
+    rules:
+      - apiGroups:
+          - serverless.kyma-project.io
+        apiVersions:
+          - v1alpha2
+        operations:
+          - CREATE
+          - UPDATE
+        resources:
+          - functions
+          - functions/status
+        scope: '*'

--- a/resources/serverless/charts/webhook/templates/webhooks.yaml
+++ b/resources/serverless/charts/webhook/templates/webhooks.yaml
@@ -1,4 +1,3 @@
-
 # this stub is created to allow the reconciler to track this/these resource(s). It should not be deleted. The actual content of this resource and managed and reconciled by the function-webhook.
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
@@ -11,20 +10,20 @@ webhooks:
       service:
         name: {{ template "webhook.fullname" . }}
         namespace: {{ .Release.Namespace }}
-        path:  "/validation/function"
-        port : {{ .Values.service.ports.httpsWebhook.port}}
+        path: "/validation/function"
+        port: {{ .Values.service.ports.httpsWebhook.port}}
     failurePolicy: Fail
     sideEffects: None
     matchPolicy: Exact
     timeoutSeconds: 10
-    admissionReviewVersions: ["v1beta1", "v1"]
+    admissionReviewVersions: [ "v1beta1", "v1" ]
     name: validation.webhook.serverless.kyma-project.io
     namespaceSelector:
       matchExpressions:
-      - key: gardener.cloud/purpose
-        operator: NotIn
-        values:
-        - kube-system
+        - key: gardener.cloud/purpose
+          operator: NotIn
+          values:
+            - kube-system
     rules:
       - apiGroups:
           - serverless.kyma-project.io
@@ -45,36 +44,40 @@ metadata:
   labels:
     {{- include "tplValue" ( dict "value" .Values.commonLabels "context" . ) | nindent 4 }}
 webhooks:
-  - clientConfig:
+  - name: mutating.secret.webhook.serverless.kyma-project.io
+    clientConfig:
       service:
         name: {{ template "webhook.fullname" . }}
         namespace: {{ .Release.Namespace }}
-        path: /defaulting/registry-config-secrets
+        path: "/defaulting/registry-config-secrets"
         port: {{ .Values.service.ports.httpsWebhook.port}}
     failurePolicy: Fail
     sideEffects: None
     matchPolicy: Exact
     timeoutSeconds: 10
-    admissionReviewVersions: ["v1beta1", "v1"]
-    name: defaulting.webhook.serverless.kyma-project.io
+    admissionReviewVersions: [ "v1beta1", "v1" ]
+    objectSelector:
+      matchLabels:
+        "serverless.kyma-project.io/remote-registry": "config"
     namespaceSelector:
       matchExpressions:
-      - key: gardener.cloud/purpose
-        operator: NotIn
-        values:
-        - kube-system
+        - key: gardener.cloud/purpose
+          operator: NotIn
+          values:
+            - kube-system
     rules:
       - apiGroups:
           - ""
         apiVersions:
           - v1
+        resources:
+          - secrets
         operations:
           - CREATE
           - UPDATE
-        resources:
-          - secrets
         scope: '*'
-  - clientConfig:
+  - name: defaulting.webhook.serverless.kyma-project.io
+    clientConfig:
       service:
         name: {{ template "webhook.fullname" . }}
         namespace: {{ .Release.Namespace }}
@@ -84,14 +87,13 @@ webhooks:
     sideEffects: None
     matchPolicy: Exact
     timeoutSeconds: 10
-    admissionReviewVersions: ["v1beta1", "v1"]
-    name: mutating.secret.webhook.serverless.kyma-project.io
+    admissionReviewVersions: [ "v1beta1", "v1" ]
     namespaceSelector:
       matchExpressions:
-      - key: gardener.cloud/purpose
-        operator: NotIn
-        values:
-        - kube-system
+        - key: gardener.cloud/purpose
+          operator: NotIn
+          values:
+            - kube-system
     rules:
       - apiGroups:
           - serverless.kyma-project.io

--- a/resources/serverless/charts/webhook/templates/webhooks.yaml
+++ b/resources/serverless/charts/webhook/templates/webhooks.yaml
@@ -6,7 +6,8 @@ metadata:
   labels:
     {{- include "tplValue" ( dict "value" .Values.commonLabels "context" . ) | nindent 4 }}
 webhooks:
-  - clientConfig:
+  - name: validation.webhook.serverless.kyma-project.io
+    clientConfig:
       service:
         name: {{ template "webhook.fullname" . }}
         namespace: {{ .Release.Namespace }}
@@ -17,7 +18,6 @@ webhooks:
     matchPolicy: Exact
     timeoutSeconds: 10
     admissionReviewVersions: [ "v1beta1", "v1" ]
-    name: validation.webhook.serverless.kyma-project.io
     namespaceSelector:
       matchExpressions:
         - key: gardener.cloud/purpose

--- a/resources/serverless/values.yaml
+++ b/resources/serverless/values.yaml
@@ -80,13 +80,13 @@ global:
       directory: "tpi"
     function_controller:
       name: "function-controller"
-      version: "PR-17092"
+      version: "PR-17187"
     function_webhook:
       name: "function-webhook"
-      version: "PR-17092"
+      version: "PR-17187"
     function_build_init:
       name: "function-build-init"
-      version: "PR-17092"
+      version: "PR-17187"
     function_runtime_nodejs14:
       name: "function-runtime-nodejs14"
       version: "v20230302-a6a85f47"


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**
When serverless's CRD and serverless's yaml are applied together, the configuration of webhook is not yes initialized.
To prevent user from applying not defaulted correct function CR, the mutating and validation webhook configuration is fulfilled without CABundle.
Changes proposed in this pull request:

- add configuration for mutating webhook
- add configuration for validating webhook

**Related issue(s)**
[<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->](https://github.com/kyma-project/kyma/issues/17147)
