### PR TITLE
Bump kiwigrid k8s-sidecar to 1.24.6 version

### DIFF
--- a/resources/monitoring/charts/grafana/templates/_pod.tpl
+++ b/resources/monitoring/charts/grafana/templates/_pod.tpl
@@ -95,6 +95,8 @@ initContainers:
     image: "{{ include "imageurl" (dict "reg" .Values.global.containerRegistry "img" .Values.global.images.k8s_sidecar) }}"
     imagePullPolicy: {{ .Values.sidecar.imagePullPolicy }}
     env:
+      - name: IGNORE_ALREADY_PROCESSED
+        value: "true"
       - name: METHOD
         value: LIST
       - name: LABEL
@@ -140,6 +142,8 @@ containers:
     image: "{{ include "imageurl" (dict "reg" .Values.global.containerRegistry "img" .Values.global.images.k8s_sidecar) }}"
     imagePullPolicy: {{ .Values.sidecar.imagePullPolicy }}
     env:
+      - name: IGNORE_ALREADY_PROCESSED
+        value: "true"
       - name: METHOD
         value: {{ .Values.sidecar.datasources.watchMethod }}
       - name: LABEL
@@ -179,6 +183,8 @@ containers:
     image: "{{ include "imageurl" (dict "reg" .Values.global.containerRegistry "img" .Values.global.images.k8s_sidecar) }}"
     imagePullPolicy: {{ .Values.sidecar.imagePullPolicy }}
     env:
+      - name: IGNORE_ALREADY_PROCESSED
+        value: "true"
       - name: METHOD
         value: {{ .Values.sidecar.dashboards.watchMethod }}
       - name: LABEL

--- a/resources/monitoring/values.yaml
+++ b/resources/monitoring/values.yaml
@@ -155,8 +155,8 @@ global:
       sha: ""
     k8s_sidecar:
       name: "k8s-sidecar"
-      version: "PR-364"
-      directory: "dev/tpi"
+      version: "1.24.6-8a6ab896"
+      directory: "prod/tpi"
       sha: ""
     oauth2_proxy:
       name: "oauth2-proxy"

--- a/resources/monitoring/values.yaml
+++ b/resources/monitoring/values.yaml
@@ -155,8 +155,8 @@ global:
       sha: ""
     k8s_sidecar:
       name: "k8s-sidecar"
-      version: "1.15.9-1a4f8cec"
-      directory: "prod/tpi"
+      version: "PR-364"
+      directory: "dev/tpi"
       sha: ""
     oauth2_proxy:
       name: "oauth2-proxy"


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**
We did not update the sidecar version for a long time as we observed increased resource consumption.
I tried it once more and using the additional flag IGNORE_ALREADY_PROCESSED the consumption is very similar as before. The big advantage is that logs are now in JSON and the info logs are reduced to a minimum. As the resources are not getting processed constantly anymore but only on changes, the amount of logs is reduced heavily.


Changes proposed in this pull request:

- update to latest version 1.24.6
- add new flag which works from k8s 1.19 on, to process only changed resources

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
https://github.com/kyma-project/third-party-images/pull/364