### PR TITLE
Adjust API Exposure tutorials to the removal of serverless functions in version v1alpha1

### DIFF
--- a/docs/03-tutorials/00-api-exposure/apix-04-expose-workload/apix-04-03-expose-workloads-multiple-namespaces.md
+++ b/docs/03-tutorials/00-api-exposure/apix-04-expose-workload/apix-04-03-expose-workloads-multiple-namespaces.md
@@ -8,14 +8,17 @@ This tutorial shows how to expose service endpoints in multiple Namespaces using
 
 ##  Prerequisites
 
-1. Create three Namespaces: one for an instance of the HttpBin service, one for a sample Function, and one for an APIRule custom resource (CR). Deploy an instance of the HttpBin service and a sample Function in their respective Namespaces. To learn how to do it, follow the [Create a workload](../apix-01-create-workload.md) tutorial. Export the Namespaces' names as environment variables:
+1. Create three Namespaces: one for an instance of the HttpBin service, one for a sample Function, and one for an APIRule custom resource (CR). Deploy an instance of the HttpBin service and a sample Function in their respective Namespaces. To learn how to do it, follow the [Create a workload](../apix-01-create-workload.md) tutorial. 
+
+  >**NOTE:** Remember to enable the Istio sidecar proxy injection.
+
+2. Export the Namespaces' names as environment variables:
 
   ```bash
   export NAMESPACE_HTTPBIN={NAMESPACE_NAME}
   export NAMESPACE_FUNCTION={NAMESPACE_NAME}
   export NAMESPACE_APIRULE={NAMESPACE_NAME}
   ```
-  >**NOTE** Remember to enable the Istio sidecar proxy injection.
   
 2. Depending on whether you use your custom domain or a Kyma domain, export the necessary values as environment variables:
   

--- a/docs/03-tutorials/00-api-exposure/apix-04-expose-workload/apix-04-03-expose-workloads-multiple-namespaces.md
+++ b/docs/03-tutorials/00-api-exposure/apix-04-expose-workload/apix-04-03-expose-workloads-multiple-namespaces.md
@@ -8,7 +8,7 @@ This tutorial shows how to expose service endpoints in multiple Namespaces using
 
 ##  Prerequisites
 
-1. Create three Namespaces: one for an instance of the HttpBin service, one for a sample function, and one for an APIRule CR. Deploy an instance of the HttpBin service and a sample Function in their respective Namespaces. To learn how to do it, follow the [Create a workload](../apix-01-create-workload.md) tutorial. Remember to enable the Istio sidecar proxy injection. Export the namespaces' names as environment variables:
+1. Create three Namespaces: one for an instance of the HttpBin service, one for a sample Function, and one for an APIRule custom resource (CR). Deploy an instance of the HttpBin service and a sample Function in their respective Namespaces. To learn how to do it, follow the [Create a workload](../apix-01-create-workload.md) tutorial. Remember to enable the Istio sidecar proxy injection. Export the Namespaces' names as environment variables:
 
   ```bash
   export NAMESPACE_HTTPBIN={NAMESPACE_NAME}

--- a/docs/03-tutorials/00-api-exposure/apix-04-expose-workload/apix-04-03-expose-workloads-multiple-namespaces.md
+++ b/docs/03-tutorials/00-api-exposure/apix-04-expose-workload/apix-04-03-expose-workloads-multiple-namespaces.md
@@ -20,7 +20,7 @@ This tutorial shows how to expose service endpoints in multiple Namespaces using
   export NAMESPACE_APIRULE={NAMESPACE_NAME}
   ```
   
-2. Depending on whether you use your custom domain or a Kyma domain, export the necessary values as environment variables:
+3. Depending on whether you use your custom domain or a Kyma domain, export the necessary values as environment variables:
   
 <div tabs name="export-values">
 

--- a/docs/03-tutorials/00-api-exposure/apix-04-expose-workload/apix-04-03-expose-workloads-multiple-namespaces.md
+++ b/docs/03-tutorials/00-api-exposure/apix-04-expose-workload/apix-04-03-expose-workloads-multiple-namespaces.md
@@ -8,17 +8,15 @@ This tutorial shows how to expose service endpoints in multiple Namespaces using
 
 ##  Prerequisites
 
