### PR TITLE
adjusted namespace in migration script

### DIFF
--- a/docs/assets/2.11-2.12-cleanup-servicemonitors.sh
+++ b/docs/assets/2.11-2.12-cleanup-servicemonitors.sh
@@ -13,6 +13,6 @@ kubectl delete -n kyma-system --ignore-not-found=true servicemonitors.monitoring
 kubectl delete -n kyma-system --ignore-not-found=true servicemonitors.monitoring.coreos.com telemetry-trace-collector
 kubectl delete -n kyma-system --ignore-not-found=true servicemonitors.monitoring.coreos.com tracing-jaeger
 kubectl delete -n kyma-system --ignore-not-found=true servicemonitors.monitoring.coreos.com tracing-jaeger-operator
-kubectl delete -n istio-system --ignore-not-found=true servicemonitors.monitoring.coreos.com istio-component-monitor
+kubectl delete -n kyma-system --ignore-not-found=true servicemonitors.monitoring.coreos.com istio-component-monitor
 
 kubectl delete -n kyma-system --ignore-not-found=true prometheusrules.monitoring.coreos.com logging-loki-kyma-loki.rules


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

With https://github.com/kyma-project/kyma/pull/16805/files#diff-5ff0dd7ad9c43bc63a154aa0147c900175c2f9530fa8ab6d4bf2e542c2cc1b21L9 the servicemonitor of istio got removed. However, the wrong namespace got used in the cleanup script. This PR fixes that.

Changes proposed in this pull request:

- adjust namespacr of istio servicemonitor to the proper namespace
- ...
- ...

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
