### PR TITLE
Update compass runtime agent image to version v20231218-ff3777c4

### DIFF
--- a/resources/compass-runtime-agent/values.yaml
+++ b/resources/compass-runtime-agent/values.yaml
@@ -5,7 +5,7 @@ global:
   images:
     compass_runtime_agent:
       name: "compass-runtime-agent"
-      version: "v20231025-ecda502a"
+      version: "v20231218-ff3777c4"
       directory: "prod"
   istio:
     gateway:


### PR DESCRIPTION
It is needed to use latest image version with some securituy fixes