### PR TITLE
Fix broken links

### DIFF
--- a/docs/03-tutorials/00-serverless/svls-07-set-external-registry.md
+++ b/docs/03-tutorials/00-serverless/svls-07-set-external-registry.md
@@ -5,7 +5,7 @@ title: Set an external Docker registry
 By default, you install Kyma with Serverless that uses the internal Docker registry running on a cluster. This tutorial shows how to override this default setup with an external Docker registry from one of these cloud providers:
 
 - [Docker Hub](https://hub.docker.com/)
-- [Google Container Registry (GCR)](https://cloud.google.com/container-registry)
+- [Google Artifact Registry (GAR)](https://cloud.google.com/artifact-registry)
 - [Azure Container Registry (ACR)](https://azure.microsoft.com/en-us/services/container-registry/)
 
 >**CAUTION:** Function images are not cached in the Docker Hub. The reason is that this registry is not compatible with the caching logic defined in [Kaniko](https://cloud.google.com/cloud-build/docs/kaniko-cache) that Serverless uses for building images.
@@ -22,8 +22,8 @@ By default, you install Kyma with Serverless that uses the internal Docker regis
 
   </details>
   <details>
-  <summary label="gcr">
-  GCR
+  <summary label="gar">
+  GAR
   </summary>
 
 - [kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl/)
@@ -73,11 +73,11 @@ By default, you install Kyma with Serverless that uses the internal Docker regis
 
   </details>
   <details>
-  <summary label="gcr">
-  GCR
+  <summary label="gar">
+  GAR
   </summary>
 
-To use GCR, create a Google service account that has a private key and the **Storage Admin** role permissions. Follow these steps:
+To use GAR, create a Google service account that has a private key and the **Storage Admin** role permissions. Follow these steps:
 
 1. Run the `export {VARIABLE}={value}` command to set up these environment variables, where:
 
@@ -96,7 +96,7 @@ To use GCR, create a Google service account that has a private key and the **Sto
     export PROJECT=test-project-012345
     export SECRET_FILE=my-private-key-path
     export ROLE=roles/storage.admin
-    export SERVER_ADDRESS=gcr.io
+    export SERVER_ADDRESS=gar.io
     ```
 
 2. When you communicate with Google Cloud for the first time, set the context for your Google Cloud project. Run this command:
@@ -226,8 +226,8 @@ EOF
 
   </details>
   <details>
-  <summary label="gcr">
-  GCR
+  <summary label="gar">
+  GAR
   </summary>
 
 ```bash

--- a/docs/03-tutorials/00-serverless/svls-08-switch-to-external-registry.md
+++ b/docs/03-tutorials/00-serverless/svls-08-switch-to-external-registry.md
@@ -5,7 +5,7 @@ title: Switch to an external Docker registry at runtime
 This tutorial shows how you can [switch to an external Docker registry](../../05-technical-reference/svls-03-switching-registries.md) in a specific Namespace, with Serverless already installed on your cluster. This example relies on the `default` Namespace but you can use any other. You will create a Secret custom resource (CR) with credentials to one of these registries:
 
 - [Docker Hub](https://hub.docker.com/)
-- [Google Container Registry (GCR)](https://cloud.google.com/container-registry)
+- [Google Artifact Registry (GAR)](https://cloud.google.com/artifact-registry)
 - [Azure Container Registry (ACR)](https://azure.microsoft.com/en-us/services/container-registry/)
 
 After this change, any Function deployed in the `default` Namespace will store images in this registry.
@@ -24,8 +24,8 @@ After this change, any Function deployed in the `default` Namespace will store i
 
   </details>
   <details>
-  <summary label="gcr">
-  GCR
+  <summary label="gar">
+  GAR
   </summary>
 
 - [kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl/)


### PR DESCRIPTION

**Description**

Changes proposed in this pull request:

- Replaced the outdated links to Google Cloud Container Registry with the link to GC Artifact Registry
- Replaced `GCR` with `GAR`

**Related issue(s)**
