### PR TITLE
Scan keda images from external dir

### DIFF
--- a/resources/keda-manager/values.yaml
+++ b/resources/keda-manager/values.yaml
@@ -1,18 +1,20 @@
 global:
   containerRegistry:
-    path: ghcr.io/kedacore
+    path: europe-docker.pkg.dev/kyma-project
   images:
     keda_manager:
       name: "keda-manager"
-      version: "v20230425-c16f4893"
-      containerRegistryPath: "europe-docker.pkg.dev/kyma-project"
+      version: "v20230516-35a38a26"
       directory: "prod"
     keda:
       name: "keda"
-      version: "2.10.0"
+      version: "2.10.1"
+      directory: "prod/external"
     keda_admission_webhooks:
       name: "keda-admission-webhooks"
-      version: "2.10.0"
+      version: "2.10.1"
+      directory: "prod/external"
     keda_metrics_apiserver:
       name: "keda-metrics-apiserver"
-      version: "2.10.0"
+      version: "2.10.1"
+      directory: "prod/external"


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- change location for keda images that are now synced into `/external` dir in `europe-docker.pkg.dev/kyma-project`

**Related issue(s)**
https://github.com/kyma-project/keda-manager/issues/157