### PR TITLE
Use different path for configuration files

### DIFF
--- a/components/function-controller/cmd/manager/main.go
+++ b/components/function-controller/cmd/manager/main.go
@@ -50,7 +50,7 @@ type config struct {
 	SecretMutatingWebhookPort int    `envconfig:"default=8443"`
 	Kubernetes                k8s.Config
 	Function                  serverless.FunctionConfig
-	LogConfigPath             string `envconfig:"default=/appdata/log-config.yaml"`
+	LogConfigPath             string `envconfig:"default=/appconfig/log-config.yaml"`
 }
 
 type healthzConfig struct {

--- a/components/function-controller/internal/webhook/config.go
+++ b/components/function-controller/internal/webhook/config.go
@@ -5,6 +5,6 @@ type Config struct {
 	ServiceName     string `envconfig:"default=serverless-webhook"`
 	SecretName      string `envconfig:"default=serverless-webhook"`
 	Port            int    `envconfig:"default=8443"`
-	LogConfigPath   string `envconfig:"default=/appdata/log_config.yaml"`
-	ConfigPath      string `envconfig:"default=/appdata/config.yaml"`
+	LogConfigPath   string `envconfig:"default=/appconfig/log_config.yaml"`
+	ConfigPath      string `envconfig:"default=/appconfig/config.yaml"`
 }

--- a/resources/serverless/values.yaml
+++ b/resources/serverless/values.yaml
@@ -68,7 +68,7 @@ global:
   registryNodePort: 32137
   configuration:
     configmapName: "serverless-configuration"
-    targetDir: "/appdata"
+    targetDir: "/appconfig"
     logFilename: "log-config.yaml"
     filename: "config.yaml"
   ingress:

--- a/resources/serverless/values.yaml
+++ b/resources/serverless/values.yaml
@@ -82,11 +82,11 @@ global:
       directory: "prod"
     function_controller:
       name: "function-controller"
-      version: "PR-18070"
+      version: "PR-18115"
       directory: "dev"
     function_webhook:
       name: "function-webhook"
-      version: "PR-18070"
+      version: "PR-18115"
       directory: "dev"
     function_build_init:
       name: "function-build-init"


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- Use different configuration path because reconciler merges old deployment with new one. The result is:
```
    volumeMounts:
    - mountPath: /appdata/log-config.yaml
      name: log-configuration
      subPath: config.yaml
    - mountPath: /appdata/config.yaml
      name: configuration
      subPath: config.yaml
    - mountPath: /appdata
      name: configuration
```
Changes regarding configuration: https://github.com/kyma-project/kyma/pull/18070
**Related issue(s)**
https://github.com/kyma-project/kyma/issues/18113
