### PR TITLE
Remove pr images in eventing for release 2.18

### DIFF
--- a/resources/eventing/values.yaml
+++ b/resources/eventing/values.yaml
@@ -5,8 +5,8 @@ global:
   images:
     eventing_controller:
       name: eventing-controller
-      version: PR-17906
-      directory: dev
+      version: v20230824-c2e2e731
+      directory: prod
       pullPolicy: "IfNotPresent"
     publisher_proxy:
       name: event-publisher-proxy

--- a/resources/eventing/values.yaml
+++ b/resources/eventing/values.yaml
@@ -10,8 +10,8 @@ global:
       pullPolicy: "IfNotPresent"
     publisher_proxy:
       name: event-publisher-proxy
-      version: PR-17904
-      directory: dev
+      version: v20230824-01c828ca
+      directory: prod
     certHandler:
       name: eventing-webhook-certificates
       version: 1.7.0


### PR DESCRIPTION
This PR removes the PR-images for eventing-contoller and event-publisher-proxy for the release of Kyma v2.18.

related PRs:
https://github.com/kyma-project/kyma/pull/17906
https://github.com/kyma-project/kyma/pull/17904