### PR TITLE
Bump images for golang.org/x/net to 0.7 in application-connectivity in 2.12

### DIFF
--- a/resources/application-connector/values.yaml
+++ b/resources/application-connector/values.yaml
@@ -31,10 +31,10 @@ global:
   images:
     central_application_connectivity_validator:
       name: "central-application-connectivity-validator"
-      version: "v20230419-a64fd498"
+      version: "v20230421-9affdff4"
     central_application_gateway:
       name: "central-application-gateway"
-      version: "v20230419-a64fd498"
+      version: "v20230421-9affdff4"
     busybox:
       name: "busybox"
       version: "1.34.1"

--- a/resources/compass-runtime-agent/values.yaml
+++ b/resources/compass-runtime-agent/values.yaml
@@ -5,7 +5,7 @@ global:
   images:
     compass_runtime_agent:
       name: "compass-runtime-agent"
-      version: "v20230419-a64fd498"
+      version: "v20230421-9affdff4"
   istio:
     gateway:
       name: kyma-gateway


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- bumps images for fixes in https://github.com/kyma-project/kyma/pull/17364
- ...
- ...

**Related issue(s)**
https://github.com/kyma-project/kyma/pull/17364