### PR TITLE
simplify sender interface

### DIFF
--- a/components/event-publisher-proxy/pkg/commander/eventmesh/eventmesh.go
+++ b/components/event-publisher-proxy/pkg/commander/eventmesh/eventmesh.go
@@ -81,7 +81,7 @@ func (c *Commander) Start() error {
 	defer client.CloseIdleConnections()
 
 	// configure message sender
-	messageSender := eventmesh.NewSender(c.envCfg.EventMeshPublishURL, client)
+	messageSender := eventmesh.NewSender(c.envCfg.EventMeshPublishURL, client, c.logger)
 
 	// cluster config
 	k8sConfig := config.GetConfigOrDie()

--- a/components/event-publisher-proxy/pkg/commander/eventmesh/eventmesh.go
+++ b/components/event-publisher-proxy/pkg/commander/eventmesh/eventmesh.go
@@ -123,7 +123,7 @@ func (c *Commander) Start() error {
 		applicationLister, c.logger)
 
 	// start handler which blocks until it receives a shutdown signal
-	if err := handler.NewHandler(
+	if err := handler.New(
 		messageReceiver,
 		messageSender,
 		health.NewChecker(),

--- a/components/event-publisher-proxy/pkg/commander/nats/nats.go
+++ b/components/event-publisher-proxy/pkg/commander/nats/nats.go
@@ -132,8 +132,22 @@ func (c *Commander) Start() error {
 		applicationLister, c.logger)
 
 	// start handler which blocks until it receives a shutdown signal
-	if err := handler.NewHandler(messageReceiver, messageSender, messageSender, c.envCfg.RequestTimeout, legacyTransformer, c.opts,
-		subscribedProcessor, c.logger, c.metricsCollector, eventTypeCleanerV1, ceBuilder, c.envCfg.EventTypePrefix, env.JetStreamBackend).Start(ctx); err != nil {
+	h := handler.New(
+		messageReceiver,
+		messageSender,
+		messageSender,
+		c.envCfg.RequestTimeout,
+		legacyTransformer,
+		c.opts,
+		subscribedProcessor,
+		c.logger,
+		c.metricsCollector,
+		eventTypeCleanerV1,
+		ceBuilder,
+		c.envCfg.EventTypePrefix,
+		env.JetStreamBackend,
+	)
+	if err := h.Start(ctx); err != nil {
 		return xerrors.Errorf("failed to start handler for %s : %v", natsCommanderName, err)
 	}
 

--- a/components/event-publisher-proxy/pkg/handler/handler.go
+++ b/components/event-publisher-proxy/pkg/handler/handler.go
@@ -315,8 +315,6 @@ func (h *Handler) sendEventAndRecordMetrics(ctx context.Context, event *cev2even
 			code = pubErr.Code()
 		}
 		h.collector.RecordBackendLatency(duration, code, host)
-		h.collector.RecordBackendRequests(code, host)
-		h.collector.RecordBackendError()
 		return err
 	}
 	originalEventType := event.Type()
@@ -334,7 +332,6 @@ func (h *Handler) sendEventAndRecordMetrics(ctx context.Context, event *cev2even
 	}
 	h.collector.RecordEventType(originalEventType, event.Source(), http.StatusNoContent)
 	h.collector.RecordBackendLatency(duration, http.StatusNoContent, host)
-	h.collector.RecordBackendRequests(http.StatusNoContent, host)
 	return nil
 }
 

--- a/components/event-publisher-proxy/pkg/handler/handler.go
+++ b/components/event-publisher-proxy/pkg/handler/handler.go
@@ -129,7 +129,7 @@ func (h *Handler) handleSendEventAndRecordMetricsLegacy(
 		h.namedLogger().Error(err)
 		httpStatus := http.StatusInternalServerError
 		var pubErr sender.PublishError
-		if ok := errors.As(err, &pubErr); ok {
+		if errors.As(err, &pubErr) {
 			httpStatus = pubErr.Code()
 		}
 		h.LegacyTransformer.WriteCEResponseAsLegacyResponse(writer, httpStatus, event, err.Error())
@@ -263,7 +263,7 @@ func (h *Handler) publishCloudEvents(writer http.ResponseWriter, request *http.R
 	if err != nil {
 		httpStatus := http.StatusInternalServerError
 		var pubErr sender.PublishError
-		if ok := errors.As(err, &pubErr); ok {
+		if errors.As(err, &pubErr) {
 			httpStatus = pubErr.Code()
 		}
 		writer.WriteHeader(httpStatus)
@@ -305,7 +305,7 @@ func (h *Handler) sendEventAndRecordMetrics(ctx context.Context, event *cev2even
 	if err != nil {
 		var pubErr sender.PublishError
 		code := 500
-		if ok := errors.As(err, &pubErr); ok {
+		if errors.As(err, &pubErr) {
 			code = pubErr.Code()
 		}
 		h.collector.RecordBackendLatency(duration, code, host)

--- a/components/event-publisher-proxy/pkg/handler/handler.go
+++ b/components/event-publisher-proxy/pkg/handler/handler.go
@@ -123,27 +123,25 @@ func (h *Handler) maxBytes(f http.HandlerFunc) http.HandlerFunc {
 // It writes to the user request if any error occurs.
 // Otherwise, returns the result.
 func (h *Handler) handleSendEventAndRecordMetricsLegacy(
-	writer http.ResponseWriter, request *http.Request, event *cev2event.Event) (sender.PublishResult, error) {
-	result, err := h.sendEventAndRecordMetrics(request.Context(), event, h.Sender.URL(), request.Header)
+	writer http.ResponseWriter, request *http.Request, event *cev2event.Event) error {
+	err := h.sendEventAndRecordMetrics(request.Context(), event, h.Sender.URL(), request.Header)
 	if err != nil {
 		h.namedLogger().Error(err)
 		httpStatus := http.StatusInternalServerError
-		if errors.Is(err, sender.ErrInsufficientStorage) {
-			httpStatus = http.StatusInsufficientStorage
-		} else if errors.Is(err, sender.ErrBackendTargetNotFound) {
-			httpStatus = http.StatusBadGateway
+		var pubErr sender.PublishError
+		if ok := errors.As(err, &pubErr); ok {
+			httpStatus = pubErr.Code()
 		}
 		h.LegacyTransformer.WriteCEResponseAsLegacyResponse(writer, httpStatus, event, err.Error())
-		return nil, err
+		return err
 	}
-	h.namedLogger().Debug(result)
-	return result, nil
+	return nil
 }
 
 // handlePublishLegacyEvent handles the publishing of events for Subscription v1alpha2 CRD.
 // It writes to the user request if any error occurs.
 // Otherwise, return the published event.
-func (h *Handler) handlePublishLegacyEvent(writer http.ResponseWriter, publishData *api.PublishRequestData, request *http.Request) (sender.PublishResult, *cev2event.Event) {
+func (h *Handler) handlePublishLegacyEvent(writer http.ResponseWriter, publishData *api.PublishRequestData, request *http.Request) (*cev2event.Event, error) {
 	ceEvent, err := h.LegacyTransformer.TransformPublishRequestToCloudEvent(publishData)
 	if err != nil {
 		legacy.WriteJSONResponse(writer, legacy.ErrorResponse(http.StatusInternalServerError, err))
@@ -154,41 +152,38 @@ func (h *Handler) handlePublishLegacyEvent(writer http.ResponseWriter, publishDa
 	event, err := h.ceBuilder.Build(*ceEvent)
 	if err != nil {
 		legacy.WriteJSONResponse(writer, legacy.ErrorResponseBadRequest(err.Error()))
-		return nil, nil
+		return nil, err
 	}
 
-	result, err := h.handleSendEventAndRecordMetricsLegacy(writer, request, event)
+	err = h.handleSendEventAndRecordMetricsLegacy(writer, request, event)
 	if err != nil {
-		return nil, nil
+		return nil, err
 	}
 
-	return result, event
+	return event, err
 }
 
 // handlePublishLegacyEventV1alpha1 handles the publishing of events for Subscription v1alpha1 CRD.
 // It writes to the user request if any error occurs.
 // Otherwise, return the published event.
-func (h *Handler) handlePublishLegacyEventV1alpha1(writer http.ResponseWriter, publishData *api.PublishRequestData, request *http.Request) (sender.PublishResult, *cev2event.Event) {
+func (h *Handler) handlePublishLegacyEventV1alpha1(writer http.ResponseWriter, publishData *api.PublishRequestData, request *http.Request) (*cev2event.Event, error) {
 	event, _ := h.LegacyTransformer.WriteLegacyRequestsToCE(writer, publishData)
 	if event == nil {
 		h.namedLogger().Error("Failed to transform legacy event to CloudEvent, event is nil")
 		return nil, nil
 	}
 
-	result, err := h.handleSendEventAndRecordMetricsLegacy(writer, request, event)
+	err := h.handleSendEventAndRecordMetricsLegacy(writer, request, event)
 	if err != nil {
-		return nil, nil
+		return nil, err
 	}
 
-	return result, event
+	return event, err
 }
 
 // publishLegacyEventsAsCE converts an incoming request in legacy event format to a cloudevent and dispatches it using
 // the configured GenericSender.
 func (h *Handler) publishLegacyEventsAsCE(writer http.ResponseWriter, request *http.Request) {
-	var publishedEvent *cev2event.Event
-	var successResult sender.PublishResult
-
 	// extract publish data from request
 	publishRequestData, errResp, _ := h.LegacyTransformer.ExtractPublishRequestData(request)
 	if errResp != nil {
@@ -197,10 +192,10 @@ func (h *Handler) publishLegacyEventsAsCE(writer http.ResponseWriter, request *h
 	}
 
 	// publish event for Subscription
-	successResult, publishedEvent = h.handlePublishLegacyEvent(writer, publishRequestData, request)
+	publishedEvent, err := h.handlePublishLegacyEvent(writer, publishRequestData, request)
 	// if publishedEvent is nil, then it means that the publishing failed
 	// and the response is already returned to the user
-	if publishedEvent == nil {
+	if err != nil {
 		return
 	}
 
@@ -210,17 +205,17 @@ func (h *Handler) publishLegacyEventsAsCE(writer http.ResponseWriter, request *h
 	// i.e. with prefix (`sap.kyma.custom`) and without prefix
 	// this behaviour will be deprecated when we remove support for JetStream with Subscription `exact` typeMatching
 	if h.activeBackend == env.JetStreamBackend {
-		successResult, publishedEvent = h.handlePublishLegacyEventV1alpha1(writer, publishRequestData, request)
+		publishedEvent, err = h.handlePublishLegacyEventV1alpha1(writer, publishRequestData, request)
 		// if publishedEvent is nil, then it means that the publishing failed
 		// and the response is already returned to the user
-		if publishedEvent == nil {
+		if err != nil {
 			return
 		}
 	}
 
 	// return success response to user
 	// change response as per old error codes
-	h.LegacyTransformer.WriteCEResponseAsLegacyResponse(writer, successResult.HTTPStatus(), publishedEvent, string(successResult.ResponseBody()))
+	h.LegacyTransformer.WriteCEResponseAsLegacyResponse(writer, http.StatusNoContent, publishedEvent, "")
 }
 
 // publishCloudEvents validates an incoming cloudevent and dispatches it using
@@ -264,19 +259,18 @@ func (h *Handler) publishCloudEvents(writer http.ResponseWriter, request *http.R
 		event.SetType(eventTypeClean)
 	}
 
-	result, err := h.sendEventAndRecordMetrics(ctx, event, h.Sender.URL(), request.Header)
+	err = h.sendEventAndRecordMetrics(ctx, event, h.Sender.URL(), request.Header)
 	if err != nil {
 		httpStatus := http.StatusInternalServerError
-		if errors.Is(err, sender.ErrInsufficientStorage) {
-			httpStatus = http.StatusInsufficientStorage
+		var pubErr sender.PublishError
+		if ok := errors.As(err, &pubErr); ok {
+			httpStatus = pubErr.Code()
 		}
 		writer.WriteHeader(httpStatus)
 		h.namedLogger().With().Error(err)
 		return
 	}
-	h.namedLogger().With().Debug(result)
-
-	err = writeResponse(writer, result.HTTPStatus(), result.ResponseBody())
+	err = writeResponse(writer, http.StatusNoContent, []byte(""))
 	if err != nil {
 		h.namedLogger().With().Error(err)
 	}
@@ -300,23 +294,24 @@ func extractCloudEventFromRequest(request *http.Request) (*cev2event.Event, erro
 }
 
 // sendEventAndRecordMetrics dispatches an Event and records metrics based on dispatch success.
-func (h *Handler) sendEventAndRecordMetrics(ctx context.Context, event *cev2event.Event, host string, header http.Header) (sender.PublishResult, error) {
+func (h *Handler) sendEventAndRecordMetrics(ctx context.Context, event *cev2event.Event, host string, header http.Header) error {
 	ctx, cancel := context.WithTimeout(ctx, h.RequestTimeout)
 	defer cancel()
 	h.applyDefaults(ctx, event)
 	tracing.AddTracingContextToCEExtensions(header, event)
 	start := time.Now()
-	result, err := h.Sender.Send(ctx, event)
+	err := h.Sender.Send(ctx, event)
 	duration := time.Since(start)
 	if err != nil {
-		status := 500
-		if result != nil {
-			status = result.HTTPStatus()
+		var pubErr sender.PublishError
+		code := 500
+		if ok := errors.As(err, &pubErr); ok {
+			code = pubErr.Code()
 		}
-		h.collector.RecordBackendLatency(duration, status, host)
-		h.collector.RecordBackendRequests(status, host)
+		h.collector.RecordBackendLatency(duration, code, host)
+		h.collector.RecordBackendRequests(code, host)
 		h.collector.RecordBackendError()
-		return nil, err
+		return err
 	}
 	originalEventType := event.Type()
 	originalTypeHeader, ok := event.Extensions()[builder.OriginalTypeHeaderName]
@@ -331,10 +326,10 @@ func (h *Handler) sendEventAndRecordMetrics(ctx context.Context, event *cev2even
 			originalEventType = event.Type()
 		}
 	}
-	h.collector.RecordEventType(originalEventType, event.Source(), result.HTTPStatus())
-	h.collector.RecordBackendLatency(duration, result.HTTPStatus(), host)
-	h.collector.RecordBackendRequests(result.HTTPStatus(), host)
-	return result, nil
+	h.collector.RecordEventType(originalEventType, event.Source(), http.StatusNoContent)
+	h.collector.RecordBackendLatency(duration, http.StatusNoContent, host)
+	h.collector.RecordBackendRequests(http.StatusNoContent, host)
+	return nil
 }
 
 // writeResponse writes the HTTP response given the status code and response body.

--- a/components/event-publisher-proxy/pkg/handler/handler_test.go
+++ b/components/event-publisher-proxy/pkg/handler/handler_test.go
@@ -73,29 +73,9 @@ func TestHandler_publishCloudEvents(t *testing.T) {
 				request: CreateValidStructuredRequestV1Alpha1(t),
 			},
 			wantStatus: 204,
-			wantTEF: `
-				# HELP eventing_epp_event_type_published_total The total number of events published for a given eventTypeLabel
-				# TYPE eventing_epp_event_type_published_total counter
-				eventing_epp_event_type_published_total{code="204",event_source="/default/sap.kyma/id",event_type=""} 1
-				# HELP eventing_epp_backend_duration_milliseconds The duration of sending events to the messaging server in milliseconds
-				# TYPE eventing_epp_backend_duration_milliseconds histogram
-				eventing_epp_backend_duration_milliseconds_bucket{code="204",destination_service="FOO",le="0.005"} 1
-				eventing_epp_backend_duration_milliseconds_bucket{code="204",destination_service="FOO",le="0.01"} 1
-				eventing_epp_backend_duration_milliseconds_bucket{code="204",destination_service="FOO",le="0.025"} 1
-				eventing_epp_backend_duration_milliseconds_bucket{code="204",destination_service="FOO",le="0.05"} 1
-				eventing_epp_backend_duration_milliseconds_bucket{code="204",destination_service="FOO",le="0.1"} 1
-				eventing_epp_backend_duration_milliseconds_bucket{code="204",destination_service="FOO",le="0.25"} 1
-				eventing_epp_backend_duration_milliseconds_bucket{code="204",destination_service="FOO",le="0.5"} 1
-				eventing_epp_backend_duration_milliseconds_bucket{code="204",destination_service="FOO",le="1"} 1
-				eventing_epp_backend_duration_milliseconds_bucket{code="204",destination_service="FOO",le="2.5"} 1
-				eventing_epp_backend_duration_milliseconds_bucket{code="204",destination_service="FOO",le="5"} 1
-				eventing_epp_backend_duration_milliseconds_bucket{code="204",destination_service="FOO",le="10"} 1
-				eventing_epp_backend_duration_milliseconds_bucket{code="204",destination_service="FOO",le="+Inf"} 1
-				eventing_epp_backend_duration_milliseconds_count{code="204",destination_service="FOO"} 1
-				# HELP eventing_epp_backend_requests_total The total number of backend requests
-				# TYPE eventing_epp_backend_requests_total counter
-				eventing_epp_backend_requests_total{code="204",destination_service="FOO"} 1
-			`,
+			wantTEF: metricstest.MakeTEFBackendDuration(204, "FOO") +
+				metricstest.MakeTEFBackendRequests(204, "FOO") +
+				metricstest.MakeTEFEventTypePublished(204, "/default/sap.kyma/id", ""),
 		},
 		{
 			name: "Publish binary Cloudevent for Subscription v1alpha1",
@@ -111,30 +91,9 @@ func TestHandler_publishCloudEvents(t *testing.T) {
 				request: CreateValidBinaryRequestV1Alpha1(t),
 			},
 			wantStatus: 204,
-			wantTEF: `
-				# HELP eventing_epp_event_type_published_total The total number of events published for a given eventTypeLabel
-				# TYPE eventing_epp_event_type_published_total counter
-				eventing_epp_event_type_published_total{code="204",event_source="/default/sap.kyma/id",event_type=""} 1
-				# HELP eventing_epp_backend_duration_milliseconds The duration of sending events to the messaging server in milliseconds
-				# TYPE eventing_epp_backend_duration_milliseconds histogram
-				eventing_epp_backend_duration_milliseconds_bucket{code="204",destination_service="FOO",le="0.005"} 1
-				eventing_epp_backend_duration_milliseconds_bucket{code="204",destination_service="FOO",le="0.01"} 1
-				eventing_epp_backend_duration_milliseconds_bucket{code="204",destination_service="FOO",le="0.025"} 1
-				eventing_epp_backend_duration_milliseconds_bucket{code="204",destination_service="FOO",le="0.05"} 1
-				eventing_epp_backend_duration_milliseconds_bucket{code="204",destination_service="FOO",le="0.1"} 1
-				eventing_epp_backend_duration_milliseconds_bucket{code="204",destination_service="FOO",le="0.25"} 1
-				eventing_epp_backend_duration_milliseconds_bucket{code="204",destination_service="FOO",le="0.5"} 1
-				eventing_epp_backend_duration_milliseconds_bucket{code="204",destination_service="FOO",le="1"} 1
-				eventing_epp_backend_duration_milliseconds_bucket{code="204",destination_service="FOO",le="2.5"} 1
-				eventing_epp_backend_duration_milliseconds_bucket{code="204",destination_service="FOO",le="5"} 1
-				eventing_epp_backend_duration_milliseconds_bucket{code="204",destination_service="FOO",le="10"} 1
-				eventing_epp_backend_duration_milliseconds_bucket{code="204",destination_service="FOO",le="+Inf"} 1
-				eventing_epp_backend_duration_milliseconds_sum{destination_service="FOO",code="204"} 0
-				eventing_epp_backend_duration_milliseconds_count{destination_service="FOO",code="204"} 1
-				# HELP eventing_epp_backend_requests_total The total number of backend requests
-				# TYPE eventing_epp_backend_requests_total counter
-				eventing_epp_backend_requests_total{code="204",destination_service="FOO"} 1
-			`,
+			wantTEF: metricstest.MakeTEFBackendDuration(204, "FOO") +
+				metricstest.MakeTEFBackendRequests(204, "FOO") +
+				metricstest.MakeTEFEventTypePublished(204, "/default/sap.kyma/id", ""),
 		},
 		{
 			name: "Publish structured Cloudevent",
@@ -150,29 +109,9 @@ func TestHandler_publishCloudEvents(t *testing.T) {
 				request: CreateValidStructuredRequest(t),
 			},
 			wantStatus: 204,
-			wantTEF: `
-				# HELP eventing_epp_event_type_published_total The total number of events published for a given eventTypeLabel
-				# TYPE eventing_epp_event_type_published_total counter
-				eventing_epp_event_type_published_total{code="204",event_source="testapp1023",event_type="order.created.v1"} 1
-				# HELP eventing_epp_backend_duration_milliseconds The duration of sending events to the messaging server in milliseconds
-				# TYPE eventing_epp_backend_duration_milliseconds histogram
-				eventing_epp_backend_duration_milliseconds_bucket{code="204",destination_service="FOO",le="0.005"} 1
-				eventing_epp_backend_duration_milliseconds_bucket{code="204",destination_service="FOO",le="0.01"} 1
-				eventing_epp_backend_duration_milliseconds_bucket{code="204",destination_service="FOO",le="0.025"} 1
-				eventing_epp_backend_duration_milliseconds_bucket{code="204",destination_service="FOO",le="0.05"} 1
-				eventing_epp_backend_duration_milliseconds_bucket{code="204",destination_service="FOO",le="0.1"} 1
-				eventing_epp_backend_duration_milliseconds_bucket{code="204",destination_service="FOO",le="0.25"} 1
-				eventing_epp_backend_duration_milliseconds_bucket{code="204",destination_service="FOO",le="0.5"} 1
-				eventing_epp_backend_duration_milliseconds_bucket{code="204",destination_service="FOO",le="1"} 1
-				eventing_epp_backend_duration_milliseconds_bucket{code="204",destination_service="FOO",le="2.5"} 1
-				eventing_epp_backend_duration_milliseconds_bucket{code="204",destination_service="FOO",le="5"} 1
-				eventing_epp_backend_duration_milliseconds_bucket{code="204",destination_service="FOO",le="10"} 1
-				eventing_epp_backend_duration_milliseconds_bucket{code="204",destination_service="FOO",le="+Inf"} 1
-				eventing_epp_backend_duration_milliseconds_count{code="204",destination_service="FOO"} 1
-				# HELP eventing_epp_backend_requests_total The total number of backend requests
-				# TYPE eventing_epp_backend_requests_total counter
-				eventing_epp_backend_requests_total{code="204",destination_service="FOO"} 1
-			`,
+			wantTEF: metricstest.MakeTEFBackendDuration(204, "FOO") +
+				metricstest.MakeTEFBackendRequests(204, "FOO") +
+				metricstest.MakeTEFEventTypePublished(204, "testapp1023", "order.created.v1"),
 		},
 		{
 			name: "Publish binary Cloudevent",
@@ -188,30 +127,9 @@ func TestHandler_publishCloudEvents(t *testing.T) {
 				request: CreateValidBinaryRequest(t),
 			},
 			wantStatus: 204,
-			wantTEF: `
-				# HELP eventing_epp_event_type_published_total The total number of events published for a given eventTypeLabel
-				# TYPE eventing_epp_event_type_published_total counter
-				eventing_epp_event_type_published_total{code="204",event_source="testapp1023",event_type="order.created.v1"} 1
-				# HELP eventing_epp_backend_duration_milliseconds The duration of sending events to the messaging server in milliseconds
-				# TYPE eventing_epp_backend_duration_milliseconds histogram
-				eventing_epp_backend_duration_milliseconds_bucket{code="204",destination_service="FOO",le="0.005"} 1
-				eventing_epp_backend_duration_milliseconds_bucket{code="204",destination_service="FOO",le="0.01"} 1
-				eventing_epp_backend_duration_milliseconds_bucket{code="204",destination_service="FOO",le="0.025"} 1
-				eventing_epp_backend_duration_milliseconds_bucket{code="204",destination_service="FOO",le="0.05"} 1
-				eventing_epp_backend_duration_milliseconds_bucket{code="204",destination_service="FOO",le="0.1"} 1
-				eventing_epp_backend_duration_milliseconds_bucket{code="204",destination_service="FOO",le="0.25"} 1
-				eventing_epp_backend_duration_milliseconds_bucket{code="204",destination_service="FOO",le="0.5"} 1
-				eventing_epp_backend_duration_milliseconds_bucket{code="204",destination_service="FOO",le="1"} 1
-				eventing_epp_backend_duration_milliseconds_bucket{code="204",destination_service="FOO",le="2.5"} 1
-				eventing_epp_backend_duration_milliseconds_bucket{code="204",destination_service="FOO",le="5"} 1
-				eventing_epp_backend_duration_milliseconds_bucket{code="204",destination_service="FOO",le="10"} 1
-				eventing_epp_backend_duration_milliseconds_bucket{code="204",destination_service="FOO",le="+Inf"} 1
-				eventing_epp_backend_duration_milliseconds_sum{destination_service="FOO",code="204"} 0
-				eventing_epp_backend_duration_milliseconds_count{destination_service="FOO",code="204"} 1
-				# HELP eventing_epp_backend_requests_total The total number of backend requests
-				# TYPE eventing_epp_backend_requests_total counter
-				eventing_epp_backend_requests_total{code="204",destination_service="FOO"} 1
-			`,
+			wantTEF: metricstest.MakeTEFBackendDuration(204, "FOO") +
+				metricstest.MakeTEFBackendRequests(204, "FOO") +
+				metricstest.MakeTEFEventTypePublished(204, "testapp1023", "order.created.v1"),
 		},
 		{
 			name: "Publish invalid structured CloudEvent",
@@ -251,30 +169,9 @@ func TestHandler_publishCloudEvents(t *testing.T) {
 				request: CreateValidBinaryRequest(t),
 			},
 			wantStatus: 500,
-			wantTEF: `
-				# HELP eventing_epp_backend_duration_milliseconds The duration of sending events to the messaging server in milliseconds
-				# TYPE eventing_epp_backend_duration_milliseconds histogram
-				eventing_epp_backend_duration_milliseconds_bucket{code="500",destination_service="",le="0.005"} 1
-				eventing_epp_backend_duration_milliseconds_bucket{code="500",destination_service="",le="0.01"} 1
-				eventing_epp_backend_duration_milliseconds_bucket{code="500",destination_service="",le="0.025"} 1
-				eventing_epp_backend_duration_milliseconds_bucket{code="500",destination_service="",le="0.05"} 1
-				eventing_epp_backend_duration_milliseconds_bucket{code="500",destination_service="",le="0.1"} 1
-				eventing_epp_backend_duration_milliseconds_bucket{code="500",destination_service="",le="0.25"} 1
-				eventing_epp_backend_duration_milliseconds_bucket{code="500",destination_service="",le="0.5"} 1
-				eventing_epp_backend_duration_milliseconds_bucket{code="500",destination_service="",le="1"} 1
-				eventing_epp_backend_duration_milliseconds_bucket{code="500",destination_service="",le="2.5"} 1
-				eventing_epp_backend_duration_milliseconds_bucket{code="500",destination_service="",le="5"} 1
-				eventing_epp_backend_duration_milliseconds_bucket{code="500",destination_service="",le="10"} 1
-				eventing_epp_backend_duration_milliseconds_bucket{code="500",destination_service="",le="+Inf"} 1
-				eventing_epp_backend_duration_milliseconds_sum{code="500",destination_service=""} 0
-				eventing_epp_backend_duration_milliseconds_count{code="500",destination_service=""} 1
-				# HELP eventing_epp_backend_errors_total The total number of backend errors while sending events to the messaging server
-				# TYPE eventing_epp_backend_errors_total counter
-				eventing_epp_backend_errors_total 1
-				# HELP eventing_epp_backend_requests_total The total number of backend requests
-				# TYPE eventing_epp_backend_requests_total counter
-				eventing_epp_backend_requests_total{code="500",destination_service=""} 1
-`,
+			wantTEF: metricstest.MakeTEFBackendDuration(500, "") +
+				metricstest.MakeTEFBackendRequests(500, "") +
+				metricstest.MakeTEFBackendErrors(),
 		},
 		{
 			name: "Publish binary CloudEvent but backend is full",
@@ -289,30 +186,9 @@ func TestHandler_publishCloudEvents(t *testing.T) {
 				request: CreateValidBinaryRequest(t),
 			},
 			wantStatus: 507,
-			wantTEF: `
-				# HELP eventing_epp_backend_duration_milliseconds The duration of sending events to the messaging server in milliseconds
-				# TYPE eventing_epp_backend_duration_milliseconds histogram
-				eventing_epp_backend_duration_milliseconds_bucket{code="507",destination_service="",le="0.005"} 1
-				eventing_epp_backend_duration_milliseconds_bucket{code="507",destination_service="",le="0.01"} 1
-				eventing_epp_backend_duration_milliseconds_bucket{code="507",destination_service="",le="0.025"} 1
-				eventing_epp_backend_duration_milliseconds_bucket{code="507",destination_service="",le="0.05"} 1
-				eventing_epp_backend_duration_milliseconds_bucket{code="507",destination_service="",le="0.1"} 1
-				eventing_epp_backend_duration_milliseconds_bucket{code="507",destination_service="",le="0.25"} 1
-				eventing_epp_backend_duration_milliseconds_bucket{code="507",destination_service="",le="0.5"} 1
-				eventing_epp_backend_duration_milliseconds_bucket{code="507",destination_service="",le="1"} 1
-				eventing_epp_backend_duration_milliseconds_bucket{code="507",destination_service="",le="2.5"} 1
-				eventing_epp_backend_duration_milliseconds_bucket{code="507",destination_service="",le="5"} 1
-				eventing_epp_backend_duration_milliseconds_bucket{code="507",destination_service="",le="10"} 1
-				eventing_epp_backend_duration_milliseconds_bucket{code="507",destination_service="",le="+Inf"} 1
-				eventing_epp_backend_duration_milliseconds_sum{code="507",destination_service=""} 0
-				eventing_epp_backend_duration_milliseconds_count{code="507",destination_service=""} 1
-				# HELP eventing_epp_backend_errors_total The total number of backend errors while sending events to the messaging server
-				# TYPE eventing_epp_backend_errors_total counter
-				eventing_epp_backend_errors_total 1
-				# HELP eventing_epp_backend_requests_total The total number of backend requests
-				# TYPE eventing_epp_backend_requests_total counter
-				eventing_epp_backend_requests_total{code="507",destination_service=""} 1
-			`,
+			wantTEF: metricstest.MakeTEFBackendDuration(507, "") +
+				metricstest.MakeTEFBackendRequests(507, "") +
+				metricstest.MakeTEFBackendErrors(),
 		},
 	}
 	for _, tt := range tests {
@@ -379,32 +255,9 @@ func TestHandler_publishLegacyEventsAsCE(t *testing.T) {
 			givenCollector:         metrics.NewCollector(latency),
 			givenRequest:           legacytest.ValidLegacyRequestOrDie(t, "v1", "testapp", "object.created"),
 			wantHTTPStatus:         http.StatusOK,
-			wantTEF: `
-					# HELP eventing_epp_event_type_published_total The total number of events published for a given eventTypeLabel
-					# TYPE eventing_epp_event_type_published_total counter
-					eventing_epp_event_type_published_total{code="204",event_source="testapp",event_type="object.created.v1"} 1
-
-					# HELP eventing_epp_backend_duration_milliseconds The duration of sending events to the messaging server in milliseconds
-					# TYPE eventing_epp_backend_duration_milliseconds histogram
-					eventing_epp_backend_duration_milliseconds_bucket{code="204",destination_service="FOO",le="0.005"} 1
-					eventing_epp_backend_duration_milliseconds_bucket{code="204",destination_service="FOO",le="0.01"} 1
-					eventing_epp_backend_duration_milliseconds_bucket{code="204",destination_service="FOO",le="0.025"} 1
-					eventing_epp_backend_duration_milliseconds_bucket{code="204",destination_service="FOO",le="0.05"} 1
-					eventing_epp_backend_duration_milliseconds_bucket{code="204",destination_service="FOO",le="0.1"} 1
-					eventing_epp_backend_duration_milliseconds_bucket{code="204",destination_service="FOO",le="0.25"} 1
-					eventing_epp_backend_duration_milliseconds_bucket{code="204",destination_service="FOO",le="0.5"} 1
-					eventing_epp_backend_duration_milliseconds_bucket{code="204",destination_service="FOO",le="1"} 1
-					eventing_epp_backend_duration_milliseconds_bucket{code="204",destination_service="FOO",le="2.5"} 1
-					eventing_epp_backend_duration_milliseconds_bucket{code="204",destination_service="FOO",le="5"} 1
-					eventing_epp_backend_duration_milliseconds_bucket{code="204",destination_service="FOO",le="10"} 1
-					eventing_epp_backend_duration_milliseconds_bucket{code="204",destination_service="FOO",le="+Inf"} 1
-					eventing_epp_backend_duration_milliseconds_sum{destination_service="FOO",code="204"} 0
-					eventing_epp_backend_duration_milliseconds_count{code="204",destination_service="FOO"} 1
-
-					# HELP eventing_epp_backend_requests_total The total number of backend requests
-					# TYPE eventing_epp_backend_requests_total counter
-					eventing_epp_backend_requests_total{code="204",destination_service="FOO"} 1
-				`,
+			wantTEF: metricstest.MakeTEFBackendDuration(204, "FOO") +
+				metricstest.MakeTEFBackendRequests(204, "FOO") +
+				metricstest.MakeTEFEventTypePublished(204, "testapp", "object.created.v1"),
 		},
 		{
 			name: "Send valid legacy event but cannot send to backend due to target not found (e.g. stream missing)",
@@ -416,30 +269,9 @@ func TestHandler_publishLegacyEventsAsCE(t *testing.T) {
 			givenCollector:         metrics.NewCollector(latency),
 			givenRequest:           legacytest.ValidLegacyRequestOrDie(t, "v1", "testapp", "object.created"),
 			wantHTTPStatus:         http.StatusNotFound,
-			wantTEF: `
-				# HELP eventing_epp_backend_duration_milliseconds The duration of sending events to the messaging server in milliseconds
-				# TYPE eventing_epp_backend_duration_milliseconds histogram
-				eventing_epp_backend_duration_milliseconds_bucket{code="404",destination_service="FOO",le="0.005"} 1
-				eventing_epp_backend_duration_milliseconds_bucket{code="404",destination_service="FOO",le="0.01"} 1
-				eventing_epp_backend_duration_milliseconds_bucket{code="404",destination_service="FOO",le="0.025"} 1
-				eventing_epp_backend_duration_milliseconds_bucket{code="404",destination_service="FOO",le="0.05"} 1
-				eventing_epp_backend_duration_milliseconds_bucket{code="404",destination_service="FOO",le="0.1"} 1
-				eventing_epp_backend_duration_milliseconds_bucket{code="404",destination_service="FOO",le="0.25"} 1
-				eventing_epp_backend_duration_milliseconds_bucket{code="404",destination_service="FOO",le="0.5"} 1
-				eventing_epp_backend_duration_milliseconds_bucket{code="404",destination_service="FOO",le="1"} 1
-				eventing_epp_backend_duration_milliseconds_bucket{code="404",destination_service="FOO",le="2.5"} 1
-				eventing_epp_backend_duration_milliseconds_bucket{code="404",destination_service="FOO",le="5"} 1
-				eventing_epp_backend_duration_milliseconds_bucket{code="404",destination_service="FOO",le="10"} 1
-				eventing_epp_backend_duration_milliseconds_bucket{code="404",destination_service="FOO",le="+Inf"} 1
-				eventing_epp_backend_duration_milliseconds_sum{code="404",destination_service="FOO"} 0
-				eventing_epp_backend_duration_milliseconds_count{code="404",destination_service="FOO"} 1
-				# HELP eventing_epp_backend_errors_total The total number of backend errors while sending events to the messaging server
-				# TYPE eventing_epp_backend_errors_total counter
-				eventing_epp_backend_errors_total 1
-				# HELP eventing_epp_backend_requests_total The total number of backend requests
-				# TYPE eventing_epp_backend_requests_total counter
-				eventing_epp_backend_requests_total{code="404",destination_service="FOO"} 1
-				`,
+			wantTEF: metricstest.MakeTEFBackendDuration(404, "FOO") +
+				metricstest.MakeTEFBackendRequests(404, "FOO") +
+				metricstest.MakeTEFBackendErrors(),
 		},
 		{
 			name: "Send valid legacy event but cannot send to backend due to full storage",
@@ -451,30 +283,9 @@ func TestHandler_publishLegacyEventsAsCE(t *testing.T) {
 			givenCollector:         metrics.NewCollector(latency),
 			givenRequest:           legacytest.ValidLegacyRequestOrDie(t, "v1", "testapp", "object.created"),
 			wantHTTPStatus:         507,
-			wantTEF: `
-				# HELP eventing_epp_backend_duration_milliseconds The duration of sending events to the messaging server in milliseconds
-				# TYPE eventing_epp_backend_duration_milliseconds histogram
-				eventing_epp_backend_duration_milliseconds_bucket{code="507",destination_service="FOO",le="0.005"} 1
-				eventing_epp_backend_duration_milliseconds_bucket{code="507",destination_service="FOO",le="0.01"} 1
-				eventing_epp_backend_duration_milliseconds_bucket{code="507",destination_service="FOO",le="0.025"} 1
-				eventing_epp_backend_duration_milliseconds_bucket{code="507",destination_service="FOO",le="0.05"} 1
-				eventing_epp_backend_duration_milliseconds_bucket{code="507",destination_service="FOO",le="0.1"} 1
-				eventing_epp_backend_duration_milliseconds_bucket{code="507",destination_service="FOO",le="0.25"} 1
-				eventing_epp_backend_duration_milliseconds_bucket{code="507",destination_service="FOO",le="0.5"} 1
-				eventing_epp_backend_duration_milliseconds_bucket{code="507",destination_service="FOO",le="1"} 1
-				eventing_epp_backend_duration_milliseconds_bucket{code="507",destination_service="FOO",le="2.5"} 1
-				eventing_epp_backend_duration_milliseconds_bucket{code="507",destination_service="FOO",le="5"} 1
-				eventing_epp_backend_duration_milliseconds_bucket{code="507",destination_service="FOO",le="10"} 1
-				eventing_epp_backend_duration_milliseconds_bucket{code="507",destination_service="FOO",le="+Inf"} 1
-				eventing_epp_backend_duration_milliseconds_sum{code="507",destination_service="FOO"} 0
-				eventing_epp_backend_duration_milliseconds_count{code="507",destination_service="FOO"} 1
-				# HELP eventing_epp_backend_errors_total The total number of backend errors while sending events to the messaging server
-				# TYPE eventing_epp_backend_errors_total counter
-				eventing_epp_backend_errors_total 1
-				# HELP eventing_epp_backend_requests_total The total number of backend requests
-				# TYPE eventing_epp_backend_requests_total counter
-				eventing_epp_backend_requests_total{code="507",destination_service="FOO"} 1
-				`,
+			wantTEF: metricstest.MakeTEFBackendDuration(507, "FOO") +
+				metricstest.MakeTEFBackendRequests(507, "FOO") +
+				metricstest.MakeTEFBackendErrors(),
 		},
 		{
 			name: "Send valid legacy event but cannot send to backend",
@@ -486,30 +297,9 @@ func TestHandler_publishLegacyEventsAsCE(t *testing.T) {
 			givenCollector:         metrics.NewCollector(latency),
 			givenRequest:           legacytest.ValidLegacyRequestOrDie(t, "v1", "testapp", "object.created"),
 			wantHTTPStatus:         500,
-			wantTEF: `
-				# HELP eventing_epp_backend_duration_milliseconds The duration of sending events to the messaging server in milliseconds
-				# TYPE eventing_epp_backend_duration_milliseconds histogram
-				eventing_epp_backend_duration_milliseconds_bucket{code="500",destination_service="FOO",le="0.005"} 1
-				eventing_epp_backend_duration_milliseconds_bucket{code="500",destination_service="FOO",le="0.01"} 1
-				eventing_epp_backend_duration_milliseconds_bucket{code="500",destination_service="FOO",le="0.025"} 1
-				eventing_epp_backend_duration_milliseconds_bucket{code="500",destination_service="FOO",le="0.05"} 1
-				eventing_epp_backend_duration_milliseconds_bucket{code="500",destination_service="FOO",le="0.1"} 1
-				eventing_epp_backend_duration_milliseconds_bucket{code="500",destination_service="FOO",le="0.25"} 1
-				eventing_epp_backend_duration_milliseconds_bucket{code="500",destination_service="FOO",le="0.5"} 1
-				eventing_epp_backend_duration_milliseconds_bucket{code="500",destination_service="FOO",le="1"} 1
-				eventing_epp_backend_duration_milliseconds_bucket{code="500",destination_service="FOO",le="2.5"} 1
-				eventing_epp_backend_duration_milliseconds_bucket{code="500",destination_service="FOO",le="5"} 1
-				eventing_epp_backend_duration_milliseconds_bucket{code="500",destination_service="FOO",le="10"} 1
-				eventing_epp_backend_duration_milliseconds_bucket{code="500",destination_service="FOO",le="+Inf"} 1
-				eventing_epp_backend_duration_milliseconds_sum{code="500",destination_service="FOO"} 0
-				eventing_epp_backend_duration_milliseconds_count{code="500",destination_service="FOO"} 1
-				# HELP eventing_epp_backend_errors_total The total number of backend errors while sending events to the messaging server
-				# TYPE eventing_epp_backend_errors_total counter
-				eventing_epp_backend_errors_total 1
-				# HELP eventing_epp_backend_requests_total The total number of backend requests
-				# TYPE eventing_epp_backend_requests_total counter
-				eventing_epp_backend_requests_total{code="500",destination_service="FOO"} 1
-				`,
+			wantTEF: metricstest.MakeTEFBackendDuration(500, "FOO") +
+				metricstest.MakeTEFBackendRequests(500, "FOO") +
+				metricstest.MakeTEFBackendErrors(),
 		},
 		{
 			name: "Send invalid legacy event",

--- a/components/event-publisher-proxy/pkg/handler/handler_test.go
+++ b/components/event-publisher-proxy/pkg/handler/handler_test.go
@@ -74,7 +74,6 @@ func TestHandler_publishCloudEvents(t *testing.T) {
 			},
 			wantStatus: 204,
 			wantTEF: metricstest.MakeTEFBackendDuration(204, "FOO") +
-				metricstest.MakeTEFBackendRequests(204, "FOO") +
 				metricstest.MakeTEFEventTypePublished(204, "/default/sap.kyma/id", ""),
 		},
 		{
@@ -92,7 +91,6 @@ func TestHandler_publishCloudEvents(t *testing.T) {
 			},
 			wantStatus: 204,
 			wantTEF: metricstest.MakeTEFBackendDuration(204, "FOO") +
-				metricstest.MakeTEFBackendRequests(204, "FOO") +
 				metricstest.MakeTEFEventTypePublished(204, "/default/sap.kyma/id", ""),
 		},
 		{
@@ -110,7 +108,6 @@ func TestHandler_publishCloudEvents(t *testing.T) {
 			},
 			wantStatus: 204,
 			wantTEF: metricstest.MakeTEFBackendDuration(204, "FOO") +
-				metricstest.MakeTEFBackendRequests(204, "FOO") +
 				metricstest.MakeTEFEventTypePublished(204, "testapp1023", "order.created.v1"),
 		},
 		{
@@ -128,7 +125,6 @@ func TestHandler_publishCloudEvents(t *testing.T) {
 			},
 			wantStatus: 204,
 			wantTEF: metricstest.MakeTEFBackendDuration(204, "FOO") +
-				metricstest.MakeTEFBackendRequests(204, "FOO") +
 				metricstest.MakeTEFEventTypePublished(204, "testapp1023", "order.created.v1"),
 		},
 		{
@@ -169,9 +165,7 @@ func TestHandler_publishCloudEvents(t *testing.T) {
 				request: CreateValidBinaryRequest(t),
 			},
 			wantStatus: 500,
-			wantTEF: metricstest.MakeTEFBackendDuration(500, "") +
-				metricstest.MakeTEFBackendRequests(500, "") +
-				metricstest.MakeTEFBackendErrors(),
+			wantTEF:    metricstest.MakeTEFBackendDuration(500, ""),
 		},
 		{
 			name: "Publish binary CloudEvent but backend is full",
@@ -186,9 +180,7 @@ func TestHandler_publishCloudEvents(t *testing.T) {
 				request: CreateValidBinaryRequest(t),
 			},
 			wantStatus: 507,
-			wantTEF: metricstest.MakeTEFBackendDuration(507, "") +
-				metricstest.MakeTEFBackendRequests(507, "") +
-				metricstest.MakeTEFBackendErrors(),
+			wantTEF:    metricstest.MakeTEFBackendDuration(507, ""),
 		},
 	}
 	for _, tt := range tests {
@@ -256,7 +248,6 @@ func TestHandler_publishLegacyEventsAsCE(t *testing.T) {
 			givenRequest:           legacytest.ValidLegacyRequestOrDie(t, "v1", "testapp", "object.created"),
 			wantHTTPStatus:         http.StatusOK,
 			wantTEF: metricstest.MakeTEFBackendDuration(204, "FOO") +
-				metricstest.MakeTEFBackendRequests(204, "FOO") +
 				metricstest.MakeTEFEventTypePublished(204, "testapp", "object.created.v1"),
 		},
 		{
@@ -269,9 +260,7 @@ func TestHandler_publishLegacyEventsAsCE(t *testing.T) {
 			givenCollector:         metrics.NewCollector(latency),
 			givenRequest:           legacytest.ValidLegacyRequestOrDie(t, "v1", "testapp", "object.created"),
 			wantHTTPStatus:         http.StatusNotFound,
-			wantTEF: metricstest.MakeTEFBackendDuration(404, "FOO") +
-				metricstest.MakeTEFBackendRequests(404, "FOO") +
-				metricstest.MakeTEFBackendErrors(),
+			wantTEF:                metricstest.MakeTEFBackendDuration(404, "FOO"),
 		},
 		{
 			name: "Send valid legacy event but cannot send to backend due to full storage",
@@ -283,9 +272,7 @@ func TestHandler_publishLegacyEventsAsCE(t *testing.T) {
 			givenCollector:         metrics.NewCollector(latency),
 			givenRequest:           legacytest.ValidLegacyRequestOrDie(t, "v1", "testapp", "object.created"),
 			wantHTTPStatus:         507,
-			wantTEF: metricstest.MakeTEFBackendDuration(507, "FOO") +
-				metricstest.MakeTEFBackendRequests(507, "FOO") +
-				metricstest.MakeTEFBackendErrors(),
+			wantTEF:                metricstest.MakeTEFBackendDuration(507, "FOO"),
 		},
 		{
 			name: "Send valid legacy event but cannot send to backend",
@@ -297,9 +284,7 @@ func TestHandler_publishLegacyEventsAsCE(t *testing.T) {
 			givenCollector:         metrics.NewCollector(latency),
 			givenRequest:           legacytest.ValidLegacyRequestOrDie(t, "v1", "testapp", "object.created"),
 			wantHTTPStatus:         500,
-			wantTEF: metricstest.MakeTEFBackendDuration(500, "FOO") +
-				metricstest.MakeTEFBackendRequests(500, "FOO") +
-				metricstest.MakeTEFBackendErrors(),
+			wantTEF:                metricstest.MakeTEFBackendDuration(500, "FOO"),
 		},
 		{
 			name: "Send invalid legacy event",

--- a/components/event-publisher-proxy/pkg/handler/handler_v1alpha1_test.go
+++ b/components/event-publisher-proxy/pkg/handler/handler_v1alpha1_test.go
@@ -661,7 +661,7 @@ func TestHandler_sendEventAndRecordMetrics_TracingAndDefaults(t *testing.T) {
 	// given
 	stub := &GenericSenderStub{
 		SleepDuration: 0,
-		Err:           common.BackendPublishError{HttpCode: http.StatusInternalServerError},
+		Err:           common.BackendPublishError{HTTPCode: http.StatusInternalServerError},
 	}
 
 	const bucketsFunc = "Buckets"

--- a/components/event-publisher-proxy/pkg/handler/handler_v1alpha1_test.go
+++ b/components/event-publisher-proxy/pkg/handler/handler_v1alpha1_test.go
@@ -202,30 +202,9 @@ func TestHandler_publishCloudEvents_v1alpha1(t *testing.T) {
 				request: CreateValidStructuredRequestV1Alpha1(t),
 			},
 			wantStatus: 204,
-
-			wantTEF: `
-				# HELP eventing_epp_event_type_published_total The total number of events published for a given eventTypeLabel
-				# TYPE eventing_epp_event_type_published_total counter
-				eventing_epp_event_type_published_total{code="204",event_source="/default/sap.kyma/id",event_type=""} 1
-				# HELP eventing_epp_backend_duration_milliseconds The duration of sending events to the messaging server in milliseconds
-				# TYPE eventing_epp_backend_duration_milliseconds histogram
-				eventing_epp_backend_duration_milliseconds_bucket{code="204",destination_service="FOO",le="0.005"} 1
-				eventing_epp_backend_duration_milliseconds_bucket{code="204",destination_service="FOO",le="0.01"} 1
-				eventing_epp_backend_duration_milliseconds_bucket{code="204",destination_service="FOO",le="0.025"} 1
-				eventing_epp_backend_duration_milliseconds_bucket{code="204",destination_service="FOO",le="0.05"} 1
-				eventing_epp_backend_duration_milliseconds_bucket{code="204",destination_service="FOO",le="0.1"} 1
-				eventing_epp_backend_duration_milliseconds_bucket{code="204",destination_service="FOO",le="0.25"} 1
-				eventing_epp_backend_duration_milliseconds_bucket{code="204",destination_service="FOO",le="0.5"} 1
-				eventing_epp_backend_duration_milliseconds_bucket{code="204",destination_service="FOO",le="1"} 1
-				eventing_epp_backend_duration_milliseconds_bucket{code="204",destination_service="FOO",le="2.5"} 1
-				eventing_epp_backend_duration_milliseconds_bucket{code="204",destination_service="FOO",le="5"} 1
-				eventing_epp_backend_duration_milliseconds_bucket{code="204",destination_service="FOO",le="10"} 1
-				eventing_epp_backend_duration_milliseconds_bucket{code="204",destination_service="FOO",le="+Inf"} 1
-				eventing_epp_backend_duration_milliseconds_count{code="204",destination_service="FOO"} 1
-				# HELP eventing_epp_backend_requests_total The total number of backend requests
-				# TYPE eventing_epp_backend_requests_total counter
-				eventing_epp_backend_requests_total{code="204",destination_service="FOO"} 1
-			`,
+			wantTEF: metricstest.MakeTEFBackendDuration(204, "FOO") +
+				metricstest.MakeTEFBackendRequests(204, "FOO") +
+				metricstest.MakeTEFEventTypePublished(204, "/default/sap.kyma/id", ""),
 		},
 		{
 			name: "Publish binary Cloudevent",
@@ -241,31 +220,9 @@ func TestHandler_publishCloudEvents_v1alpha1(t *testing.T) {
 				request: CreateValidBinaryRequestV1Alpha1(t),
 			},
 			wantStatus: 204,
-
-			wantTEF: `
-				# HELP eventing_epp_event_type_published_total The total number of events published for a given eventTypeLabel
-				# TYPE eventing_epp_event_type_published_total counter
-				eventing_epp_event_type_published_total{code="204",event_source="/default/sap.kyma/id",event_type=""} 1
-				# HELP eventing_epp_backend_duration_milliseconds The duration of sending events to the messaging server in milliseconds
-				# TYPE eventing_epp_backend_duration_milliseconds histogram
-				eventing_epp_backend_duration_milliseconds_bucket{code="204",destination_service="FOO",le="0.005"} 1
-				eventing_epp_backend_duration_milliseconds_bucket{code="204",destination_service="FOO",le="0.01"} 1
-				eventing_epp_backend_duration_milliseconds_bucket{code="204",destination_service="FOO",le="0.025"} 1
-				eventing_epp_backend_duration_milliseconds_bucket{code="204",destination_service="FOO",le="0.05"} 1
-				eventing_epp_backend_duration_milliseconds_bucket{code="204",destination_service="FOO",le="0.1"} 1
-				eventing_epp_backend_duration_milliseconds_bucket{code="204",destination_service="FOO",le="0.25"} 1
-				eventing_epp_backend_duration_milliseconds_bucket{code="204",destination_service="FOO",le="0.5"} 1
-				eventing_epp_backend_duration_milliseconds_bucket{code="204",destination_service="FOO",le="1"} 1
-				eventing_epp_backend_duration_milliseconds_bucket{code="204",destination_service="FOO",le="2.5"} 1
-				eventing_epp_backend_duration_milliseconds_bucket{code="204",destination_service="FOO",le="5"} 1
-				eventing_epp_backend_duration_milliseconds_bucket{code="204",destination_service="FOO",le="10"} 1
-				eventing_epp_backend_duration_milliseconds_bucket{code="204",destination_service="FOO",le="+Inf"} 1
-				eventing_epp_backend_duration_milliseconds_sum{destination_service="FOO",code="204"} 0
-				eventing_epp_backend_duration_milliseconds_count{destination_service="FOO",code="204"} 1
-				# HELP eventing_epp_backend_requests_total The total number of backend requests
-				# TYPE eventing_epp_backend_requests_total counter
-				eventing_epp_backend_requests_total{code="204",destination_service="FOO"} 1
-			`,
+			wantTEF: metricstest.MakeTEFBackendDuration(204, "FOO") +
+				metricstest.MakeTEFBackendRequests(204, "FOO") +
+				metricstest.MakeTEFEventTypePublished(204, "/default/sap.kyma/id", ""),
 		},
 		{
 			name: "Publish invalid structured CloudEvent",
@@ -322,31 +279,9 @@ func TestHandler_publishCloudEvents_v1alpha1(t *testing.T) {
 				request: CreateValidBinaryRequestV1Alpha1(t),
 			},
 			wantStatus: 500,
-
-			wantTEF: `
-				# HELP eventing_epp_backend_duration_milliseconds The duration of sending events to the messaging server in milliseconds
-				# TYPE eventing_epp_backend_duration_milliseconds histogram
-				eventing_epp_backend_duration_milliseconds_bucket{code="500",destination_service="",le="0.005"} 1
-				eventing_epp_backend_duration_milliseconds_bucket{code="500",destination_service="",le="0.01"} 1
-				eventing_epp_backend_duration_milliseconds_bucket{code="500",destination_service="",le="0.025"} 1
-				eventing_epp_backend_duration_milliseconds_bucket{code="500",destination_service="",le="0.05"} 1
-				eventing_epp_backend_duration_milliseconds_bucket{code="500",destination_service="",le="0.1"} 1
-				eventing_epp_backend_duration_milliseconds_bucket{code="500",destination_service="",le="0.25"} 1
-				eventing_epp_backend_duration_milliseconds_bucket{code="500",destination_service="",le="0.5"} 1
-				eventing_epp_backend_duration_milliseconds_bucket{code="500",destination_service="",le="1"} 1
-				eventing_epp_backend_duration_milliseconds_bucket{code="500",destination_service="",le="2.5"} 1
-				eventing_epp_backend_duration_milliseconds_bucket{code="500",destination_service="",le="5"} 1
-				eventing_epp_backend_duration_milliseconds_bucket{code="500",destination_service="",le="10"} 1
-				eventing_epp_backend_duration_milliseconds_bucket{code="500",destination_service="",le="+Inf"} 1
-				eventing_epp_backend_duration_milliseconds_sum{code="500",destination_service=""} 0
-				eventing_epp_backend_duration_milliseconds_count{code="500",destination_service=""} 1
-				# HELP eventing_epp_backend_errors_total The total number of backend errors while sending events to the messaging server
-				# TYPE eventing_epp_backend_errors_total counter
-				eventing_epp_backend_errors_total 1
-				# HELP eventing_epp_backend_requests_total The total number of backend requests
-				# TYPE eventing_epp_backend_requests_total counter
-				eventing_epp_backend_requests_total{code="500",destination_service=""} 1
-			`,
+			wantTEF: metricstest.MakeTEFBackendDuration(500, "") +
+				metricstest.MakeTEFBackendRequests(500, "") +
+				metricstest.MakeTEFBackendErrors(),
 		},
 		{
 			name: "Publish binary CloudEvent but backend is full",
@@ -361,30 +296,9 @@ func TestHandler_publishCloudEvents_v1alpha1(t *testing.T) {
 				request: CreateValidBinaryRequestV1Alpha1(t),
 			},
 			wantStatus: http.StatusInsufficientStorage,
-			wantTEF: `
-				# HELP eventing_epp_backend_duration_milliseconds The duration of sending events to the messaging server in milliseconds
-				# TYPE eventing_epp_backend_duration_milliseconds histogram
-				eventing_epp_backend_duration_milliseconds_bucket{code="507",destination_service="",le="0.005"} 1
-				eventing_epp_backend_duration_milliseconds_bucket{code="507",destination_service="",le="0.01"} 1
-				eventing_epp_backend_duration_milliseconds_bucket{code="507",destination_service="",le="0.025"} 1
-				eventing_epp_backend_duration_milliseconds_bucket{code="507",destination_service="",le="0.05"} 1
-				eventing_epp_backend_duration_milliseconds_bucket{code="507",destination_service="",le="0.1"} 1
-				eventing_epp_backend_duration_milliseconds_bucket{code="507",destination_service="",le="0.25"} 1
-				eventing_epp_backend_duration_milliseconds_bucket{code="507",destination_service="",le="0.5"} 1
-				eventing_epp_backend_duration_milliseconds_bucket{code="507",destination_service="",le="1"} 1
-				eventing_epp_backend_duration_milliseconds_bucket{code="507",destination_service="",le="2.5"} 1
-				eventing_epp_backend_duration_milliseconds_bucket{code="507",destination_service="",le="5"} 1
-				eventing_epp_backend_duration_milliseconds_bucket{code="507",destination_service="",le="10"} 1
-				eventing_epp_backend_duration_milliseconds_bucket{code="507",destination_service="",le="+Inf"} 1
-				eventing_epp_backend_duration_milliseconds_sum{code="507",destination_service=""} 0
-				eventing_epp_backend_duration_milliseconds_count{code="507",destination_service=""} 1
-				# HELP eventing_epp_backend_errors_total The total number of backend errors while sending events to the messaging server
-				# TYPE eventing_epp_backend_errors_total counter
-				eventing_epp_backend_errors_total 1
-				# HELP eventing_epp_backend_requests_total The total number of backend requests
-				# TYPE eventing_epp_backend_requests_total counter
-				eventing_epp_backend_requests_total{code="507",destination_service=""} 1
-			`,
+			wantTEF: metricstest.MakeTEFBackendDuration(507, "") +
+				metricstest.MakeTEFBackendRequests(507, "") +
+				metricstest.MakeTEFBackendErrors(),
 		},
 	}
 	for _, tt := range tests {
@@ -602,30 +516,13 @@ func TestHandler_sendEventAndRecordMetrics(t *testing.T) {
 				event: &cev2event.Event{},
 			},
 			wants: wants{
-				result:          nil,
-				assertionFunc:   assert.Error,
-				metricErrors:    1,
-				metricTotal:     1,
-				metricLatency:   1,
-				metricPublished: 0,
-				metricLatencyTEF: `
-					# HELP eventing_epp_backend_duration_milliseconds The duration of sending events to the messaging server in milliseconds
-					# TYPE eventing_epp_backend_duration_milliseconds histogram
-					eventing_epp_backend_duration_milliseconds_bucket{code="500",destination_service="foo",le="0.005"} 1
-					eventing_epp_backend_duration_milliseconds_bucket{code="500",destination_service="foo",le="0.01"} 1
-					eventing_epp_backend_duration_milliseconds_bucket{code="500",destination_service="foo",le="0.025"} 1
-					eventing_epp_backend_duration_milliseconds_bucket{code="500",destination_service="foo",le="0.05"} 1
-					eventing_epp_backend_duration_milliseconds_bucket{code="500",destination_service="foo",le="0.1"} 1
-					eventing_epp_backend_duration_milliseconds_bucket{code="500",destination_service="foo",le="0.25"} 1
-					eventing_epp_backend_duration_milliseconds_bucket{code="500",destination_service="foo",le="0.5"} 1
-					eventing_epp_backend_duration_milliseconds_bucket{code="500",destination_service="foo",le="1"} 1
-					eventing_epp_backend_duration_milliseconds_bucket{code="500",destination_service="foo",le="2.5"} 1
-					eventing_epp_backend_duration_milliseconds_bucket{code="500",destination_service="foo",le="5"} 1
-					eventing_epp_backend_duration_milliseconds_bucket{code="500",destination_service="foo",le="10"} 1
-					eventing_epp_backend_duration_milliseconds_bucket{code="500",destination_service="foo",le="+Inf"} 1
-					eventing_epp_backend_duration_milliseconds_sum{code="500",destination_service="foo"} 0
-					eventing_epp_backend_duration_milliseconds_count{code="500",destination_service="foo"} 1
-				`,
+				result:           nil,
+				assertionFunc:    assert.Error,
+				metricErrors:     1,
+				metricTotal:      1,
+				metricLatency:    1,
+				metricPublished:  0,
+				metricLatencyTEF: metricstest.MakeTEFBackendDuration(500, "foo"),
 			},
 		},
 	}

--- a/components/event-publisher-proxy/pkg/handler/handler_v1alpha1_test.go
+++ b/components/event-publisher-proxy/pkg/handler/handler_v1alpha1_test.go
@@ -203,7 +203,6 @@ func TestHandler_publishCloudEvents_v1alpha1(t *testing.T) {
 			},
 			wantStatus: 204,
 			wantTEF: metricstest.MakeTEFBackendDuration(204, "FOO") +
-				metricstest.MakeTEFBackendRequests(204, "FOO") +
 				metricstest.MakeTEFEventTypePublished(204, "/default/sap.kyma/id", ""),
 		},
 		{
@@ -221,7 +220,6 @@ func TestHandler_publishCloudEvents_v1alpha1(t *testing.T) {
 			},
 			wantStatus: 204,
 			wantTEF: metricstest.MakeTEFBackendDuration(204, "FOO") +
-				metricstest.MakeTEFBackendRequests(204, "FOO") +
 				metricstest.MakeTEFEventTypePublished(204, "/default/sap.kyma/id", ""),
 		},
 		{
@@ -279,9 +277,7 @@ func TestHandler_publishCloudEvents_v1alpha1(t *testing.T) {
 				request: CreateValidBinaryRequestV1Alpha1(t),
 			},
 			wantStatus: 500,
-			wantTEF: metricstest.MakeTEFBackendDuration(500, "") +
-				metricstest.MakeTEFBackendRequests(500, "") +
-				metricstest.MakeTEFBackendErrors(),
+			wantTEF:    metricstest.MakeTEFBackendDuration(500, ""),
 		},
 		{
 			name: "Publish binary CloudEvent but backend is full",
@@ -296,9 +292,7 @@ func TestHandler_publishCloudEvents_v1alpha1(t *testing.T) {
 				request: CreateValidBinaryRequestV1Alpha1(t),
 			},
 			wantStatus: http.StatusInsufficientStorage,
-			wantTEF: metricstest.MakeTEFBackendDuration(507, "") +
-				metricstest.MakeTEFBackendRequests(507, "") +
-				metricstest.MakeTEFBackendErrors(),
+			wantTEF:    metricstest.MakeTEFBackendDuration(507, ""),
 		},
 	}
 	for _, tt := range tests {
@@ -544,8 +538,6 @@ func TestHandler_sendEventAndRecordMetrics(t *testing.T) {
 			if !tt.wants.assertionFunc(t, err, fmt.Sprintf("sendEventAndRecordMetrics(%v, %v, %v)", tt.args.ctx, tt.args.host, tt.args.event)) {
 				return
 			}
-			metricstest.EnsureMetricErrors(t, h.collector, tt.wants.metricErrors)
-			metricstest.EnsureMetricTotalRequests(t, h.collector, tt.wants.metricTotal)
 			metricstest.EnsureMetricLatency(t, h.collector, tt.wants.metricLatency)
 			metricstest.EnsureMetricEventTypePublished(t, h.collector, tt.wants.metricPublished)
 			metricstest.EnsureMetricMatchesTextExpositionFormat(t, h.collector, tt.wants.metricLatencyTEF, "eventing_epp_backend_duration_milliseconds")

--- a/components/event-publisher-proxy/pkg/metrics/collector_test.go
+++ b/components/event-publisher-proxy/pkg/metrics/collector_test.go
@@ -18,13 +18,9 @@ func TestNewCollector(t *testing.T) {
 
 	// then
 	assert.NotNil(t, collector)
-	assert.NotNil(t, collector.backendErrors)
-	assert.NotNil(t, collector.backendErrors.MetricVec)
 	assert.NotNil(t, collector.backendLatency)
 	assert.NotNil(t, collector.backendLatency.MetricVec)
 	assert.NotNil(t, collector.eventType)
 	assert.NotNil(t, collector.eventType.MetricVec)
-	assert.NotNil(t, collector.backendRequests)
-	assert.NotNil(t, collector.backendRequests.MetricVec)
 	latency.AssertExpectations(t)
 }

--- a/components/event-publisher-proxy/pkg/metrics/metricstest/metricstest.go
+++ b/components/event-publisher-proxy/pkg/metrics/metricstest/metricstest.go
@@ -69,8 +69,8 @@ func (p PublishingMetricsCollectorStub) RecordEventType(_, _ string, _ int) {
 func (p PublishingMetricsCollectorStub) RecordRequests(_ int, _ string) {
 }
 
+//nolint:lll // that's how TEF has to look like
 func MakeTEFBackendDuration(code int, service string) string {
-
 	tef := strings.ReplaceAll(`# HELP eventing_epp_backend_duration_milliseconds The duration of sending events to the messaging server in milliseconds
 					# TYPE eventing_epp_backend_duration_milliseconds histogram
 					eventing_epp_backend_duration_milliseconds_bucket{code="%%code%%",destination_service="%%service%%",le="0.005"} 1
@@ -99,6 +99,7 @@ func MakeTEFBackendRequests(code int, service string) string {
 	return strings.ReplaceAll(tef, "%%service%%", service)
 }
 
+//nolint:lll // that's how TEF has to look like
 func MakeTEFBackendErrors() string {
 	return `# HELP eventing_epp_backend_errors_total The total number of backend errors while sending events to the messaging server
         # TYPE eventing_epp_backend_errors_total counter
@@ -106,6 +107,7 @@ func MakeTEFBackendErrors() string {
 		`
 }
 
+//nolint:lll // that's how TEF has to look like
 func MakeTEFEventTypePublished(code int, source, eventtype string) string {
 	tef := strings.ReplaceAll(`# HELP eventing_epp_event_type_published_total The total number of events published for a given eventTypeLabel
         # TYPE eventing_epp_event_type_published_total counter

--- a/components/event-publisher-proxy/pkg/metrics/metricstest/metricstest.go
+++ b/components/event-publisher-proxy/pkg/metrics/metricstest/metricstest.go
@@ -2,6 +2,7 @@
 package metricstest
 
 import (
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -66,4 +67,50 @@ func (p PublishingMetricsCollectorStub) RecordEventType(_, _ string, _ int) {
 }
 
 func (p PublishingMetricsCollectorStub) RecordRequests(_ int, _ string) {
+}
+
+func MakeTEFBackendDuration(code int, service string) string {
+
+	tef := strings.ReplaceAll(`# HELP eventing_epp_backend_duration_milliseconds The duration of sending events to the messaging server in milliseconds
+					# TYPE eventing_epp_backend_duration_milliseconds histogram
+					eventing_epp_backend_duration_milliseconds_bucket{code="%%code%%",destination_service="%%service%%",le="0.005"} 1
+					eventing_epp_backend_duration_milliseconds_bucket{code="%%code%%",destination_service="%%service%%",le="0.01"} 1
+					eventing_epp_backend_duration_milliseconds_bucket{code="%%code%%",destination_service="%%service%%",le="0.025"} 1
+					eventing_epp_backend_duration_milliseconds_bucket{code="%%code%%",destination_service="%%service%%",le="0.05"} 1
+					eventing_epp_backend_duration_milliseconds_bucket{code="%%code%%",destination_service="%%service%%",le="0.1"} 1
+					eventing_epp_backend_duration_milliseconds_bucket{code="%%code%%",destination_service="%%service%%",le="0.25"} 1
+					eventing_epp_backend_duration_milliseconds_bucket{code="%%code%%",destination_service="%%service%%",le="0.5"} 1
+					eventing_epp_backend_duration_milliseconds_bucket{code="%%code%%",destination_service="%%service%%",le="1"} 1
+					eventing_epp_backend_duration_milliseconds_bucket{code="%%code%%",destination_service="%%service%%",le="2.5"} 1
+					eventing_epp_backend_duration_milliseconds_bucket{code="%%code%%",destination_service="%%service%%",le="5"} 1
+					eventing_epp_backend_duration_milliseconds_bucket{code="%%code%%",destination_service="%%service%%",le="10"} 1
+					eventing_epp_backend_duration_milliseconds_bucket{code="%%code%%",destination_service="%%service%%",le="+Inf"} 1
+					eventing_epp_backend_duration_milliseconds_sum{code="%%code%%",destination_service="%%service%%"} 0
+					eventing_epp_backend_duration_milliseconds_count{code="%%code%%",destination_service="%%service%%"} 1
+					`, "%%code%%", strconv.Itoa(code))
+	return strings.ReplaceAll(tef, "%%service%%", service)
+}
+
+func MakeTEFBackendRequests(code int, service string) string {
+	tef := strings.ReplaceAll(`# HELP eventing_epp_backend_requests_total The total number of backend requests
+					# TYPE eventing_epp_backend_requests_total counter
+					eventing_epp_backend_requests_total{code="%%code%%",destination_service="%%service%%"} 1
+					`, "%%code%%", strconv.Itoa(code))
+	return strings.ReplaceAll(tef, "%%service%%", service)
+}
+
+func MakeTEFBackendErrors() string {
+	return `# HELP eventing_epp_backend_errors_total The total number of backend errors while sending events to the messaging server
+        # TYPE eventing_epp_backend_errors_total counter
+        eventing_epp_backend_errors_total 1
+		`
+}
+
+func MakeTEFEventTypePublished(code int, source, eventtype string) string {
+	tef := strings.ReplaceAll(`# HELP eventing_epp_event_type_published_total The total number of events published for a given eventTypeLabel
+        # TYPE eventing_epp_event_type_published_total counter
+        eventing_epp_event_type_published_total{code="204",event_source="%%source%%",event_type="%%type%%"} 1
+					`, "%%code%%", strconv.Itoa(code))
+	tef = strings.ReplaceAll(tef, "%%source%%", source)
+	return strings.ReplaceAll(tef, "%%type%%", eventtype)
 }

--- a/components/event-publisher-proxy/pkg/metrics/metricstest/metricstest.go
+++ b/components/event-publisher-proxy/pkg/metrics/metricstest/metricstest.go
@@ -13,11 +13,6 @@ import (
 	"github.com/kyma-project/kyma/components/event-publisher-proxy/pkg/metrics"
 )
 
-// EnsureMetricErrors ensures metric eventing_epp_backend_errors_total exists.
-func EnsureMetricErrors(t *testing.T, collector metrics.PublishingMetricsCollector, count int) {
-	ensureMetricCount(t, collector, metrics.BackendErrorsKey, count)
-}
-
 // EnsureMetricLatency ensures metric eventing_epp_backend_duration_seconds exists.
 func EnsureMetricLatency(t *testing.T, collector metrics.PublishingMetricsCollector, count int) {
 	ensureMetricCount(t, collector, metrics.BackendLatencyKey, count)
@@ -26,11 +21,6 @@ func EnsureMetricLatency(t *testing.T, collector metrics.PublishingMetricsCollec
 // EnsureMetricEventTypePublished ensures metric eventing_epp_event_type_published_total exists.
 func EnsureMetricEventTypePublished(t *testing.T, collector metrics.PublishingMetricsCollector, count int) {
 	ensureMetricCount(t, collector, metrics.EventTypePublishedMetricKey, count)
-}
-
-// EnsureMetricTotalRequests ensures metric eventing_epp_backend_requests_total exists.
-func EnsureMetricTotalRequests(t *testing.T, collector metrics.PublishingMetricsCollector, count int) {
-	ensureMetricCount(t, collector, metrics.BackendRequestsKey, count)
 }
 
 func ensureMetricCount(t *testing.T, collector metrics.PublishingMetricsCollector, metric string, expectedCount int) {

--- a/components/event-publisher-proxy/pkg/sender/common/backendpublisherror.go
+++ b/components/event-publisher-proxy/pkg/sender/common/backendpublisherror.go
@@ -1,0 +1,55 @@
+package common
+
+import (
+	"net/http"
+
+	"github.com/kyma-project/kyma/components/event-publisher-proxy/pkg/sender"
+)
+
+var _ sender.PublishError = &BackendPublishError{}
+
+//nolint:lll //reads better this way
+var (
+	ErrInsufficientStorage    = BackendPublishError{HTTPCode: http.StatusInsufficientStorage, Info: "insufficient storage on backend"}
+	ErrBackendTargetNotFound  = BackendPublishError{HTTPCode: http.StatusNotFound, Info: "publishing target on backend not found"}
+	ErrClientNoConnection     = BackendPublishError{HTTPCode: http.StatusBadGateway, Info: "no connection to backend"}
+	ErrInternalBackendError   = BackendPublishError{HTTPCode: http.StatusInternalServerError, Info: "internal error on backend"}
+	ErrClientConversionFailed = BackendPublishError{HTTPCode: http.StatusBadRequest, Info: "conversion to target format failed"}
+)
+
+type BackendPublishError struct {
+	HTTPCode int
+	Info     string
+	err      error
+}
+
+func (e BackendPublishError) Error() string {
+	return e.Info
+}
+
+func (e *BackendPublishError) Unwrap() error {
+	return e.err
+}
+
+func (e *BackendPublishError) Wrap(wrappedError error) {
+	e.err = wrappedError
+}
+
+func (e BackendPublishError) Code() int {
+	if e.HTTPCode == 0 {
+		return http.StatusInternalServerError
+	}
+	return e.HTTPCode
+}
+
+func (e BackendPublishError) Message() string {
+	return e.Info
+}
+
+func (e *BackendPublishError) Is(target error) bool {
+	t, ok := target.(*BackendPublishError) //nolint:errorlint //we dont want to check the error chain here
+	if !ok {
+		return false
+	}
+	return (e.HTTPCode == t.HTTPCode) && (e.Info == t.Info)
+}

--- a/components/event-publisher-proxy/pkg/sender/eventmesh/eventmesh.go
+++ b/components/event-publisher-proxy/pkg/sender/eventmesh/eventmesh.go
@@ -73,7 +73,7 @@ func (s *Sender) Send(ctx context.Context, event *cev2event.Event) sender.Publis
 	if err != nil {
 		return common.ErrInternalBackendError
 	}
-	return common.BackendPublishError{HttpCode: resp.StatusCode, Info: string(body)}
+	return common.BackendPublishError{HTTPCode: resp.StatusCode, Info: string(body)}
 }
 
 // NewSender returns a new Sender instance with the given target and client.

--- a/components/event-publisher-proxy/pkg/sender/eventmesh/eventmesh.go
+++ b/components/event-publisher-proxy/pkg/sender/eventmesh/eventmesh.go
@@ -8,6 +8,9 @@ import (
 	"github.com/cloudevents/sdk-go/v2/binding"
 	cev2event "github.com/cloudevents/sdk-go/v2/event"
 
+	"github.com/kyma-project/kyma/components/eventing-controller/logger"
+	"go.uber.org/zap"
+
 	"github.com/kyma-project/kyma/components/event-publisher-proxy/internal"
 	"github.com/kyma-project/kyma/components/event-publisher-proxy/pkg/cloudevents"
 	"github.com/kyma-project/kyma/components/event-publisher-proxy/pkg/eventmesh"
@@ -27,10 +30,16 @@ var (
 	}
 )
 
+const (
+	backend     = "eventmesh"
+	handlerName = "eventmesh-handler"
+)
+
 // Sender is responsible for sending messages over HTTP.
 type Sender struct {
 	Client *http.Client
 	Target string
+	logger *logger.Logger
 }
 
 func (s *Sender) URL() string {
@@ -54,6 +63,7 @@ func (s *Sender) Send(ctx context.Context, event *cev2event.Event) sender.Publis
 
 	err = cloudevents.WriteRequestWithHeaders(ctx, message, request, additionalHeaders)
 	if err != nil {
+		s.namedLogger().Error("error", err)
 		e := common.ErrInternalBackendError
 		e.Wrap(err)
 		return e
@@ -61,6 +71,7 @@ func (s *Sender) Send(ctx context.Context, event *cev2event.Event) sender.Publis
 
 	resp, err := s.Client.Do(request)
 	if err != nil {
+		s.namedLogger().Error("error", err)
 		e := common.ErrInternalBackendError
 		e.Wrap(err)
 		return e
@@ -71,17 +82,23 @@ func (s *Sender) Send(ctx context.Context, event *cev2event.Event) sender.Publis
 	body, err := io.ReadAll(resp.Body)
 	defer func() { _ = resp.Body.Close() }()
 	if err != nil {
+		s.namedLogger().Error("error", err)
 		return common.ErrInternalBackendError
 	}
+	s.namedLogger().Error("error", string(body), "code", resp.StatusCode)
 	return common.BackendPublishError{HTTPCode: resp.StatusCode, Info: string(body)}
 }
 
 // NewSender returns a new Sender instance with the given target and client.
-func NewSender(target string, client *http.Client) *Sender {
-	return &Sender{Client: client, Target: target}
+func NewSender(target string, c *http.Client, l *logger.Logger) *Sender {
+	return &Sender{Client: c, Target: target, logger: l}
 }
 
 // NewRequestWithTarget returns a new HTTP POST request with the given context and target.
 func (s *Sender) NewRequestWithTarget(ctx context.Context, target string) (*http.Request, error) {
 	return http.NewRequestWithContext(ctx, http.MethodPost, target, nil)
+}
+
+func (s *Sender) namedLogger() *zap.SugaredLogger {
+	return s.logger.WithContext().Named(handlerName).With("backend", backend)
 }

--- a/components/event-publisher-proxy/pkg/sender/eventmesh/eventmesh_test.go
+++ b/components/event-publisher-proxy/pkg/sender/eventmesh/eventmesh_test.go
@@ -161,7 +161,7 @@ func TestSender_Send(t *testing.T) {
 				builder: testing2.NewCloudEventBuilder(),
 			},
 			wantErr: common.BackendPublishError{
-				HttpCode: 400,
+				HTTPCode: 400,
 			},
 		},
 		{

--- a/components/event-publisher-proxy/pkg/sender/jetstream/jetstream.go
+++ b/components/event-publisher-proxy/pkg/sender/jetstream/jetstream.go
@@ -27,7 +27,7 @@ import (
 const (
 	JSStoreFailedCode     = 10077
 	natsBackend           = "nats"
-	jestreamHandlerName   = "jetstream-handler"
+	handlerName           = "jetstream-handler"
 	noSpaceLeftErrMessage = "no space left on device"
 )
 
@@ -79,6 +79,7 @@ func (s *Sender) Send(_ context.Context, event *event.Event) sender.PublishError
 
 	msg, err := s.eventToNATSMsg(event)
 	if err != nil {
+		s.namedLogger().Error("error", err)
 		e := common.ErrClientConversionFailed
 		e.Wrap(err)
 		return e
@@ -149,5 +150,5 @@ func (s *Sender) getJsSubjectToPublish(subject string) string {
 }
 
 func (s *Sender) namedLogger() *zap.SugaredLogger {
-	return s.logger.WithContext().Named(jestreamHandlerName).With("backend", natsBackend, "jetstream enabled", true)
+	return s.logger.WithContext().Named(handlerName).With("backend", natsBackend, "jetstream enabled", true)
 }

--- a/components/event-publisher-proxy/pkg/sender/jetstream/jetstream.go
+++ b/components/event-publisher-proxy/pkg/sender/jetstream/jetstream.go
@@ -35,10 +35,11 @@ const (
 var _ sender.GenericSender = &Sender{}
 var _ health.Checker = &Sender{}
 
+//nolint:lll // reads better this way
 var (
-	ErrNotConnected        = common.BackendPublishError{HttpCode: http.StatusBadGateway, Info: "no connection to NATS JetStream server"}
-	ErrCannotSendToStream  = common.BackendPublishError{HttpCode: http.StatusGatewayTimeout, Info: "cannot send to stream"}
-	ErrNoSpaceLeftOnDevice = common.BackendPublishError{HttpCode: http.StatusInsufficientStorage, Info: "insufficient resources on target stream"}
+	ErrNotConnected        = common.BackendPublishError{HTTPCode: http.StatusBadGateway, Info: "no connection to NATS JetStream server"}
+	ErrCannotSendToStream  = common.BackendPublishError{HTTPCode: http.StatusGatewayTimeout, Info: "cannot send to stream"}
+	ErrNoSpaceLeftOnDevice = common.BackendPublishError{HTTPCode: http.StatusInsufficientStorage, Info: "insufficient resources on target stream"}
 )
 
 // Sender is responsible for sending messages over HTTP.
@@ -102,12 +103,12 @@ func natsErrorToPublishError(err error) sender.PublishError {
 	}
 
 	var apiErr nats.JetStreamError
-	e := common.BackendPublishError{HttpCode: http.StatusInternalServerError}
+	e := common.BackendPublishError{HTTPCode: http.StatusInternalServerError}
 	if errors.As(err, &apiErr) {
 		if apiErr.APIError().ErrorCode == JSStoreFailedCode {
 			return ErrNoSpaceLeftOnDevice
 		}
-		e.HttpCode = apiErr.APIError().Code
+		e.HTTPCode = apiErr.APIError().Code
 		e.Info = apiErr.APIError().Description
 		e.Wrap(err)
 		return e

--- a/components/event-publisher-proxy/pkg/sender/jetstream/jetstream.go
+++ b/components/event-publisher-proxy/pkg/sender/jetstream/jetstream.go
@@ -72,8 +72,9 @@ func (s *Sender) Send(_ context.Context, event *event.Event) sender.PublishError
 		return ErrNotConnected
 	}
 
-	jsCtx, jsError := s.connection.JetStream()
-	if jsError != nil {
+	jsCtx, err := s.connection.JetStream()
+	if err != nil {
+		s.namedLogger().Error("error", err)
 		return common.ErrClientNoConnection
 	}
 

--- a/components/event-publisher-proxy/pkg/sender/sender.go
+++ b/components/event-publisher-proxy/pkg/sender/sender.go
@@ -2,24 +2,17 @@ package sender
 
 import (
 	"context"
-	"errors"
 
 	"github.com/cloudevents/sdk-go/v2/event"
 )
 
-var (
-	ErrInsufficientStorage   = errors.New("insufficient storage on backend")
-	ErrBackendTargetNotFound = errors.New("publishing target on backend not found")
-	ErrNoConnection          = errors.New("no connection to backend")
-	ErrInternalBackendError  = errors.New("internal error on backend")
-)
-
 type GenericSender interface {
-	Send(context.Context, *event.Event) (PublishResult, error)
+	Send(context.Context, *event.Event) PublishError
 	URL() string
 }
 
-type PublishResult interface {
-	HTTPStatus() int
-	ResponseBody() []byte
+type PublishError interface {
+	error
+	Code() int
+	Message() string
 }

--- a/docs/04-operation-guides/operations/evnt-02-eventing-metrics.md
+++ b/docs/04-operation-guides/operations/evnt-02-eventing-metrics.md
@@ -9,12 +9,10 @@ The metrics follow the [Prometheus naming convention](https://prometheus.io/docs
 
 | Metric                                          | Description                                                                      |
 | ----------------------------------------------- | :------------------------------------------------------------------------------- |
-| **eventing_epp_backend_requests_total**         | The total number of backend requests                                             |
+| **eventing_epp_requests_total**                 | The total number of requests                                                     |
+| **eventing_epp_backend_duration_milliseconds**  | The duration of sending events to the messaging server in milliseconds           |
 | **eventing_epp_event_type_published_total**     | The total number of events published for a given eventTypeLabel                  |
 | **eventing_epp_requests_duration_milliseconds** | The duration of processing an incoming request (includes sending to the backend) |
-| **eventing_epp_requests_total**                 | The total number of requests                                                     |
-| **eventing_epp_backend_errors_total**           | The total number of backend errors while sending events to the messaging server  |
-| **eventing_epp_backend_duration_milliseconds**  | The duration of sending events to the messaging server in milliseconds           |
 
 ### Metrics Emitted by Eventing Controller:
 

--- a/resources/eventing/values.yaml
+++ b/resources/eventing/values.yaml
@@ -10,7 +10,7 @@ global:
       pullPolicy: "IfNotPresent"
     publisher_proxy:
       name: event-publisher-proxy
-      version: PR-17803
+      version: PR-17822
       directory: dev
     certHandler:
       name: eventing-webhook-certificates


### PR DESCRIPTION

<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

previously the sender had to return
- a PublishResult
- an Error

The problem here was that PublishResult was treated as an error
indicator for the eventMesh Backend, and the error was for other senders
such as the on Nats

The new interface just expects an Error to be returned in case of an
error. Any successful call will result in a 204 response with an empty
message.

This means now the sender has to map its errors or error responses onto
an error object, and any other function in the chain can just treat all
errors equally.

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
