### PR TITLE
Increase memory limit for telemetry operator

### DIFF
--- a/resources/telemetry/charts/operator/values.yaml
+++ b/resources/telemetry/charts/operator/values.yaml
@@ -69,7 +69,7 @@ fluentbit:
 resources:
   limits:
     cpu: 100m
-    memory: 256Mi
+    memory: 384Mi
   requests:
     cpu: 5m
     memory: 20Mi

--- a/resources/telemetry/charts/operator/values.yaml
+++ b/resources/telemetry/charts/operator/values.yaml
@@ -72,7 +72,7 @@ resources:
     memory: 384Mi
   requests:
     cpu: 5m
-    memory: 20Mi
+    memory: 100Mi
 
 terminationGracePeriodSeconds: 10
 


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- Telemetry operator is watching many resources in the cluster like secrets, configmaps etc. It can happen that when in a cluster there are many of these resources it would cause the cache to be big. Current limit 256 Mi would not be enough in such cases so increase it to 384Mi

- Change is telemetry manager repo [here](https://github.com/kyma-project/telemetry-manager/pull/197)
**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
