### PR TITLE
bumps images for application-connector components tests

### DIFF
--- a/tests/components/application-connector/resources/charts/application-connectivity-validator-test/values.yaml
+++ b/tests/components/application-connector/resources/charts/application-connectivity-validator-test/values.yaml
@@ -9,7 +9,7 @@ global:
   images:
     validatorTest:
       name: "connectivity-validator-test"
-      version: "v20230824-a02c92c2"
+      version: "v20230818-dad1db65"
       directory: "prod"
 
   namespace: "test"

--- a/tests/components/application-connector/resources/charts/application-connectivity-validator-test/values.yaml
+++ b/tests/components/application-connector/resources/charts/application-connectivity-validator-test/values.yaml
@@ -9,7 +9,7 @@ global:
   images:
     validatorTest:
       name: "connectivity-validator-test"
-      version: "PR-17914"
-      directory: "dev"
-      
+      version: "v20230824-a02c92c2"
+      directory: "prod"
+
   namespace: "test"

--- a/tests/components/application-connector/resources/charts/compass-runtime-agent-test/values.yaml
+++ b/tests/components/application-connector/resources/charts/compass-runtime-agent-test/values.yaml
@@ -11,8 +11,8 @@ containerRegistry:
 images:
   compassTest:
     name: "compass-runtime-agent-test"
-    version: "PR-17914"
-    directory: "dev"
+      version: "v20230824-a02c92c2"
+      directory: "prod"
 
 compassCredentials:
   clientID: ""

--- a/tests/components/application-connector/resources/charts/compass-runtime-agent-test/values.yaml
+++ b/tests/components/application-connector/resources/charts/compass-runtime-agent-test/values.yaml
@@ -11,8 +11,8 @@ containerRegistry:
 images:
   compassTest:
     name: "compass-runtime-agent-test"
-      version: "v20230824-a02c92c2"
-      directory: "prod"
+    version: "v20230824-a02c92c2"
+    directory: "prod"
 
 compassCredentials:
   clientID: ""

--- a/tests/components/application-connector/resources/charts/compass-runtime-agent-test/values.yaml
+++ b/tests/components/application-connector/resources/charts/compass-runtime-agent-test/values.yaml
@@ -11,7 +11,7 @@ containerRegistry:
 images:
   compassTest:
     name: "compass-runtime-agent-test"
-    version: "v20230824-a02c92c2"
+    version: "v20230818-dad1db65"
     directory: "prod"
 
 compassCredentials:

--- a/tests/components/application-connector/resources/charts/gateway-test/values.yaml
+++ b/tests/components/application-connector/resources/charts/gateway-test/values.yaml
@@ -5,12 +5,12 @@ global:
   images:
     gatewayTest:
       name: "gateway-test"
-      version: "v20230824-a02c92c2"
+      version: "v20230818-dad1db65"
       directory: "prod"
 
     mockApplication:
       name: "mock-app"
-      version: "v20230824-a02c92c2"
+      version: "v20230818-dad1db65"
       directory: "prod"
 
   serviceAccountName: "test-account"

--- a/tests/components/application-connector/resources/charts/gateway-test/values.yaml
+++ b/tests/components/application-connector/resources/charts/gateway-test/values.yaml
@@ -5,13 +5,13 @@ global:
   images:
     gatewayTest:
       name: "gateway-test"
-      version: "PR-17914"
-      directory: "dev"
+      version: "v20230824-a02c92c2"
+      directory: "prod"
 
     mockApplication:
       name: "mock-app"
-      version: "PR-17914"
-      directory: "dev"
+      version: "v20230824-a02c92c2"
+      directory: "prod"
 
   serviceAccountName: "test-account"
   namespace: "test"


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- bumps images for application-connector components tests for 2.18
- ...
- ...

**Related issue(s)**