### PR TITLE
omit creating oauth2client when eventing-webhook-auth is enabled

### DIFF
--- a/resources/eventing/charts/controller/templates/oauth2-client.yaml
+++ b/resources/eventing/charts/controller/templates/oauth2-client.yaml
@@ -1,3 +1,4 @@
+{{ if not .Values.eventingWebhookAuth.enabled}}
 # Used by controller for BEB backend
 apiVersion: hydra.ory.sh/v1alpha1
 kind: OAuth2Client
@@ -11,3 +12,4 @@ spec:
   metadata: null
   scope: read write beb uaa.resource
   secretName: {{ include "controller.fullname" . }}{{ .Values.bebSecret.nameSuffix }}
+{{ end }}


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- in case we use an external webhook authentication backend we do not create an ORY based oauth2client

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
