### PR TITLE
Update Telemetry-related Busola extensions

### DIFF
--- a/resources/telemetry/charts/operator/templates/logparser_busola_extension_cm.yaml
+++ b/resources/telemetry/charts/operator/templates/logparser_busola_extension_cm.yaml
@@ -6,7 +6,7 @@ metadata:
     busola.io/extension: resource
     busola.io/extension-version: "0.5"
   name: logparsers.telemetry.kyma-project.io
-  namespace: kube-public
+  namespace: kyma-system
 data:
   details: |-
     {

--- a/resources/telemetry/charts/operator/templates/logparser_busola_extension_cm.yaml
+++ b/resources/telemetry/charts/operator/templates/logparser_busola_extension_cm.yaml
@@ -45,7 +45,7 @@ data:
       "category": "Observability",
       "urlPath": "logparsers",
       "scope": "cluster",
-      "description": "{{[LogParser](https://kyma-project.io/docs/kyma/latest/05-technical-reference/00-custom-resources/telemetry-02-logparser)}} configures a custom Log Parser",
+      "description": "{{"{{[LogParser](https://kyma-project.io/docs/kyma/latest/05-technical-reference/00-custom-resources/telemetry-02-logparser)}}"}} configures a custom Log Parser",
     }
   list: |-
     [

--- a/resources/telemetry/charts/operator/templates/logparser_busola_extension_cm.yaml
+++ b/resources/telemetry/charts/operator/templates/logparser_busola_extension_cm.yaml
@@ -45,7 +45,7 @@ data:
       "category": "Observability",
       "urlPath": "logparsers",
       "scope": "cluster",
-      "description": "Configure custom Log Parsers",
+      "description": "{{[LogParser](https://kyma-project.io/docs/kyma/latest/05-technical-reference/00-custom-resources/telemetry-02-logparser)}} configures a custom Log Parser",
     }
   list: |-
     [

--- a/resources/telemetry/charts/operator/templates/logparser_busola_extension_cm.yaml
+++ b/resources/telemetry/charts/operator/templates/logparser_busola_extension_cm.yaml
@@ -2,10 +2,10 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   labels:
-    app.kubernetes.io/name: logparsers.telemetry.kyma-project.io
+    app.kubernetes.io/name: telemetry-logparsers
     busola.io/extension: resource
     busola.io/extension-version: "0.5"
-  name: logparsers.telemetry.kyma-project.io
+  name: telemetry-logparsers
   namespace: kyma-system
 data:
   details: |-

--- a/resources/telemetry/charts/operator/templates/logpipeline_busola_extension_cm.yaml
+++ b/resources/telemetry/charts/operator/templates/logpipeline_busola_extension_cm.yaml
@@ -6,7 +6,7 @@ metadata:
     busola.io/extension: resource
     busola.io/extension-version: "0.5"
   name: logpipelines.telemetry.kyma-project.io
-  namespace: kube-public
+  namespace: kyma-system
 data:
   details: |-
     {

--- a/resources/telemetry/charts/operator/templates/logpipeline_busola_extension_cm.yaml
+++ b/resources/telemetry/charts/operator/templates/logpipeline_busola_extension_cm.yaml
@@ -2,10 +2,10 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   labels:
-    app.kubernetes.io/name: logpipelines.telemetry.kyma-project.io
+    app.kubernetes.io/name: telemetry-logpipelines
     busola.io/extension: resource
     busola.io/extension-version: "0.5"
-  name: logpipelines.telemetry.kyma-project.io
+  name: telemetry-logpipelines
   namespace: kyma-system
 data:
   details: |-

--- a/resources/telemetry/charts/operator/templates/logpipeline_busola_extension_cm.yaml
+++ b/resources/telemetry/charts/operator/templates/logpipeline_busola_extension_cm.yaml
@@ -485,7 +485,7 @@ data:
       "category": "Observability",
       "urlPath": "logpipelines",
       "scope": "cluster",
-      "description": "Configure log selection, filters, and outputs",
+      "description": "{{[LogPipeline](https://kyma-project.io/docs/kyma/latest/05-technical-reference/00-custom-resources/telemetry-01-logpipeline)}} configures log selection, filters, and outputs",
     }
   list: |-
     [

--- a/resources/telemetry/charts/operator/templates/logpipeline_busola_extension_cm.yaml
+++ b/resources/telemetry/charts/operator/templates/logpipeline_busola_extension_cm.yaml
@@ -485,7 +485,7 @@ data:
       "category": "Observability",
       "urlPath": "logpipelines",
       "scope": "cluster",
-      "description": "{{[LogPipeline](https://kyma-project.io/docs/kyma/latest/05-technical-reference/00-custom-resources/telemetry-01-logpipeline)}} configures log selection, filters, and outputs",
+      "description": "{{"{{[LogPipeline](https://kyma-project.io/docs/kyma/latest/05-technical-reference/00-custom-resources/telemetry-01-logpipeline)}}"}} configures log selection, filters, and outputs",
     }
   list: |-
     [

--- a/resources/telemetry/charts/operator/templates/tracepipeline_busola_extension_cm.yaml
+++ b/resources/telemetry/charts/operator/templates/tracepipeline_busola_extension_cm.yaml
@@ -376,7 +376,7 @@ data:
       "category": "Observability",
       "urlPath": "tracepipelines",
       "scope": "cluster",
-      "description": "Configure custom Trace Pipeline",
+      "description": "{{[TracePipeline](https://kyma-project.io/docs/kyma/latest/05-technical-reference/00-custom-resources/telemetry-03-tracepipeline)}} configures a custom Trace Pipeline",
     }
   list: |-
     [

--- a/resources/telemetry/charts/operator/templates/tracepipeline_busola_extension_cm.yaml
+++ b/resources/telemetry/charts/operator/templates/tracepipeline_busola_extension_cm.yaml
@@ -3,10 +3,10 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   labels:
-    app.kubernetes.io/name: tracepipelines.telemetry.kyma-project.io
+    app.kubernetes.io/name: telemetry-tracepipelines
     busola.io/extension: resource
     busola.io/extension-version: "0.5"
-  name: tracepipelines.telemetry.kyma-project.io
+  name: telemetry-tracepipelines
   namespace: kyma-system
 data:
   details: |-

--- a/resources/telemetry/charts/operator/templates/tracepipeline_busola_extension_cm.yaml
+++ b/resources/telemetry/charts/operator/templates/tracepipeline_busola_extension_cm.yaml
@@ -7,7 +7,7 @@ metadata:
     busola.io/extension: resource
     busola.io/extension-version: "0.5"
   name: tracepipelines.telemetry.kyma-project.io
-  namespace: kube-public
+  namespace: kyma-system
 data:
   details: |-
     {

--- a/resources/telemetry/charts/operator/templates/tracepipeline_busola_extension_cm.yaml
+++ b/resources/telemetry/charts/operator/templates/tracepipeline_busola_extension_cm.yaml
@@ -376,7 +376,7 @@ data:
       "category": "Observability",
       "urlPath": "tracepipelines",
       "scope": "cluster",
-      "description": "{{[TracePipeline](https://kyma-project.io/docs/kyma/latest/05-technical-reference/00-custom-resources/telemetry-03-tracepipeline)}} configures a custom Trace Pipeline",
+      "description": "{{"{{[TracePipeline](https://kyma-project.io/docs/kyma/latest/05-technical-reference/00-custom-resources/telemetry-03-tracepipeline)}}"}} configures a custom Trace Pipeline",
     }
   list: |-
     [


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- Change namespace from `kube-public` to `kyma-system` for busola extensions of `LogParser`, `LogPipeline` and `TracePipeline`. This is needed to allow smooth migration to `telemetry-manager` module where all the resources of the module will be deployed in `kyma-system` namespace.
- Update names for for busola extensions of `LogParser`, `LogPipeline` and `TracePipeline` to contain the prefix `telemetry-` and simplify their names. The `telemetry-` prefix is needed to also allow smooth migration to `telemetry-manager` module where the name of all the module resources will have the `telemetry-` prefix.
- Add the documentation links for our CRDs in busola extensions of `LogParser`, `LogPipeline` and `TracePipeline`.

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
kyma-project/telemetry-manager#150