### PR TITLE
Mitigate dependency to non-existing serverless component in upgraed tests

### DIFF
--- a/tests/fast-integration/Makefile
+++ b/tests/fast-integration/Makefile
@@ -20,6 +20,8 @@ ci-compass:
 
 .PHONY: ci-pre-upgrade
 ci-pre-upgrade:
+	kubectl apply -f https://github.com/kyma-project/serverless-manager/releases/latest/download/serverless-operator.yaml
+	kubectl apply -f https://github.com/kyma-project/serverless-manager/releases/latest/download/default_serverless_cr.yaml -n kyma-system
 	npm install
 	npm run upgrade-test-prep
 	npm run upgrade-test-tests


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- ensure serverless module installed before running upgrade tests

**Related issue(s)**
https://github.com/kyma-project/kyma/issues/18285