### PR TITLE
Deconfigure istio proxy tracer explicit to avoid DNS lookups

### DIFF
--- a/resources/istio/values.yaml
+++ b/resources/istio/values.yaml
@@ -4,6 +4,7 @@ helmValues:
     priorityClassName: "kyma-system-priority"
     imagePullPolicy: IfNotPresent
     proxy:
+      tracer: none
       readinessFailureThreshold: 40
       readinessInitialDelaySeconds: 5
       readinessPeriodSeconds: 5
@@ -43,10 +44,6 @@ meshConfig:
     tracing: []
   defaultConfig:
     holdApplicationUntilProxyStarts: true
-    tracing:
-      zipkin:
-        # workaround till https://github.com/istio/istio/issues/45890 is solved
-        address: 127.0.0.1:9411
   enablePrometheusMerge: false
   enableTracing: false
   extensionProviders:

--- a/resources/istio/values.yaml
+++ b/resources/istio/values.yaml
@@ -43,6 +43,10 @@ meshConfig:
     tracing: []
   defaultConfig:
     holdApplicationUntilProxyStarts: true
+    tracing:
+      zipkin:
+        # workaround till https://github.com/istio/istio/issues/45890 is solved
+        address: 127.0.0.1:9411
   enablePrometheusMerge: false
   enableTracing: false
   extensionProviders:


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Debugging a kyma cluster using tcpdump on a privileged pod reveals that constantly DNS lookups for `zipkin.istio-system` are performed. Analyzing the configuration further revealed that the extensionProvider configuration mechanism seems to enable the zipkin tracer additionally to the configured providers. An upstream ticket got created for now https://github.com/istio/istio/issues/45890, we still need to see if we can contribute a fix.
As the main problem is the additional stress to CoreDNS with negative DNS lookups, this PR disabled explicitly the tracer in the proxy config as described as a workaround in the upstream bug report. 

To validate that the change will not cause any additional DNS entries, deploy a privileged pod (for example using the Gardener terminal) and execute `tcpdump -i any -vvv -s0 -w capture.pcap`.
Then copy the captured file using
```
kubectl -n term-host-11327686835437096980 cp term-11327686835437096980:/capture.pcap capture.pcap
```
and analyze the file using [wireshark](https://www.wireshark.org/). Enter "dns" as the filter criteria.

Changes proposed in this pull request:

- disable proxy tracer explicitly to avoid negative DNS lookups

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
https://github.com/istio/istio/issues/45890