### PR TITLE
bump serverless images before v2.19

### DIFF
--- a/resources/serverless/values.yaml
+++ b/resources/serverless/values.yaml
@@ -82,20 +82,20 @@ global:
       directory: "prod"
     function_controller:
       name: "function-controller"
-      version: "PR-18164"
-      directory: "dev"
+      version: "v20230921-354ba85f"
+      directory: "prod"
     function_webhook:
       name: "function-webhook"
-      version: "PR-18164"
-      directory: "dev"
+      version: "v20230921-354ba85f"
+      directory: "prod"
     function_build_init:
       name: "function-build-init"
-      version: "PR-18164"
-      directory: "dev"
+      version: "v20230921-354ba85f"
+      directory: "prod"
     function_registry_gc:
       name: "function-registry-gc"
-      version: "PR-18202"
-      directory: "dev"
+      version: "v20230921-354ba85f"
+      directory: "prod"
     function_runtime_nodejs16:
       name: "function-runtime-nodejs16"
       version: "v20230831-fb331fc0"


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- use prod tags for serverless images
