### PR TITLE
Cherry-pick the fix for adding alertmanagers/status to prometheus-operator clusterrole

### DIFF
--- a/resources/monitoring/templates/prometheus-operator/clusterrole.yaml
+++ b/resources/monitoring/templates/prometheus-operator/clusterrole.yaml
@@ -11,6 +11,7 @@ rules:
   - monitoring.coreos.com
   resources:
   - alertmanagers
+  - alertmanagers/status
   - alertmanagers/finalizers
   - alertmanagerconfigs
   - prometheuses


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

-  Cherry-pick the fix for adding `alertmanagers/status` to `prometheus-operator` clusterrole: https://github.com/kyma-project/kyma/pull/17472


**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
