### PR TITLE
Update Istio app-connector-gateway to remove obsolete cipher suites and align TLS configuration with kyma-gateway

### DIFF
--- a/resources/application-connector/templates/application-connector-gateway.yaml
+++ b/resources/application-connector/templates/application-connector-gateway.yaml
@@ -21,13 +21,6 @@ spec:
       tls:
         mode: MUTUAL
         credentialName: kyma-gateway-certs
-        minProtocolVersion: TLSV1_2
-        cipherSuites:
-        - ECDHE-RSA-CHACHA20-POLY1305
-        - ECDHE-RSA-AES256-GCM-SHA384
-        - ECDHE-RSA-AES256-SHA
-        - ECDHE-RSA-AES128-GCM-SHA256
-        - ECDHE-RSA-AES128-SHA
       hosts:
         - "gateway.{{ .Values.global.domainName }}"
 {{- end }}


### PR DESCRIPTION
Since Kyma 2.15 ECDHE-RSA-AES256-SHA and ECDHE-RSA-AES128-SHA cipher suites are deprecated and Kyma security team recommendation. Remove cipher suites configuration from TLS on kyma gateway since envoy is already [configuring cipher suites](https://www.envoyproxy.io/docs/envoy/latest/api-v3/extensions/transport_sockets/tls/v3/common.proto) by default. Remove minProtocolVersion since it's redundant to [istio default configuration](https://istio.io/latest/docs/reference/config/networking/gateway/#ServerTLSSettings).

GH Issue: https://github.com/kyma-project/kyma/issues/18270
Issue for Kyma Gateway - https://github.com/kyma-project/kyma/issues/17616
Pull request for Kyma Gateway - https://github.com/kyma-project/kyma/pull/18085