### PR TITLE
simplify readiness check for event-publisher-proxy

### DIFF
--- a/components/event-publisher-proxy/pkg/sender/jetstream/health.go
+++ b/components/event-publisher-proxy/pkg/sender/jetstream/health.go
@@ -12,7 +12,7 @@ import (
 // It checks the NATS server connection status and reports 2XX if connected, otherwise reports 5XX.
 // It panics if the given NATS Handler is nil.
 func (s *Sender) ReadinessCheck(w http.ResponseWriter, _ *http.Request) {
-	if status := s.ConnectionStatus(); status == nats.RECONNECTING {
+	if status := s.ConnectionStatus(); status == nats.DISCONNECTED {
 		s.namedLogger().Error("Readiness check failed: not connected to nats server")
 		w.WriteHeader(health.StatusCodeNotHealthy)
 		return

--- a/components/event-publisher-proxy/pkg/sender/jetstream/health.go
+++ b/components/event-publisher-proxy/pkg/sender/jetstream/health.go
@@ -12,7 +12,7 @@ import (
 // It checks the NATS server connection status and reports 2XX if connected, otherwise reports 5XX.
 // It panics if the given NATS Handler is nil.
 func (s *Sender) ReadinessCheck(w http.ResponseWriter, _ *http.Request) {
-	if status := s.ConnectionStatus(); status != nats.CONNECTED {
+	if status := s.ConnectionStatus(); status == nats.RECONNECTING {
 		s.namedLogger().Error("Readiness check failed: not connected to nats server")
 		w.WriteHeader(health.StatusCodeNotHealthy)
 		return

--- a/components/event-publisher-proxy/pkg/sender/jetstream/health.go
+++ b/components/event-publisher-proxy/pkg/sender/jetstream/health.go
@@ -3,8 +3,6 @@ package jetstream
 import (
 	"net/http"
 
-	"github.com/nats-io/nats.go"
-
 	"github.com/kyma-project/kyma/components/event-publisher-proxy/pkg/handler/health"
 )
 
@@ -12,11 +10,6 @@ import (
 // It checks the NATS server connection status and reports 2XX if connected, otherwise reports 5XX.
 // It panics if the given NATS Handler is nil.
 func (s *Sender) ReadinessCheck(w http.ResponseWriter, _ *http.Request) {
-	if status := s.ConnectionStatus(); status == nats.DISCONNECTED {
-		s.namedLogger().Error("Readiness check failed: not connected to nats server")
-		w.WriteHeader(health.StatusCodeNotHealthy)
-		return
-	}
 	w.WriteHeader(health.StatusCodeHealthy)
 }
 

--- a/resources/eventing/values.yaml
+++ b/resources/eventing/values.yaml
@@ -5,7 +5,7 @@ global:
   images:
     eventing_controller:
       name: eventing-controller
-      version: PR-18307
+      version: PR-18281
       directory: dev
       pullPolicy: "IfNotPresent"
     publisher_proxy:

--- a/resources/eventing/values.yaml
+++ b/resources/eventing/values.yaml
@@ -30,7 +30,7 @@ global:
       directory: prod/external
 
   jetstream:
-    enabled: true # If set to `false` then NATS resources will not be deployed to the cluster.
+    enabled: false # If set to `false` then NATS resources will not be deployed to the cluster.
     # Storage type of the stream, memory or file.
     storage: file
     fileStorage:

--- a/resources/eventing/values.yaml
+++ b/resources/eventing/values.yaml
@@ -5,12 +5,12 @@ global:
   images:
     eventing_controller:
       name: eventing-controller
-      version: PR-18281
+      version: PR-18307
       directory: dev
       pullPolicy: "IfNotPresent"
     publisher_proxy:
       name: event-publisher-proxy
-      version: PR-18259
+      version: PR-18307
       directory: dev
     certHandler:
       name: eventing-webhook-certificates

--- a/resources/eventing/values.yaml
+++ b/resources/eventing/values.yaml
@@ -30,7 +30,7 @@ global:
       directory: prod/external
 
   jetstream:
-    enabled: false # If set to `false` then NATS resources will not be deployed to the cluster.
+    enabled: true # If set to `false` then NATS resources will not be deployed to the cluster.
     # Storage type of the stream, memory or file.
     storage: file
     fileStorage:


### PR DESCRIPTION
Let's decouple the readiness state of the epp and the availability of NATS, since the state of NATS will be reflected in the eventingBackendCR already.