### PR TITLE
bumps images for the fix of golang.org/x/net-v0.5.0:CVE-2022-41723 in 2.13

### DIFF
--- a/resources/application-connector/values.yaml
+++ b/resources/application-connector/values.yaml
@@ -34,7 +34,7 @@ global:
       version: "v20230419-808991fb"
     central_application_gateway:
       name: "central-application-gateway"
-      version: "v20230419-808991fb"
+      version: "v20230426-690d6f45"
     busybox:
       name: "busybox"
       version: "1.34.1"

--- a/resources/compass-runtime-agent/values.yaml
+++ b/resources/compass-runtime-agent/values.yaml
@@ -5,7 +5,7 @@ global:
   images:
     compass_runtime_agent:
       name: "compass-runtime-agent"
-      version: "v20230419-808991fb"
+      version: "v20230426-690d6f45"
   istio:
     gateway:
       name: kyma-gateway


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- bumps images for the fix of golang.org/x/net-v0.5.0:CVE-2022-41723
- ...
- ...

**Related issue(s)**
- https://github.com/kyma-project/kyma/pull/17385/files