### PR TITLE
Add namespace to docker-registry sub chart

### DIFF
--- a/resources/serverless/charts/docker-registry/templates/configmap.yaml
+++ b/resources/serverless/charts/docker-registry/templates/configmap.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ template "docker-registry.fullname" . }}-config
+  namespace: {{ .Release.Namespace }}
   labels:
     app: {{ template "docker-registry.name" . }}
     chart: {{ .Chart.Name }}-{{ .Chart.Version }}

--- a/resources/serverless/charts/docker-registry/templates/cronjob.yaml
+++ b/resources/serverless/charts/docker-registry/templates/cronjob.yaml
@@ -3,6 +3,7 @@ apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: {{ template "docker-registry.name" . }}-image-gc
+  namespace: {{ .Release.Namespace }}
 spec:
   # Not using a common time slice to avoid load spikes.
   schedule: "42 * * * *"

--- a/resources/serverless/charts/docker-registry/templates/deployment.yaml
+++ b/resources/serverless/charts/docker-registry/templates/deployment.yaml
@@ -4,6 +4,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "docker-registry.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     app: {{ template "docker-registry.name" . }}
     chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}

--- a/resources/serverless/charts/docker-registry/templates/ingress.yaml
+++ b/resources/serverless/charts/docker-registry/templates/ingress.yaml
@@ -6,6 +6,7 @@ apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
   name: {{ template "docker-registry.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     app: {{ template "docker-registry.name" . }}
     chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}

--- a/resources/serverless/charts/docker-registry/templates/poddisruptionbudget.yaml
+++ b/resources/serverless/charts/docker-registry/templates/poddisruptionbudget.yaml
@@ -3,6 +3,7 @@ apiVersion: policy/v1beta1
 kind: PodDisruptionBudget
 metadata:
   name: {{ template "docker-registry.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     app: {{ template "docker-registry.name" . }}
     chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}

--- a/resources/serverless/charts/docker-registry/templates/pvc.yaml
+++ b/resources/serverless/charts/docker-registry/templates/pvc.yaml
@@ -4,6 +4,7 @@ kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:
   name: {{ template "docker-registry.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     app: {{ template "docker-registry.fullname" . }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"

--- a/resources/serverless/charts/docker-registry/templates/secret.yaml
+++ b/resources/serverless/charts/docker-registry/templates/secret.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ template "docker-registry.fullname" . }}-secret
+  namespace: {{ .Release.Namespace }}
   labels:
     app: {{ template "docker-registry.name" . }}
     chart: {{ .Chart.Name }}-{{ .Chart.Version }}

--- a/resources/serverless/charts/docker-registry/templates/service.yaml
+++ b/resources/serverless/charts/docker-registry/templates/service.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ template "docker-registry.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     app: {{ template "docker-registry.name" . }}
     chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- add namespace metadata to docker-registry sub-chart templates so that they are installable by serverless-manager

**Related issue(s)**
https://github.com/kyma-project/serverless-manager/issues/107