### PR TITLE
Deploy Loki resource during upgrade process (#17791)

### DIFF
--- a/tests/fast-integration/upgrade-test/upgrade-test-tests.js
+++ b/tests/fast-integration/upgrade-test/upgrade-test-tests.js
@@ -1,6 +1,11 @@
+const k8s = require('@kubernetes/client-node');
+const fs = require('fs');
+const path = require('path');
+
 const {
   printRestartReport,
   getContainerRestartsForAllNamespaces,
+  deployLoki,
 } = require('../utils');
 const {loggingTests} = require('../logging');
 const {
@@ -23,6 +28,16 @@ describe('Upgrade test tests', function() {
 
   it('Deploys Istio access logs', async function() {
     await createIstioAccessLogResource();
+  });
+
+  it('Deploys the Loki resource', async function() {
+    const lokiYaml = fs.readFileSync(
+        path.join(__dirname, '../test/fixtures/loki/loki.yaml'),
+        {
+          encoding: 'utf8',
+        },
+    );
+    await deployLoki(k8s.loadAllYaml(lokiYaml));
   });
 
   it('Listing all pods in cluster', async function() {


### PR DESCRIPTION
**Description**

The kyma-upgrade-gardener-kyma2-minor-versions job fails because of a missing Loki datasource when running fast-integration tests after upgrading to 2.16.0. This PR backports the missing change to fix the test at least after the next release.

Changes proposed in this pull request:

- Backport #17791 to 2.16.x

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
https://github.com/kyma-project/kyma/issues/17606