### PR TITLE
Add the plugin docsify-fix-pageload-scroll

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -99,6 +99,7 @@
     }
   </script>
   <!-- Docsify v4 -->
+  <script src="https://cdn.jsdelivr.net/gh/rizdaprasetya/docsify-fix-pageload-scroll@master/index.js"></script>
   <script src="https://unpkg.com/docsify-plugin-flexible-alerts"></script>
   <script src="//cdn.jsdelivr.net/npm/docsify@4"></script>
   <script src="https://cdn.jsdelivr.net/npm/docsify-themeable@0/dist/js/docsify-themeable.min.js"></script>


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- Add the plugin: https://github.com/rizdaprasetya/docsify-fix-pageload-scroll
When a page uses docsify-tabs, the deep links don't work as expected. This plugin fixes it
It causes a small delay before the page scrolls to the right position but I have no better solution for now

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
