### PR TITLE
bumps the app-con images with 1.21.1 golang bump

### DIFF
--- a/resources/application-connector/values.yaml
+++ b/resources/application-connector/values.yaml
@@ -31,12 +31,12 @@ global:
   images:
     central_application_connectivity_validator:
       name: "central-application-connectivity-validator"
-      version: "PR-18221"
-      directory: "dev"
+      version: "v20230925-75c3a9a8"
+      directory: "prod"
     central_application_gateway:
       name: "central-application-gateway"
-      version: "PR-18221"
-      directory: "dev"
+      version: "v20230925-75c3a9a8"
+      directory: "prod"
     busybox:
       name: "busybox"
       version: "1.34.1-v1"

--- a/resources/compass-runtime-agent/values.yaml
+++ b/resources/compass-runtime-agent/values.yaml
@@ -5,8 +5,8 @@ global:
   images:
     compass_runtime_agent:
       name: "compass-runtime-agent"
-      version: "PR-18221"
-      directory: "dev"
+      version: "v20230925-75c3a9a8"
+      directory: "prod"
   istio:
     gateway:
       name: kyma-gateway

--- a/tests/components/application-connector/resources/charts/application-connectivity-validator-test/values.yaml
+++ b/tests/components/application-connector/resources/charts/application-connectivity-validator-test/values.yaml
@@ -9,7 +9,7 @@ global:
   images:
     validatorTest:
       name: "connectivity-validator-test"
-      version: "PR-18221"
-      directory: "dev"
+      version: "v20230925-75c3a9a8"
+      directory: "prod"
 
   namespace: "test"

--- a/tests/components/application-connector/resources/charts/compass-runtime-agent-test/values.yaml
+++ b/tests/components/application-connector/resources/charts/compass-runtime-agent-test/values.yaml
@@ -11,8 +11,8 @@ containerRegistry:
 images:
   compassTest:
     name: "compass-runtime-agent-test"
-    version: "PR-18221"
-    directory: "dev"
+    version: "v20230925-75c3a9a8"
+    directory: "prod"
 
 compassCredentials:
   clientID: ""

--- a/tests/components/application-connector/resources/charts/gateway-test/values.yaml
+++ b/tests/components/application-connector/resources/charts/gateway-test/values.yaml
@@ -5,12 +5,12 @@ global:
   images:
     gatewayTest:
       name: "gateway-test"
-      version: "PR-18221"
-      directory: "dev"
+      version: "v20230925-75c3a9a8"
+      directory: "prod"
     mockApplication:
       name: "mock-app"
-      version: "PR-18221"
-      directory: "dev"
+      version: "v20230925-75c3a9a8"
+      directory: "prod"
 
   serviceAccountName: "test-account"
   namespace: "test"


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- see the title
- ...
- ...

**Related issue(s)**
- https://github.com/kyma-project/kyma/pull/18221 

/area application-connector
/kind chore