### PR TITLE
Change mlc schedule

### DIFF
--- a/.github/workflows/daily-markdown-link-check.yaml
+++ b/.github/workflows/daily-markdown-link-check.yaml
@@ -2,8 +2,8 @@ name: Daily Markdown Link Check
 run-name: ${{github.event.pull_request.title}}
 on:
     schedule:
-    # Run every 5 minutes for the first days, then will be updated to run everyday at 6:00 AM
-    - cron: "*/5 * * * *"
+    # Run everyday at 5:00 AM
+    - cron: "0 5 * * *"
 jobs:
   markdown-link-check:
     runs-on: ubuntu-latest


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Change the Daily Markdown Link Check schedule to run daily at 5 AM

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
