### PR TITLE
Fix code block formatting

### DIFF
--- a/docs/03-tutorials/00-api-exposure/apix-03-set-up-tls-gateway.md
+++ b/docs/03-tutorials/00-api-exposure/apix-03-set-up-tls-gateway.md
@@ -60,19 +60,19 @@ To create a TLS Gateway in simple mode, run:
           app: istio-ingressgateway
         servers:
           - port:
-            number: 443
-            name: https
-            protocol: HTTPS
-          tls:
-            mode: MUTUAL
-            credentialName: ${TLS_SECRET}
-            minProtocolVersion: TLSV1_2
-            cipherSuites:
-              - ECDHE-RSA-CHACHA20-POLY1305
-              - ECDHE-RSA-AES256-GCM-SHA384
-              - ECDHE-RSA-AES256-SHA
-              - ECDHE-RSA-AES128-GCM-SHA256
-              - ECDHE-RSA-AES128-SHA
+              number: 443
+              name: https
+              protocol: HTTPS
+            tls:
+              mode: MUTUAL
+              credentialName: ${TLS_SECRET}
+              minProtocolVersion: TLSV1_2
+              cipherSuites:
+                - ECDHE-RSA-CHACHA20-POLY1305
+                - ECDHE-RSA-AES256-GCM-SHA384
+                - ECDHE-RSA-AES256-SHA
+                - ECDHE-RSA-AES128-GCM-SHA256
+                - ECDHE-RSA-AES128-SHA
             hosts:
               - '*.${DOMAIN_TO_EXPOSE_WORKLOADS}'
           - port:

--- a/docs/03-tutorials/00-api-exposure/apix-03-set-up-tls-gateway.md
+++ b/docs/03-tutorials/00-api-exposure/apix-03-set-up-tls-gateway.md
@@ -31,15 +31,15 @@ This tutorial shows how to set up a TLS Gateway in both manual and simple modes.
           istio: ingressgateway # Use Istio Ingress Gateway as default
         servers:
           - port:
-              number: 443
-              name: https
-               protocol: HTTPS
-            tls:
-              mode: SIMPLE
-              credentialName: $TLS_SECRET
-            hosts:
-              - "*.$DOMAIN_TO_EXPOSE_WORKLOADS"
-    EOF
+            number: 443
+            name: https
+            protocol: HTTPS
+          tls:
+            mode: SIMPLE
+            credentialName: $TLS_SECRET
+          hosts:
+            - "*.$DOMAIN_TO_EXPOSE_WORKLOADS"
+      EOF
     ```
     
 ## Set up a TLS Gateway in mutual mode
@@ -83,7 +83,7 @@ This tutorial shows how to set up a TLS Gateway in both manual and simple modes.
               httpsRedirect: true
             hosts:
               - '*.${DOMAIN_TO_EXPOSE_WORKLOADS}'
-    EOF
+      EOF
     ```
   2. Export the following value as an environment variable:
 
@@ -104,5 +104,5 @@ This tutorial shows how to set up a TLS Gateway in both manual and simple modes.
       type: Opaque
       data:
         cacert: ${CLIENT_ROOT_CA_CRT_ENCODED}
-    EOF
+      EOF
     ```

--- a/docs/03-tutorials/00-api-exposure/apix-03-set-up-tls-gateway.md
+++ b/docs/03-tutorials/00-api-exposure/apix-03-set-up-tls-gateway.md
@@ -18,7 +18,7 @@ This tutorial shows how to set up a TLS Gateway in both manual and simple modes.
 
 To create a TLS Gateway in simple mode, run:
 
-    ```bash
+  ```bash
       cat <<EOF | kubectl apply -f -
       ---
       apiVersion: networking.istio.io/v1alpha3

--- a/docs/03-tutorials/00-api-exposure/apix-03-set-up-tls-gateway.md
+++ b/docs/03-tutorials/00-api-exposure/apix-03-set-up-tls-gateway.md
@@ -19,27 +19,27 @@ This tutorial shows how to set up a TLS Gateway in both manual and simple modes.
 To create a TLS Gateway in simple mode, run:
 
   ```bash
