### PR TITLE
switch prometheus pushgateway to upstream docker image

### DIFF
--- a/resources/monitoring/charts/prometheus-pushgateway/templates/deployment.yaml
+++ b/resources/monitoring/charts/prometheus-pushgateway/templates/deployment.yaml
@@ -30,7 +30,7 @@ spec:
     {{- end }}
       containers:
         - name: pushgateway
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          image: "{{ .Values.upstream.image.repository }}:{{ .Values.upstream.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
         {{- if .Values.extraVars }}
           env:

--- a/resources/monitoring/charts/prometheus-pushgateway/templates/deployment.yaml
+++ b/resources/monitoring/charts/prometheus-pushgateway/templates/deployment.yaml
@@ -30,7 +30,7 @@ spec:
     {{- end }}
       containers:
         - name: pushgateway
-          image: "{{ include "imageurl" (dict "reg" .Values.global.containerRegistry "img" .Values.global.images.pushgateway) }}"
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
         {{- if .Values.extraVars }}
           env:

--- a/resources/monitoring/charts/prometheus-pushgateway/values.yaml
+++ b/resources/monitoring/charts/prometheus-pushgateway/values.yaml
@@ -8,10 +8,11 @@ nameOverride: ""
 # Provide a name to substitute for the full names of resources
 fullnameOverride: ""
 
-image:
-  repository: prom/pushgateway
-  tag: v1.4.3
-  pullPolicy: IfNotPresent
+upstream:
+  image:
+    repository: prom/pushgateway
+    tag: v1.4.3
+    pullPolicy: IfNotPresent
 
 # Optional pod imagePullSecrets
 imagePullSecrets: []

--- a/resources/monitoring/charts/prometheus-pushgateway/values.yaml
+++ b/resources/monitoring/charts/prometheus-pushgateway/values.yaml
@@ -8,11 +8,10 @@ nameOverride: ""
 # Provide a name to substitute for the full names of resources
 fullnameOverride: ""
 
-upstream:
-  image:
-    repository: prom/pushgateway
-    tag: v1.4.3
-    pullPolicy: IfNotPresent
+image:
+  repository: prom/pushgateway
+  tag: v1.4.3
+  pullPolicy: IfNotPresent
 
 # Optional pod imagePullSecrets
 imagePullSecrets: []

--- a/resources/monitoring/charts/prometheus-pushgateway/values.yaml
+++ b/resources/monitoring/charts/prometheus-pushgateway/values.yaml
@@ -9,6 +9,8 @@ nameOverride: ""
 fullnameOverride: ""
 
 image:
+  repository: prom/pushgateway
+  tag: v1.4.3
   pullPolicy: IfNotPresent
 
 # Optional pod imagePullSecrets

--- a/resources/monitoring/values.yaml
+++ b/resources/monitoring/values.yaml
@@ -135,10 +135,6 @@ global:
       version: "v2.40.7"
       directory: "prod/external/quay.io/prometheus"
       sha: ""
-    pushgateway:
-      name: "pushgateway"
-      version: v1.4.3
-      directory: "prod/external/prom"
     node_exporter:
       name: "node-exporter"
       version: "1.5.0-945764ea"


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**
The prometheus-pushgateway is provided by a sub-chart of the monitoring component. The gateway was never enabled by default and not really maintained actively, especially the image is not maintained by the kyma team actively. That should be made transparent by not serving it anymore by the kyma specific registry.

Changes proposed in this pull request:

- switch the image used by the disabled pushgateway chart to use the upstream image directly
- ...
- ...

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
