### PR TITLE
Bump telemetry manager to fix metric exposure which is not following prometheus specification (fix rel-2.17)

### DIFF
--- a/resources/telemetry/values.yaml
+++ b/resources/telemetry/values.yaml
@@ -8,7 +8,7 @@ global:
       directory: "prod"
     telemetry_operator:
       name: "telemetry-manager"
-      version: "v20230728-bd026443"
+      version: "v20230818-0aadd5f3"
       directory: "prod"
     telemetry_otel_collector:
       name: "otel-collector"


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Fluent-bit metric exposure changes reverted for release 2.17

**Related issue(s)**
https://github.com/kyma-project/kyma/issues/17976
https://github.com/kyma-project/telemetry-manager/pull/340