-    cat <<EOF | kubectl apply -f -
-    ---
-    apiVersion: networking.istio.io/v1alpha3
-    kind: Gateway
-    metadata:
-      name: httpbin-gateway
-      namespace: $NAMESPACE
-    spec:
-      selector:
-        istio: ingressgateway # Use Istio Ingress Gateway as default
-      servers:
-        - port:
-            number: 443
-            name: https
-            protocol: HTTPS
-          tls:
-            mode: SIMPLE
-            credentialName: $TLS_SECRET
-          hosts:
-            - "*.$DOMAIN_TO_EXPOSE_WORKLOADS"
-    EOF        
+  cat <<EOF | kubectl apply -f -
+  ---
+  apiVersion: networking.istio.io/v1alpha3
+  kind: Gateway
+  metadata:
+    name: httpbin-gateway
+    namespace: $NAMESPACE
+  spec:
+    selector:
+      istio: ingressgateway # Use Istio Ingress Gateway as default
+    servers:
+      - port:
+          number: 443
+          name: https
+          protocol: HTTPS
+        tls:
+          mode: SIMPLE
+          credentialName: $TLS_SECRET
+        hosts:
+          - "*.$DOMAIN_TO_EXPOSE_WORKLOADS"
+  EOF        
   ```
     
 ## Set up a TLS Gateway in mutual mode
@@ -47,43 +47,43 @@ To create a TLS Gateway in simple mode, run:
   1. Create a mutual TLS Gateway. Run:
     
     ```bash
-      cat <<EOF | kubectl apply -f -
-      ---
-      apiVersion: networking.istio.io/v1beta1
-      kind: Gateway
-      metadata:
-        name: ${MTLS_GATEWAY_NAME}
-        namespace: ${NAMESPACE}
-      spec:
-        selector:
-          istio: ingressgateway
-          app: istio-ingressgateway
-        servers:
-          - port:
-              number: 443
-              name: https
-              protocol: HTTPS
-            tls:
-              mode: MUTUAL
-              credentialName: ${TLS_SECRET}
-              minProtocolVersion: TLSV1_2
-              cipherSuites:
-                - ECDHE-RSA-CHACHA20-POLY1305
-                - ECDHE-RSA-AES256-GCM-SHA384
-                - ECDHE-RSA-AES256-SHA
-                - ECDHE-RSA-AES128-GCM-SHA256
-                - ECDHE-RSA-AES128-SHA
-            hosts:
-              - '*.${DOMAIN_TO_EXPOSE_WORKLOADS}'
-          - port:
-              number: 80
-              name: http
-              protocol: HTTP
-            tls:
-              httpsRedirect: true
-            hosts:
-              - '*.${DOMAIN_TO_EXPOSE_WORKLOADS}'
-      EOF
+    cat <<EOF | kubectl apply -f -
+    ---
+    apiVersion: networking.istio.io/v1beta1
+    kind: Gateway
+    metadata:
+      name: ${MTLS_GATEWAY_NAME}
+      namespace: ${NAMESPACE}
+    spec:
+      selector:
+        istio: ingressgateway
+        app: istio-ingressgateway
+      servers:
+        - port:
+            number: 443
+            name: https
+            protocol: HTTPS
+          tls:
+            mode: MUTUAL
+            credentialName: ${TLS_SECRET}
+            minProtocolVersion: TLSV1_2
+            cipherSuites:
+              - ECDHE-RSA-CHACHA20-POLY1305
+              - ECDHE-RSA-AES256-GCM-SHA384
+              - ECDHE-RSA-AES256-SHA
+              - ECDHE-RSA-AES128-GCM-SHA256
+              - ECDHE-RSA-AES128-SHA
+          hosts:
+            - '*.${DOMAIN_TO_EXPOSE_WORKLOADS}'
+        - port:
+            number: 80
+            name: http
+            protocol: HTTP
+          tls:
+            httpsRedirect: true
+          hosts:
+            - '*.${DOMAIN_TO_EXPOSE_WORKLOADS}'
+    EOF
     ```
   2. Export the following value as an environment variable:
 
@@ -94,15 +94,15 @@ To create a TLS Gateway in simple mode, run:
   3. Add client root CA to the CA cert bundle Secret for mTLS Gateway. Run:
 
     ```bash
-      cat <<EOF | kubectl apply -f -
-      ---
-      apiVersion: v1
-      kind: Secret
-      metadata:
-        name: ${TLS_SECRET}-cacert
-        namespace: istio-system
-      type: Opaque
-      data:
-        cacert: ${CLIENT_ROOT_CA_CRT_ENCODED}
-      EOF
+    cat <<EOF | kubectl apply -f -
+    ---
+    apiVersion: v1
+    kind: Secret
+    metadata:
+      name: ${TLS_SECRET}-cacert
+      namespace: istio-system
+    type: Opaque
+    data:
+      cacert: ${CLIENT_ROOT_CA_CRT_ENCODED}
+    EOF
     ```

--- a/docs/03-tutorials/00-api-exposure/apix-03-set-up-tls-gateway.md
+++ b/docs/03-tutorials/00-api-exposure/apix-03-set-up-tls-gateway.md
@@ -20,25 +20,26 @@ This tutorial shows how to set up a TLS Gateway in both manual and simple modes.
 
     ```bash
       cat <<EOF | kubectl apply -f -
