### PR TITLE
Remove annotation from webhook

### DIFF
--- a/resources/serverless/charts/webhook/values.yaml
+++ b/resources/serverless/charts/webhook/values.yaml
@@ -37,7 +37,6 @@ deployment:
 pod:
   annotations:
     sidecar.istio.io/inject: "false"
-    cluster-autoscaler.kubernetes.io/safe-to-evict: "false"
   extraProperties:
     # the following guidelines should be followed for this https://github.com/kyma-project/community/tree/main/concepts/psp-replacement
     securityContext:


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- GKE Warden rejest serverless webhook with annotation: `cluster-autoscaler.kubernetes.io/safe-to-evict: "false"`

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
