### PR TITLE
fix: Remove new lines from generated CRD description

### DIFF
--- a/hack/table-gen/main.go
+++ b/hack/table-gen/main.go
@@ -340,7 +340,7 @@ func convertUnstructuredToElementTree(obj interface{}, name string, required boo
 	e.name = name
 	e.required = required
 	if d, ok := m["description"].(string); ok {
-		e.description = d
+		e.description = strings.ReplaceAll(d, "\n", " ")
 	}
 
 	e.elemtype = getType(m)


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Recent controller-gen versions introduced line breaks in CRD field descriptions. This change breaks the generated markdown tables by table-gen. This change replaces all line breaks by spaces in the description fields.

Changes proposed in this pull request:

- Remove new lines from generated CRD description

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
https://github.com/kyma-project/telemetry-manager/pull/900/