### PR TITLE
Add the link to the Eventing module documentation

### DIFF
--- a/docs/06-modules/README.md
+++ b/docs/06-modules/README.md
@@ -20,6 +20,6 @@ The table of Kyma modules:
 | [Serverless](https://kyma-project.io/#/serverless-manager/user/README.md) | With the Serverless module, you can define simple code snippets (Functions) with minimal implementation effort. |
 | [Telemetry](https://kyma-project.io/#/telemetry-manager/user/README.md) | Enable telemetry agents to easily collect application logs and distributed traces for your application and dispatch them to backends.|
 | [NATS](https://kyma-project.io/#/nats-manager/user/README.md) | NATS deploys a NATS cluster within the Kyma cluster. You can use it as a backend for Kyma Eventing. |
-| [Eventing*](https://github.com/kyma-project/eventing-manager) | Eventing provides functionality to publish and subscribe to CloudEvents. <br> At the moment, the SAP Event Mesh default plan and NATS (provided by the NATS module) are supported. | 
+| [Eventing](https://github.com/kyma-project/eventing-manager) | Eventing provides functionality to publish and subscribe to CloudEvents. <br> At the moment, the SAP Event Mesh default plan and NATS (provided by the NATS module) are supported. | 
 | [API Gateway*](https://github.com/kyma-project/api-gateway) | API Gateway provides functionalities that allow you to expose and secure APIs. |
 | [Istio*](https://github.com/kyma-project/istio) | Istio is a service mesh with the Kyma-specific configuration. |

--- a/docs/_sidebar.md
+++ b/docs/_sidebar.md
@@ -12,5 +12,6 @@
   * [Serverless](/serverless-manager/user/README.md)
   * [Telemetry](/telemetry-manager/user/README.md)
   * [NATS](/nats-manager/user/README.md)
+  * [Eventing](/eventing-manager/user/README.md)
 * [Glossary](/glossary.md)
 <!-- markdown-link-check-enable -->


### PR DESCRIPTION

**Description**

Changes proposed in this pull request:

- Add the link to the Eventing module documentation to the `_sidebar.md` file in the `kyma` repository.
- Remove the asterisk from the Eventing module in the OS modules table.

**Related issue(s)**
#17474 