-1. Create two Namespaces. Export their names as `NAMESPACE_HTTPBIN` and `NAMESPACE_FUNCTION` environment variables. Deploy an instance of the HttpBin service in the former Namespace and a sample Function in the latter. To learn how to do it, follow the [Create a workload](../apix-01-create-workload.md) tutorial. 
-
-2. Create a Namespace for the APIRule CR and export its value as an environment variable. Run:
+1. Create three Namespaces: one for an instance of HttpBin service, one for a sample function and one for APIRule CR. Deploy an instance of the HttpBin service and a sample Function in their respective Namespaces. To learn how to do it, follow the [Create a workload](../apix-01-create-workload.md) tutorial. Remember to enable the Istio sidecar proxy injection. Export the following environment variables:
 
   ```bash
-  export NAMESPACE={NAMESPACE}
-  kubectl create ns $NAMESPACE
-  kubectl label namespace $NAMESPACE istio-injection=enabled --overwrite
+  export NAMESPACE_HTTPBIN={NAMESPACE_NAME}
+  export NAMESPACE_FUNCTION={NAMESPACE_NAME}
+  export NAMESPACE_APIRULE={NAMESPACE_NAME}
   ```
 
-3. Depending on whether you use your custom domain or a Kyma domain, export the necessary values as environment variables:
+2. Depending on whether you use your custom domain or a Kyma domain, export the necessary values as environment variables:
   
 <div tabs name="export-values">
 
@@ -29,7 +27,7 @@ This tutorial shows how to expose service endpoints in multiple Namespaces using
     
   ```bash
   export DOMAIN_TO_EXPOSE_WORKLOADS={DOMAIN_NAME}
-  export GATEWAY=$NAMESPACE/httpbin-gateway
+  export GATEWAY=$NAMESPACE_APIRULE/httpbin-gateway
   ```
   </details>
 
@@ -55,7 +53,7 @@ This tutorial shows how to expose service endpoints in multiple Namespaces using
    kind: APIRule
    metadata:
      name: httpbin-and-function
-     namespace: $NAMESPACE
+     namespace: $NAMESPACE_APIRULE
    spec:
      host: httpbin-and-function.$DOMAIN_TO_EXPOSE_WORKLOADS
      gateway: $GATEWAY

--- a/docs/03-tutorials/00-api-exposure/apix-04-expose-workload/apix-04-03-expose-workloads-multiple-namespaces.md
+++ b/docs/03-tutorials/00-api-exposure/apix-04-expose-workload/apix-04-03-expose-workloads-multiple-namespaces.md
@@ -8,37 +8,9 @@ This tutorial shows how to expose service endpoints in multiple Namespaces using
 
 ##  Prerequisites
 
-1. Create a sample HttpBin service deployment and a sample Function in the separate Namespaces:
+1. Create two Namespaces. Export their names as `NAMESPACE_HTTPBIN` and `NAMESPACE_FUNCTION` environment variables. Deploy an instance of the HttpBin service in the former Namespace and a sample Function in the latter. To learn how to do it, follow the [Create a workload](../apix-01-create-workload.md) tutorial. 
 
