### PR TITLE
Update telemetry-operator to introduce re-usable webhook CA bundle

### DIFF
--- a/resources/telemetry/values.yaml
+++ b/resources/telemetry/values.yaml
@@ -8,7 +8,7 @@ global:
       directory: "prod"
     telemetry_operator:
       name: "telemetry-manager"
-      version: "v20230526-2a52aa21"
+      version: "v20230526-aee48202"
       directory: "prod"
     telemetry_otel_collector:
       name: "otel-collector"


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- Reconcile ValidatingWebhookConfiguration in telemetry controller
- Split webhook certificate into long-living CA bundle and regenerated server certificate
- Add CA bundle rotation before expiry

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
See also https://github.com/kyma-project/telemetry-manager/pull/173, https://github.com/kyma-project/kyma/issues/16626