### PR TITLE
Remove relative link from CRD description

### DIFF
--- a/docs/05-technical-reference/00-custom-resources/telemetry-01-logpipeline.md
+++ b/docs/05-technical-reference/00-custom-resources/telemetry-01-logpipeline.md
@@ -148,6 +148,6 @@ For details, see the [LogPipeline specification file](https://github.com/kyma-pr
 | **conditions.&#x200b;lastTransitionTime**  | string | An array of conditions describing the status of the pipeline. |
 | **conditions.&#x200b;reason**  | string | An array of conditions describing the status of the pipeline. |
 | **conditions.&#x200b;type**  | string | The possible transition types are:<br>- `Running`: The instance is ready and usable.<br>- `Pending`: The pipeline is being activated. |
-| **unsupportedMode**  | boolean | Is active when the LogPipeline uses a `custom` output or filter; see [unsupported mode](./../../01-overview/telemetry/telemetry-02-logs.md#unsupported-mode#unsupported-mode). |
+| **unsupportedMode**  | boolean | Is active when the LogPipeline uses a `custom` output or filter; see [unsupported mode](https://kyma-project.io/docs/kyma/main/01-overview/telemetry/telemetry-02-logs#unsupported-mode). |
 
 <!-- TABLE-END -->

--- a/hack/table-gen/Makefile
+++ b/hack/table-gen/Makefile
@@ -3,15 +3,15 @@ generate: telemetry-docs cra-docs eventing-docs apix-docs istio-docs
 
 .PHONY: telemetry-tracepipeline
 telemetry-tracepipeline:
-	go run main.go --crd-filename ../../installation/resources/crds/telemetry/tracepipelines.crd.yaml --md-filename ../docs/05-technical-reference/00-custom-resources/telemetry-03-tracepipeline.md
+	go run main.go --crd-filename ../../installation/resources/crds/telemetry/tracepipelines.crd.yaml --md-filename ../../docs/05-technical-reference/00-custom-resources/telemetry-03-tracepipeline.md
 
 .PHONY: telemetry-logpipeline
 telemetry-logpipeline:
-	go run main.go --crd-filename ../../installation/resources/crds/telemetry/logpipelines.crd.yaml --md-filename ../docs/05-technical-reference/00-custom-resources/telemetry-01-logpipeline.md
+	go run main.go --crd-filename ../../installation/resources/crds/telemetry/logpipelines.crd.yaml --md-filename ../../docs/05-technical-reference/00-custom-resources/telemetry-01-logpipeline.md
 
 .PHONY: telemetry-logparser
 telemetry-logparser:
-	go run main.go --crd-filename ../../installation/resources/crds/telemetry/logparsers.crd.yaml --md-filename ../docs/05-technical-reference/00-custom-resources/telemetry-02-logparser.md
+	go run main.go --crd-filename ../../installation/resources/crds/telemetry/logparsers.crd.yaml --md-filename ../../docs/05-technical-reference/00-custom-resources/telemetry-02-logparser.md
 
 .PHONY: telemetry-docs
 telemetry-docs: telemetry-tracepipeline telemetry-logparser telemetry-logpipeline

--- a/installation/resources/crds/telemetry/logpipelines.crd.yaml
+++ b/installation/resources/crds/telemetry/logpipelines.crd.yaml
@@ -341,7 +341,7 @@ spec:
                 type: array
               unsupportedMode:
                 description: Is active when the LogPipeline uses a `custom` output
-                  or filter; see [unsupported mode](./../../01-overview/telemetry/telemetry-02-logs.md#unsupported-mode#unsupported-mode).
+                  or filter; see [unsupported mode](https://kyma-project.io/docs/kyma/main/01-overview/telemetry/telemetry-02-logs#unsupported-mode).
                 type: boolean
             type: object
         type: object


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

The CRD description for the unsupportedMode status field contained a relative link to the docs. Since this description has also other purposes, this PR makes it an absolute link that work everywhere.

We may change the link from `main` to `latest` once the new docs structure is released.

Changes proposed in this pull request:

- Remove relative link from CRD description
- Fix table-gen commands in Makefile

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
See https://github.com/kyma-project/kyma/pull/17454