### PR TITLE
bump kyma-project/prod/external/golang from 1.20.5-alpine3.18 to 1.20.6-alpine3.18 in application connector components

### DIFF
--- a/components/central-application-connectivity-validator/Dockerfile
+++ b/components/central-application-connectivity-validator/Dockerfile
@@ -1,4 +1,4 @@
-FROM europe-docker.pkg.dev/kyma-project/prod/external/golang:1.20.5-alpine3.18 as builder
+FROM europe-docker.pkg.dev/kyma-project/prod/external/golang:1.20.6-alpine3.18 as builder
 
 ARG DOCK_PKG_DIR=/go/src/github.com/kyma-project/kyma/components/central-application-connectivity-validator
 WORKDIR $DOCK_PKG_DIR

--- a/components/central-application-gateway/Dockerfile
+++ b/components/central-application-gateway/Dockerfile
@@ -1,4 +1,4 @@
-FROM europe-docker.pkg.dev/kyma-project/prod/external/golang:1.20.5-alpine3.18 as builder
+FROM europe-docker.pkg.dev/kyma-project/prod/external/golang:1.20.6-alpine3.18 as builder
 
 ARG DOCK_PKG_DIR=/go/src/github.com/kyma-project/kyma/components/central-application-gateway
 WORKDIR $DOCK_PKG_DIR

--- a/components/compass-runtime-agent/Dockerfile
+++ b/components/compass-runtime-agent/Dockerfile
@@ -1,4 +1,4 @@
-FROM europe-docker.pkg.dev/kyma-project/prod/external/golang:1.20.5-alpine3.18 as builder
+FROM europe-docker.pkg.dev/kyma-project/prod/external/golang:1.20.6-alpine3.18 as builder
 
 ARG DOCK_PKG_DIR=/compass-runtime-agent
 WORKDIR $DOCK_PKG_DIR

--- a/resources/application-connector/values.yaml
+++ b/resources/application-connector/values.yaml
@@ -31,12 +31,12 @@ global:
   images:
     central_application_connectivity_validator:
       name: "central-application-connectivity-validator"
-      version: "v20230724-03904880"
-      directory: "prod"
+      version: "PR-17914"
+      directory: "dev"
     central_application_gateway:
       name: "central-application-gateway"
-      version: "v20230724-ce05f398"
-      directory: "prod"
+      version: "PR-17914"
+      directory: "dev"
     busybox:
       name: "busybox"
       version: "1.34.1-v1"

--- a/resources/compass-runtime-agent/values.yaml
+++ b/resources/compass-runtime-agent/values.yaml
@@ -5,8 +5,8 @@ global:
   images:
     compass_runtime_agent:
       name: "compass-runtime-agent"
-      version: "v20230724-3559a1b6"
-      directory: "prod"
+      version: "PR-17914"
+      directory: "dev"
   istio:
     gateway:
       name: kyma-gateway

--- a/tests/components/application-connector/Dockerfile.compass-runtime-agent
+++ b/tests/components/application-connector/Dockerfile.compass-runtime-agent
@@ -1,4 +1,4 @@
-FROM eu.gcr.io/kyma-project/external/golang:1.19.0-alpine3.16 as builder
+FROM europe-docker.pkg.dev/kyma-project/prod/external/golang:1.20.6-alpine3.18 as builder
 
 WORKDIR /compass-test/
 

--- a/tests/components/application-connector/Dockerfile.connectivity-validator
+++ b/tests/components/application-connector/Dockerfile.connectivity-validator
@@ -1,4 +1,4 @@
-FROM eu.gcr.io/kyma-project/external/golang:1.19.0-alpine3.16 as builder
+FROM europe-docker.pkg.dev/kyma-project/prod/external/golang:1.20.6-alpine3.18 as builder
 
 WORKDIR /validator-test/
 

--- a/tests/components/application-connector/Dockerfile.gateway
+++ b/tests/components/application-connector/Dockerfile.gateway
@@ -1,4 +1,4 @@
-FROM eu.gcr.io/kyma-project/external/golang:1.19.0-alpine3.16 as builder
+FROM europe-docker.pkg.dev/kyma-project/prod/external/golang:1.20.6-alpine3.18 as builder
 
 WORKDIR /gateway-test/
 

--- a/tests/components/application-connector/Dockerfile.mockapp
+++ b/tests/components/application-connector/Dockerfile.mockapp
@@ -1,4 +1,4 @@
-FROM eu.gcr.io/kyma-project/external/golang:1.19.0-alpine3.16 as builder
+FROM europe-docker.pkg.dev/kyma-project/prod/external/golang:1.20.6-alpine3.18 as builder
 
 WORKDIR /mock-app/
 

--- a/tests/components/application-connector/resources/charts/application-connectivity-validator-test/values.yaml
+++ b/tests/components/application-connector/resources/charts/application-connectivity-validator-test/values.yaml
@@ -9,7 +9,7 @@ global:
   images:
     validatorTest:
       name: "connectivity-validator-test"
-      version: "v20230222-59da7511"
-      directory: "prod"
+      version: "PR-17914"
+      directory: "dev"
       
   namespace: "test"

--- a/tests/components/application-connector/resources/charts/compass-runtime-agent-test/values.yaml
+++ b/tests/components/application-connector/resources/charts/compass-runtime-agent-test/values.yaml
@@ -11,8 +11,8 @@ containerRegistry:
 images:
   compassTest:
     name: "compass-runtime-agent-test"
-    version: "v20230705-788e1cea"
-    directory: "prod"
+    version: "PR-17914"
+    directory: "dev"
 
 compassCredentials:
   clientID: ""

--- a/tests/components/application-connector/resources/charts/gateway-test/values.yaml
+++ b/tests/components/application-connector/resources/charts/gateway-test/values.yaml
@@ -5,13 +5,13 @@ global:
   images:
     gatewayTest:
       name: "gateway-test"
-      version: "v20230222-59da7511"
-      directory: "prod"
+      version: "PR-17914"
+      directory: "dev"
 
     mockApplication:
       name: "mock-app"
-      version: "v20230222-59da7511"
-      directory: "prod"
+      version: "PR-17914"
+      directory: "dev"
 
   serviceAccountName: "test-account"
   namespace: "test"


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->
**Description**

Changes proposed in this pull request:

- bump kyma-project/prod/external/golang from 1.20.5-alpine3.18 to 1.20.6-alpine3.18 in application connector components
- ...
- ...

**Related issue(s)**
- https://github.com/kyma-project/kyma/pull/17908
- https://github.com/kyma-project/kyma/pull/17907
- https://github.com/kyma-project/kyma/pull/17903

/hold until release branch will be created