### PR TITLE
Deploy Loki resource during upgrade process

### DIFF
--- a/tests/fast-integration/upgrade-test/upgrade-test-tests.js
+++ b/tests/fast-integration/upgrade-test/upgrade-test-tests.js
@@ -5,6 +5,7 @@ const path = require('path');
 const {
   printRestartReport,
   getContainerRestartsForAllNamespaces,
+  deployLoki,
 } = require('../utils');
 const {loggingTests} = require('../logging');
 const {


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- The loki resources is deployed in upgrade prep phase in 2.16 its not there in 2.15.1 so the upgrade test from 2.15.1->2.16 fails.
- [PJTester run](https://storage.googleapis.com/kyma-prow-logs/logs/rakesh-garimella_test_of_prowjob_kyma-upgrade-k3d-kyma2-to-main/1676160089465032704/build-log.txt) is green

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
https://github.com/kyma-project/kyma/issues/17755
