### PR TITLE
Omit Dev Dependencies in nodejs runtimes

### DIFF
--- a/resources/serverless/templates/runtimes.yaml
+++ b/resources/serverless/templates/runtimes.yaml
@@ -43,7 +43,7 @@ data:
     COPY /registry-config/* /usr/src/app/function/
     COPY $SRC_DIR/package.json /usr/src/app/function/package.json
 
-    RUN npm install --production
+    RUN npm install --omit=dev
     COPY $SRC_DIR /usr/src/app/function
     RUN ls -l /usr/src/app/function
     WORKDIR /usr/src/app
@@ -71,7 +71,7 @@ data:
     COPY /registry-config/* /usr/src/app/function/
     COPY $SRC_DIR/package.json /usr/src/app/function/package.json
 
-    RUN npm install --production
+    RUN npm install --omit=dev
     COPY $SRC_DIR /usr/src/app/function
     RUN ls -l /usr/src/app/function
     WORKDIR /usr/src/app


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Omit dev dependencies while building nodejs functions