### PR TITLE
Added feature flag to disable provisioning of NATS as part of eventing

### DIFF
--- a/components/eventing-controller/cmd/eventing-controller/main.go
+++ b/components/eventing-controller/cmd/eventing-controller/main.go
@@ -69,6 +69,7 @@ func main() {
 	// Get env config and set feature flags
 	envConfig := env.GetConfig()
 	featureflags.SetEventingWebhookAuthEnabled(envConfig.EventingWebhookAuthEnabled)
+	featureflags.SetNATSProvisioningEnabled(envConfig.NATSProvisioningEnabled)
 
 	bebSubMgr := eventmesh.NewSubscriptionManager(restCfg,
 		opts.MetricsAddr,

--- a/components/eventing-controller/controllers/backend/reconciler.go
+++ b/components/eventing-controller/controllers/backend/reconciler.go
@@ -147,8 +147,10 @@ func (r *Reconciler) Reconcile(ctx context.Context, _ ctrl.Request) (ctrl.Result
 	}
 
 	// Create NATS Secret for the eventing-nats statefulset
-	if createErr := r.createNATSSecret(ctx); createErr != nil {
-		return ctrl.Result{}, createErr
+	if featureflags.IsNATSProvisioningEnabled() {
+		if createErr := r.createNATSSecret(ctx); createErr != nil {
+			return ctrl.Result{}, createErr
+		}
 	}
 
 	var secretList v1.SecretList

--- a/components/eventing-controller/internal/featureflags/featureflags.go
+++ b/components/eventing-controller/internal/featureflags/featureflags.go
@@ -7,6 +7,7 @@ var f = &flags{
 
 type flags struct {
 	eventingWebhookAuthEnabled bool
+	natsProvisioningEnabled    bool
 }
 
 // SetEventingWebhookAuthEnabled enable/disable the Eventing webhook auth feature flag.
@@ -18,4 +19,15 @@ func SetEventingWebhookAuthEnabled(enabled bool) {
 // otherwise returns false.
 func IsEventingWebhookAuthEnabled() bool {
 	return f.eventingWebhookAuthEnabled
+}
+
+// SetNATSProvisioningEnabled enable/disable the NATS resources provisioning feature flag.
+func SetNATSProvisioningEnabled(enabled bool) {
+	f.natsProvisioningEnabled = enabled
+}
+
+// IsNATSProvisioningEnabled returns true if the NATS resources provisioning feature flag is enabled,
+// otherwise returns false.
+func IsNATSProvisioningEnabled() bool {
+	return f.natsProvisioningEnabled
 }

--- a/components/eventing-controller/pkg/env/config.go
+++ b/components/eventing-controller/pkg/env/config.go
@@ -61,6 +61,9 @@ type Config struct {
 
 	// EventingWebhookAuthEnabled enable/disable the Eventing webhook auth feature flag.
 	EventingWebhookAuthEnabled bool `envconfig:"EVENTING_WEBHOOK_AUTH_ENABLED" required:"false" default:"false"`
+
+	// NATSProvisioningEnabled enable/disable the NATS resources provisioning feature flag.
+	NATSProvisioningEnabled bool `envconfig:"NATS_PROVISIONING_ENABLED" required:"false" default:"true"`
 }
 
 func GetConfig() Config {

--- a/components/eventing-controller/pkg/env/config_test.go
+++ b/components/eventing-controller/pkg/env/config_test.go
@@ -41,4 +41,5 @@ func Test_GetConfig(t *testing.T) {
 	webhookActivationTimeout, err := time.ParseDuration(envs["WEBHOOK_ACTIVATION_TIMEOUT"])
 	g.Expect(err).ShouldNot(HaveOccurred())
 	g.Expect(config.WebhookActivationTimeout).To(Equal(webhookActivationTimeout))
+	g.Expect(config.NATSProvisioningEnabled).To(Equal(true))
 }

--- a/components/eventing-controller/testing/eventmeshmock.go
+++ b/components/eventing-controller/testing/eventmeshmock.go
@@ -15,6 +15,7 @@ import (
 	. "github.com/onsi/gomega" //nolint:revive,stylecheck // using . import for convenience
 	"golang.org/x/oauth2"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
+
 	// gcp auth etc.
 	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
 

--- a/resources/eventing/charts/controller/templates/deployment.yaml
+++ b/resources/eventing/charts/controller/templates/deployment.yaml
@@ -94,6 +94,8 @@ spec:
             value: {{ .Values.eventingWebhookAuth.secret.name | quote }}
           - name: EVENTING_WEBHOOK_AUTH_SECRET_NAMESPACE
             value: {{ .Values.eventingWebhookAuth.secret.namespace | quote }}
+          - name: NATS_PROVISIONING_ENABLED
+            value: {{ .Values.global.jetstream.enabled | quote }}
           resources:
             requests:
               cpu: {{ .Values.resources.requests.cpu }}

--- a/resources/eventing/charts/nats/templates/configmap.yaml
+++ b/resources/eventing/charts/nats/templates/configmap.yaml
@@ -1,4 +1,4 @@
----
+{{- if .Values.global.jetstream.enabled }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -161,3 +161,4 @@ data:
     {{- end }}
     {{- end }}
     {{- end }}
+{{- end }}

--- a/resources/eventing/charts/nats/templates/destination-rule.yaml
+++ b/resources/eventing/charts/nats/templates/destination-rule.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.global.jetstream.enabled }}
 apiVersion: networking.istio.io/v1alpha3
 kind: DestinationRule
 metadata:
@@ -10,3 +11,4 @@ spec:
   trafficPolicy:
     tls:
       mode: DISABLE
+{{- end }}

--- a/resources/eventing/charts/nats/templates/service.yaml
+++ b/resources/eventing/charts/nats/templates/service.yaml
@@ -1,4 +1,4 @@
----
+{{- if .Values.global.jetstream.enabled }}
 apiVersion: v1
 kind: Service
 metadata:
@@ -53,3 +53,4 @@ spec:
     {{- if .Values.appProtocol.enabled }}
     appProtocol: tcp
     {{- end }}
+{{- end }}

--- a/resources/eventing/charts/nats/templates/statefulset.yaml
+++ b/resources/eventing/charts/nats/templates/statefulset.yaml
@@ -1,4 +1,4 @@
----
+{{- if .Values.global.jetstream.enabled }}
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
@@ -306,3 +306,4 @@ spec:
         storageClassName: {{ .Values.nats.jetstream.fileStorage.storageClassName | quote }}
         {{- end }}
   {{- end }}
+{{- end }}

--- a/resources/eventing/values.yaml
+++ b/resources/eventing/values.yaml
@@ -5,7 +5,7 @@ global:
   images:
     eventing_controller:
       name: eventing-controller
-      version: PR-17906
+      version: PR-18041
       directory: dev
       pullPolicy: "IfNotPresent"
     publisher_proxy:

--- a/resources/eventing/values.yaml
+++ b/resources/eventing/values.yaml
@@ -30,6 +30,7 @@ global:
       directory: prod/external
 
   jetstream:
+    enabled: true # If set to `false` then NATS resources will not be deployed to the cluster.
     # Storage type of the stream, memory or file.
     storage: file
     fileStorage:


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- Added feature flag to disable provisioning of NATS as part of eventing.
- `kyma deploy --source=PR-18041 --profile=production --value eventing.global.jetstream.enabled=false`

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
- https://github.com/kyma-project/nats-manager/issues/96