### PR TITLE
Updating the Kyma backup documentation

### DIFF
--- a/docs/04-operation-guides/operations/10-backup-kyma.md
+++ b/docs/04-operation-guides/operations/10-backup-kyma.md
@@ -27,8 +27,7 @@ You can create on-demand volume snapshots manually, or set up a periodic job tha
 
 ## Back Up Resources Using Velero
 
-You can back up and restore individual resources manually or automatically with Velero. For more information, read the [Velero documentation](https://velero.io/docs/).
-Be aware that a full backup of a Kyma cluster isn't supported. Start with the existing Kyma installation and restore specific resources individually.
+Velero backup is not supported at this time.
 
 ## Create On-Demand Volume Snapshots
 

--- a/docs/04-operation-guides/operations/10-backup-kyma.md
+++ b/docs/04-operation-guides/operations/10-backup-kyma.md
@@ -25,9 +25,9 @@ Taking volume snapshots is possible thanks to [Container Storage Interface (CSI)
 
 You can create on-demand volume snapshots manually, or set up a periodic job that takes automatic snapshots periodically.
 
-## Back Up Resources Using Velero
+## Back Up Resources Using 3rd Parties Tools
 
-Velero backup is not supported at this time.
+3rd part tols like velero backup is not supported at this time.
 
 ## Create On-Demand Volume Snapshots
 

--- a/docs/04-operation-guides/operations/10-backup-kyma.md
+++ b/docs/04-operation-guides/operations/10-backup-kyma.md
@@ -27,7 +27,7 @@ You can create on-demand volume snapshots manually, or set up a periodic job tha
 
 ## Back Up Resources Using Third-Party Parties Tools
 >[!WARNING]
-> Third-party tools like Velero Backup are not currently supported. These tools may have limitations and might not fully support automated cluster backups. They often require specific access rights to cluster infrastructure, which may not be available in Kyma's managed offerings, where access rights to the infrastructure account are restricted.
+> Third-party tools like Velero are not currently supported. These tools may have limitations and might not fully support automated cluster backups. They often require specific access rights to cluster infrastructure, which may not be available in Kyma's managed offerings, where access rights to the infrastructure account are restricted.
 
 ## Create On-Demand Volume Snapshots
 

--- a/docs/04-operation-guides/operations/10-backup-kyma.md
+++ b/docs/04-operation-guides/operations/10-backup-kyma.md
@@ -173,7 +173,7 @@ spec:
                   name: volume-snapshot-${RANDOM_ID}
                   namespace: {NAMESPACE}
                   labels:
-                    job: volume-snapshotter-{PVC_NAME}
+                    job: volume-snapshotter
                     name: volume-snapshot-${RANDOM_ID}
                 spec:
                   volumeSnapshotClassName: {SNAPSHOT_CLASS_NAME}

--- a/docs/04-operation-guides/operations/10-backup-kyma.md
+++ b/docs/04-operation-guides/operations/10-backup-kyma.md
@@ -25,9 +25,9 @@ Taking volume snapshots is possible thanks to [Container Storage Interface (CSI)
 
 You can create on-demand volume snapshots manually, or set up a periodic job that takes automatic snapshots periodically.
 
-## Back Up Resources Using 3rd Parties Tools
+## Back Up Resources Using Third-Party Parties Tools
 
-3rd part tols like velero backup is not supported at this time.
+Third-Party party tools like velero backup is not supported at this time.
 
 ## Create On-Demand Volume Snapshots
 

--- a/docs/04-operation-guides/operations/10-backup-kyma.md
+++ b/docs/04-operation-guides/operations/10-backup-kyma.md
@@ -25,7 +25,7 @@ Taking volume snapshots is possible thanks to [Container Storage Interface (CSI)
 
 You can create on-demand volume snapshots manually, or set up a periodic job that takes automatic snapshots periodically.
 
-## Back Up Resources Using Third-Party Parties Tools
+## Back Up Resources Using Third-Party Tools
 >[!WARNING]
 > Third-party tools like Velero are not currently supported. These tools may have limitations and might not fully support automated cluster backups. They often require specific access rights to cluster infrastructure, which may not be available in Kyma's managed offerings, where access rights to the infrastructure account are restricted.
 

--- a/docs/04-operation-guides/operations/10-backup-kyma.md
+++ b/docs/04-operation-guides/operations/10-backup-kyma.md
@@ -26,8 +26,8 @@ Taking volume snapshots is possible thanks to [Container Storage Interface (CSI)
 You can create on-demand volume snapshots manually, or set up a periodic job that takes automatic snapshots periodically.
 
 ## Back Up Resources Using Third-Party Parties Tools
-
-Third-Party party tools like velero backup is not supported at this time.
+>[!WARNING]
+> Third-party tools like Velero Backup are not currently supported. These tools may have limitations and might not fully support automated cluster backups. They often require specific access rights to cluster infrastructure, which may not be available in Kyma's managed offerings, where access rights to the infrastructure account are restricted.
 
 ## Create On-Demand Volume Snapshots
 


### PR DESCRIPTION
Description

Updating the PVC backup documentation to reflect the latest K8s APIs
back-up-kyma

Reasons

Outdated documentation which will not work on latest Kyma clusters. Refer to https://kyma-project.io/#/04-operation-guides/operations/10-backup-kyma?id=create-a-periodic-snapshot-job
Here the K8s API version referred as v1beta1 which is not the current API version of current Kyma clusters.

Assignees

@kyma-project/technical-writers

Attachments