### PR TITLE
fix formatting for Grafana tip

### DIFF
--- a/docs/04-operation-guides/security/sec-06-access-expose-grafana.md
+++ b/docs/04-operation-guides/security/sec-06-access-expose-grafana.md
@@ -1,7 +1,8 @@
 ---
 title: Access and Expose Grafana
 ---
->  - To replace [deprecated](https://kyma-project.io/blog/2022/12/9/monitoring-deprecation) Prometheus and Grafana, take a look at [Install a custom kube-prometheus-stack in Kyma](https://github.com/kyma-project/examples/tree/main/prometheus).
+
+> **TIP:** To replace [deprecated](https://kyma-project.io/blog/2022/12/9/monitoring-deprecation) Prometheus and Grafana, take a look at [Install a custom kube-prometheus-stack in Kyma](https://github.com/kyma-project/examples/tree/main/prometheus).
 
 By default, Kyma does not expose Grafana. However, you can still access them using port forwarding. If you want to expose Grafana, use an identity provider of your choice.
 

--- a/docs/04-operation-guides/security/sec-06-access-expose-grafana.md
+++ b/docs/04-operation-guides/security/sec-06-access-expose-grafana.md
@@ -2,7 +2,7 @@
 title: Access and Expose Grafana
 ---
 
-> **TIP:** To replace [deprecated](https://kyma-project.io/blog/2022/12/9/monitoring-deprecation) Prometheus and Grafana, take a look at [Install a custom kube-prometheus-stack in Kyma](https://github.com/kyma-project/examples/tree/main/prometheus).
+> **TIP:** To replace [deprecated](https://github.com/kyma-project/website/blob/main/content/blog-posts/2023-01-17-release-notes-2.10/index.md#deprecation-of-monitoring) Prometheus and Grafana, take a look at [Install a custom kube-prometheus-stack in Kyma](https://github.com/kyma-project/examples/tree/main/prometheus).
 
 By default, Kyma does not expose Grafana. However, you can still access them using port forwarding. If you want to expose Grafana, use an identity provider of your choice.
 


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- change formatting for the tip; it was formatted as part of the title 
- replace link target


<img width="830" alt="image" src="https://github.com/kyma-project/kyma/assets/76950046/fad05484-cda9-4597-a59d-8826106a216a">

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
