### PR TITLE
bumps golang to 1.20.3 in application-connectivity modules for release-2.13

### DIFF
--- a/components/central-application-connectivity-validator/Dockerfile
+++ b/components/central-application-connectivity-validator/Dockerfile
@@ -1,4 +1,4 @@
-FROM eu.gcr.io/kyma-project/external/golang:1.20.2-alpine3.17 as builder
+FROM eu.gcr.io/kyma-project/external/golang:1.20.3-alpine3.17 as builder
 
 ARG DOCK_PKG_DIR=/go/src/github.com/kyma-project/kyma/components/central-application-connectivity-validator
 WORKDIR $DOCK_PKG_DIR

--- a/components/central-application-gateway/Dockerfile
+++ b/components/central-application-gateway/Dockerfile
@@ -1,4 +1,4 @@
-FROM eu.gcr.io/kyma-project/external/golang:1.20.2-alpine3.17 as builder
+FROM eu.gcr.io/kyma-project/external/golang:1.20.3-alpine3.17 as builder
 
 ARG DOCK_PKG_DIR=/go/src/github.com/kyma-project/kyma/components/central-application-gateway
 WORKDIR $DOCK_PKG_DIR

--- a/components/compass-runtime-agent/Dockerfile
+++ b/components/compass-runtime-agent/Dockerfile
@@ -1,4 +1,4 @@
-FROM eu.gcr.io/kyma-project/external/golang:1.20.2-alpine3.17 as builder
+FROM eu.gcr.io/kyma-project/external/golang:1.20.3-alpine3.17 as builder
 
 ARG DOCK_PKG_DIR=/compass-runtime-agent
 WORKDIR $DOCK_PKG_DIR


### PR DESCRIPTION
**Description**

aims to fix multiple CVEs

Changes proposed in this pull request:

- bumps golang to 1.20.3 in application-connectivity modules for release-2.13
- ...
- ...

bump to the final image will be done in a separate PR