### PR TITLE
added traceparent attribute to default access log format

### DIFF
--- a/docs/01-overview/main-areas/api-exposure/apix-02-useful-links.md
+++ b/docs/01-overview/main-areas/api-exposure/apix-02-useful-links.md
@@ -13,6 +13,7 @@ If you're interested in learning more about API Exposure in Kyma, follow these l
   - [Get a JWT](../../../03-tutorials/00-api-exposure/apix-05-expose-and-secure-a-workload/apix-05-02-get-jwt.md)
   - [Expose and secure a workload with Istio](../../../03-tutorials/00-api-exposure/apix-05-expose-and-secure-a-workload/apix-05-04-expose-and-secure-workload-istio.md)
   - [Expose and secure a workload with JWT](../../../03-tutorials/00-api-exposure/apix-05-expose-and-secure-a-workload/apix-05-03-expose-and-secure-workload-jwt.md)
+  - [Activate access logs](../../../04-operation-guides/operations/obsv-01-access-logs.md)
 
 - Troubleshoot API Exposure-related issues when:
 

--- a/docs/01-overview/main-areas/telemetry/telemetry-03-traces.md
+++ b/docs/01-overview/main-areas/telemetry/telemetry-03-traces.md
@@ -241,7 +241,7 @@ Kyma bundles several modules which are potentially involved in user flows. Appli
 
 ### Istio
 
