### PR TITLE
adjust the naming

### DIFF
--- a/docs/04-operation-guides/troubleshooting/api-exposure/apix-03-cert-mgt-issuer-not-created.md
+++ b/docs/04-operation-guides/troubleshooting/api-exposure/apix-03-cert-mgt-issuer-not-created.md
@@ -4,11 +4,11 @@ title: Certificate management - Issuer not created
 
 ## Symptom
 
-When you try to create an Issuer CR using `cert.gardener.cloud/v1alpha1`, the resource is not created. There are no logs in the `cert-management` controller.
+When you try to create an Issuer CR using `cert.gardener.cloud/v1alpha1`, the resource is not created. There are no logs in `cert-controller-manager`.
 
 ## Cause
 
-The Namespace in which the Issuer CR was created is incorrect. By default, the `cert-management` watches the `default` Namespace for all Issuer CRs.
+The Namespace in which the Issuer CR was created is incorrect. By default, `cert-controller-manager` watches the `default` Namespace for all Issuer CRs.
 
 ## Remedy
 
@@ -18,4 +18,4 @@ Make sure that you created the Issuer CR in the `default` Namespace. Run:
 kubectl get issuers -A
 ```
 
-If you want to create the Issuer CR in a different Namespace, adjust the `cert-management` settings during the installation.
+If you want to create the Issuer CR in a different Namespace, adjust the settings of `cert-controller-manager` during the installation.


### PR DESCRIPTION
Changes proposed in this pull request:

- replace the name `cert-management` with `cert-controller-manager` as this is the correct name. See the [Gardener documentation](github.com/gardener/cert-management). 