### PR TITLE
istio access log test is flaky

### DIFF
--- a/tests/fast-integration/logging/index.js
+++ b/tests/fast-integration/logging/index.js
@@ -5,7 +5,12 @@ module.exports = {
 };
 
 const loki = require('./loki');
-const {k8sApply, k8sDelete, sleep} = require('../utils');
+const {
+  k8sApply,
+  k8sDelete,
+  sleep,
+  waitForService,
+} = require('../utils');
 const fs = require('fs');
 const path = require('path');
 const k8s = require('@kubernetes/client-node');
@@ -45,6 +50,7 @@ function istioAccessLogsTests(startTimestamp) {
     it('Should create the Istio Access Logs resource for Loki', async () => {
       await k8sApply(istioAccessLogsResource, namespace);
       await sleep(20000);
+      waitForService('telemetry-trace-collector-internal', 'kyma-system');
     });
 
     it('Should query Loki and verify format of Istio Access Logs', async () => {

--- a/tests/fast-integration/logging/loki.js
+++ b/tests/fast-integration/logging/loki.js
@@ -87,7 +87,7 @@ async function verifyIstioAccessLogFormat(startTimestamp) {
   verifyLogAttributeIsPresent('upstream_local_address', log);
   verifyLogAttributeIsPresent('downstream_local_address', log);
   verifyLogAttributeIsPresent('downstream_remote_address', log);
-  verifyLogAttributeIsPresent('requested_server_name'), log;
+  verifyLogAttributeIsPresent('requested_server_name', log);
   verifyLogAttributeIsPresent('route_name', log);
   verifyLogAttributeIsPresent('traceparent', log);
   verifyLogAttributeIsPresent('tracestate', log);

--- a/tests/fast-integration/logging/loki.js
+++ b/tests/fast-integration/logging/loki.js
@@ -66,9 +66,33 @@ async function verifyIstioAccessLogFormat(startTimestamp) {
   const entry = JSON.parse(responseBody.data.result[0].values[0][1]);
   const log = parseJson(entry.log);
   assert.isDefined(log, `Istio access log is not in JSON format: ${entry.log}`);
-  assert.isDefined(log['response_code'], `Istio access log does not have 'response_code' field: ${log}`);
-  assert.isDefined(log['bytes_received'], `Istio access log does not have 'bytes_received' field: ${log}`);
-  assert.isDefined(log['bytes_sent'], `Istio access log does not have 'bytes_sent' field: ${log}`);
-  assert.isDefined(log['duration'], `Istio access log does not have 'duration' field: ${log}`);
-  assert.isDefined(log['start_time'], `Istio access log does not have 'start_time' field: ${log}`);
+  verifyLogAttributeIsPresent('method', log);
+  verifyLogAttributeIsPresent('path', log);
+  verifyLogAttributeIsPresent('protocol', log);
+  verifyLogAttributeIsPresent('response_code', log);
+  verifyLogAttributeIsPresent('response_flags', log);
+  verifyLogAttributeIsPresent('response_code_details', log);
+  verifyLogAttributeIsPresent('connection_termination_details', log);
+  verifyLogAttributeIsPresent('upstream_transport_failure_reason', log);
+  verifyLogAttributeIsPresent('bytes_received', log);
+  verifyLogAttributeIsPresent('bytes_sent', log);
+  verifyLogAttributeIsPresent('duration', log);
+  verifyLogAttributeIsPresent('upstream_service_time', log);
+  verifyLogAttributeIsPresent('x_forwarded_for', log);
+  verifyLogAttributeIsPresent('user_agent', log);
+  verifyLogAttributeIsPresent('request_id', log);
+  verifyLogAttributeIsPresent('authority', log);
+  verifyLogAttributeIsPresent('upstream_host', log);
+  verifyLogAttributeIsPresent('upstream_cluster', log);
+  verifyLogAttributeIsPresent('upstream_local_address', log);
+  verifyLogAttributeIsPresent('downstream_local_address', log);
+  verifyLogAttributeIsPresent('downstream_remote_address', log);
+  verifyLogAttributeIsPresent('requested_server_name'), log;
+  verifyLogAttributeIsPresent('route_name', log);
+  verifyLogAttributeIsPresent('traceparent', log);
+  verifyLogAttributeIsPresent('tracestate', log);
+}
+
+function verifyLogAttributeIsPresent(attribute, logBody) {
+  assert.isDefined(logBody[attribute], `Istio access log does not have '${attribute}' field: ${logBody}`);
 }

--- a/tests/fast-integration/utils/index.js
+++ b/tests/fast-integration/utils/index.js
@@ -555,6 +555,21 @@ function waitForDeployment(name, namespace = 'default', timeout = 90_000) {
   );
 }
 
+function waitForService(name, namespace = 'default', timeout = 90_000) {
+  return waitForK8sObject(
+      `/apis/apps/v1/namespaces/${namespace}/service`,
+      {},
+      (_type, _apiObj, watchObj) => {
+        return (
+          watchObj.object.metadata.name === name &&
+          watchObj.object.clusterIP
+        );
+      },
+      timeout,
+      `Waiting for service ${name} timeout (${timeout} ms)`,
+  );
+}
+
 function waitForStatefulSet(name, namespace = 'default', timeout = 90_000) {
   return waitForK8sObject(
       `/apis/apps/v1/namespaces/${namespace}/statefulsets`,
@@ -1848,6 +1863,7 @@ module.exports = {
   waitForClusterAddonsConfiguration,
   waitForVirtualService,
   waitForDeployment,
+  waitForService,
   waitForDaemonSet,
   waitForStatefulSet,
   waitForTokenRequest,


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

The istio-proxy prints access logs to stdout and these logs are getting validated by the test case. However, if there is an error log in the proxy, the test case might pick it up. A typical error log was errors when sending traces as the trace backend is not ready yet. So I added a wait for the related service to improve the situation. Also I extended the attribute verification in the test to assure compatibility

Changes proposed in this pull request:

- added a wait for the internal tracing service
- added verification of all expected access log attributes
- ...

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
https://github.com/kyma-project/kyma/pull/17305
https://github.com/kyma-project/kyma/pull/17304