### PR TITLE
Enable Webhook Auth by  default

### DIFF
--- a/components/eventing-controller/controllers/backend/reconciler_internal_integration_test.go
+++ b/components/eventing-controller/controllers/backend/reconciler_internal_integration_test.go
@@ -31,6 +31,7 @@ import (
 	kymalogger "github.com/kyma-project/kyma/common/logging/logger"
 
 	eventingv1alpha1 "github.com/kyma-project/kyma/components/eventing-controller/api/v1alpha1"
+	"github.com/kyma-project/kyma/components/eventing-controller/internal/featureflags"
 	"github.com/kyma-project/kyma/components/eventing-controller/logger"
 	"github.com/kyma-project/kyma/components/eventing-controller/pkg/deployment"
 	"github.com/kyma-project/kyma/components/eventing-controller/pkg/env"
@@ -77,6 +78,8 @@ var _ = BeforeSuite(func(done Done) {
 	newCABundle := make([]byte, 20)
 	_, err2 = rand.Read(newCABundle)
 	Expect(err2).NotTo(HaveOccurred())
+
+	featureflags.SetEventingWebhookAuthEnabled(false)
 
 	// setup dummy mutating webhook
 	url := "https://eventing-controller.kyma-system.svc.cluster.local"

--- a/components/eventing-controller/internal/featureflags/featureflags.go
+++ b/components/eventing-controller/internal/featureflags/featureflags.go
@@ -2,7 +2,7 @@ package featureflags
 
 //nolint:gochecknoglobals // This is global only inside the package.
 var f = &flags{
-	eventingWebhookAuthEnabled: false,
+	eventingWebhookAuthEnabled: true,
 }
 
 type flags struct {

--- a/components/eventing-controller/pkg/backend/eventmesh/eventmesh_integration_test.go
+++ b/components/eventing-controller/pkg/backend/eventmesh/eventmesh_integration_test.go
@@ -179,7 +179,7 @@ func Test_handleKymaSubModified(t *testing.T) {
 			givenKymaSub: &eventingv1alpha2.Subscription{
 				Status: eventingv1alpha2.SubscriptionStatus{
 					Backend: eventingv1alpha2.Backend{
-						Ev2hash: int64(-9219276050977208880),
+						EventMeshLocalHash: int64(-9219276050977208880),
 					},
 				},
 			},


### PR DESCRIPTION
Enable Webhook Auth feature flag by default. This is required by the eventing-manager as eventing manager is implemented explicitly with eventing webhook auth.