### PR TITLE
Adjust Logpipeline name in fast-integration test

### DIFF
--- a/tests/fast-integration/telemetry-test/suite.js
+++ b/tests/fast-integration/telemetry-test/suite.js
@@ -136,12 +136,12 @@ describe('Telemetry Operator', function() {
   });
 
   context('Configurable Logging', function() {
-    context('Default Loki LogPipeline', function() {
+    context('Custom Loki LogPipeline', function() {
       it('Should be \'Running\'', async function() {
-        await waitForLogPipelineStatusRunning('loki');
+        await waitForLogPipelineStatusRunning('loki-test');
       });
 
-      it('Should push system logs to Kyma Loki', async function() {
+      it('Should push system logs to Loki', async function() {
         const labels = '{namespace="kyma-system", job="telemetry-fluent-bit"}';
         const logsPresent = await logsPresentInLoki(labels, testStartTimestamp, 10);
         assert.isTrue(logsPresent, 'No logs present in Loki with namespace="kyma-system"');


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- The  name of the custom Logpipeline currently installed in the fast-integration test is `loki-test` and not `loki` which was the name for the old default Loki Logpipeline.

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
#17636 