-   * Create a Namespace for the HttpBin service and export its value as an environment variable. Run:
-
-     ```bash
-     export NAMESPACE_HTTPBIN={NAMESPACE_HTTPBIN}
-     kubectl create ns $NAMESPACE_HTTPBIN
-     kubectl label namespace $NAMESPACE_HTTPBIN istio-injection=enabled --overwrite
-     ```
-
-   * Create a different Namespace for the Function service and export its value as an environment variable. Run:
-
-     ```bash
-     export NAMESPACE_FUNCTION={NAMESPACE_FUNCTION}
-     kubectl create ns $NAMESPACE_FUNCTION
-     kubectl label namespace $NAMESPACE_FUNCTION istio-injection=enabled --overwrite
-     ```
-
-   * Deploy an instance of the HttpBin service in its Namespace using the [sample code](https://raw.githubusercontent.com/istio/istio/master/samples/httpbin/httpbin.yaml):
-
-     ```bash
-     kubectl -n $NAMESPACE_HTTPBIN create -f https://raw.githubusercontent.com/istio/istio/master/samples/httpbin/httpbin.yaml
-     ```
-
-   * Create a Function in its Namespace using the [sample code](../assets/function.yaml):
-
-     ```bash
-     kubectl -n $NAMESPACE_FUNCTION apply -f https://raw.githubusercontent.com/kyma-project/kyma/main/docs/03-tutorials/assets/function.yaml
-     ```
-
-2. Create a Namespace for the Gateway and APIRule CRs and export its value as the environment variable. Run:
+2. Create a Namespace for the APIRule CR and export its value as an environment variable. Run:
 
   ```bash
   export NAMESPACE={NAMESPACE}

--- a/docs/03-tutorials/00-api-exposure/apix-04-expose-workload/apix-04-03-expose-workloads-multiple-namespaces.md
+++ b/docs/03-tutorials/00-api-exposure/apix-04-expose-workload/apix-04-03-expose-workloads-multiple-namespaces.md
@@ -10,7 +10,7 @@ This tutorial shows how to expose service endpoints in multiple Namespaces using
 
 1. Create three Namespaces: one for an instance of the HttpBin service, one for a sample Function, and one for an APIRule custom resource (CR). Deploy an instance of the HttpBin service and a sample Function in their respective Namespaces. To learn how to do it, follow the [Create a workload](../apix-01-create-workload.md) tutorial. 
 
-  >**NOTE:** Remember to enable the Istio sidecar proxy injection.
+  >**NOTE:** Remember to [enable the Istio sidecar proxy injection](https://kyma-project.io/docs/kyma/latest/04-operation-guides/operations/smsh-01-istio-enable-sidecar-injection/).
 
 2. Export the Namespaces' names as environment variables:
 

--- a/docs/03-tutorials/00-api-exposure/apix-04-expose-workload/apix-04-03-expose-workloads-multiple-namespaces.md
+++ b/docs/03-tutorials/00-api-exposure/apix-04-expose-workload/apix-04-03-expose-workloads-multiple-namespaces.md
@@ -10,7 +10,7 @@ This tutorial shows how to expose service endpoints in multiple Namespaces using
 
 1. Create three Namespaces: one for an instance of the HttpBin service, one for a sample Function, and one for an APIRule custom resource (CR). Deploy an instance of the HttpBin service and a sample Function in their respective Namespaces. To learn how to do it, follow the [Create a workload](../apix-01-create-workload.md) tutorial. 
 
-  >**NOTE:** Remember to [enable the Istio sidecar proxy injection](https://kyma-project.io/docs/kyma/latest/04-operation-guides/operations/smsh-01-istio-enable-sidecar-injection/).
+  >**NOTE:** Remember to [enable the Istio sidecar proxy injection](https://kyma-project.io/docs/kyma/latest/04-operation-guides/operations/smsh-01-istio-enable-sidecar-injection/) in each Namespace.
 
 2. Export the Namespaces' names as environment variables:
 

--- a/docs/03-tutorials/00-api-exposure/apix-04-expose-workload/apix-04-03-expose-workloads-multiple-namespaces.md
+++ b/docs/03-tutorials/00-api-exposure/apix-04-expose-workload/apix-04-03-expose-workloads-multiple-namespaces.md
@@ -8,7 +8,7 @@ This tutorial shows how to expose service endpoints in multiple Namespaces using
 
 ##  Prerequisites
 
-1. Create three Namespaces: one for an instance of HttpBin service, one for a sample function and one for APIRule CR. Deploy an instance of the HttpBin service and a sample Function in their respective Namespaces. To learn how to do it, follow the [Create a workload](../apix-01-create-workload.md) tutorial. Remember to enable the Istio sidecar proxy injection. Export the following environment variables:
+1. Create three Namespaces: one for an instance of the HttpBin service, one for a sample function, and one for an APIRule CR. Deploy an instance of the HttpBin service and a sample Function in their respective Namespaces. To learn how to do it, follow the [Create a workload](../apix-01-create-workload.md) tutorial. Remember to enable the Istio sidecar proxy injection. Export the following environment variables:
 
   ```bash
   export NAMESPACE_HTTPBIN={NAMESPACE_NAME}

--- a/docs/03-tutorials/00-api-exposure/apix-04-expose-workload/apix-04-03-expose-workloads-multiple-namespaces.md
+++ b/docs/03-tutorials/00-api-exposure/apix-04-expose-workload/apix-04-03-expose-workloads-multiple-namespaces.md
@@ -8,14 +8,15 @@ This tutorial shows how to expose service endpoints in multiple Namespaces using
 
 ##  Prerequisites
 
-1. Create three Namespaces: one for an instance of the HttpBin service, one for a sample Function, and one for an APIRule custom resource (CR). Deploy an instance of the HttpBin service and a sample Function in their respective Namespaces. To learn how to do it, follow the [Create a workload](../apix-01-create-workload.md) tutorial. Remember to enable the Istio sidecar proxy injection. Export the Namespaces' names as environment variables:
+1. Create three Namespaces: one for an instance of the HttpBin service, one for a sample Function, and one for an APIRule custom resource (CR). Deploy an instance of the HttpBin service and a sample Function in their respective Namespaces. To learn how to do it, follow the [Create a workload](../apix-01-create-workload.md) tutorial. Export the Namespaces' names as environment variables:
 
   ```bash
   export NAMESPACE_HTTPBIN={NAMESPACE_NAME}
   export NAMESPACE_FUNCTION={NAMESPACE_NAME}
   export NAMESPACE_APIRULE={NAMESPACE_NAME}
   ```
-
+  >**NOTE** Remember to enable the Istio sidecar proxy injection.
+  
 2. Depending on whether you use your custom domain or a Kyma domain, export the necessary values as environment variables:
   
 <div tabs name="export-values">

--- a/docs/03-tutorials/00-api-exposure/apix-04-expose-workload/apix-04-03-expose-workloads-multiple-namespaces.md
+++ b/docs/03-tutorials/00-api-exposure/apix-04-expose-workload/apix-04-03-expose-workloads-multiple-namespaces.md
@@ -8,7 +8,7 @@ This tutorial shows how to expose service endpoints in multiple Namespaces using
 
 ##  Prerequisites
 
-1. Create three Namespaces: one for an instance of the HttpBin service, one for a sample function, and one for an APIRule CR. Deploy an instance of the HttpBin service and a sample Function in their respective Namespaces. To learn how to do it, follow the [Create a workload](../apix-01-create-workload.md) tutorial. Remember to enable the Istio sidecar proxy injection. Export the following environment variables:
+1. Create three Namespaces: one for an instance of the HttpBin service, one for a sample function, and one for an APIRule CR. Deploy an instance of the HttpBin service and a sample Function in their respective Namespaces. To learn how to do it, follow the [Create a workload](../apix-01-create-workload.md) tutorial. Remember to enable the Istio sidecar proxy injection. Export the namespaces' names as environment variables:
 
   ```bash
   export NAMESPACE_HTTPBIN={NAMESPACE_NAME}

--- a/docs/03-tutorials/00-api-exposure/assets/function.yaml
+++ b/docs/03-tutorials/00-api-exposure/assets/function.yaml
@@ -1,8 +1,7 @@
 apiVersion: serverless.kyma-project.io/v1alpha2
 kind: Function
 metadata:
-  name: $NAME
-  namespace: $NAMESPACE
+  name: function
 spec:
   runtime: nodejs16
   source:

--- a/docs/03-tutorials/00-api-exposure/assets/function.yaml
+++ b/docs/03-tutorials/00-api-exposure/assets/function.yaml
@@ -1,4 +1,4 @@
-apiVersion: serverless.kyma-project.io/v1alpha1
+apiVersion: serverless.kyma-project.io/v1alpha2
 kind: Function
 metadata:
   name: function

--- a/docs/03-tutorials/00-api-exposure/assets/function.yaml
+++ b/docs/03-tutorials/00-api-exposure/assets/function.yaml
@@ -1,20 +1,15 @@
 apiVersion: serverless.kyma-project.io/v1alpha2
 kind: Function
 metadata:
-  name: function
+  name: $NAME
+  namespace: $NAMESPACE
 spec:
-  source: |
-    module.exports = {
-      main: function(event, context) {
-        return 'Hello World';
-      }
-    }
-  minReplicas: 1
-  maxReplicas: 1
-  resources:
-    limits:
-      cpu: 100m
-      memory: 128Mi
-    requests:
-      cpu: 100m
-      memory: 100Mi
+  runtime: nodejs16
+  source:
+    inline:
+      source: |
+        module.exports = {
+          main: function(event, context) {
+            return 'Hello World!'
+          }
+        }


### PR DESCRIPTION
Changes proposed in this pull request:

- In [Expose workloads in multiple Namespaces with a single APIRule definition](https://kyma-project.io/docs/kyma/main/03-tutorials/00-api-exposure/apix-04-expose-workload/apix-04-03-expose-workloads-multiple-namespaces/), simplify the prerequisites. Link to the Create a workload tutorial that contains the detailed instructions.
- Update the function.yaml file