-        apiVersion: networking.istio.io/v1alpha3
-        kind: Gateway
-        metadata:
-          name: httpbin-gateway
-          namespace: $NAMESPACE
-        spec:
-          selector:
-            istio: ingressgateway # Use Istio Ingress Gateway as default
-          servers:
-            - port:
-                number: 443
-                name: https
-                protocol: HTTPS
-              tls:
-                mode: SIMPLE
-                credentialName: $TLS_SECRET
-              hosts:
-                - "*.$DOMAIN_TO_EXPOSE_WORKLOADS"
-      EOF
+      ---
+      apiVersion: networking.istio.io/v1alpha3
+      kind: Gateway
+      metadata:
+        name: httpbin-gateway
+        namespace: $NAMESPACE
+      spec:
+        selector:
+          istio: ingressgateway # Use Istio Ingress Gateway as default
+        servers:
+          - port:
+              number: 443
+              name: https
+               protocol: HTTPS
+            tls:
+              mode: SIMPLE
+              credentialName: $TLS_SECRET
+            hosts:
+              - "*.$DOMAIN_TO_EXPOSE_WORKLOADS"
+    EOF
     ```
     
 ## Set up a TLS Gateway in mutual mode

--- a/docs/03-tutorials/00-api-exposure/apix-03-set-up-tls-gateway.md
+++ b/docs/03-tutorials/00-api-exposure/apix-03-set-up-tls-gateway.md
@@ -19,27 +19,27 @@ This tutorial shows how to set up a TLS Gateway in both manual and simple modes.
 To create a TLS Gateway in simple mode, run:
 
   ```bash
-      cat <<EOF | kubectl apply -f -
-      ---
-      apiVersion: networking.istio.io/v1alpha3
-      kind: Gateway
-      metadata:
-        name: httpbin-gateway
-        namespace: $NAMESPACE
-      spec:
-        selector:
-          istio: ingressgateway # Use Istio Ingress Gateway as default
-        servers:
-          - port:
-              number: 443
-              name: https
-              protocol: HTTPS
-            tls:
-              mode: SIMPLE
-              credentialName: $TLS_SECRET
-            hosts:
-              - "*.$DOMAIN_TO_EXPOSE_WORKLOADS"
-      EOF
+    cat <<EOF | kubectl apply -f -
+    ---
+    apiVersion: networking.istio.io/v1alpha3
+    kind: Gateway
+    metadata:
+      name: httpbin-gateway
+      namespace: $NAMESPACE
+    spec:
+      selector:
+        istio: ingressgateway # Use Istio Ingress Gateway as default
+      servers:
+        - port:
+            number: 443
+            name: https
+            protocol: HTTPS
+          tls:
+            mode: SIMPLE
+            credentialName: $TLS_SECRET
+          hosts:
+            - "*.$DOMAIN_TO_EXPOSE_WORKLOADS"
+    EOF        
   ```
     
 ## Set up a TLS Gateway in mutual mode

--- a/docs/03-tutorials/00-api-exposure/apix-03-set-up-tls-gateway.md
+++ b/docs/03-tutorials/00-api-exposure/apix-03-set-up-tls-gateway.md
@@ -40,7 +40,7 @@ To create a TLS Gateway in simple mode, run:
             hosts:
               - "*.$DOMAIN_TO_EXPOSE_WORKLOADS"
       EOF
-    ```
+  ```
     
 ## Set up a TLS Gateway in mutual mode
   

--- a/docs/03-tutorials/00-api-exposure/apix-03-set-up-tls-gateway.md
+++ b/docs/03-tutorials/00-api-exposure/apix-03-set-up-tls-gateway.md
@@ -9,28 +9,28 @@ This tutorial shows how to set up a TLS Gateway in both manual and simple modes.
 * Deploy [a sample HttpBin service and a sample Function](./apix-01-create-workload.md).
 * Set up [your custom domain](./apix-02-setup-custom-domain-for-workload.md) and export the following values as environment variables:
 
-    ```bash
-    export DOMAIN_TO_EXPOSE_WORKLOADS={DOMAIN_NAME}
-    export GATEWAY=$NAMESPACE/httpbin-gateway
-    ```
+  ```bash
+  export DOMAIN_TO_EXPOSE_WORKLOADS={DOMAIN_NAME}
+  export GATEWAY=$NAMESPACE/httpbin-gateway
+  ```
    
 ## Set up a TLS Gateway in simple mode
 
   To create a TLS Gateway in simple mode, run:
 
     ```bash
