### PR TITLE
Bump gce-proxy image version to 1.33.6

### DIFF
--- a/resources/ory/values.yaml
+++ b/resources/ory/values.yaml
@@ -37,7 +37,7 @@ global:
     ## ref: https://cloud.google.com/sql/docs/postgres/sql-proxy
     gce_proxy:
       name: "gce-proxy"
-      version: "v1.33.4-3cfeacc2"
+      version: "v1.33.6-1bdccf0a"
       directory: "tpi/cloudsql-docker"
     hydra:
       name: "hydra"


### PR DESCRIPTION
Bump gce-proxy image in ory charts to v1.33.6