### PR TITLE
increased cpu limit for grafana sidecars

### DIFF
--- a/resources/monitoring/charts/grafana/values.yaml
+++ b/resources/monitoring/charts/grafana/values.yaml
@@ -644,7 +644,7 @@ sidecar:
   imagePullPolicy: IfNotPresent
   resources:
     limits:
-      cpu: 100m
+      cpu: 300m
       memory: 100Mi
     requests:
       cpu: 10m


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

The grafana sidecar responsible for loading dashboards dynamical from configmaps reached a CPU throttling treshold where alert rules from kube-prometheus-stack are firing.

Changes proposed in this pull request:

- Increased the memory limit for the sidecar which is reducing the trottling percentage
- ...
- ...

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
