### PR TITLE
add sleep to help istio propagate some changes to the proxies in fastintegration-test

### DIFF
--- a/tests/fast-integration/utils/index.js
+++ b/tests/fast-integration/utils/index.js
@@ -1865,6 +1865,7 @@ async function deployJaeger(jaegerObj) {
   await k8sApply(jaegerObj, 'kyma-system').catch(console.error);
   await waitForDeployment('tracing-jaeger', 'kyma-system');
   await waitForTracePipeline('jaeger');
+  await sleep(20 * 1000); // give istio some time to propagate the changes to the proxies
 }
 
 module.exports = {


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- istio needs a bit more time to configure the proxies in the eventing-upgrade test. Added a sleep for 20s

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
