### PR TITLE
bumps golang runtime due to CVE-2023-24532 in validator

### DIFF
--- a/resources/application-connector/values.yaml
+++ b/resources/application-connector/values.yaml
@@ -31,7 +31,7 @@ global:
   images:
     central_application_connectivity_validator:
       name: "central-application-connectivity-validator"
-      version: "PR-17200"
+      version: "PR-17240"
     central_application_gateway:
       name: "central-application-gateway"
       version: "PR-17231"


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- bumps golang runtime due to CVE-2023-24532
- ...
- ...