### PR TITLE
bumps golang runtime in central-application-connectivity-validator due to CVE-2023-24532

### DIFF
--- a/components/central-application-connectivity-validator/Dockerfile
+++ b/components/central-application-connectivity-validator/Dockerfile
@@ -1,4 +1,4 @@
-FROM eu.gcr.io/kyma-project/external/golang:1.20.1-alpine3.17 as builder
+FROM eu.gcr.io/kyma-project/external/golang:1.20.2-alpine3.17 as builder
 
 ARG DOCK_PKG_DIR=/go/src/github.com/kyma-project/kyma/components/central-application-connectivity-validator
 WORKDIR $DOCK_PKG_DIR


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- bumps golang runtime due to CVE-2023-24532
- ...
- ...