-      cat <<EOF | kubectl apply -f -
-      ---
-      apiVersion: networking.istio.io/v1alpha3
-      kind: Gateway
-      metadata:
-        name: httpbin-gateway
-        namespace: $NAMESPACE
-      spec:
-        selector:
-          istio: ingressgateway # Use Istio Ingress Gateway as default
-        servers:
-          - port:
+    cat <<EOF | kubectl apply -f -
+    ---
+    apiVersion: networking.istio.io/v1alpha3
+    kind: Gateway
+    metadata:
+      name: httpbin-gateway
+      namespace: $NAMESPACE
+    spec:
+      selector:
+        istio: ingressgateway # Use Istio Ingress Gateway as default
+      servers:
+        - port:
             number: 443
             name: https
             protocol: HTTPS
@@ -39,7 +39,7 @@ This tutorial shows how to set up a TLS Gateway in both manual and simple modes.
             credentialName: $TLS_SECRET
           hosts:
             - "*.$DOMAIN_TO_EXPOSE_WORKLOADS"
-      EOF
+    EOF
     ```
     
 ## Set up a TLS Gateway in mutual mode

--- a/docs/03-tutorials/00-api-exposure/apix-03-set-up-tls-gateway.md
+++ b/docs/03-tutorials/00-api-exposure/apix-03-set-up-tls-gateway.md
@@ -16,30 +16,30 @@ This tutorial shows how to set up a TLS Gateway in both manual and simple modes.
    
 ## Set up a TLS Gateway in simple mode
 
-  To create a TLS Gateway in simple mode, run:
+To create a TLS Gateway in simple mode, run:
 
     ```bash
-    cat <<EOF | kubectl apply -f -
-    ---
-    apiVersion: networking.istio.io/v1alpha3
-    kind: Gateway
-    metadata:
-      name: httpbin-gateway
-      namespace: $NAMESPACE
-    spec:
-      selector:
-        istio: ingressgateway # Use Istio Ingress Gateway as default
-      servers:
-        - port:
-            number: 443
-            name: https
-            protocol: HTTPS
-          tls:
-            mode: SIMPLE
-            credentialName: $TLS_SECRET
-          hosts:
-            - "*.$DOMAIN_TO_EXPOSE_WORKLOADS"
-    EOF
+      cat <<EOF | kubectl apply -f -
+      ---
+      apiVersion: networking.istio.io/v1alpha3
+      kind: Gateway
+      metadata:
+        name: httpbin-gateway
+        namespace: $NAMESPACE
+      spec:
+        selector:
+          istio: ingressgateway # Use Istio Ingress Gateway as default
+        servers:
+          - port:
+              number: 443
+              name: https
+              protocol: HTTPS
+            tls:
+              mode: SIMPLE
+              credentialName: $TLS_SECRET
+            hosts:
+              - "*.$DOMAIN_TO_EXPOSE_WORKLOADS"
+      EOF
     ```
     
 ## Set up a TLS Gateway in mutual mode

--- a/docs/03-tutorials/00-api-exposure/apix-03-set-up-tls-gateway.md
+++ b/docs/03-tutorials/00-api-exposure/apix-03-set-up-tls-gateway.md
@@ -20,25 +20,25 @@ This tutorial shows how to set up a TLS Gateway in both manual and simple modes.
 
     ```bash
       cat <<EOF | kubectl apply -f -
-      apiVersion: networking.istio.io/v1alpha3
-      kind: Gateway
-      metadata:
-        name: httpbin-gateway
-        namespace: $NAMESPACE
-      spec:
-        selector:
-          istio: ingressgateway # Use Istio Ingress Gateway as default
-        servers:
-          - port:
-              number: 443
-              name: https
-              protocol: HTTPS
-            tls:
-              mode: SIMPLE
-              credentialName: $TLS_SECRET
-            hosts:
-              - "*.$DOMAIN_TO_EXPOSE_WORKLOADS"
-    EOF
+        apiVersion: networking.istio.io/v1alpha3
+        kind: Gateway
+        metadata:
+          name: httpbin-gateway
+          namespace: $NAMESPACE
+        spec:
+          selector:
+            istio: ingressgateway # Use Istio Ingress Gateway as default
+          servers:
+            - port:
+                number: 443
+                name: https
+                protocol: HTTPS
+              tls:
+                mode: SIMPLE
+                credentialName: $TLS_SECRET
+              hosts:
+                - "*.$DOMAIN_TO_EXPOSE_WORKLOADS"
+      EOF
     ```
     
 ## Set up a TLS Gateway in mutual mode


### PR DESCRIPTION
Changes proposed in this pull request:

- Fix formatting of a Markdown code block in the tutorial [Set up a TLS Gateway](https://kyma-project.io/docs/kyma/main/03-tutorials/00-api-exposure/apix-03-set-up-tls-gateway/).
