### PR TITLE
Contract test between api-gateway and serverless

### DIFF
--- a/tests/function-controller/cmd/main.go
+++ b/tests/function-controller/cmd/main.go
@@ -60,13 +60,13 @@ type scenario struct {
 }
 
 var availableScenarios = map[string][]scenario{
-	//"serverless-integration": {
-	//	{displayName: "simple", scenario: scenarios.SimpleFunctionTest},
-	//	{displayName: "gitops", scenario: scenarios.GitopsSteps},
-	//},
-	//"git-auth-integration": {{displayName: "gitauth", scenario: scenarios.GitAuthTestSteps}},
-	//"simple-tracing":       {{displayName: "tracing", scenario: scenarios.SimpleFunctionTracingTest}},
-	"simple-api-gateway": {{displayName: "api-gateway", scenario: scenarios.SimpleFunctionAPIGatewayTest}},
+	"serverless-integration": {
+		{displayName: "simple", scenario: scenarios.SimpleFunctionTest},
+		{displayName: "gitops", scenario: scenarios.GitopsSteps},
+	},
+	"git-auth-integration": {{displayName: "gitauth", scenario: scenarios.GitAuthTestSteps}},
+	"simple-tracing":       {{displayName: "tracing", scenario: scenarios.SimpleFunctionTracingTest}},
+	"simple-api-gateway":   {{displayName: "api-gateway", scenario: scenarios.SimpleFunctionAPIGatewayTest}},
 }
 
 type config struct {

--- a/tests/function-controller/cmd/main.go
+++ b/tests/function-controller/cmd/main.go
@@ -60,12 +60,13 @@ type scenario struct {
 }
 
 var availableScenarios = map[string][]scenario{
-	"serverless-integration": {
-		{displayName: "simple", scenario: scenarios.SimpleFunctionTest},
-		{displayName: "gitops", scenario: scenarios.GitopsSteps},
-	},
-	"git-auth-integration": {{displayName: "gitauth", scenario: scenarios.GitAuthTestSteps}},
-	"simple-tracing":       {{displayName: "tracing", scenario: scenarios.SimpleFunctionTracingTest}},
+	//"serverless-integration": {
+	//	{displayName: "simple", scenario: scenarios.SimpleFunctionTest},
+	//	{displayName: "gitops", scenario: scenarios.GitopsSteps},
+	//},
+	//"git-auth-integration": {{displayName: "gitauth", scenario: scenarios.GitAuthTestSteps}},
+	//"simple-tracing":       {{displayName: "tracing", scenario: scenarios.SimpleFunctionTracingTest}},
+	"simple-api-gateway": {{displayName: "api-gateway", scenario: scenarios.SimpleFunctionAPIGatewayTest}},
 }
 
 type config struct {

--- a/tests/function-controller/testsuite/scenarios/api_gateway.go
+++ b/tests/function-controller/testsuite/scenarios/api_gateway.go
@@ -21,6 +21,12 @@ import (
 	"github.com/kyma-project/kyma/tests/function-controller/testsuite/teststep"
 )
 
+const (
+	nodejs16 = "nodejs16"
+	nodejs18 = "nodejs18"
+	python39 = "python39"
+)
+
 func SimpleFunctionAPIGatewayTest(restConfig *rest.Config, cfg testsuite.Config, logf *logrus.Entry) (step.Step, error) {
 	now := time.Now()
 	cfg.Namespace = fmt.Sprintf("%s-%02dh%02dm%02ds", "test-simple-api-gateway", now.Hour(), now.Minute(), now.Second())
@@ -70,11 +76,11 @@ func SimpleFunctionAPIGatewayTest(restConfig *rest.Config, cfg testsuite.Config,
 			//),
 			step.NewSerialTestRunner(nodejs16Logger, "NodeJS16 test",
 				teststep.CreateFunction(nodejs16Logger, nodejs16Fn, "Create NodeJS16 Function", runtimes.BasicNodeJSFunction("Hello from nodejs16", serverlessv1alpha2.NodeJs16)),
-				teststep.NewAPIGatewayFunctionCheck("nodejs16", nodejs16Fn, coreCli, genericContainer.Namespace),
+				teststep.NewAPIGatewayFunctionCheck("nodejs16", nodejs16Fn, coreCli, genericContainer.Namespace, nodejs16),
 			),
 			step.NewSerialTestRunner(nodejs18Logger, "NodeJS18 test",
 				teststep.CreateFunction(nodejs18Logger, nodejs18Fn, "Create NodeJS18 Function", runtimes.BasicNodeJSFunction("Hello from nodejs18", serverlessv1alpha2.NodeJs18)),
-				teststep.NewAPIGatewayFunctionCheck("nodejs18", nodejs18Fn, coreCli, genericContainer.Namespace),
+				teststep.NewAPIGatewayFunctionCheck("nodejs18", nodejs18Fn, coreCli, genericContainer.Namespace, nodejs18),
 			),
 		),
 	), nil

--- a/tests/function-controller/testsuite/scenarios/api_gateway.go
+++ b/tests/function-controller/testsuite/scenarios/api_gateway.go
@@ -46,7 +46,7 @@ func SimpleFunctionAPIGatewayTest(restConfig *rest.Config, cfg testsuite.Config,
 		return nil, errors.Wrapf(err, "while creating k8s apps client")
 	}
 
-	//	python39Logger := logf.WithField(scenarioKey, "python39")
+	python39Logger := logf.WithField(scenarioKey, "python39")
 	nodejs16Logger := logf.WithField(scenarioKey, "nodejs16")
 	nodejs18Logger := logf.WithField(scenarioKey, "nodejs18")
 
@@ -58,7 +58,7 @@ func SimpleFunctionAPIGatewayTest(restConfig *rest.Config, cfg testsuite.Config,
 		Log:         logf,
 	}
 
-	//	python39Fn := function.NewFunction("python39", cfg.KubectlProxyEnabled, genericContainer.WithLogger(python39Logger))
+	python39Fn := function.NewFunction("python39", cfg.KubectlProxyEnabled, genericContainer.WithLogger(python39Logger))
 
 	nodejs16Fn := function.NewFunction("nodejs16", cfg.KubectlProxyEnabled, genericContainer.WithLogger(nodejs16Logger))
 
@@ -70,10 +70,10 @@ func SimpleFunctionAPIGatewayTest(restConfig *rest.Config, cfg testsuite.Config,
 		teststep.NewNamespaceStep("Create test namespace", coreCli, genericContainer),
 		teststep.NewApplication("Create HTTP basic application", HTTPAppName, HTTPAppImage, int32(80), appsCli.Deployments(genericContainer.Namespace), coreCli.Services(genericContainer.Namespace), genericContainer),
 		step.NewParallelRunner(logf, "Fn tests",
-			//step.NewSerialTestRunner(python39Logger, "Python39 test",
-			//	teststep.CreateFunction(python39Logger, python39Fn, "Create Python39 Function", runtimes.BasicTracingPythonFunction(serverlessv1alpha2.Python39, httpAppURL.String())),
-			//	teststep.NewTracingHTTPCheck(python39Logger, "Python39 tracing headers check", python39Fn.FunctionURL, poll),
-			//),
+			step.NewSerialTestRunner(python39Logger, "Python39 test",
+				teststep.CreateFunction(python39Logger, python39Fn, "Create Python39 Function", runtimes.BasicPythonFunction("Hello from python39", serverlessv1alpha2.Python39)),
+				teststep.NewAPIGatewayFunctionCheck("python39", python39Fn, coreCli, genericContainer.Namespace, python39),
+			),
 			step.NewSerialTestRunner(nodejs16Logger, "NodeJS16 test",
 				teststep.CreateFunction(nodejs16Logger, nodejs16Fn, "Create NodeJS16 Function", runtimes.BasicNodeJSFunction("Hello from nodejs16", serverlessv1alpha2.NodeJs16)),
 				teststep.NewAPIGatewayFunctionCheck("nodejs16", nodejs16Fn, coreCli, genericContainer.Namespace, nodejs16),

--- a/tests/function-controller/testsuite/scenarios/api_gateway.go
+++ b/tests/function-controller/testsuite/scenarios/api_gateway.go
@@ -1,0 +1,81 @@
+package scenarios
+
+import (
+	"fmt"
+	"github.com/pkg/errors"
+	typedappsv1 "k8s.io/client-go/kubernetes/typed/apps/v1"
+	"time"
+
+	"github.com/kyma-project/kyma/tests/function-controller/pkg/function"
+
+	serverlessv1alpha2 "github.com/kyma-project/kyma/components/function-controller/pkg/apis/serverless/v1alpha2"
+	"github.com/sirupsen/logrus"
+	"k8s.io/client-go/dynamic"
+	typedcorev1 "k8s.io/client-go/kubernetes/typed/core/v1"
+	"k8s.io/client-go/rest"
+
+	"github.com/kyma-project/kyma/tests/function-controller/pkg/shared"
+	"github.com/kyma-project/kyma/tests/function-controller/pkg/step"
+	"github.com/kyma-project/kyma/tests/function-controller/testsuite"
+	"github.com/kyma-project/kyma/tests/function-controller/testsuite/runtimes"
+	"github.com/kyma-project/kyma/tests/function-controller/testsuite/teststep"
+)
+
+func SimpleFunctionAPIGatewayTest(restConfig *rest.Config, cfg testsuite.Config, logf *logrus.Entry) (step.Step, error) {
+	now := time.Now()
+	cfg.Namespace = fmt.Sprintf("%s-%02dh%02dm%02ds", "test-simple-api-gateway", now.Hour(), now.Minute(), now.Second())
+
+	dynamicCli, err := dynamic.NewForConfig(restConfig)
+	if err != nil {
+		return nil, errors.Wrapf(err, "while creating dynamic client")
+	}
+
+	coreCli, err := typedcorev1.NewForConfig(restConfig)
+	if err != nil {
+		return nil, errors.Wrap(err, "while creating k8s CoreV1Client")
+	}
+
+	appsCli, err := typedappsv1.NewForConfig(restConfig)
+	if err != nil {
+		return nil, errors.Wrapf(err, "while creating k8s apps client")
+	}
+
+	//	python39Logger := logf.WithField(scenarioKey, "python39")
+	nodejs16Logger := logf.WithField(scenarioKey, "nodejs16")
+	nodejs18Logger := logf.WithField(scenarioKey, "nodejs18")
+
+	genericContainer := shared.Container{
+		DynamicCli:  dynamicCli,
+		Namespace:   cfg.Namespace,
+		WaitTimeout: cfg.WaitTimeout,
+		Verbose:     cfg.Verbose,
+		Log:         logf,
+	}
+
+	//	python39Fn := function.NewFunction("python39", cfg.KubectlProxyEnabled, genericContainer.WithLogger(python39Logger))
+
+	nodejs16Fn := function.NewFunction("nodejs16", cfg.KubectlProxyEnabled, genericContainer.WithLogger(nodejs16Logger))
+
+	nodejs18Fn := function.NewFunction("nodejs18", cfg.KubectlProxyEnabled, genericContainer.WithLogger(nodejs18Logger))
+
+	logf.Infof("Testing function in namespace: %s", cfg.Namespace)
+
+	return step.NewSerialTestRunner(logf, "Runtime test",
+		teststep.NewNamespaceStep("Create test namespace", coreCli, genericContainer),
+		teststep.NewApplication("Create HTTP basic application", HTTPAppName, HTTPAppImage, int32(80), appsCli.Deployments(genericContainer.Namespace), coreCli.Services(genericContainer.Namespace), genericContainer),
+		step.NewParallelRunner(logf, "Fn tests",
+			//step.NewSerialTestRunner(python39Logger, "Python39 test",
+			//	teststep.CreateFunction(python39Logger, python39Fn, "Create Python39 Function", runtimes.BasicTracingPythonFunction(serverlessv1alpha2.Python39, httpAppURL.String())),
+			//	teststep.NewTracingHTTPCheck(python39Logger, "Python39 tracing headers check", python39Fn.FunctionURL, poll),
+			//),
+			step.NewSerialTestRunner(nodejs16Logger, "NodeJS16 test",
+				teststep.CreateFunction(nodejs16Logger, nodejs16Fn, "Create NodeJS16 Function", runtimes.BasicNodeJSFunction("Hello from nodejs16", serverlessv1alpha2.NodeJs16)),
+				teststep.NewAPIGatewayFunctionCheck("nodejs16", nodejs16Fn, coreCli, genericContainer.Namespace),
+			),
+			step.NewSerialTestRunner(nodejs18Logger, "NodeJS18 test",
+				teststep.CreateFunction(nodejs18Logger, nodejs18Fn, "Create NodeJS18 Function", runtimes.BasicNodeJSFunction("Hello from nodejs18", serverlessv1alpha2.NodeJs18)),
+				teststep.NewAPIGatewayFunctionCheck("nodejs18", nodejs18Fn, coreCli, genericContainer.Namespace),
+			),
+		),
+	), nil
+}

--- a/tests/function-controller/testsuite/teststep/check.go
+++ b/tests/function-controller/testsuite/teststep/check.go
@@ -3,7 +3,7 @@ package teststep
 import (
 	"context"
 	"encoding/json"
-	errors2 "errors"
+	goerrors "errors"
 	"fmt"
 	"io"
 	corev1 "k8s.io/api/core/v1"
@@ -318,7 +318,7 @@ func checkIfContractIsFulfilled(pod corev1.Pod, service corev1.Service) error {
 				delete(service.Spec.Selector, k)
 			} else {
 				err := errors.Errorf("Expected %s but got %s", v, val)
-				errJoined = errors2.Join(err)
+				errJoined = goerrors.Join(err)
 			}
 		}
 	}
@@ -335,11 +335,11 @@ func checkIfRequiredLabelsExists(labels map[string]string, isService bool) error
 	}
 
 	var errJoined error
-	
+
 	for _, label := range requiredLabels {
 		if _, exists := labels[label]; !exists {
 			err := errors.New(fmt.Sprintf("Label %s is missing", label))
-			errJoined = errors2.Join(err)
+			errJoined = goerrors.Join(err)
 		}
 	}
 	return errJoined


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Kubernetes resources produced by serverless must satisfy API-gateway label selectors so that when istio and api-gateway are installed, user may add a sidecar to the function pod and expose its API.

Changes proposed in this pull request:

- Add contract test for all runtimes which check if labels in `Pod` and `Service` are the same

**Related issue(s)**
https://github.com/kyma-project/kyma/issues/17506
