### PR TITLE
Bump gce-proxy to 1.33.8

### DIFF
--- a/resources/ory/values.yaml
+++ b/resources/ory/values.yaml
@@ -37,7 +37,7 @@ global:
     ## ref: https://cloud.google.com/sql/docs/postgres/sql-proxy
     gce_proxy:
       name: "gce-proxy"
-      version: "v1.33.6-1bdccf0a"
+      version: "v1.33.8-afb993b8"
       directory: "prod/tpi/cloudsql-docker"
     hydra:
       name: "hydra"


### PR DESCRIPTION
Bump gce proxy image version to [Image](https://console.cloud.google.com/artifacts/docker/kyma-project/europe/prod/tpi%2Fcloudsql-docker%2Fgce-proxy/sha256:7470bc26e064c771a8975ea5cb19e7dc7a002dcc80db59f76bd0688b4a8c93b0)