### PR TITLE
consolidate access logging in istio profiles

### DIFF
--- a/resources/istio/profile-evaluation.yaml
+++ b/resources/istio/profile-evaluation.yaml
@@ -1,6 +1,4 @@
 ---
-meshConfig:
-  accessLogFile: ""
 
 helmValues:
   global:

--- a/resources/istio/profile-production.yaml
+++ b/resources/istio/profile-production.yaml
@@ -1,6 +1,4 @@
 ---
-meshConfig:
-  accessLogFile: ""
 
 helmValues:
   global:

--- a/resources/istio/values.yaml
+++ b/resources/istio/values.yaml
@@ -38,15 +38,13 @@ helmValues:
     rewriteAppHTTPProbe: true
 
 meshConfig:
-  accessLogFile: /dev/stdout
-  accessLogEncoding: JSON
   trustDomain: cluster.local
   defaultProviders:
     tracing: []
   defaultConfig:
     holdApplicationUntilProxyStarts: true
   enablePrometheusMerge: false
-  enableTracing: "{{ .Values.global.tracing.enabled }}"
+  enableTracing: false
   extensionProviders:
     - name: kyma-traces
       opencensus:
@@ -165,7 +163,6 @@ global:
       version: "1.17.1-distroless"
       directory: "external/istio"
       containerRegistryPath: "eu.gcr.io/kyma-project"
-  tracing:
-    enabled: true
+
   # This configuration is only temporary and will be removed in kyma version 2.7.x.
   sidecarMigration: false


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Access logs for istio are disabled in evaluation and production profile and should be enabled individually via telemetry API, in default profile they are enabled via the old API not being clear on the effect of using new telemetry API.

This PR is consolidating the approach by not configuring access logging via the old meshconfig API at all and only supports individual enablement via the telemetry API.


Changes proposed in this pull request:

- disable access logs by default
- remove custom settings for evaluation and production profile as it will be the same as in the default
- removed unused variable for tracing as it has no effect (will be overruled by telemetry API always)

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
