### PR TITLE
disabling Prometheus operator reconcilation on monitoring-system

### DIFF
--- a/resources/monitoring/values.yaml
+++ b/resources/monitoring/values.yaml
@@ -1781,7 +1781,7 @@ prometheusOperator:
 
   ## Namespaces not to scope the interaction of the Prometheus Operator (deny list).
   ##
-  denyNamespaces: []
+  denyNamespaces: "monitoring-system"
 
   ## Filter namespaces to look for prometheus-operator custom resources
   ##


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Kyma's Prometheus operator configured to deny reconciling the monitoring-system namespace. This is done in order to refactor of deployment of Prometheus stack  

**Related issue(s)**
https://github.tools.sap/kyma/backlog/issues/3736