### PR TITLE
get `branch-to-merge-against` and use it as `base-branch`

### DIFF
--- a/.github/workflows/lint-markdown-links-pr.yml
+++ b/.github/workflows/lint-markdown-links-pr.yml
@@ -6,6 +6,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+
       - uses: gaurav-nelson/github-action-markdown-link-check@v1
         with:
           use-quiet-mode: 'yes'  
@@ -14,4 +15,4 @@ jobs:
           folder-path: '.'
           max-depth: -1
           check-modified-files-only: 'yes'
-          base-branch: 'main'
+          base-branch: ${{ github.base_ref }}


### PR DESCRIPTION
this PR uses the branch any PR tries to merge against as the `base-branch` in the link check workflow.

from the docs of https://github.com/gaurav-nelson/github-action-markdown-link-check

>  base-branch | Use this variable to specify the branch to compare when finding modified markdown files. | master


