### PR TITLE
Fix the subscription migration from v1alpha1 to v1alpha2 if the prefix is not supported

### DIFF
--- a/components/eventing-controller/api/v1alpha1/subscription_conversion_unit_test.go
+++ b/components/eventing-controller/api/v1alpha1/subscription_conversion_unit_test.go
@@ -324,7 +324,9 @@ func Test_CleanupInV1ToV2Conversion(t *testing.T) {
 			givenCleaner: true,
 			givenPrefix:  "prefix",
 			givenAlpha1Sub: newDefaultSubscription(
-				testingv1.WithFilter(eventSource, "invalid.test-app.Segme@@nt1.Segment2.Segment3.Segment4-Part1-Part2-Ä.Segment5-Part1-Part2-Ä.v1"),
+				testingv1.WithFilter(eventSource,
+					"invalid.test-app.Segme@@nt1.Segment2.Segment3.Segment4-Part1-Part2-Ä.Segment5-Part1-Part2-Ä.v1",
+				),
 			),
 			wantTypes: []string{
 				"invalid.test-app.Segme@@nt1.Segment2.Segment3.Segment4-Part1-Part2-Ä.Segment5-Part1-Part2-Ä.v1",
@@ -336,7 +338,9 @@ func Test_CleanupInV1ToV2Conversion(t *testing.T) {
 			givenCleaner: true,
 			givenPrefix:  "prefix",
 			givenAlpha1Sub: newDefaultSubscription(
-				testingv1.WithFilter(eventSource, "test-app.Segme@@nt1.Segment2.Segment3.Segment4-Part1-Part2-Ä.Segment5-Part1-Part2-Ä.v1"),
+				testingv1.WithFilter(eventSource,
+					"test-app.Segme@@nt1.Segment2.Segment3.Segment4-Part1-Part2-Ä.Segment5-Part1-Part2-Ä.v1",
+				),
 			),
 			wantTypes: []string{
 				"test-app.Segme@@nt1.Segment2.Segment3.Segment4-Part1-Part2-Ä.Segment5-Part1-Part2-Ä.v1",

--- a/resources/eventing/values.yaml
+++ b/resources/eventing/values.yaml
@@ -5,7 +5,7 @@ global:
   images:
     eventing_controller:
       name: eventing-controller
-      version: PR-17279
+      version: PR-17291
       pullPolicy: "IfNotPresent"
     publisher_proxy:
       name: event-publisher-proxy


### PR DESCRIPTION
**Description**

Fix the subscription migration from v1alpha1 to v1alpha2 if the prefix is not supported.

**Related issue(s)**

- https://github.com/kyma-project/kyma/issues/17103
