### PR TITLE
Make eventing-controller to not crash when nats is not present

### DIFF
--- a/components/eventing-controller/controllers/subscription/jetstream/reconciler.go
+++ b/components/eventing-controller/controllers/subscription/jetstream/reconciler.go
@@ -69,10 +69,6 @@ func NewReconciler(ctx context.Context, client client.Client, jsBackend jetstrea
 		customEventsChannel: make(chan event.GenericEvent),
 		collector:           collector,
 	}
-	if err := jsBackend.Initialize(reconciler.handleNatsConnClose); err != nil {
-		logger.WithContext().Errorw("Failed to start reconciler", "name", reconcilerName, "error", err)
-		panic(err)
-	}
 	return reconciler
 }
 
@@ -217,11 +213,11 @@ func (r *Reconciler) updateSubscriptionMetrics(current, desired *eventingv1alpha
 	}
 }
 
-// handleNatsConnClose is called by NATS when the connection to the NATS server is closed. When it
+// HandleNatsConnClose is called by NATS when the connection to the NATS server is closed. When it
 // is called, the reconnect-attempts have exceeded the defined value.
 // It forces reconciling the subscription to make sure the subscription is marked as not ready, until
 // it is possible to connect to the NATS server again.
-func (r *Reconciler) handleNatsConnClose(_ *nats.Conn) {
+func (r *Reconciler) HandleNatsConnClose(_ *nats.Conn) {
 	r.namedLogger().Info("JetStream connection is closed and reconnect attempts are exceeded!")
 	var subs eventingv1alpha2.SubscriptionList
 	if err := r.Client.List(context.Background(), &subs); err != nil {

--- a/components/eventing-controller/controllers/subscription/jetstream/reconciler_internal_unit_test.go
+++ b/components/eventing-controller/controllers/subscription/jetstream/reconciler_internal_unit_test.go
@@ -78,7 +78,6 @@ func Test_Reconcile(t *testing.T) {
 			givenSubscription: testSub,
 			givenReconcilerSetup: func() (*Reconciler, *mocks.Backend) {
 				te := setupTestEnvironment(t, testSub)
-				//te.Backend.On("Initialize", mock.Anything).Return(nil)
 				te.Backend.On("SyncSubscription", mock.Anything).Return(nil)
 				te.Backend.On("GetJetStreamSubjects", mock.Anything, mock.Anything, mock.Anything).Return(
 					[]string{controllertesting.JetStreamSubject})
@@ -101,7 +100,6 @@ func Test_Reconcile(t *testing.T) {
 			givenSubscription: testSub,
 			givenReconcilerSetup: func() (*Reconciler, *mocks.Backend) {
 				te := setupTestEnvironment(t)
-				//te.Backend.On("Initialize", mock.Anything).Return(nil)
 				return NewReconciler(ctx,
 						te.Client,
 						te.Backend,
@@ -120,7 +118,6 @@ func Test_Reconcile(t *testing.T) {
 			givenSubscription: controllertesting.NewSubscription(subscriptionName, namespaceName),
 			givenReconcilerSetup: func() (*Reconciler, *mocks.Backend) {
 				te := setupTestEnvironment(t, controllertesting.NewSubscription(subscriptionName, namespaceName))
-				//te.Backend.On("Initialize", mock.Anything).Return(nil)
 				return NewReconciler(ctx,
 						te.Client,
 						te.Backend,
@@ -139,7 +136,6 @@ func Test_Reconcile(t *testing.T) {
 			givenSubscription: testSub,
 			givenReconcilerSetup: func() (*Reconciler, *mocks.Backend) {
 				te := setupTestEnvironment(t, testSub)
-				//te.Backend.On("Initialize", mock.Anything).Return(nil)
 				te.Backend.On("SyncSubscription", mock.Anything).Return(backendSyncErr)
 				te.Backend.On("GetJetStreamSubjects", mock.Anything, mock.Anything, mock.Anything).Return(
 					[]string{controllertesting.JetStreamSubject})
@@ -164,7 +160,6 @@ func Test_Reconcile(t *testing.T) {
 			givenSubscription: testSub,
 			givenReconcilerSetup: func() (*Reconciler, *mocks.Backend) {
 				te := setupTestEnvironment(t, testSub)
-				//te.Backend.On("Initialize", mock.Anything).Return(nil)
 				te.Backend.On("SyncSubscription", mock.Anything).Return(missingSubSyncErr)
 				te.Backend.On("GetJetStreamSubjects", mock.Anything, mock.Anything, mock.Anything).Return(
 					[]string{controllertesting.JetStreamSubject})
@@ -187,7 +182,6 @@ func Test_Reconcile(t *testing.T) {
 			givenSubscription: testSubUnderDeletion,
 			givenReconcilerSetup: func() (*Reconciler, *mocks.Backend) {
 				te := setupTestEnvironment(t, testSubUnderDeletion)
-				//te.Backend.On("Initialize", mock.Anything).Return(nil)
 				te.Backend.On("DeleteSubscription", mock.Anything).Return(backendDeleteErr)
 				return NewReconciler(ctx,
 						te.Client,
@@ -207,7 +201,6 @@ func Test_Reconcile(t *testing.T) {
 			givenSubscription: testSub,
 			givenReconcilerSetup: func() (*Reconciler, *mocks.Backend) {
 				te := setupTestEnvironment(t, testSub)
-				//te.Backend.On("Initialize", mock.Anything).Return(nil)
 				te.Backend.On("DeleteSubscriptionsOnly", mock.Anything).Return(nil)
 				te.Backend.On("GetJetStreamSubjects", mock.Anything, mock.Anything, mock.Anything).Return(
 					[]string{controllertesting.JetStreamSubject})

--- a/components/eventing-controller/controllers/subscription/jetstream/reconciler_internal_unit_test.go
+++ b/components/eventing-controller/controllers/subscription/jetstream/reconciler_internal_unit_test.go
@@ -78,7 +78,7 @@ func Test_Reconcile(t *testing.T) {
 			givenSubscription: testSub,
 			givenReconcilerSetup: func() (*Reconciler, *mocks.Backend) {
 				te := setupTestEnvironment(t, testSub)
-				te.Backend.On("Initialize", mock.Anything).Return(nil)
+				//te.Backend.On("Initialize", mock.Anything).Return(nil)
 				te.Backend.On("SyncSubscription", mock.Anything).Return(nil)
 				te.Backend.On("GetJetStreamSubjects", mock.Anything, mock.Anything, mock.Anything).Return(
 					[]string{controllertesting.JetStreamSubject})
@@ -101,7 +101,7 @@ func Test_Reconcile(t *testing.T) {
 			givenSubscription: testSub,
 			givenReconcilerSetup: func() (*Reconciler, *mocks.Backend) {
 				te := setupTestEnvironment(t)
-				te.Backend.On("Initialize", mock.Anything).Return(nil)
+				//te.Backend.On("Initialize", mock.Anything).Return(nil)
 				return NewReconciler(ctx,
 						te.Client,
 						te.Backend,
@@ -120,7 +120,7 @@ func Test_Reconcile(t *testing.T) {
 			givenSubscription: controllertesting.NewSubscription(subscriptionName, namespaceName),
 			givenReconcilerSetup: func() (*Reconciler, *mocks.Backend) {
 				te := setupTestEnvironment(t, controllertesting.NewSubscription(subscriptionName, namespaceName))
-				te.Backend.On("Initialize", mock.Anything).Return(nil)
+				//te.Backend.On("Initialize", mock.Anything).Return(nil)
 				return NewReconciler(ctx,
 						te.Client,
 						te.Backend,
@@ -139,7 +139,7 @@ func Test_Reconcile(t *testing.T) {
 			givenSubscription: testSub,
 			givenReconcilerSetup: func() (*Reconciler, *mocks.Backend) {
 				te := setupTestEnvironment(t, testSub)
-				te.Backend.On("Initialize", mock.Anything).Return(nil)
+				//te.Backend.On("Initialize", mock.Anything).Return(nil)
 				te.Backend.On("SyncSubscription", mock.Anything).Return(backendSyncErr)
 				te.Backend.On("GetJetStreamSubjects", mock.Anything, mock.Anything, mock.Anything).Return(
 					[]string{controllertesting.JetStreamSubject})
@@ -164,7 +164,7 @@ func Test_Reconcile(t *testing.T) {
 			givenSubscription: testSub,
 			givenReconcilerSetup: func() (*Reconciler, *mocks.Backend) {
 				te := setupTestEnvironment(t, testSub)
-				te.Backend.On("Initialize", mock.Anything).Return(nil)
+				//te.Backend.On("Initialize", mock.Anything).Return(nil)
 				te.Backend.On("SyncSubscription", mock.Anything).Return(missingSubSyncErr)
 				te.Backend.On("GetJetStreamSubjects", mock.Anything, mock.Anything, mock.Anything).Return(
 					[]string{controllertesting.JetStreamSubject})
@@ -187,7 +187,7 @@ func Test_Reconcile(t *testing.T) {
 			givenSubscription: testSubUnderDeletion,
 			givenReconcilerSetup: func() (*Reconciler, *mocks.Backend) {
 				te := setupTestEnvironment(t, testSubUnderDeletion)
-				te.Backend.On("Initialize", mock.Anything).Return(nil)
+				//te.Backend.On("Initialize", mock.Anything).Return(nil)
 				te.Backend.On("DeleteSubscription", mock.Anything).Return(backendDeleteErr)
 				return NewReconciler(ctx,
 						te.Client,
@@ -207,7 +207,7 @@ func Test_Reconcile(t *testing.T) {
 			givenSubscription: testSub,
 			givenReconcilerSetup: func() (*Reconciler, *mocks.Backend) {
 				te := setupTestEnvironment(t, testSub)
-				te.Backend.On("Initialize", mock.Anything).Return(nil)
+				//te.Backend.On("Initialize", mock.Anything).Return(nil)
 				te.Backend.On("DeleteSubscriptionsOnly", mock.Anything).Return(nil)
 				te.Backend.On("GetJetStreamSubjects", mock.Anything, mock.Anything, mock.Anything).Return(
 					[]string{controllertesting.JetStreamSubject})

--- a/components/eventing-controller/pkg/backend/jetstream/jetstream.go
+++ b/components/eventing-controller/pkg/backend/jetstream/jetstream.go
@@ -345,7 +345,7 @@ func (js *JetStream) initCloudEventClient(config env.NATSConfig) error {
 
 // checkJetStreamConnection reconnects to the server if the server is not connected.
 func (js *JetStream) checkJetStreamConnection() error {
-	if js.Conn.Status() != nats.CONNECTED {
+	if js.Conn == nil || js.Conn.Status() != nats.CONNECTED {
 		if err := js.Initialize(js.connClosedHandler); err != nil {
 			return fmt.Errorf("failed to connect to JetStream with status %d: %w", js.Conn.Status(), err)
 		}

--- a/components/eventing-controller/pkg/subscriptionmanager/jetstream/jetstream.go
+++ b/components/eventing-controller/pkg/subscriptionmanager/jetstream/jetstream.go
@@ -119,6 +119,10 @@ func (sm *SubscriptionManager) Start(defaultSubsConfig env.DefaultSubscriptionCo
 	)
 	sm.backendv2 = jetStreamReconciler.Backend
 
+	if err := jetStreamHandler.Initialize(jetStreamReconciler.HandleNatsConnClose); err != nil {
+		return fmt.Errorf("failed to initialise jetstream reconciler: %w", err)
+	}
+
 	// delete dangling invalid consumers here
 	var subs eventingv1alpha2.SubscriptionList
 	if err := client.List(context.Background(), &subs); err != nil {

--- a/resources/eventing/values.yaml
+++ b/resources/eventing/values.yaml
@@ -5,7 +5,7 @@ global:
   images:
     eventing_controller:
       name: eventing-controller
-      version: PR-18100
+      version: PR-18175
       directory: dev
       pullPolicy: "IfNotPresent"
     publisher_proxy:


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- Make eventing-controller to not crash when nats is not present

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
