### PR TITLE
Add serverless-contract-tests scenario

### DIFF
--- a/tests/function-controller/Makefile
+++ b/tests/function-controller/Makefile
@@ -20,6 +20,6 @@ serverless-integration: ## Run serverless integration scenario with kubectl prox
 git-auth-integration: ## Run git authorization integration scenario with kubectl proxy
 	./run-local.sh git-auth-integration
 
-.PHONY: simple-tracing
-simple-tracing: ## Run simple tracing scenario with kubectl proxy
-	./run-local.sh simple-tracing
+.PHONY: serverless-contract-tests
+serverless-contract-tests: ## Run serverless contract tests with kubectl proxy
+	./run-local.sh serverless-contract-tests

--- a/tests/function-controller/cmd/main.go
+++ b/tests/function-controller/cmd/main.go
@@ -65,8 +65,10 @@ var availableScenarios = map[string][]scenario{
 		{displayName: "gitops", scenario: scenarios.GitopsSteps},
 	},
 	"git-auth-integration": {{displayName: "gitauth", scenario: scenarios.GitAuthTestSteps}},
-	"simple-tracing":       {{displayName: "tracing", scenario: scenarios.SimpleFunctionTracingTest}},
-	"simple-api-gateway":   {{displayName: "api-gateway", scenario: scenarios.SimpleFunctionAPIGatewayTest}},
+	"serverless-contract-tests": {
+		{displayName: "tracing", scenario: scenarios.SimpleFunctionTracingTest},
+		{displayName: "api-gateway", scenario: scenarios.SimpleFunctionAPIGatewayTest},
+	},
 }
 
 type config struct {

--- a/tests/function-controller/testsuite/scenarios/api_gateway.go
+++ b/tests/function-controller/testsuite/scenarios/api_gateway.go
@@ -3,7 +3,6 @@ package scenarios
 import (
 	"fmt"
 	"github.com/pkg/errors"
-	typedappsv1 "k8s.io/client-go/kubernetes/typed/apps/v1"
 	"time"
 
 	"github.com/kyma-project/kyma/tests/function-controller/pkg/function"
@@ -41,11 +40,6 @@ func SimpleFunctionAPIGatewayTest(restConfig *rest.Config, cfg testsuite.Config,
 		return nil, errors.Wrap(err, "while creating k8s CoreV1Client")
 	}
 
-	appsCli, err := typedappsv1.NewForConfig(restConfig)
-	if err != nil {
-		return nil, errors.Wrapf(err, "while creating k8s apps client")
-	}
-
 	python39Logger := logf.WithField(scenarioKey, "python39")
 	nodejs16Logger := logf.WithField(scenarioKey, "nodejs16")
 	nodejs18Logger := logf.WithField(scenarioKey, "nodejs18")
@@ -68,7 +62,6 @@ func SimpleFunctionAPIGatewayTest(restConfig *rest.Config, cfg testsuite.Config,
 
 	return step.NewSerialTestRunner(logf, "Runtime test",
 		teststep.NewNamespaceStep("Create test namespace", coreCli, genericContainer),
-		teststep.NewApplication("Create HTTP basic application", HTTPAppName, HTTPAppImage, int32(80), appsCli.Deployments(genericContainer.Namespace), coreCli.Services(genericContainer.Namespace), genericContainer),
 		step.NewParallelRunner(logf, "Fn tests",
 			step.NewSerialTestRunner(python39Logger, "Python39 test",
 				teststep.CreateFunction(python39Logger, python39Fn, "Create Python39 Function", runtimes.BasicPythonFunction("Hello from python39", serverlessv1alpha2.Python39)),


### PR DESCRIPTION

**Description**

Changes proposed in this pull request:

- create `serverless-contract-tests` scenario to collect all contract tests
- create new `makefile` target
- delete creating HTTP app in `api-gateway` test scenario

**Related issue(s)**

