### PR TITLE
Use ce-sdk when emitting cloudevents from functions

### DIFF
--- a/components/function-runtimes/nodejs/lib/ce.js
+++ b/components/function-runtimes/nodejs/lib/ce.js
@@ -125,12 +125,12 @@ function emitCloudEvent(type, source, data, optionalCloudEventAttributes) {
     
     cloudEventInput = Object.assign(cloudEventInput, optionalCloudEventAttributesInput)
     const ce = new CloudEvent(cloudEventInput);
+    const message = HTTP.structured(ce)
+
     return axios({
         method: "post",
         baseURL: publishProxyAddress,
-        headers: {
-            "Content-Type": "application/cloudevents+json"
-        },
-        data: ce.toJSON(),
+        headers: message.headers,
+        data: message.body,
     });
 }

--- a/components/function-runtimes/python39/kubeless/ce.py
+++ b/components/function-runtimes/python39/kubeless/ce.py
@@ -1,10 +1,12 @@
+import bottle
 import io
 import json
+import logging
 import os
 
-import bottle
 import requests
-from cloudevents.http import from_http
+from cloudevents.http import from_http, CloudEvent
+from cloudevents.conversion import to_structured
 
 publisher_proxy_address = os.getenv('PUBLISHER_PROXY_ADDRESS')
 
@@ -98,7 +100,21 @@ class Event:
     def __setitem__(self, name, value):
         self.ceHeaders[name] = value
 
+    def emitCloudEvent(self, type, source, data, optionalCloudEventAttributes=None):
+        attributes = {
+            "type": type,
+            "source": source,
+        }
+        if optionalCloudEventAttributes is not None:
+            attributes.update(optionalCloudEventAttributes)
+            
+        event = CloudEvent(attributes, data)
+        headers, body = to_structured(event)
+
+        requests.post(publisher_proxy_address, data=body, headers=headers)
+
     def publishCloudEvent(self, data):
+        logging.warn('"publishCloudEvent" is deprecated. Use "emitCloudEvent"')
         return requests.post(
             publisher_proxy_address,
             data=json.dumps(data, default=str),
@@ -106,6 +122,7 @@ class Event:
         )
 
     def buildResponseCloudEvent(self, event_id, event_type, event_data):
+        logging.warn('"buildResponseCloudEvent" is deprecated. Use "emitCloudEvent"')
         return {
             'type': event_type,
             'source': self.ceHeaders['ce-source'],


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Use cloudevents sdk when emitting cloudevents

**Related issue(s)**
#18044 