### PR TITLE
bumps golang to 1.20.3 in application-connectivity modules

### DIFF
--- a/components/central-application-connectivity-validator/Dockerfile
+++ b/components/central-application-connectivity-validator/Dockerfile
@@ -1,4 +1,4 @@
-FROM eu.gcr.io/kyma-project/external/golang:1.20.2-alpine3.17 as builder
+FROM eu.gcr.io/kyma-project/external/golang:1.20.3-alpine3.17 as builder
 
 ARG DOCK_PKG_DIR=/go/src/github.com/kyma-project/kyma/components/central-application-connectivity-validator
 WORKDIR $DOCK_PKG_DIR

--- a/components/central-application-gateway/Dockerfile
+++ b/components/central-application-gateway/Dockerfile
@@ -1,4 +1,4 @@
-FROM eu.gcr.io/kyma-project/external/golang:1.20.2-alpine3.17 as builder
+FROM eu.gcr.io/kyma-project/external/golang:1.20.3-alpine3.17 as builder
 
 ARG DOCK_PKG_DIR=/go/src/github.com/kyma-project/kyma/components/central-application-gateway
 WORKDIR $DOCK_PKG_DIR

--- a/components/compass-runtime-agent/Dockerfile
+++ b/components/compass-runtime-agent/Dockerfile
@@ -1,4 +1,4 @@
-FROM eu.gcr.io/kyma-project/external/golang:1.20.2-alpine3.17 as builder
+FROM eu.gcr.io/kyma-project/external/golang:1.20.3-alpine3.17 as builder
 
 ARG DOCK_PKG_DIR=/compass-runtime-agent
 WORKDIR $DOCK_PKG_DIR

--- a/resources/application-connector/values.yaml
+++ b/resources/application-connector/values.yaml
@@ -31,10 +31,10 @@ global:
   images:
     central_application_connectivity_validator:
       name: "central-application-connectivity-validator"
-      version: "v20230407-c4254253"
+      version: "PR-17343"
     central_application_gateway:
       name: "central-application-gateway"
-      version: "v20230404-a2cf56f6"
+      version: "PR-17343"
     busybox:
       name: "busybox"
       version: "1.34.1"

--- a/resources/compass-runtime-agent/values.yaml
+++ b/resources/compass-runtime-agent/values.yaml
@@ -5,7 +5,7 @@ global:
   images:
     compass_runtime_agent:
       name: "compass-runtime-agent"
-      version: "v20230404-5b35513e"
+      version: "PR-17343"
   istio:
     gateway:
       name: kyma-gateway


### PR DESCRIPTION
**Description**

aims to fix multiple CVEs

Changes proposed in this pull request:

- bumps golang to 1.20.3 in application-connectivity modules
- ...
- ...

bump to the final image will be done in a separate PR