### PR TITLE
Remove PR images for release 2.19 in eventing

### DIFF
--- a/resources/eventing/values.yaml
+++ b/resources/eventing/values.yaml
@@ -10,8 +10,8 @@ global:
       pullPolicy: "IfNotPresent"
     publisher_proxy:
       name: event-publisher-proxy
-      version: PR-18100
-      directory: dev
+      version: v20230908-cec11ad9
+      directory: prod
     certHandler:
       name: eventing-webhook-certificates
       version: 1.7.0

--- a/resources/eventing/values.yaml
+++ b/resources/eventing/values.yaml
@@ -5,8 +5,8 @@ global:
   images:
     eventing_controller:
       name: eventing-controller
-      version: PR-18183
-      directory: dev
+      version: v20230915-13242b5f
+      directory: prod
       pullPolicy: "IfNotPresent"
     publisher_proxy:
       name: event-publisher-proxy


### PR DESCRIPTION
Replace the PR images used in eventing with build-job images for the upcoming release `2.19`.
Image for EPP from [this PR's build job](https://github.com/kyma-project/kyma/pull/18100)
Image for EC from [this PR's build job](https://github.com/kyma-project/kyma/pull/18183)