### PR TITLE
fix docsify-tabs regex

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -43,11 +43,11 @@
           // remove title metadata section
           hook.beforeEach(function (markdown) {
             markdown = markdown.replaceAll(/---.*\ntitle: (.*)\n---.*\n/gm, "# $1");
-            markdown = markdown.replace(/(<div tabs.*>)((.|\n)*?)(<\/div>)/gm,function(match,g1,g2,g3,g4){
-              let tab = g2.replace(/<details.*?>(.|\n)*?<summary.*?>(\n|\s)*(.*)(.|\n)*?\n.*<\/summary>((.|\n)*?).*<\/details>/gm,
-                "#### **$3**\n$5\n");
-              return '<!-- tabs:start -->\n'+tab+'<!-- tabs:end -->\n'
-            })
+            markdown = markdown.replace(/(<div tabs.*?>)((.|\n)*?)(<\/div>)/gm, function(match, g1, g2, g3, g4) {
+              let tab = g2.replace(/<details.*?>((.|\n)*?)<summary.*?>(\n|\s)*(.*?)(\n|\s)*<\/summary>((.|\n)*?).*?<\/details>/gm,
+                "#### **$4**\n$6\n");
+              return '<!-- tabs:start -->\n' + tab + '<!-- tabs:end -->\n';
+            });
             return markdown
           });
           


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- The `div tabs` sections are broken in the telemetry module, e.g., https://kyma-project.io/#/telemetry-manager/user/03-traces?id=step-3a-add-authentication-details-from-plain-text or https://kyma-project.io/#/telemetry-manager/user/04-metrics?id=step-2b-add-authentication-details-from-secrets
- The reason is that the regex converting the markdown `div tabs` sections to proper [docsify-tabs](https://github.com/jhildenbiddle/docsify-tabs) sections is failing when the markdown sections are badly formatted. Badly formatted means that a `\n` or tab or whitespace is at the wrong place
- I formatted the telemetry markdown `div tabs` sections in https://github.com/kyma-project/telemetry-manager/pull/439
- This PR improves the regex that converts to markdown `div tabs` sections regex to docsify-tabs sections
- I also had a look at some other tabs sections and verified the new regex does not break them

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
