### PR TITLE
Remove Application connector PR images for kyma 2 17 Release

### DIFF
--- a/resources/application-connector/values.yaml
+++ b/resources/application-connector/values.yaml
@@ -31,12 +31,12 @@ global:
   images:
     central_application_connectivity_validator:
       name: "central-application-connectivity-validator"
-      version: "PR-17873"
-      directory: "dev"
+      version: "v20230724-03904880"
+      directory: "prod"
     central_application_gateway:
       name: "central-application-gateway"
-      version: "PR-17872"
-      directory: "dev"
+      version: "v20230724-ce05f398"
+      directory: "prod"
     busybox:
       name: "busybox"
       version: "1.34.1-v1"

--- a/resources/compass-runtime-agent/values.yaml
+++ b/resources/compass-runtime-agent/values.yaml
@@ -5,8 +5,8 @@ global:
   images:
     compass_runtime_agent:
       name: "compass-runtime-agent"
-      version: "PR-17868"
-      directory: "dev"
+      version: "v20230724-3559a1b6"
+      directory: "prod"
   istio:
     gateway:
       name: kyma-gateway

--- a/tests/components/application-connector/resources/charts/compass-runtime-agent-test/values.yaml
+++ b/tests/components/application-connector/resources/charts/compass-runtime-agent-test/values.yaml
@@ -11,8 +11,8 @@ containerRegistry:
 images:
   compassTest:
     name: "compass-runtime-agent-test"
-    version: "PR-17740"
-    directory: "dev"
+    version: "v20230705-788e1cea"
+    directory: "prod"
 
 compassCredentials:
   clientID: ""


### PR DESCRIPTION
- central-application-connectivity-validator -
 `PR-17873` -> `v20230724-03904880`
- central-application-gateway 
  `PR-17872` -> `v20230724-ce05f398`
- compass-runtime-agent 
  `PR-17868` -> `v20230724-3559a1b6`
- compass-runtime-agent-test 
  `PR-17740` -> `v20230705-788e1cea`