### PR TITLE
bumps golang runtime in central-application-connectivity-validator due to CVE-2023-24532

### DIFF
--- a/components/central-application-connectivity-validator/Dockerfile
+++ b/components/central-application-connectivity-validator/Dockerfile
@@ -1,4 +1,4 @@
-FROM eu.gcr.io/kyma-project/external/golang:1.20.1-alpine3.17 as builder
+FROM eu.gcr.io/kyma-project/external/golang:1.20.2-alpine3.17 as builder
 
 ARG DOCK_PKG_DIR=/go/src/github.com/kyma-project/kyma/components/central-application-connectivity-validator
 WORKDIR $DOCK_PKG_DIR

--- a/resources/application-connector/values.yaml
+++ b/resources/application-connector/values.yaml
@@ -31,7 +31,7 @@ global:
   images:
     central_application_connectivity_validator:
       name: "central-application-connectivity-validator"
-      version: "PR-17200"
+      version: "PR-17245"
     central_application_gateway:
       name: "central-application-gateway"
       version: "PR-17231"

--- a/resources/application-connector/values.yaml
+++ b/resources/application-connector/values.yaml
@@ -31,7 +31,7 @@ global:
   images:
     central_application_connectivity_validator:
       name: "central-application-connectivity-validator"
-      version: "PR-17245"
+      version: "PR-17256"
     central_application_gateway:
       name: "central-application-gateway"
       version: "PR-17231"


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- bumps golang runtime due to CVE-2023-24532
- ...
- ...