### PR TITLE
Add the link to the BTP Operator module

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -31,7 +31,7 @@
       themeColor: 'blue',
       // basePath: 'https://raw.githubusercontent.com/pbochynski/kyma/main/docs/',
       alias: {
-        '/btp-manager/(.*)': 'https://raw.githubusercontent.com/pbochynski/btp-manager/docsify/docs/user/$1',
+        '/btp-manager/(.*)': 'https://raw.githubusercontent.com/kyma-project/btp-manager/main/docs/$1',
         '/keda-manager/(.*)': 'https://raw.githubusercontent.com/kyma-project/keda-manager/main/docs/$1',
         '/serverless-manager/(.*)': 'https://raw.githubusercontent.com/pbochynski/serverless-manager/grego952-move-technical-docs/docs/$1',
         '/telemetry-manager/(.*)': 'https://raw.githubusercontent.com/pbochynski/telemetry-manager/docsify/docs/$1',


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Replace the temporary BTP Operator module link in the `index.html` file.