### PR TITLE
Bump telemetry-operator image to support multiple pipelines

### DIFF
--- a/resources/telemetry/charts/operator/templates/deployment.yaml
+++ b/resources/telemetry/charts/operator/templates/deployment.yaml
@@ -44,6 +44,8 @@ spec:
             - --fluent-bit-exporter-image={{ include "imageurl" (dict "reg" .Values.global.containerRegistry "img" .Values.global.images.directory_size_exporter) }}
             - --validating-webhook-enabled={{ .Values.webhook.enabled }}
             - --enable-telemetry-manager-module=false
+            - --trace-collector-pipelines=1
+            - --metric-gateway-pipelines=1
 {{- if or .Values.priorityClassName .Values.global.highPriorityClassName }}
             - --fluent-bit-priority-class-name={{ coalesce .Values.priorityClassName .Values.global.highPriorityClassName }}
 {{- end }}

--- a/resources/telemetry/values.yaml
+++ b/resources/telemetry/values.yaml
@@ -8,8 +8,8 @@ global:
       directory: "prod"
     telemetry_operator:
       name: "telemetry-manager"
-      version: "v20230428-c64807e3"
-      directory: "prod"
+      version: "PR-146"
+      directory: "dev"
     telemetry_otel_collector:
       name: "otel-collector"
       version: "0.75.0-6ea7fe7a"

--- a/resources/telemetry/values.yaml
+++ b/resources/telemetry/values.yaml
@@ -8,8 +8,8 @@ global:
       directory: "prod"
     telemetry_operator:
       name: "telemetry-manager"
-      version: "PR-146"
-      directory: "dev"
+      version: "v20230509-cfd6f4a7"
+      directory: "prod"
     telemetry_otel_collector:
       name: "otel-collector"
       version: "0.75.0-6ea7fe7a"

--- a/tests/fast-integration/telemetry-test/suite.js
+++ b/tests/fast-integration/telemetry-test/suite.js
@@ -15,7 +15,8 @@ const {
   getGateway,
   getVirtualService,
   retryPromise,
-  deployJaeger, waitForConfigMap,
+  deployJaeger,
+  waitForConfigMap,
 } = require('../utils');
 const {
   logsPresentInLoki,

--- a/tests/fast-integration/telemetry-test/suite.js
+++ b/tests/fast-integration/telemetry-test/suite.js
@@ -15,7 +15,7 @@ const {
   getGateway,
   getVirtualService,
   retryPromise,
-  deployJaeger,
+  deployJaeger, waitForConfigMap,
 } = require('../utils');
 const {
   logsPresentInLoki,
@@ -386,7 +386,7 @@ describe('Telemetry Operator', function() {
 
         it('Should have created telemetry-trace-collector secret', async () => {
           const secret = await getSecret('telemetry-trace-collector', 'kyma-system');
-          assert.equal(secret.data.OTLP_ENDPOINT, 'aHR0cDovL25vLWVuZHBvaW50');
+          assert.equal(secret.data.OTLP_ENDPOINT_OTLP_OUTPUT_ENDPOINT_SECRET_REF_1, 'aHR0cDovL25vLWVuZHBvaW50');
         });
 
         it(`Should reflect secret ref change in telemetry-trace-collector secret and pod restart`, async function() {
@@ -403,7 +403,7 @@ describe('Telemetry Operator', function() {
           await k8sApply(loadTestData('secret-patched-trace-endpoint.yaml'), 'default');
           await sleep(5*1000);
           const secret = await getSecret('telemetry-trace-collector', 'kyma-system');
-          assert.equal(secret.data.OTLP_ENDPOINT, 'aHR0cDovL2Fub3RoZXItZW5kcG9pbnQ=');
+          assert.equal(secret.data.OTLP_ENDPOINT_OTLP_OUTPUT_ENDPOINT_SECRET_REF_1, 'aHR0cDovL2Fub3RoZXItZW5kcG9pbnQ=');
 
           const newPodRes = await k8sCoreV1Api.listNamespacedPod(
               'kyma-system',
@@ -458,11 +458,12 @@ describe('Telemetry Operator', function() {
 
         it('Should have created telemetry-trace-collector secret', async () => {
           const secret = await getSecret('telemetry-trace-collector', 'kyma-system');
-          assert.equal(fromBase64(secret.data.OTLP_ENDPOINT), 'http://foo-bar');
+          assert.equal(fromBase64(secret.data.OTLP_ENDPOINT_TEST_TRACE), 'http://foo-bar');
         });
 
         it(`Should create override configmap with paused flag`, async function() {
           await k8sApply(overrideConfig);
+          await waitForConfigMap('telemetry-override-config', 'kyma-system');
         });
 
         it(`Tries to change the otlp endpoint`, async function() {
@@ -473,7 +474,7 @@ describe('Telemetry Operator', function() {
         it(`Should not change the OTLP endpoint in the telemetry-trace-collector secret in paused state`, async () => {
           await sleep(5*1000);
           const secret = await getSecret('telemetry-trace-collector', 'kyma-system');
-          assert.equal(fromBase64(secret.data.OTLP_ENDPOINT), 'http://foo-bar');
+          assert.equal(fromBase64(secret.data.OTLP_ENDPOINT_TEST_TRACE), 'http://foo-bar');
         });
 
         it(`Deletes the override configmap`, async function() {
@@ -491,7 +492,7 @@ describe('Telemetry Operator', function() {
         it(`Should now change the OTLP endpoint in the telemetry-trace-collector secret`, async function() {
           await sleep(5*1000);
           const secret = await getSecret('telemetry-trace-collector', 'kyma-system');
-          assert.equal(fromBase64(secret.data.OTLP_ENDPOINT), 'http://another-foo-bar');
+          assert.equal(fromBase64(secret.data.OTLP_ENDPOINT_TEST_TRACE), 'http://another-foo-bar');
         });
 
         it(`Should delete TracePipeline`, async function() {


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Add changes from https://github.com/kyma-project/telemetry-manager/pull/146 and https://github.com/kyma-project/telemetry-manager/pull/140. The new telemetry-operator version contains support for multiple Trace- and MetricPipeliens. Since no proper resource requests and limits for more than one pipeline are applied yet, the telemetry chart still limits the number of pipelines to 1.

Changes proposed in this pull request:

- Update telemetry-operator image
- Add limitations for the number of pipelines
- Adjust telemetry fast-integration test to new Secret keys

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
https://github.com/kyma-project/kyma/issues/17234