### PR TITLE
fix broken link

### DIFF
--- a/docs/03-tutorials/00-serverless/svls-12-customize-function-traces.md
+++ b/docs/03-tutorials/00-serverless/svls-12-customize-function-traces.md
@@ -75,7 +75,7 @@ The following code samples illustrate how to enrich the default trace with custo
    Python
    </summary>
 
-      [OpenTelemetry SDK](https://opentelemetry.io/docs/instrumentation/python/manual/#tracing) allows you to customize trace spans and events.
+      [OpenTelemetry SDK](https://opentelemetry.io/docs/instrumentation/python/manual/#traces) allows you to customize trace spans and events.
       Additionally, if you are using the `requests` library then all the HTTP communication can be auto-instrumented:
 
       ```python


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Fix broken link in the [Customize Function traces](https://kyma-project.io/docs/kyma/latest/03-tutorials/00-serverless/svls-12-customize-function-traces/) tutorial. The link changed because of this commit: https://github.com/open-telemetry/opentelemetry.io/commit/5b82523be1d8c0fb5bb86afd1719e98e0fdf9d3c
