### PR TITLE
fixed links to access logs page

### DIFF
--- a/docs/01-overview/main-areas/api-exposure/apix-02-useful-links.md
+++ b/docs/01-overview/main-areas/api-exposure/apix-02-useful-links.md
@@ -13,7 +13,7 @@ If you're interested in learning more about API Exposure in Kyma, follow these l
   - [Get a JWT](../../../03-tutorials/00-api-exposure/apix-05-expose-and-secure-a-workload/apix-05-02-get-jwt.md)
   - [Expose and secure a workload with Istio](../../../03-tutorials/00-api-exposure/apix-05-expose-and-secure-a-workload/apix-05-04-expose-and-secure-workload-istio.md)
   - [Expose and secure a workload with JWT](../../../03-tutorials/00-api-exposure/apix-05-expose-and-secure-a-workload/apix-05-03-expose-and-secure-workload-jwt.md)
-  - [Activate access logs](../../../04-operation-guides/operations/obsv-01-access-logs.md)
+  - [Activate access logs](../../../04-operation-guides/operations/obsv-03-enable-istio-access-logs.md)
 
 - Troubleshoot API Exposure-related issues when:
 

--- a/docs/01-overview/main-areas/telemetry/telemetry-03-traces.md
+++ b/docs/01-overview/main-areas/telemetry/telemetry-03-traces.md
@@ -294,7 +294,7 @@ spec:
     randomSamplingPercentage: 100.00
 ```
 
-To enable the propagation of the [w3c-tracecontext](https://www.w3.org/TR/trace-context/) only, without reporting any spans (so the actual tracing feature is disabled), you must enable the `kyma-traces` provider with a sampling rate of 0. With this configuration, you get the relevant trace context into the [access logs](../../../04-operation-guides/operations/obsv-01-access-logs.md) without any active trace reporting.
+To enable the propagation of the [w3c-tracecontext](https://www.w3.org/TR/trace-context/) only, without reporting any spans (so the actual tracing feature is disabled), you must enable the `kyma-traces` provider with a sampling rate of 0. With this configuration, you get the relevant trace context into the [access logs](../../../04-operation-guides/operations/obsv-03-enable-istio-access-logs.md) without any active trace reporting.
 
 ```yaml
 apiVersion: telemetry.istio.io/v1alpha1


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

With https://github.com/kyma-project/kyma/pull/17304 more links to the access logs docu were added. Unfortunately the wrong page got linked.

Changes proposed in this pull request:

- fixed links to the access logs page
- ...
- ...

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