-The Istio module is a crucial enabler in distributed tracing as it provides [ingress gateway](https://istio.io/latest/docs/tasks/traffic-management/ingress/ingress-control/) where usually external requests enter the cluster scope and are enriched with trace context if it hasn't happened yet. Furthermore, every component being part of the Istio Service Mesh is running an Istio proxy, which propagates the context properly but also creates span data. Having Istio tracing activated and doing trace propagation in your application already ensures that you will get a complete picture of a trace, as every component will automatically contribute span data. Also, Istio tracing is preconfigured to be based on the vendor-neutral [w3c-tracecontext](https://www.w3.org/TR/trace-context/) protocol.
+The Istio module is a crucial enabler in distributed tracing as it provides [ingress gateway](https://istio.io/latest/docs/tasks/traffic-management/ingress/ingress-control/) where usually external requests enter the cluster scope and are enriched with trace context if it hasn't happened yet. Furthermore, every component being part of the Istio Service Mesh is running an Istio proxy, which propagates the context properly but also creates span data. Having Istio tracing activated and doing trace propagation in your application already ensures that you will get a complete picture of a trace, as every component will automatically contribute span data. Also, Istio tracing is pre-configured to be based on the vendor-neutral [w3c-tracecontext](https://www.w3.org/TR/trace-context/) protocol.
 
 >**CAUTION:** The provided Istio feature uses an API in alpha state, which may change in future releases.
 
@@ -294,7 +294,7 @@ spec:
     randomSamplingPercentage: 100.00
 ```
 
-To enable the propagation of the [w3c-tracecontext](https://www.w3.org/TR/trace-context/) only, without reporting any spans ( so having the actual tracing feature disabled), you need to enable the `kyma-traces` provider with a sampling rate of 0. Having that, you will get for example the relevant trace context in to the [access logs](../../../04-operation-guides/operations/obsv-01-access-logs.md) without having any trace reporting active.
+To enable the propagation of the [w3c-tracecontext](https://www.w3.org/TR/trace-context/) only, without reporting any spans (so the actual tracing feature is disabled), you must enable the `kyma-traces` provider with a sampling rate of 0. With this configuration, you get the relevant trace context into the [access logs](../../../04-operation-guides/operations/obsv-01-access-logs.md) without any active trace reporting.
 
 ```yaml
 apiVersion: telemetry.istio.io/v1alpha1

--- a/docs/01-overview/main-areas/telemetry/telemetry-03-traces.md
+++ b/docs/01-overview/main-areas/telemetry/telemetry-03-traces.md
@@ -241,11 +241,11 @@ Kyma bundles several modules which are potentially involved in user flows. Appli
 
 ### Istio
 
-The Istio module is a crucial enabler in distributed tracing as it provides [ingress gateway](https://istio.io/latest/docs/tasks/traffic-management/ingress/ingress-control/) where usually external requests enter the cluster scope and are enriched with trace context if it hasn't happened yet. Furthermore, every component being part of the Istio Service Mesh is running an Istio proxy, which propagates the context properly but also creates span data. Having Istio tracing activated and doing trace propagation in your application already ensures that you will get a complete picture of a trace, as every component will automatically contribute span data.
+The Istio module is a crucial enabler in distributed tracing as it provides [ingress gateway](https://istio.io/latest/docs/tasks/traffic-management/ingress/ingress-control/) where usually external requests enter the cluster scope and are enriched with trace context if it hasn't happened yet. Furthermore, every component being part of the Istio Service Mesh is running an Istio proxy, which propagates the context properly but also creates span data. Having Istio tracing activated and doing trace propagation in your application already ensures that you will get a complete picture of a trace, as every component will automatically contribute span data. Also, Istio tracing is preconfigured to be based on the vendor-neutral [w3c-tracecontext](https://www.w3.org/TR/trace-context/) protocol.
 
 >**CAUTION:** The provided Istio feature uses an API in alpha state, which may change in future releases.
 
-The Istio module is configured with an [extension provider](https://istio.io/latest/docs/tasks/observability/telemetry/) called `kyma-traces`. The provider can be activated on the global mesh label using the Istio [Telemetry API](https://istio.io/latest/docs/reference/config/telemetry/#Tracing) by placing a resource to the istio-system namespace like that:
+The Istio module is configured with an [extension provider](https://istio.io/latest/docs/tasks/observability/telemetry/) called `kyma-traces`. The provider can be activated on the global mesh level using the Istio [Telemetry API](https://istio.io/latest/docs/reference/config/telemetry/#Tracing) by placing a resource to the istio-system namespace like that:
 
 ```yaml
 apiVersion: telemetry.istio.io/v1alpha1
@@ -294,6 +294,20 @@ spec:
     randomSamplingPercentage: 100.00
 ```
 
+To enable the propagation of the [w3c-tracecontext](https://www.w3.org/TR/trace-context/) only, without reporting any spans ( so having the actual tracing feature disabled), you need to enable the `kyma-traces` provider with a sampling rate of 0. Having that, you will get for example the relevant trace context in to the [access logs](../../../04-operation-guides/operations/obsv-01-access-logs.md) without having any trace reporting active.
+
+```yaml
+apiVersion: telemetry.istio.io/v1alpha1
+kind: Telemetry
+metadata:
+  name: tracing-default
+  namespace: istio-system
+spec:
+  tracing:
+  - providers:
+    - name: "kyma-traces"
+    randomSamplingPercentage: 0
+```
 
 ### Eventing
 The Kyma [Eventing](./../../main-areas/eventing/README.md) component dispatches events from an in- or out-cluster backend to your workload. Hereby, it is leveraging the [cloudevents](https://cloudevents.io/) protocol which natively supports the [W3C Trace Context](https://www.w3.org/TR/trace-context) propagation. That said, the Eventing component already propagates trace context properly but does not enrich a trace with more advanced span data.

--- a/docs/04-operation-guides/operations/obsv-03-enable-istio-access-logs.md
+++ b/docs/04-operation-guides/operations/obsv-03-enable-istio-access-logs.md
@@ -12,11 +12,12 @@ The Istio setup shipped with Kyma provides a pre-configured [extension provider]
         logFormat:
           labels:
             # default Istio log format plus relevant entries for trace context
+            ...
             traceparent: "%REQ(TRACEPARENT)%"
             tracestate: "%REQ(TRACESTATE)%"
 
 ```
-The [log format](https://github.com/kyma-project/kyma/blob/main/resources/istio/values.yaml#L62) is based on the Istio default format enhanced with the attributes relevant for identifying the related trace context conform to the [w3c-tracecontext](https://www.w3.org/TR/trace-context/) protocol. See [tracing](./../../01-overview/main-areas/telemetry/telemetry-03-traces.md) for more enable on how to configure tracing in Kyma.
+The [log format](https://github.com/kyma-project/kyma/blob/main/resources/istio/values.yaml#L62) is based on the Istio default format enhanced with the attributes relevant for identifying the related trace context conform to the [w3c-tracecontext](https://www.w3.org/TR/trace-context/) protocol. See [Kyma tracing](./../../01-overview/main-areas/telemetry/telemetry-03-traces.md) for more details on tracing. See [Istio tracing](./../../01-overview/main-areas/telemetry/telemetry-03-traces.md#istio) on how to enable trace context propagation with Istio.
 
 >**CAUTION:** Enabling access logs may drastically increase logs volume and might quickly fill up your log storage. Also, the provided feature uses an API in alpha state, which may change in future releases.
 

--- a/docs/04-operation-guides/operations/obsv-03-enable-istio-access-logs.md
+++ b/docs/04-operation-guides/operations/obsv-03-enable-istio-access-logs.md
@@ -2,7 +2,7 @@
 title: Enable Istio access logs
 ---
 
-You can enable [Istio access logs](https://istio.io/latest/docs/tasks/observability/logs/access-log/) to provide fine-grained details about the access to workloads which are part of the Istio service mesh. This can help in indicating the four “golden signals” of monitoring (latency, traffic, errors, and saturation), and troubleshooting anomalies.
+You can enable [Istio access logs](https://istio.io/latest/docs/tasks/observability/logs/access-log/) to provide fine-grained details about the access to workloads that are part of the Istio service mesh. This can help in indicating the four “golden signals” of monitoring (latency, traffic, errors, and saturation), and troubleshooting anomalies.
 The Istio setup shipped with Kyma provides a pre-configured [extension provider](https://istio.io/latest/docs/tasks/observability/telemetry) for access logs which will configure the istio-proxies to print access logs to stdout using JSON format. It uses a configuration like this:
 ```yaml
   extensionProviders:
@@ -23,7 +23,7 @@ The [log format](https://github.com/kyma-project/kyma/blob/main/resources/istio/
 
 ## Configuration
 
-Istio access logs can be enabled selectively using the Telemetry API. User can enable access logs for the entire namespace, for a selective workload or on Istio gateway scope.
+Istio access logs can be enabled selectively using the Telemetry API. User can enable access logs for the entire Namespace, for a selective workload, or on Istio gateway scope.
 
 ### Configure Istio access logs for the entire Namespace
 
@@ -35,7 +35,7 @@ apiVersion: telemetry.istio.io/v1alpha1
 kind: Telemetry
 metadata:
   name: access-config
-  namespace: istio-system
+  namespace: {YOUR_NAMESPACE}
 spec:
   accessLogging:
     - providers:
@@ -62,7 +62,7 @@ spec:
 
 ### Configure Istio access logs for a specific gateway
 
-Instead of enabling the access logs for all the individual proxies of the workloads you have, you could instead enable the logs for the proxy used by the related Istio ingress gateway.
+Instead of enabling the access logs for all the individual proxies of the workloads you have, you can enable the logs for the proxy used by the related Istio ingress gateway:
 
 ```yaml
 apiVersion: telemetry.istio.io/v1alpha1

--- a/docs/04-operation-guides/operations/obsv-03-enable-istio-access-logs.md
+++ b/docs/04-operation-guides/operations/obsv-03-enable-istio-access-logs.md
@@ -58,6 +58,9 @@ spec:
   selector:
     matchLabels:
       service.istio.io/canonical-name: {YOUR_LABEL}
+  accessLogging:
+    - providers:
+      - name: stdout-json
 ```
 
 ### Configure Istio access logs for a specific gateway
@@ -74,4 +77,7 @@ spec:
   selector:
     matchLabels:
       istio: ingressgateway
+  accessLogging:
+    - providers:
+      - name: stdout-json
 ```

--- a/resources/istio/values.yaml
+++ b/resources/istio/values.yaml
@@ -38,12 +38,17 @@ helmValues:
     rewriteAppHTTPProbe: true
 
 meshConfig:
-  accessLogFile: /dev/stdout
+  accessLogFile: ""
   accessLogEncoding: JSON
   trustDomain: cluster.local
   defaultProviders:
     tracing: []
   defaultConfig:
+    tracing:
+      openCensusAgent:
+        address: dns:telemetry-trace-collector-internal.kyma-system.svc.cluster.local:55678
+        context:
+          - W3C_TRACE_CONTEXT
     holdApplicationUntilProxyStarts: true
   enablePrometheusMerge: false
   enableTracing: "{{ .Values.global.tracing.enabled }}"
@@ -63,7 +68,33 @@ meshConfig:
       envoyFileAccessLog:
         path: "/dev/stdout"
         logFormat:
-          labels: {}
+          labels:
+            start_time: "%START_TIME%"
+            method: "%REQ(:METHOD)%"
+            path: "%REQ(X-ENVOY-ORIGINAL-PATH?:PATH)%"
+            protocol: "%PROTOCOL%"
+            response_code: "%RESPONSE_CODE%"
+            response_flags: "%RESPONSE_FLAGS%"
+            response_code_details: "%RESPONSE_CODE_DETAILS%"
+            connection_termination_details: "%CONNECTION_TERMINATION_DETAILS%"
+            upstream_transport_failure_reason: "%CONNECTION_TERMINATION_DETAILS%"
+            bytes_received: "%BYTES_RECEIVED%"
+            bytes_sent: "%BYTES_SENT%"
+            duration: "%DURATION%"
+            upstream_service_time: "%RESP(X-ENVOY-UPSTREAM-SERVICE-TIME)%"
+            x_forwarded_for: "%REQ(X-FORWARDED-FOR)%"
+            user_agent: "%REQ(USER-AGENT)%"
+            request_id: "%REQ(X-REQUEST-ID)%"
+            authority: "%REQ(:AUTHORITY)%"
+            upstream_host: "%UPSTREAM_HOST%"
+            upstream_cluster: "%UPSTREAM_CLUSTER%"
+            upstream_local_address: "%UPSTREAM_LOCAL_ADDRESS%"
+            downstream_local_address: "%DOWNSTREAM_LOCAL_ADDRESS%"
+            downstream_remote_address: "%DOWNSTREAM_REMOTE_ADDRESS%"
+            requested_server_name: "%REQUESTED_SERVER_NAME%"
+            route_name: "%ROUTE_NAME%"
+            traceparent: "%REQ(TRACEPARENT)%"
+            tracestate: "%REQ(TRACESTATE)%"
 
 components:
   cni:

--- a/resources/istio/values.yaml
+++ b/resources/istio/values.yaml
@@ -38,17 +38,12 @@ helmValues:
     rewriteAppHTTPProbe: true
 
 meshConfig:
-  accessLogFile: ""
+  accessLogFile: /dev/stdout
   accessLogEncoding: JSON
   trustDomain: cluster.local
   defaultProviders:
     tracing: []
   defaultConfig:
-    tracing:
-      openCensusAgent:
-        address: dns:telemetry-trace-collector-internal.kyma-system.svc.cluster.local:55678
-        context:
-          - W3C_TRACE_CONTEXT
     holdApplicationUntilProxyStarts: true
   enablePrometheusMerge: false
   enableTracing: "{{ .Values.global.tracing.enabled }}"


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

With the kyma [tracing](https://kyma-project.io/docs/kyma/latest/01-overview/main-areas/telemetry/telemetry-03-traces/) feature, the w3c-tracecontext protocol is promoted as the only protocol to use. All kyma components will support it and especially istio is configured to use it.
However, the access logs (if enabled) are not providing the trace context data and a correlation will not be possible. Also, by default, istio does not enrich requests with the proper trace context; you actively need to enable that. 

Changes proposed in this pull request:

- Enhance the default log format with trace context
- Add documentation on how to enable access logs on ingress gateway level
- Improve istio tracing documentation on how to activate propagation without active span reporting
- Add link to gateway docu on how to enable access logs

Implementation details:
There seems to be no way to take the default format and enhance it without re-specifying it. So I reverse-engineered the proper configuration by using actual access logs and combining them with the documentation [here](https://istio.io/latest/docs/tasks/observability/logs/access-log/). Indeed, the documentation seems up-to-date, a full mapping was possible. Also, I verified the new output.

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
