### PR TITLE
Revert "Change the port for the node exporter sevice (#17821)"

### DIFF
--- a/resources/monitoring/charts/prometheus-node-exporter/values.yaml
+++ b/resources/monitoring/charts/prometheus-node-exporter/values.yaml
@@ -12,8 +12,8 @@ imagePullSecrets: []
 
 service:
   type: ClusterIP
-  port: 19100
-  targetPort: 19100
+  port: 9100
+  targetPort: 9100
   nodePort:
   portName: metrics
   listenOnAllInterfaces: true


### PR DESCRIPTION
This reverts commit ae0b608cfc2e9008b6f71f5bdb207467a0c57b4f.

<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

This reverts: https://github.com/kyma-project/kyma/pull/17821/files

- The reconciler fails to update the service port during upgrade. The reason being as reconciler uses `patch` strategy to update the service name and it fails as its an array. To be able to fix the update flow the alternative would be to have a custom-reconciler or run migration script which would be too much effort for the deprecated component.

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -